### PR TITLE
Add member consumer

### DIFF
--- a/src/backend/apis/core/src/controllers/instance/consumer.ts
+++ b/src/backend/apis/core/src/controllers/instance/consumer.ts
@@ -1,7 +1,11 @@
-import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, forbiddenError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
-import { consumerProfileService, consumerService } from '@metorial/module-consumer';
+import {
+  consumerProfileService,
+  consumerService,
+  consumerSurfaceService
+} from '@metorial/module-consumer';
 import { Controller } from '@metorial/rest';
 import { checkAccess } from '../../middleware/checkAccess';
 import { hasFlags } from '../../middleware/hasFlags';
@@ -131,6 +135,54 @@ export let consumerController = Controller.create(
             name: ctx.body.name,
             email: ctx.body.email
           }
+        });
+
+        return consumerPresenter.present({ consumer });
+      }),
+
+    getMemberConsumer: instanceGroup
+      .post(instancePath('get-member-consumer', 'consumers.getMemberConsumer'), {
+        name: 'Get member consumer',
+        description:
+          'Upserts and returns the consumer for the authenticated organization member.',
+        hideInDocs: true
+      })
+      .use(checkAccess({ possibleScopes: ['instance.portal.consumers:write'] }))
+      .use(hasFlags(['identity-management', 'paid-identity']))
+      .body(
+        'default',
+        v.object({
+          surface_identifier: v.enumOf(['cli'])
+        })
+      )
+      .output(consumerPresenter)
+      .do(async ctx => {
+        let user = 'user' in ctx.auth ? ctx.auth.user : null;
+        if (!ctx.member || !user) {
+          throw new ServiceError(
+            forbiddenError({
+              message:
+                'This endpoint requires an authenticated organization member and is not available for API access.'
+            })
+          );
+        }
+
+        let consumerSurface = await consumerSurfaceService.ensureInternalConsumerSurface({
+          instance: ctx.instance,
+          identifier: ctx.body.surface_identifier,
+          name: 'CLI'
+        });
+
+        let consumerProfile = await consumerProfileService.ensureConsumerProfile({
+          surface: consumerSurface,
+          email: user.email,
+          name: user.name,
+          member: ctx.member
+        });
+
+        let consumer = await consumerService.getConsumerById({
+          instance: ctx.instance,
+          consumerId: consumerProfile.consumer.id
         });
 
         return consumerPresenter.present({ consumer });

--- a/src/backend/db/prisma/schema/consumer/consumer.prisma
+++ b/src/backend/db/prisma/schema/consumer/consumer.prisma
@@ -40,6 +40,12 @@ model InstanceConsumer {
   consumerOid BigInt
   consumer    Consumer @relation(fields: [consumerOid], references: [oid], onDelete: Cascade)
 
+  organizationMemberOid BigInt?
+  organizationMember    OrganizationMember? @relation(fields: [organizationMemberOid], references: [oid], onDelete: SetNull)
+
+  organizationActorOid BigInt?
+  organizationActor    OrganizationActor? @relation(fields: [organizationActorOid], references: [oid], onDelete: SetNull)
+
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @default(now()) @updatedAt
   consumerActors ConsumerActor[]
@@ -72,6 +78,12 @@ model ConsumerProfile {
 
   accessTagOid BigInt    @unique
   accessTag    AccessTag @relation(fields: [accessTagOid], references: [oid], onDelete: Cascade)
+
+  organizationMemberOid BigInt?
+  organizationMember    OrganizationMember? @relation(fields: [organizationMemberOid], references: [oid], onDelete: SetNull)
+
+  organizationActorOid BigInt?
+  organizationActor    OrganizationActor? @relation(fields: [organizationActorOid], references: [oid], onDelete: SetNull)
 
   personalConsumerGroupOid BigInt        @unique
   personalConsumerGroup    ConsumerGroup @relation("ConsumerProfilePersonalGroup", fields: [personalConsumerGroupOid], references: [oid], onDelete: Cascade)

--- a/src/backend/db/prisma/schema/organization/actor.prisma
+++ b/src/backend/db/prisma/schema/organization/actor.prisma
@@ -35,6 +35,8 @@ model OrganizationActor {
   oauthInstallations  OAuthInstallation[]
   projectBrandUpdates ProjectBrandUpdate[]
   consumers           Consumer[]
+  instanceConsumers   InstanceConsumer[]
+  consumerProfiles    ConsumerProfile[]
 
   @@unique([isSystem, organizationOid])
 }

--- a/src/backend/db/prisma/schema/organization/member.prisma
+++ b/src/backend/db/prisma/schema/organization/member.prisma
@@ -39,6 +39,8 @@ model OrganizationMember {
   policies                AccessPolicyAssignment[]
   apiKeyExpiredEmailSends ApiKeyExpiredEmailSend[]
   consumers               Consumer[]
+  instanceConsumers       InstanceConsumer[]
+  consumerProfiles        ConsumerProfile[]
 
   @@unique([userOid, organizationOid])
   @@index([lastActiveAt])

--- a/src/backend/modules/consumer/src/services/consumer.ts
+++ b/src/backend/modules/consumer/src/services/consumer.ts
@@ -13,6 +13,7 @@ import {
   OrganizationMember,
   withTransaction
 } from '@metorial/db';
+import { createLock } from '@metorial/lock';
 import { syncIdentityConsumerQueue } from '../queues/syncIdentityConsumer';
 
 type ConsumerWithRelations = Consumer & {
@@ -24,9 +25,29 @@ type ConsumerWithRelations = Consumer & {
   >;
 };
 
+let upsertLock = createLock({
+  name: 'cons/upsert'
+});
+
 type InstanceConsumerWithRelations = InstanceConsumer & {
   consumer: ConsumerWithRelations;
 };
+
+let getInclude = (d: { instanceOid: bigint }) => ({
+  consumer: {
+    include: {
+      organizationMember: true,
+      profiles: {
+        where: {
+          instanceOid: d.instanceOid
+        },
+        include: {
+          surface: true
+        }
+      }
+    }
+  }
+});
 
 class ConsumerServiceImpl {
   async getConsumerById(d: { instance: Instance; consumerId: string }) {
@@ -132,21 +153,7 @@ class ConsumerServiceImpl {
           name: d.input.name,
           email: d.input.email
         },
-        include: {
-          consumer: {
-            include: {
-              organizationMember: true,
-              profiles: {
-                where: {
-                  instanceOid: d.instance.oid
-                },
-                include: {
-                  surface: true
-                }
-              }
-            }
-          }
-        }
+        include: getInclude({ instanceOid: d.instance.oid })
       });
 
       await tx.consumerProfile.updateMany({
@@ -199,21 +206,7 @@ class ConsumerServiceImpl {
           name,
           email
         },
-        include: {
-          consumer: {
-            include: {
-              organizationMember: true,
-              profiles: {
-                where: {
-                  instanceOid: d.consumer.instanceOid
-                },
-                include: {
-                  surface: true
-                }
-              }
-            }
-          }
-        }
+        include: getInclude({ instanceOid: d.consumer.instanceOid })
       });
 
       await tx.consumerProfile.updateMany({
@@ -235,6 +228,57 @@ class ConsumerServiceImpl {
     });
 
     return consumer;
+  }
+
+  async upsertConsumer(d: {
+    organization: Organization;
+    instance: Instance;
+    input: {
+      name: string;
+      email: string;
+    };
+  }) {
+    let existing = await db.instanceConsumer.findFirst({
+      where: {
+        instanceOid: d.instance.oid,
+        email: d.input.email
+      },
+      include: getInclude({ instanceOid: d.instance.oid })
+    });
+    if (existing) {
+      if (existing.name === d.input.name) return existing;
+
+      return await this.updateConsumer({
+        consumer: existing as InstanceConsumerWithRelations,
+        input: {
+          name: d.input.name,
+          email: d.input.email
+        }
+      });
+    }
+
+    return await upsertLock.usingLock(`${d.instance.oid}-${d.input.email}`, async () => {
+      let existing = await db.instanceConsumer.findFirst({
+        where: {
+          instanceOid: d.instance.oid,
+          email: d.input.email
+        },
+        include: getInclude({ instanceOid: d.instance.oid })
+      });
+      if (existing) {
+        if (existing.name === d.input.name) return existing;
+
+        return await this.updateConsumer({
+          consumer: existing as InstanceConsumerWithRelations,
+          input: {
+            name: d.input.name,
+            email: d.input.email
+          }
+        });
+      }
+
+      return await this.createConsumer(d);
+    });
   }
 }
 

--- a/src/backend/modules/consumer/src/services/consumerProfile.ts
+++ b/src/backend/modules/consumer/src/services/consumerProfile.ts
@@ -13,8 +13,10 @@ import {
   db,
   ID,
   InstanceConsumer,
+  OrganizationMember,
   withTransaction
 } from '@metorial/db';
+import { createLock } from '@metorial/lock';
 import { syncIdentityConsumerQueue } from '../queues/syncIdentityConsumer';
 
 let include = {
@@ -27,6 +29,10 @@ let include = {
     }
   }
 } as const;
+
+export let ensureProfileLock = createLock({
+  name: 'cons/ensureProfile'
+});
 
 class ConsumerProfileServiceImpl {
   private async getAssignableGroupsOrThrow(d: {
@@ -124,16 +130,18 @@ class ConsumerProfileServiceImpl {
 
   async ensureConsumerProfile(d: {
     surface: ConsumerSurface;
-    aresUserId: string;
     email: string;
     name: string;
+    member?: Pick<OrganizationMember, 'oid' | 'actorOid'>;
+
+    aresUserId?: string;
     ssoGroupIds?: string[];
     ssoRoles?: string[];
   }) {
-    let res = await withTransaction(async tx => {
+    let res = await withTransaction(async db => {
       let ssoGroupIds = normalizeStringList(d.ssoGroupIds);
       let ssoRoles = normalizeStringList(d.ssoRoles);
-      let existingConsumer = await tx.consumer.findUnique({
+      let existingConsumer = await db.consumer.findUnique({
         where: {
           email_organizationOid: {
             email: d.email,
@@ -142,10 +150,12 @@ class ConsumerProfileServiceImpl {
         },
         select: {
           isOrganizationMember: true,
-          isPortalConsumer: true
+          isPortalConsumer: true,
+          organizationMemberOid: true,
+          organizationActorOid: true
         }
       });
-      let consumer = await tx.consumer.upsert({
+      let consumer = await db.consumer.upsert({
         where: {
           email_organizationOid: {
             email: d.email,
@@ -157,20 +167,25 @@ class ConsumerProfileServiceImpl {
           email: d.email,
           name: d.name,
           organizationOid: d.surface.organizationOid,
+          organizationMemberOid: d.member?.oid,
+          organizationActorOid: d.member?.actorOid,
           isOrganizationMember: d.surface.type === 'organization_members',
           isPortalConsumer: d.surface.type === 'portal'
         },
         update: {
           email: d.email,
           name: d.name,
+          organizationMemberOid: d.member?.oid ?? existingConsumer?.organizationMemberOid,
+          organizationActorOid: d.member?.actorOid ?? existingConsumer?.organizationActorOid,
           isOrganizationMember:
-            existingConsumer?.isOrganizationMember ||
+            !!d.member ||
+            !!existingConsumer?.isOrganizationMember ||
             d.surface.type === 'organization_members',
           isPortalConsumer: existingConsumer?.isPortalConsumer || d.surface.type === 'portal'
         }
       });
 
-      await tx.instanceConsumer.upsert({
+      await db.instanceConsumer.upsert({
         where: {
           instanceOid_consumerOid: {
             instanceOid: d.surface.instanceOid,
@@ -182,80 +197,91 @@ class ConsumerProfileServiceImpl {
           name: d.name,
           email: d.email,
           instanceOid: d.surface.instanceOid,
-          consumerOid: consumer.oid
+          consumerOid: consumer.oid,
+          organizationMemberOid: d.member?.oid,
+          organizationActorOid: d.member?.actorOid
         },
         update: {
           name: d.name,
-          email: d.email
+          email: d.email,
+          organizationMemberOid: d.member?.oid ?? consumer.organizationMemberOid,
+          organizationActorOid: d.member?.actorOid ?? consumer.organizationActorOid
         }
       });
 
-      let existingProfile = await tx.consumerProfile.findUnique({
-        where: {
-          surfaceOid_aresUserId: {
-            surfaceOid: d.surface.oid,
-            aresUserId: d.aresUserId
-          }
+      return ensureProfileLock.usingLock(`${d.surface.instanceOid}-${d.email}`, async () => {
+        let existingProfile = await db.consumerProfile.findUnique({
+          where: d.aresUserId
+            ? {
+                surfaceOid_aresUserId: { surfaceOid: d.surface.oid, aresUserId: d.aresUserId }
+              }
+            : { email_surfaceOid: { email: d.email, surfaceOid: d.surface.oid } }
+        });
+        if (existingProfile) {
+          return {
+            consumer,
+            consumerProfile: await db.consumerProfile.update({
+              where: {
+                oid: existingProfile.oid
+              },
+              data: {
+                aresUserId: d.aresUserId,
+                email: d.email,
+                name: d.name,
+                consumerOid: consumer.oid,
+                organizationMemberOid: d.member?.oid ?? consumer.organizationMemberOid,
+                organizationActorOid: d.member?.actorOid ?? consumer.organizationActorOid,
+                ssoGroupIds,
+                ssoRoles
+              },
+              include
+            })
+          };
         }
-      });
-      if (existingProfile) {
+
+        let accessTag = await db.accessTag.create({
+          data: {
+            instanceOid: d.surface.instanceOid
+          }
+        });
+
+        let personalConsumerGroup = await db.consumerGroup.create({
+          data: {
+            id: await ID.generateId('consumerGroup'),
+            status: 'active',
+            type: 'user_access',
+            isDefault: false,
+            ssoGroupIds: [],
+            name: `Personal Group for ${d.email}`,
+            description: null,
+            surfaceOid: d.surface.oid,
+            accessTagOid: accessTag.oid
+          }
+        });
+
         return {
           consumer,
-          consumerProfile: await tx.consumerProfile.update({
-            where: {
-              oid: existingProfile.oid
-            },
+          consumerProfile: await db.consumerProfile.create({
             data: {
+              id: await ID.generateId('consumerProfile'),
               aresUserId: d.aresUserId,
               email: d.email,
               name: d.name,
-              consumerOid: consumer.oid,
               ssoGroupIds,
-              ssoRoles
-            }
+              ssoRoles,
+              organizationOid: d.surface.organizationOid,
+              instanceOid: d.surface.instanceOid,
+              surfaceOid: d.surface.oid,
+              consumerOid: consumer.oid,
+              organizationMemberOid: d.member?.oid ?? consumer.organizationMemberOid,
+              organizationActorOid: d.member?.actorOid ?? consumer.organizationActorOid,
+              accessTagOid: accessTag.oid,
+              personalConsumerGroupOid: personalConsumerGroup.oid
+            },
+            include
           })
         };
-      }
-
-      let accessTag = await tx.accessTag.create({
-        data: {
-          instanceOid: d.surface.instanceOid
-        }
       });
-
-      let personalConsumerGroup = await tx.consumerGroup.create({
-        data: {
-          id: await ID.generateId('consumerGroup'),
-          status: 'active',
-          type: 'user_access',
-          isDefault: false,
-          ssoGroupIds: [],
-          name: `Personal Group for ${d.email}`,
-          description: null,
-          surfaceOid: d.surface.oid,
-          accessTagOid: accessTag.oid
-        }
-      });
-
-      return {
-        consumer,
-        consumerProfile: await tx.consumerProfile.create({
-          data: {
-            id: await ID.generateId('consumerProfile'),
-            aresUserId: d.aresUserId,
-            email: d.email,
-            name: d.name,
-            ssoGroupIds,
-            ssoRoles,
-            organizationOid: d.surface.organizationOid,
-            instanceOid: d.surface.instanceOid,
-            surfaceOid: d.surface.oid,
-            consumerOid: consumer.oid,
-            accessTagOid: accessTag.oid,
-            personalConsumerGroupOid: personalConsumerGroup.oid
-          }
-        })
-      };
     });
 
     await syncIdentityConsumerQueue.add({

--- a/src/backend/modules/consumer/src/services/consumerSurface.ts
+++ b/src/backend/modules/consumer/src/services/consumerSurface.ts
@@ -289,7 +289,7 @@ class ConsumerSurfaceServiceImpl {
           where: { oid: d.instance.organizationOid }
         });
 
-        let surface = await this.createConsumerSurface({
+        return await this.createConsumerSurface({
           organization: org,
           instance: d.instance,
           context: { ip: '0.0.0.0', ua: 'Metorial System' },

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/providerConfigurationSelectionModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/providerConfigurationSelectionModal.tsx
@@ -17,7 +17,6 @@ import {
   OptionToggle,
   Select,
   showModal,
-  Spacer,
   Text
 } from '@metorial/ui';
 import { RiAddLine } from '@remixicon/react';
@@ -272,10 +271,6 @@ let CreateDeploymentInline = ({
 
   return (
     <Flex direction="column" gap={8}>
-      <Text size="2" color="gray600">
-        No deployments found for <strong>{providerName}</strong>. Create one to continue.
-      </Text>
-
       <form onSubmit={form.handleSubmit}>
         <Flex direction="column" gap={8}>
           <Input label="Name" required {...form.getFieldProps('name')} />
@@ -283,19 +278,20 @@ let CreateDeploymentInline = ({
 
           <Input label="Description" {...form.getFieldProps('description')} />
           <form.RenderError field="description" />
-          <Spacer height={8} />
 
-          <Dialog.Actions>
-            <Button
-              type="submit"
-              loading={createMutation.isLoading}
-              success={createMutation.isSuccess}
-            >
-              Create Deployment
-            </Button>
+          <div style={{ marginTop: 5 }}>
+            <Dialog.Actions>
+              <Button
+                type="submit"
+                loading={createMutation.isLoading}
+                success={createMutation.isSuccess}
+              >
+                Create Deployment
+              </Button>
 
-            <createMutation.RenderError />
-          </Dialog.Actions>
+              <createMutation.RenderError />
+            </Dialog.Actions>
+          </div>
         </Flex>
       </form>
     </Flex>
@@ -429,52 +425,56 @@ let DeploymentConfigureStep = ({
       />
       <form.RenderError field="selectedConfiguration" />
 
-      <Flex gap={8} align="end">
-        <div style={{ flex: 1 }}>
-          <Select
-            label="Auth Config"
-            value={form.values.selectedAuthConfigId || '__none__'}
-            onChange={v => {
-              form.setFieldValue('selectedAuthConfigId', v === '__none__' ? '' : v);
-              form.setFieldTouched('selectedAuthConfigId', false, false);
-              form.setFieldError('selectedAuthConfigId', undefined);
-            }}
-            items={[
-              { id: '__none__', label: 'None' },
-              ...authConfigItems.map(config => ({
-                id: config.id,
-                label: config.name ?? config.id
-              }))
-            ]}
-          />
-        </div>
-
-        <div
-          title={authCreation.authConfigDisabledReason ?? undefined}
-          style={{ display: 'inline-flex' }}
-        >
-          <Button
-            type="button"
-            size="3"
-            iconLeft={<RiAddLine />}
-            aria-label="Create Auth Config"
-            disabled={!authCreation.canCreateAuthConfig}
-            onClick={() =>
-              showProviderAuthConfigCreateModal({
-                instanceId,
-                providerDeploymentId: deploymentId,
-                onCreate: authConfig => {
-                  authConfigs.refetch?.();
-                  form.setFieldValue('selectedAuthConfigId', authConfig.id);
+      {(provider.data?.type.auth.status == 'enabled' || true) && (
+        <>
+          <Flex gap={8} align="end">
+            <div style={{ flex: 1 }}>
+              <Select
+                label="Auth Config"
+                value={form.values.selectedAuthConfigId || '__none__'}
+                onChange={v => {
+                  form.setFieldValue('selectedAuthConfigId', v === '__none__' ? '' : v);
                   form.setFieldTouched('selectedAuthConfigId', false, false);
                   form.setFieldError('selectedAuthConfigId', undefined);
+                }}
+                items={[
+                  { id: '__none__', label: 'None' },
+                  ...authConfigItems.map(config => ({
+                    id: config.id,
+                    label: config.name ?? config.id
+                  }))
+                ]}
+              />
+            </div>
+
+            <div
+              title={authCreation.authConfigDisabledReason ?? undefined}
+              style={{ display: 'inline-flex' }}
+            >
+              <Button
+                type="button"
+                size="3"
+                iconLeft={<RiAddLine />}
+                aria-label="Create Auth Config"
+                disabled={!authCreation.canCreateAuthConfig}
+                onClick={() =>
+                  showProviderAuthConfigCreateModal({
+                    instanceId,
+                    providerDeploymentId: deploymentId,
+                    onCreate: authConfig => {
+                      authConfigs.refetch?.();
+                      form.setFieldValue('selectedAuthConfigId', authConfig.id);
+                      form.setFieldTouched('selectedAuthConfigId', false, false);
+                      form.setFieldError('selectedAuthConfigId', undefined);
+                    }
+                  })
                 }
-              })
-            }
-          />
-        </div>
-      </Flex>
-      <form.RenderError field="selectedAuthConfigId" />
+              />
+            </div>
+          </Flex>
+          <form.RenderError field="selectedAuthConfigId" />
+        </>
+      )}
 
       {includeToolFilters && toolItems.length > 0 && (
         <div>
@@ -523,11 +523,13 @@ let DeploymentConfigureStep = ({
 
       {mutationError}
 
-      <Dialog.Actions>
-        <Button type="submit" loading={saving} size="2">
-          {submitLabel}
-        </Button>
-      </Dialog.Actions>
+      <div style={{ marginTop: 5 }}>
+        <Dialog.Actions>
+          <Button type="submit" loading={saving} size="2">
+            {submitLabel}
+          </Button>
+        </Dialog.Actions>
+      </div>
     </Flex>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly additive generated client code, but it changes several exported TypeScript types/mappers (SCM provider unions and identity-actor/consumer-profile shapes), which may be breaking for downstream consumers relying on previous typings or transforms.
> 
> **Overview**
> Adds new generated endpoints and resource mappers for managing instance `consumers`, their `profiles`, and `consumer-surfaces` across dashboard- and management-scoped routes (plus top-level `consumers`/`consumer-surfaces` controllers), and exports them via the endpoints/resources `index.ts` barrels.
> 
> Updates existing generated models: identity-actor outputs now include an optional linked `consumer` and list queries add `consumerId` filtering; portal consumer-profile outputs now include a `surface` object; and multiple SCM-related resources narrow provider `type` unions to `github | gitlab`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3adca92592409cd5e4c043af21e1479a807a97e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->