### PR TITLE
Fix horizon auth and oauth

### DIFF
--- a/src/backend/modules/machine-access/src/services/oauthAuthorization.ts
+++ b/src/backend/modules/machine-access/src/services/oauthAuthorization.ts
@@ -1060,7 +1060,10 @@ class OAuthAuthorizationService {
     let missingScopes = d.oauthAuthorizationRequest.scopes.filter(
       scope => !scopes.includes(scope)
     );
-    if (missingScopes.length > 0) {
+    if (
+      d.oauthAuthorizationRequest.oauthApplication.type == 'user_facing' &&
+      missingScopes.length > 0
+    ) {
       throw new ServiceError(
         forbiddenError({
           message: `You cannot accept this app because it requires permissions that you do not have: ${missingScopes.join(', ')}`,

--- a/src/frontend/state/src/user/auth/withAuth.ts
+++ b/src/frontend/state/src/user/auth/withAuth.ts
@@ -29,7 +29,12 @@ export let redirectToAuthIfNotAuthenticated = async <R>(fn: () => Promise<R>) =>
     return await fn();
   } catch (err: any) {
     let url = new URL(window.location.href);
-    if (!url.pathname.startsWith('/join/')) url.pathname = '/';
+
+    if ((window as any).getAuthCallbackUrl) {
+      url = new URL((window as any).getAuthCallbackUrl());
+    } else {
+      if (!url.pathname.startsWith('/join/')) url.pathname = '/';
+    }
 
     if (authRequiredRef.current) {
       if (isServiceError(err) && err.data.code == 'unauthorized') {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes OAuth authorization acceptance rules and frontend unauthenticated redirect behavior, which can affect who can authorize apps and where users are sent after auth. Risk is moderate because it touches login/OAuth flows but is narrowly scoped.
> 
> **Overview**
> **OAuth authorization acceptance now only blocks on missing user permissions for `user_facing` apps.** Non-`user_facing` OAuth application types (e.g. `cli_auth`) no longer fail acceptance solely due to the user lacking requested scopes.
> 
> **Frontend auth redirect now supports an override callback URL.** `redirectToAuthIfNotAuthenticated` will use `window.getAuthCallbackUrl()` when present; otherwise it keeps the prior behavior of normalizing most paths to `/` (excluding `/join/*`) before redirecting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1aaf18839f64cb40d17893f196f31b7a8cbfef60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->