### PR TITLE
Add explorer whitelist

### DIFF
--- a/src/backend/modules/machine-access/src/services/oauthAuthorization.ts
+++ b/src/backend/modules/machine-access/src/services/oauthAuthorization.ts
@@ -1060,7 +1060,10 @@ class OAuthAuthorizationService {
     let missingScopes = d.oauthAuthorizationRequest.scopes.filter(
       scope => !scopes.includes(scope)
     );
-    if (missingScopes.length > 0) {
+    if (
+      d.oauthAuthorizationRequest.oauthApplication.type == 'user_facing' &&
+      missingScopes.length > 0
+    ) {
       throw new ServiceError(
         forbiddenError({
           message: `You cannot accept this app because it requires permissions that you do not have: ${missingScopes.join(', ')}`,

--- a/src/frontend/apps/explorer/src/lib/mcp/endpointAllowlist.ts
+++ b/src/frontend/apps/explorer/src/lib/mcp/endpointAllowlist.ts
@@ -1,0 +1,58 @@
+let parseAllowlistFromEnv = (): string[] => {
+  let raw = import.meta.env.VITE_MCP_ENDPOINT_HOST_ALLOWLIST;
+  if (raw == null || String(raw).trim() === '') return [];
+  return String(raw)
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+};
+
+let cachedPatterns: string[] | null = null;
+
+export let getMcpEndpointHostAllowlistPatterns = (): string[] => {
+  if (cachedPatterns === null) {
+    cachedPatterns = parseAllowlistFromEnv();
+  }
+  return cachedPatterns;
+};
+
+let matchesHostPattern = (hostnameLower: string, pattern: string): boolean => {
+  let p = pattern.toLowerCase().trim();
+  if (!p) return false;
+  if (p.startsWith('*.')) {
+    let suffix = p.slice(2);
+    if (!suffix) return false;
+    return hostnameLower === suffix || hostnameLower.endsWith('.' + suffix);
+  }
+  return hostnameLower === p;
+};
+
+export let isMcpEndpointHostnameAllowed = (hostname: string): boolean => {
+  let patterns = getMcpEndpointHostAllowlistPatterns();
+  if (patterns.length === 0) return true;
+  let h = hostname.toLowerCase();
+  return patterns.some(pat => matchesHostPattern(h, pat));
+};
+
+/** When allowlist is empty, returns undefined (no restriction). */
+export let getMcpEndpointUrlAllowlistViolation = (urlString: string): string | undefined => {
+  let patterns = getMcpEndpointHostAllowlistPatterns();
+  if (patterns.length === 0) return undefined;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    return undefined;
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return 'The MCP endpoint URL must use http or https.';
+  }
+
+  if (!isMcpEndpointHostnameAllowed(parsed.hostname)) {
+    return 'This MCP endpoint host is not allowed by this deployment.';
+  }
+
+  return undefined;
+};

--- a/src/frontend/apps/explorer/src/lib/mcp/query.ts
+++ b/src/frontend/apps/explorer/src/lib/mcp/query.ts
@@ -1,3 +1,5 @@
+import { getMcpEndpointUrlAllowlistViolation } from './endpointAllowlist';
+
 export type ExplorerTransport = 'sse' | 'streamable_http';
 
 export type ExplorerConfigPayload = {
@@ -81,6 +83,10 @@ export let getConnectionParams = (
       new URL(url);
     } catch {
       errors.push('The endpoint or url query parameter is not a valid absolute URL.');
+    }
+    let allowlistViolation = getMcpEndpointUrlAllowlistViolation(url);
+    if (allowlistViolation) {
+      errors.push(allowlistViolation);
     }
   }
 

--- a/src/frontend/apps/explorer/src/vite-env.d.ts
+++ b/src/frontend/apps/explorer/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_MCP_ENDPOINT_HOST_ALLOWLIST?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/frontend/state/src/user/auth/withAuth.ts
+++ b/src/frontend/state/src/user/auth/withAuth.ts
@@ -29,7 +29,12 @@ export let redirectToAuthIfNotAuthenticated = async <R>(fn: () => Promise<R>) =>
     return await fn();
   } catch (err: any) {
     let url = new URL(window.location.href);
-    if (!url.pathname.startsWith('/join/')) url.pathname = '/';
+
+    if ((window as any).getAuthCallbackUrl) {
+      url = new URL((window as any).getAuthCallbackUrl());
+    } else {
+      if (!url.pathname.startsWith('/join/')) url.pathname = '/';
+    }
 
     if (authRequiredRef.current) {
       if (isServiceError(err) && err.data.code == 'unauthorized') {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes OAuth authorization acceptance rules for non-`user_facing` apps and alters frontend auth redirect URL selection, which could affect access/redirect behavior if misconfigured.
> 
> **Overview**
> **Explorer now supports a deployment-configured MCP endpoint allowlist.** A new `VITE_MCP_ENDPOINT_HOST_ALLOWLIST` env var (supports exact hosts and `*.` wildcards) is parsed/cached and enforced when validating `endpoint/url` query parameters, rejecting non-`http(s)` URLs or disallowed hosts.
> 
> **Auth/OAuth flow behavior is tweaked.** `withAuth` can now use a global `window.getAuthCallbackUrl()` to compute the post-login callback URL, and backend `acceptOAuthAuthorizationRequest` only blocks acceptance for missing scopes when the OAuth app type is `user_facing` (skipping that restriction for other app types).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 190d973a77b4807800dd2aa3133ecdd0d8ad38b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->