### PR TITLE
Add identity filters

### DIFF
--- a/src/backend/apis/core/src/controllers/instance/consumer.ts
+++ b/src/backend/apis/core/src/controllers/instance/consumer.ts
@@ -1,7 +1,11 @@
-import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, forbiddenError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
-import { consumerProfileService, consumerService } from '@metorial/module-consumer';
+import {
+  consumerProfileService,
+  consumerService,
+  consumerSurfaceService
+} from '@metorial/module-consumer';
 import { Controller } from '@metorial/rest';
 import { checkAccess } from '../../middleware/checkAccess';
 import { hasFlags } from '../../middleware/hasFlags';
@@ -131,6 +135,54 @@ export let consumerController = Controller.create(
             name: ctx.body.name,
             email: ctx.body.email
           }
+        });
+
+        return consumerPresenter.present({ consumer });
+      }),
+
+    getMemberConsumer: instanceGroup
+      .post(instancePath('get-member-consumer', 'consumers.getMemberConsumer'), {
+        name: 'Get member consumer',
+        description:
+          'Upserts and returns the consumer for the authenticated organization member.',
+        hideInDocs: true
+      })
+      .use(checkAccess({ possibleScopes: ['instance.portal.consumers:write'] }))
+      .use(hasFlags(['identity-management', 'paid-identity']))
+      .body(
+        'default',
+        v.object({
+          surface_identifier: v.enumOf(['cli'])
+        })
+      )
+      .output(consumerPresenter)
+      .do(async ctx => {
+        let user = 'user' in ctx.auth ? ctx.auth.user : null;
+        if (!ctx.member || !user) {
+          throw new ServiceError(
+            forbiddenError({
+              message:
+                'This endpoint requires an authenticated organization member and is not available for API access.'
+            })
+          );
+        }
+
+        let consumerSurface = await consumerSurfaceService.ensureInternalConsumerSurface({
+          instance: ctx.instance,
+          identifier: ctx.body.surface_identifier,
+          name: 'CLI'
+        });
+
+        let consumerProfile = await consumerProfileService.ensureConsumerProfile({
+          surface: consumerSurface,
+          email: user.email,
+          name: user.name,
+          member: ctx.member
+        });
+
+        let consumer = await consumerService.getConsumerById({
+          instance: ctx.instance,
+          consumerId: consumerProfile.consumer.id
         });
 
         return consumerPresenter.present({ consumer });

--- a/src/backend/apis/core/src/controllers/provider/providerAuthConfig.ts
+++ b/src/backend/apis/core/src/controllers/provider/providerAuthConfig.ts
@@ -76,6 +76,18 @@ export let providerAuthConfigController = Controller.create(
             provider_auth_method_id: v.optional(v.union([v.string(), v.array(v.string())]), {
               description: 'Filter by auth method ID(s)'
             }),
+            actor_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by actor ID(s)'
+            }),
+            consumer_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by consumer ID(s)'
+            }),
+            identity_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by identity ID(s)'
+            }),
+            identity_credential_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by identity credential ID(s)'
+            }),
             search: v.optional(v.string({ description: 'Search by name or description' })),
             created_at: dateFilterValidator('provider auth config creation time'),
             updated_at: dateFilterValidator('provider auth config last update time')
@@ -96,6 +108,10 @@ export let providerAuthConfigController = Controller.create(
             ctx.query.provider_auth_credentials_id
           ),
           providerAuthMethodIds: normalizeArrayParam(ctx.query.provider_auth_method_id),
+          actorIds: normalizeArrayParam(ctx.query.actor_id),
+          consumerIds: normalizeArrayParam(ctx.query.consumer_id),
+          identityIds: normalizeArrayParam(ctx.query.identity_id),
+          identityCredentialIds: normalizeArrayParam(ctx.query.identity_credential_id),
           createdAt: ctx.query.created_at,
           updatedAt: ctx.query.updated_at
         });

--- a/src/backend/apis/core/src/controllers/provider/providerConfig.ts
+++ b/src/backend/apis/core/src/controllers/provider/providerConfig.ts
@@ -68,6 +68,18 @@ export let providerConfigController = Controller.create(
             provider_config_vault_id: v.optional(v.union([v.string(), v.array(v.string())]), {
               description: 'Filter by config vault ID(s)'
             }),
+            actor_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by actor ID(s)'
+            }),
+            consumer_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by consumer ID(s)'
+            }),
+            identity_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by identity ID(s)'
+            }),
+            identity_credential_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by identity credential ID(s)'
+            }),
             search: v.optional(v.string({ description: 'Search by name or description' })),
             created_at: dateFilterValidator('provider config creation time'),
             updated_at: dateFilterValidator('provider config last update time')
@@ -86,6 +98,10 @@ export let providerConfigController = Controller.create(
           providerSpecificationIds: normalizeArrayParam(ctx.query.provider_specification_id),
           providerDeploymentIds: normalizeArrayParam(ctx.query.provider_deployment_id),
           providerConfigVaultIds: normalizeArrayParam(ctx.query.provider_config_vault_id),
+          actorIds: normalizeArrayParam(ctx.query.actor_id),
+          consumerIds: normalizeArrayParam(ctx.query.consumer_id),
+          identityIds: normalizeArrayParam(ctx.query.identity_id),
+          identityCredentialIds: normalizeArrayParam(ctx.query.identity_credential_id),
           createdAt: ctx.query.created_at,
           updatedAt: ctx.query.updated_at
         });

--- a/src/backend/apis/core/src/controllers/provider/providerDeployment.ts
+++ b/src/backend/apis/core/src/controllers/provider/providerDeployment.ts
@@ -149,6 +149,18 @@ export let providerDeploymentController = Controller.create(
             provider_version_id: v.optional(v.union([v.string(), v.array(v.string())]), {
               description: 'Filter by version ID(s)'
             }),
+            actor_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by actor ID(s)'
+            }),
+            consumer_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by consumer ID(s)'
+            }),
+            identity_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by identity ID(s)'
+            }),
+            identity_credential_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by identity credential ID(s)'
+            }),
             status: v.optional(
               v.union([
                 v.enumOf(['active', 'archived']),
@@ -177,6 +189,18 @@ export let providerDeploymentController = Controller.create(
             }),
             provider_version_id: v.optional(v.union([v.string(), v.array(v.string())]), {
               description: 'Filter by version ID(s)'
+            }),
+            actor_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by actor ID(s)'
+            }),
+            consumer_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by consumer ID(s)'
+            }),
+            identity_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by identity ID(s)'
+            }),
+            identity_credential_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by identity credential ID(s)'
             }),
             status: v.optional(
               v.union([
@@ -217,6 +241,10 @@ export let providerDeploymentController = Controller.create(
           ids: normalizeArrayParam(ctx.query.id),
           providerIds: normalizeArrayParam(ctx.query.provider_id),
           providerVersionIds: normalizeArrayParam(ctx.query.provider_version_id),
+          actorIds: normalizeArrayParam(ctx.query.actor_id),
+          consumerIds: normalizeArrayParam(ctx.query.consumer_id),
+          identityIds: normalizeArrayParam(ctx.query.identity_id),
+          identityCredentialIds: normalizeArrayParam(ctx.query.identity_credential_id),
           status: normalizeArrayParam(ctx.query.status),
 
           createdAt: ctx.query.created_at,

--- a/src/backend/db/prisma/schema/consumer/consumer.prisma
+++ b/src/backend/db/prisma/schema/consumer/consumer.prisma
@@ -40,6 +40,12 @@ model InstanceConsumer {
   consumerOid BigInt
   consumer    Consumer @relation(fields: [consumerOid], references: [oid], onDelete: Cascade)
 
+  organizationMemberOid BigInt?
+  organizationMember    OrganizationMember? @relation(fields: [organizationMemberOid], references: [oid], onDelete: SetNull)
+
+  organizationActorOid BigInt?
+  organizationActor    OrganizationActor? @relation(fields: [organizationActorOid], references: [oid], onDelete: SetNull)
+
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @default(now()) @updatedAt
   consumerActors ConsumerActor[]
@@ -72,6 +78,12 @@ model ConsumerProfile {
 
   accessTagOid BigInt    @unique
   accessTag    AccessTag @relation(fields: [accessTagOid], references: [oid], onDelete: Cascade)
+
+  organizationMemberOid BigInt?
+  organizationMember    OrganizationMember? @relation(fields: [organizationMemberOid], references: [oid], onDelete: SetNull)
+
+  organizationActorOid BigInt?
+  organizationActor    OrganizationActor? @relation(fields: [organizationActorOid], references: [oid], onDelete: SetNull)
 
   personalConsumerGroupOid BigInt        @unique
   personalConsumerGroup    ConsumerGroup @relation("ConsumerProfilePersonalGroup", fields: [personalConsumerGroupOid], references: [oid], onDelete: Cascade)

--- a/src/backend/db/prisma/schema/organization/actor.prisma
+++ b/src/backend/db/prisma/schema/organization/actor.prisma
@@ -35,6 +35,8 @@ model OrganizationActor {
   oauthInstallations  OAuthInstallation[]
   projectBrandUpdates ProjectBrandUpdate[]
   consumers           Consumer[]
+  instanceConsumers   InstanceConsumer[]
+  consumerProfiles    ConsumerProfile[]
 
   @@unique([isSystem, organizationOid])
 }

--- a/src/backend/db/prisma/schema/organization/member.prisma
+++ b/src/backend/db/prisma/schema/organization/member.prisma
@@ -39,6 +39,8 @@ model OrganizationMember {
   policies                AccessPolicyAssignment[]
   apiKeyExpiredEmailSends ApiKeyExpiredEmailSend[]
   consumers               Consumer[]
+  instanceConsumers       InstanceConsumer[]
+  consumerProfiles        ConsumerProfile[]
 
   @@unique([userOid, organizationOid])
   @@index([lastActiveAt])

--- a/src/backend/modules/consumer/src/services/consumer.ts
+++ b/src/backend/modules/consumer/src/services/consumer.ts
@@ -13,6 +13,7 @@ import {
   OrganizationMember,
   withTransaction
 } from '@metorial/db';
+import { createLock } from '@metorial/lock';
 import { syncIdentityConsumerQueue } from '../queues/syncIdentityConsumer';
 
 type ConsumerWithRelations = Consumer & {
@@ -24,9 +25,29 @@ type ConsumerWithRelations = Consumer & {
   >;
 };
 
+let upsertLock = createLock({
+  name: 'cons/upsert'
+});
+
 type InstanceConsumerWithRelations = InstanceConsumer & {
   consumer: ConsumerWithRelations;
 };
+
+let getInclude = (d: { instanceOid: bigint }) => ({
+  consumer: {
+    include: {
+      organizationMember: true,
+      profiles: {
+        where: {
+          instanceOid: d.instanceOid
+        },
+        include: {
+          surface: true
+        }
+      }
+    }
+  }
+});
 
 class ConsumerServiceImpl {
   async getConsumerById(d: { instance: Instance; consumerId: string }) {
@@ -132,21 +153,7 @@ class ConsumerServiceImpl {
           name: d.input.name,
           email: d.input.email
         },
-        include: {
-          consumer: {
-            include: {
-              organizationMember: true,
-              profiles: {
-                where: {
-                  instanceOid: d.instance.oid
-                },
-                include: {
-                  surface: true
-                }
-              }
-            }
-          }
-        }
+        include: getInclude({ instanceOid: d.instance.oid })
       });
 
       await tx.consumerProfile.updateMany({
@@ -199,21 +206,7 @@ class ConsumerServiceImpl {
           name,
           email
         },
-        include: {
-          consumer: {
-            include: {
-              organizationMember: true,
-              profiles: {
-                where: {
-                  instanceOid: d.consumer.instanceOid
-                },
-                include: {
-                  surface: true
-                }
-              }
-            }
-          }
-        }
+        include: getInclude({ instanceOid: d.consumer.instanceOid })
       });
 
       await tx.consumerProfile.updateMany({
@@ -235,6 +228,57 @@ class ConsumerServiceImpl {
     });
 
     return consumer;
+  }
+
+  async upsertConsumer(d: {
+    organization: Organization;
+    instance: Instance;
+    input: {
+      name: string;
+      email: string;
+    };
+  }) {
+    let existing = await db.instanceConsumer.findFirst({
+      where: {
+        instanceOid: d.instance.oid,
+        email: d.input.email
+      },
+      include: getInclude({ instanceOid: d.instance.oid })
+    });
+    if (existing) {
+      if (existing.name === d.input.name) return existing;
+
+      return await this.updateConsumer({
+        consumer: existing as InstanceConsumerWithRelations,
+        input: {
+          name: d.input.name,
+          email: d.input.email
+        }
+      });
+    }
+
+    return await upsertLock.usingLock(`${d.instance.oid}-${d.input.email}`, async () => {
+      let existing = await db.instanceConsumer.findFirst({
+        where: {
+          instanceOid: d.instance.oid,
+          email: d.input.email
+        },
+        include: getInclude({ instanceOid: d.instance.oid })
+      });
+      if (existing) {
+        if (existing.name === d.input.name) return existing;
+
+        return await this.updateConsumer({
+          consumer: existing as InstanceConsumerWithRelations,
+          input: {
+            name: d.input.name,
+            email: d.input.email
+          }
+        });
+      }
+
+      return await this.createConsumer(d);
+    });
   }
 }
 

--- a/src/backend/modules/consumer/src/services/consumerProfile.ts
+++ b/src/backend/modules/consumer/src/services/consumerProfile.ts
@@ -13,8 +13,10 @@ import {
   db,
   ID,
   InstanceConsumer,
+  OrganizationMember,
   withTransaction
 } from '@metorial/db';
+import { createLock } from '@metorial/lock';
 import { syncIdentityConsumerQueue } from '../queues/syncIdentityConsumer';
 
 let include = {
@@ -27,6 +29,10 @@ let include = {
     }
   }
 } as const;
+
+export let ensureProfileLock = createLock({
+  name: 'cons/ensureProfile'
+});
 
 class ConsumerProfileServiceImpl {
   private async getAssignableGroupsOrThrow(d: {
@@ -124,16 +130,18 @@ class ConsumerProfileServiceImpl {
 
   async ensureConsumerProfile(d: {
     surface: ConsumerSurface;
-    aresUserId: string;
     email: string;
     name: string;
+    member?: Pick<OrganizationMember, 'oid' | 'actorOid'>;
+
+    aresUserId?: string;
     ssoGroupIds?: string[];
     ssoRoles?: string[];
   }) {
-    let res = await withTransaction(async tx => {
+    let res = await withTransaction(async db => {
       let ssoGroupIds = normalizeStringList(d.ssoGroupIds);
       let ssoRoles = normalizeStringList(d.ssoRoles);
-      let existingConsumer = await tx.consumer.findUnique({
+      let existingConsumer = await db.consumer.findUnique({
         where: {
           email_organizationOid: {
             email: d.email,
@@ -142,10 +150,12 @@ class ConsumerProfileServiceImpl {
         },
         select: {
           isOrganizationMember: true,
-          isPortalConsumer: true
+          isPortalConsumer: true,
+          organizationMemberOid: true,
+          organizationActorOid: true
         }
       });
-      let consumer = await tx.consumer.upsert({
+      let consumer = await db.consumer.upsert({
         where: {
           email_organizationOid: {
             email: d.email,
@@ -157,20 +167,25 @@ class ConsumerProfileServiceImpl {
           email: d.email,
           name: d.name,
           organizationOid: d.surface.organizationOid,
+          organizationMemberOid: d.member?.oid,
+          organizationActorOid: d.member?.actorOid,
           isOrganizationMember: d.surface.type === 'organization_members',
           isPortalConsumer: d.surface.type === 'portal'
         },
         update: {
           email: d.email,
           name: d.name,
+          organizationMemberOid: d.member?.oid ?? existingConsumer?.organizationMemberOid,
+          organizationActorOid: d.member?.actorOid ?? existingConsumer?.organizationActorOid,
           isOrganizationMember:
-            existingConsumer?.isOrganizationMember ||
+            !!d.member ||
+            !!existingConsumer?.isOrganizationMember ||
             d.surface.type === 'organization_members',
           isPortalConsumer: existingConsumer?.isPortalConsumer || d.surface.type === 'portal'
         }
       });
 
-      await tx.instanceConsumer.upsert({
+      await db.instanceConsumer.upsert({
         where: {
           instanceOid_consumerOid: {
             instanceOid: d.surface.instanceOid,
@@ -182,80 +197,91 @@ class ConsumerProfileServiceImpl {
           name: d.name,
           email: d.email,
           instanceOid: d.surface.instanceOid,
-          consumerOid: consumer.oid
+          consumerOid: consumer.oid,
+          organizationMemberOid: d.member?.oid,
+          organizationActorOid: d.member?.actorOid
         },
         update: {
           name: d.name,
-          email: d.email
+          email: d.email,
+          organizationMemberOid: d.member?.oid ?? consumer.organizationMemberOid,
+          organizationActorOid: d.member?.actorOid ?? consumer.organizationActorOid
         }
       });
 
-      let existingProfile = await tx.consumerProfile.findUnique({
-        where: {
-          surfaceOid_aresUserId: {
-            surfaceOid: d.surface.oid,
-            aresUserId: d.aresUserId
-          }
+      return ensureProfileLock.usingLock(`${d.surface.instanceOid}-${d.email}`, async () => {
+        let existingProfile = await db.consumerProfile.findUnique({
+          where: d.aresUserId
+            ? {
+                surfaceOid_aresUserId: { surfaceOid: d.surface.oid, aresUserId: d.aresUserId }
+              }
+            : { email_surfaceOid: { email: d.email, surfaceOid: d.surface.oid } }
+        });
+        if (existingProfile) {
+          return {
+            consumer,
+            consumerProfile: await db.consumerProfile.update({
+              where: {
+                oid: existingProfile.oid
+              },
+              data: {
+                aresUserId: d.aresUserId,
+                email: d.email,
+                name: d.name,
+                consumerOid: consumer.oid,
+                organizationMemberOid: d.member?.oid ?? consumer.organizationMemberOid,
+                organizationActorOid: d.member?.actorOid ?? consumer.organizationActorOid,
+                ssoGroupIds,
+                ssoRoles
+              },
+              include
+            })
+          };
         }
-      });
-      if (existingProfile) {
+
+        let accessTag = await db.accessTag.create({
+          data: {
+            instanceOid: d.surface.instanceOid
+          }
+        });
+
+        let personalConsumerGroup = await db.consumerGroup.create({
+          data: {
+            id: await ID.generateId('consumerGroup'),
+            status: 'active',
+            type: 'user_access',
+            isDefault: false,
+            ssoGroupIds: [],
+            name: `Personal Group for ${d.email}`,
+            description: null,
+            surfaceOid: d.surface.oid,
+            accessTagOid: accessTag.oid
+          }
+        });
+
         return {
           consumer,
-          consumerProfile: await tx.consumerProfile.update({
-            where: {
-              oid: existingProfile.oid
-            },
+          consumerProfile: await db.consumerProfile.create({
             data: {
+              id: await ID.generateId('consumerProfile'),
               aresUserId: d.aresUserId,
               email: d.email,
               name: d.name,
-              consumerOid: consumer.oid,
               ssoGroupIds,
-              ssoRoles
-            }
+              ssoRoles,
+              organizationOid: d.surface.organizationOid,
+              instanceOid: d.surface.instanceOid,
+              surfaceOid: d.surface.oid,
+              consumerOid: consumer.oid,
+              organizationMemberOid: d.member?.oid ?? consumer.organizationMemberOid,
+              organizationActorOid: d.member?.actorOid ?? consumer.organizationActorOid,
+              accessTagOid: accessTag.oid,
+              personalConsumerGroupOid: personalConsumerGroup.oid
+            },
+            include
           })
         };
-      }
-
-      let accessTag = await tx.accessTag.create({
-        data: {
-          instanceOid: d.surface.instanceOid
-        }
       });
-
-      let personalConsumerGroup = await tx.consumerGroup.create({
-        data: {
-          id: await ID.generateId('consumerGroup'),
-          status: 'active',
-          type: 'user_access',
-          isDefault: false,
-          ssoGroupIds: [],
-          name: `Personal Group for ${d.email}`,
-          description: null,
-          surfaceOid: d.surface.oid,
-          accessTagOid: accessTag.oid
-        }
-      });
-
-      return {
-        consumer,
-        consumerProfile: await tx.consumerProfile.create({
-          data: {
-            id: await ID.generateId('consumerProfile'),
-            aresUserId: d.aresUserId,
-            email: d.email,
-            name: d.name,
-            ssoGroupIds,
-            ssoRoles,
-            organizationOid: d.surface.organizationOid,
-            instanceOid: d.surface.instanceOid,
-            surfaceOid: d.surface.oid,
-            consumerOid: consumer.oid,
-            accessTagOid: accessTag.oid,
-            personalConsumerGroupOid: personalConsumerGroup.oid
-          }
-        })
-      };
     });
 
     await syncIdentityConsumerQueue.add({

--- a/src/backend/modules/consumer/src/services/consumerSurface.ts
+++ b/src/backend/modules/consumer/src/services/consumerSurface.ts
@@ -289,7 +289,7 @@ class ConsumerSurfaceServiceImpl {
           where: { oid: d.instance.organizationOid }
         });
 
-        let surface = await this.createConsumerSurface({
+        return await this.createConsumerSurface({
           organization: org,
           instance: d.instance,
           context: { ip: '0.0.0.0', ua: 'Metorial System' },

--- a/src/backend/modules/subspace/src/lib/resolveConsumerActors.ts
+++ b/src/backend/modules/subspace/src/lib/resolveConsumerActors.ts
@@ -1,0 +1,14 @@
+import { db } from '@metorial/db';
+
+export let resolveConsumerActorIds = async (consumerIds?: string[]) => {
+  if (!consumerIds) return [];
+
+  return await db.consumerActor
+    .findMany({
+      where: {
+        instanceConsumer: { id: { in: consumerIds } }
+      },
+      select: { id: true }
+    })
+    .then(res => res.map(r => r.id));
+};

--- a/src/backend/modules/subspace/src/lib/subspaceService.ts
+++ b/src/backend/modules/subspace/src/lib/subspaceService.ts
@@ -1,5 +1,5 @@
 import { Service } from '@lowerdeck/service';
-import type { Instance, OrganizationActor } from '@metorial/db';
+import { type Instance, type OrganizationActor } from '@metorial/db';
 import type { ProviderEventBase } from '@metorial/fabric';
 import { getActorForSubspace, getTenantForSubspace } from '../subspace';
 

--- a/src/backend/modules/subspace/src/services/identityActor.ts
+++ b/src/backend/modules/subspace/src/services/identityActor.ts
@@ -7,6 +7,7 @@ import {
   InstanceConsumer,
   OrganizationMember
 } from '@metorial/db';
+import { resolveConsumerActorIds } from '../lib/resolveConsumerActors';
 import { createSubspaceService } from '../lib/subspaceService';
 import { subspace } from '../subspace';
 
@@ -63,14 +64,7 @@ export let subspaceIdentityActorService = createSubspaceService(
       }
     ) => {
       if (arg0.consumerIds) {
-        let consumerActorIds = await db.consumerActor
-          .findMany({
-            where: {
-              instanceConsumer: { id: { in: arg0.consumerIds } }
-            },
-            select: { id: true }
-          })
-          .then(res => res.map(r => r.id));
+        let consumerActorIds = await resolveConsumerActorIds(arg0.consumerIds);
 
         arg0.ids = [...(arg0.ids ?? []), ...consumerActorIds];
       }

--- a/src/backend/modules/subspace/src/services/providerAuthConfig.ts
+++ b/src/backend/modules/subspace/src/services/providerAuthConfig.ts
@@ -1,4 +1,5 @@
 import { Fabric } from '@metorial/fabric';
+import { resolveConsumerActorIds } from '../lib/resolveConsumerActors';
 import { createSubspaceService, toEventBase } from '../lib/subspaceService';
 import { subspace } from '../subspace';
 
@@ -6,6 +7,19 @@ export let subspaceProviderAuthConfigService = createSubspaceService(
   subspace.providerAuthConfig,
   ['get', 'list', 'update', 'create', 'getConfigSchema'],
   inner => ({
+    list: async (
+      arg0: Parameters<typeof inner.list>[0] & {
+        consumerIds?: string[];
+      }
+    ) => {
+      if (arg0.consumerIds) {
+        let consumerActorIds = await resolveConsumerActorIds(arg0.consumerIds);
+
+        arg0.actorIds = [...new Set([...(arg0.actorIds ?? []), ...consumerActorIds])];
+      }
+
+      return await inner.list(arg0);
+    },
     create: async (...params: Parameters<typeof inner.create>) => {
       let eventBase = toEventBase(params[0]);
       await Fabric.fire('provider.auth_config.created:before', eventBase);

--- a/src/backend/modules/subspace/src/services/providerConfig.ts
+++ b/src/backend/modules/subspace/src/services/providerConfig.ts
@@ -1,6 +1,7 @@
 import { getSentry } from '@lowerdeck/sentry';
 import { Fabric } from '@metorial/fabric';
 import { usageService } from '@metorial/module-usage';
+import { resolveConsumerActorIds } from '../lib/resolveConsumerActors';
 import { createSubspaceService, toEventBase } from '../lib/subspaceService';
 import { subspace } from '../subspace';
 
@@ -10,6 +11,19 @@ export let subspaceProviderConfigService = createSubspaceService(
   subspace.providerConfig,
   ['get', 'list', 'update', 'create', 'getConfigSchema'],
   inner => ({
+    list: async (
+      arg0: Parameters<typeof inner.list>[0] & {
+        consumerIds?: string[];
+      }
+    ) => {
+      if (arg0.consumerIds) {
+        let consumerActorIds = await resolveConsumerActorIds(arg0.consumerIds);
+
+        arg0.actorIds = [...new Set([...(arg0.actorIds ?? []), ...consumerActorIds])];
+      }
+
+      return await inner.list(arg0);
+    },
     create: async (...params: Parameters<typeof inner.create>) => {
       let eventBase = toEventBase(params[0]);
       await Fabric.fire('provider.config.created:before', eventBase);

--- a/src/backend/modules/subspace/src/services/providerDeployment.ts
+++ b/src/backend/modules/subspace/src/services/providerDeployment.ts
@@ -1,4 +1,5 @@
 import { Fabric } from '@metorial/fabric';
+import { resolveConsumerActorIds } from '../lib/resolveConsumerActors';
 import { createSubspaceService, toEventBase } from '../lib/subspaceService';
 import { subspace } from '../subspace';
 
@@ -6,6 +7,19 @@ export let subspaceProviderDeploymentService = createSubspaceService(
   subspace.providerDeployment,
   ['get', 'list', 'update', 'create'],
   inner => ({
+    list: async (
+      arg0: Parameters<typeof inner.list>[0] & {
+        consumerIds?: string[];
+      }
+    ) => {
+      if (arg0.consumerIds) {
+        let consumerActorIds = await resolveConsumerActorIds(arg0.consumerIds);
+
+        arg0.actorIds = [...new Set([...(arg0.actorIds ?? []), ...consumerActorIds])];
+      }
+
+      return await inner.list(arg0);
+    },
     create: async (...params: Parameters<typeof inner.create>) => {
       let eventBase = toEventBase(params[0]);
       await Fabric.fire('provider.deployment.created:before', eventBase);

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/providerConfigurationSelectionModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/providerConfigurationSelectionModal.tsx
@@ -17,7 +17,6 @@ import {
   OptionToggle,
   Select,
   showModal,
-  Spacer,
   Text
 } from '@metorial/ui';
 import { RiAddLine } from '@remixicon/react';
@@ -272,10 +271,6 @@ let CreateDeploymentInline = ({
 
   return (
     <Flex direction="column" gap={8}>
-      <Text size="2" color="gray600">
-        No deployments found for <strong>{providerName}</strong>. Create one to continue.
-      </Text>
-
       <form onSubmit={form.handleSubmit}>
         <Flex direction="column" gap={8}>
           <Input label="Name" required {...form.getFieldProps('name')} />
@@ -283,19 +278,20 @@ let CreateDeploymentInline = ({
 
           <Input label="Description" {...form.getFieldProps('description')} />
           <form.RenderError field="description" />
-          <Spacer height={8} />
 
-          <Dialog.Actions>
-            <Button
-              type="submit"
-              loading={createMutation.isLoading}
-              success={createMutation.isSuccess}
-            >
-              Create Deployment
-            </Button>
+          <div style={{ marginTop: 5 }}>
+            <Dialog.Actions>
+              <Button
+                type="submit"
+                loading={createMutation.isLoading}
+                success={createMutation.isSuccess}
+              >
+                Create Deployment
+              </Button>
 
-            <createMutation.RenderError />
-          </Dialog.Actions>
+              <createMutation.RenderError />
+            </Dialog.Actions>
+          </div>
         </Flex>
       </form>
     </Flex>
@@ -429,52 +425,56 @@ let DeploymentConfigureStep = ({
       />
       <form.RenderError field="selectedConfiguration" />
 
-      <Flex gap={8} align="end">
-        <div style={{ flex: 1 }}>
-          <Select
-            label="Auth Config"
-            value={form.values.selectedAuthConfigId || '__none__'}
-            onChange={v => {
-              form.setFieldValue('selectedAuthConfigId', v === '__none__' ? '' : v);
-              form.setFieldTouched('selectedAuthConfigId', false, false);
-              form.setFieldError('selectedAuthConfigId', undefined);
-            }}
-            items={[
-              { id: '__none__', label: 'None' },
-              ...authConfigItems.map(config => ({
-                id: config.id,
-                label: config.name ?? config.id
-              }))
-            ]}
-          />
-        </div>
-
-        <div
-          title={authCreation.authConfigDisabledReason ?? undefined}
-          style={{ display: 'inline-flex' }}
-        >
-          <Button
-            type="button"
-            size="3"
-            iconLeft={<RiAddLine />}
-            aria-label="Create Auth Config"
-            disabled={!authCreation.canCreateAuthConfig}
-            onClick={() =>
-              showProviderAuthConfigCreateModal({
-                instanceId,
-                providerDeploymentId: deploymentId,
-                onCreate: authConfig => {
-                  authConfigs.refetch?.();
-                  form.setFieldValue('selectedAuthConfigId', authConfig.id);
+      {(provider.data?.type.auth.status == 'enabled' || true) && (
+        <>
+          <Flex gap={8} align="end">
+            <div style={{ flex: 1 }}>
+              <Select
+                label="Auth Config"
+                value={form.values.selectedAuthConfigId || '__none__'}
+                onChange={v => {
+                  form.setFieldValue('selectedAuthConfigId', v === '__none__' ? '' : v);
                   form.setFieldTouched('selectedAuthConfigId', false, false);
                   form.setFieldError('selectedAuthConfigId', undefined);
+                }}
+                items={[
+                  { id: '__none__', label: 'None' },
+                  ...authConfigItems.map(config => ({
+                    id: config.id,
+                    label: config.name ?? config.id
+                  }))
+                ]}
+              />
+            </div>
+
+            <div
+              title={authCreation.authConfigDisabledReason ?? undefined}
+              style={{ display: 'inline-flex' }}
+            >
+              <Button
+                type="button"
+                size="3"
+                iconLeft={<RiAddLine />}
+                aria-label="Create Auth Config"
+                disabled={!authCreation.canCreateAuthConfig}
+                onClick={() =>
+                  showProviderAuthConfigCreateModal({
+                    instanceId,
+                    providerDeploymentId: deploymentId,
+                    onCreate: authConfig => {
+                      authConfigs.refetch?.();
+                      form.setFieldValue('selectedAuthConfigId', authConfig.id);
+                      form.setFieldTouched('selectedAuthConfigId', false, false);
+                      form.setFieldError('selectedAuthConfigId', undefined);
+                    }
+                  })
                 }
-              })
-            }
-          />
-        </div>
-      </Flex>
-      <form.RenderError field="selectedAuthConfigId" />
+              />
+            </div>
+          </Flex>
+          <form.RenderError field="selectedAuthConfigId" />
+        </>
+      )}
 
       {includeToolFilters && toolItems.length > 0 && (
         <div>
@@ -523,11 +523,13 @@ let DeploymentConfigureStep = ({
 
       {mutationError}
 
-      <Dialog.Actions>
-        <Button type="submit" loading={saving} size="2">
-          {submitLabel}
-        </Button>
-      </Dialog.Actions>
+      <div style={{ marginTop: 5 }}>
+        <Dialog.Actions>
+          <Button type="submit" loading={saving} size="2">
+            {submitLabel}
+          </Button>
+        </Dialog.Actions>
+      </div>
     </Flex>
   );
 };

--- a/src/systems/subspace/apps/controller/src/controllers/providerAuthConfig.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerAuthConfig.ts
@@ -47,6 +47,9 @@ export let providerAuthConfigController = app.controller({
           providerDeploymentIds: v.optional(v.array(v.string())),
           providerAuthCredentialsIds: v.optional(v.array(v.string())),
           providerAuthMethodIds: v.optional(v.array(v.string())),
+          actorIds: v.optional(v.array(v.string())),
+          identityIds: v.optional(v.array(v.string())),
+          identityCredentialIds: v.optional(v.array(v.string())),
           createdAt: createdAtValidator,
           updatedAt: updatedAtValidator
         })
@@ -68,6 +71,9 @@ export let providerAuthConfigController = app.controller({
         providerDeploymentIds: ctx.input.providerDeploymentIds,
         providerAuthCredentialsIds: ctx.input.providerAuthCredentialsIds,
         providerAuthMethodIds: ctx.input.providerAuthMethodIds,
+        actorIds: ctx.input.actorIds,
+        identityIds: ctx.input.identityIds,
+        identityCredentialIds: ctx.input.identityCredentialIds,
         createdAt: ctx.input.createdAt,
         updatedAt: ctx.input.updatedAt
       });

--- a/src/systems/subspace/apps/controller/src/controllers/providerConfig.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerConfig.ts
@@ -50,6 +50,9 @@ export let providerConfigController = app.controller({
           providerSpecificationIds: v.optional(v.array(v.string())),
           providerDeploymentIds: v.optional(v.array(v.string())),
           providerConfigVaultIds: v.optional(v.array(v.string())),
+          actorIds: v.optional(v.array(v.string())),
+          identityIds: v.optional(v.array(v.string())),
+          identityCredentialIds: v.optional(v.array(v.string())),
           createdAt: createdAtValidator,
           updatedAt: updatedAtValidator
         })
@@ -71,6 +74,9 @@ export let providerConfigController = app.controller({
         providerSpecificationIds: ctx.input.providerSpecificationIds,
         providerDeploymentIds: ctx.input.providerDeploymentIds,
         providerConfigVaultIds: ctx.input.providerConfigVaultIds,
+        actorIds: ctx.input.actorIds,
+        identityIds: ctx.input.identityIds,
+        identityCredentialIds: ctx.input.identityCredentialIds,
         createdAt: ctx.input.createdAt,
         updatedAt: ctx.input.updatedAt
       });

--- a/src/systems/subspace/apps/controller/src/controllers/providerDeployment.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerDeployment.ts
@@ -42,6 +42,9 @@ export let providerDeploymentController = app.controller({
           ids: v.optional(v.array(v.string())),
           providerIds: v.optional(v.array(v.string())),
           providerVersionIds: v.optional(v.array(v.string())),
+          actorIds: v.optional(v.array(v.string())),
+          identityIds: v.optional(v.array(v.string())),
+          identityCredentialIds: v.optional(v.array(v.string())),
 
           capabilities: v.optional(
             v.object({
@@ -76,6 +79,9 @@ export let providerDeploymentController = app.controller({
         ids: ctx.input.ids,
         providerIds: ctx.input.providerIds,
         providerVersionIds: ctx.input.providerVersionIds,
+        actorIds: ctx.input.actorIds,
+        identityIds: ctx.input.identityIds,
+        identityCredentialIds: ctx.input.identityCredentialIds,
         createdAt: ctx.input.createdAt,
         updatedAt: ctx.input.updatedAt
       });

--- a/src/systems/subspace/modules/auth/src/services/providerAuthConfig.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthConfig.ts
@@ -27,6 +27,9 @@ import {
   normalizeDateFilter,
   normalizeStatusForGet,
   normalizeStatusForList,
+  resolveIdentities,
+  resolveIdentityActors,
+  resolveIdentityCredentials,
   resolveProviderAuthCredentials,
   resolveProviderAuthMethods,
   resolveProviderDeployments,
@@ -67,6 +70,9 @@ class providerAuthConfigServiceImpl {
     providerDeploymentIds?: string[];
     providerAuthCredentialsIds?: string[];
     providerAuthMethodIds?: string[];
+    actorIds?: string[];
+    identityIds?: string[];
+    identityCredentialIds?: string[];
 
     createdAt?: DateFilter;
     updatedAt?: DateFilter;
@@ -75,6 +81,9 @@ class providerAuthConfigServiceImpl {
     let deployments = await resolveProviderDeployments(d, d.providerDeploymentIds);
     let credentials = await resolveProviderAuthCredentials(d, d.providerAuthCredentialsIds);
     let authMethods = await resolveProviderAuthMethods(d, d.providerAuthMethodIds);
+    let actors = await resolveIdentityActors(d, d.actorIds);
+    let identities = await resolveIdentities(d, d.identityIds);
+    let identityCredentials = await resolveIdentityCredentials(d, d.identityCredentialIds);
 
     let search = d.search
       ? await voyager.record.search({
@@ -105,6 +114,15 @@ class providerAuthConfigServiceImpl {
                 deployments ? { deploymentOid: deployments.in } : undefined!,
                 credentials ? { authCredentialsOid: credentials.in } : undefined!,
                 authMethods ? { authMethodOid: authMethods.in } : undefined!,
+                actors
+                  ? { identityCredentials: { some: { identity: { actor: actors.oidIn } } } }
+                  : undefined!,
+                identities
+                  ? { identityCredentials: { some: { identityOid: identities.in } } }
+                  : undefined!,
+                identityCredentials
+                  ? { identityCredentials: { some: identityCredentials.oidIn } }
+                  : undefined!,
                 d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
                 d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
               ].filter(Boolean)

--- a/src/systems/subspace/modules/deployment/src/services/providerConfig.ts
+++ b/src/systems/subspace/modules/deployment/src/services/providerConfig.ts
@@ -31,6 +31,9 @@ import {
   normalizeDateFilter,
   normalizeStatusForGet,
   normalizeStatusForList,
+  resolveIdentities,
+  resolveIdentityActors,
+  resolveIdentityCredentials,
   resolveProviderConfigs,
   resolveProviderDeployments,
   resolveProviders,
@@ -83,6 +86,9 @@ class providerConfigServiceImpl {
     providerSpecificationIds?: string[];
     providerDeploymentIds?: string[];
     providerConfigVaultIds?: string[];
+    actorIds?: string[];
+    identityIds?: string[];
+    identityCredentialIds?: string[];
 
     createdAt?: DateFilter;
     updatedAt?: DateFilter;
@@ -91,6 +97,9 @@ class providerConfigServiceImpl {
     let specifications = await resolveProviderSpecifications(d, d.providerSpecificationIds);
     let deployments = await resolveProviderDeployments(d, d.providerDeploymentIds);
     let vaults = await resolveProviderConfigs(d, d.providerConfigVaultIds);
+    let actors = await resolveIdentityActors(d, d.actorIds);
+    let identities = await resolveIdentities(d, d.identityIds);
+    let identityCredentials = await resolveIdentityCredentials(d, d.identityCredentialIds);
 
     let search = d.search
       ? await voyager.record.search({
@@ -122,6 +131,15 @@ class providerConfigServiceImpl {
                 specifications ? { specificationOid: specifications.in } : undefined!,
                 deployments ? { deploymentOid: deployments.in } : undefined!,
                 vaults ? { fromVaultOid: vaults.in } : undefined!,
+                actors
+                  ? { identityCredentials: { some: { identity: { actor: actors.oidIn } } } }
+                  : undefined!,
+                identities
+                  ? { identityCredentials: { some: { identityOid: identities.in } } }
+                  : undefined!,
+                identityCredentials
+                  ? { identityCredentials: { some: identityCredentials.oidIn } }
+                  : undefined!,
                 d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
                 d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
               ].filter(Boolean)

--- a/src/systems/subspace/modules/deployment/src/services/providerDeployment.ts
+++ b/src/systems/subspace/modules/deployment/src/services/providerDeployment.ts
@@ -27,6 +27,9 @@ import {
   normalizeDateFilter,
   normalizeStatusForGet,
   normalizeStatusForList,
+  resolveIdentities,
+  resolveIdentityActors,
+  resolveIdentityCredentials,
   resolveProviders,
   resolveProviderVersions
 } from '@metorial-subspace/list-utils';
@@ -74,6 +77,9 @@ class providerDeploymentServiceImpl {
     ids?: string[];
     providerIds?: string[];
     providerVersionIds?: string[];
+    actorIds?: string[];
+    identityIds?: string[];
+    identityCredentialIds?: string[];
 
     capabilities?: ProviderCapabilityFilter;
 
@@ -82,6 +88,9 @@ class providerDeploymentServiceImpl {
   }) {
     let providers = await resolveProviders(d, d.providerIds);
     let versions = await resolveProviderVersions(d, d.providerVersionIds);
+    let actors = await resolveIdentityActors(d, d.actorIds);
+    let identities = await resolveIdentities(d, d.identityIds);
+    let identityCredentials = await resolveIdentityCredentials(d, d.identityCredentialIds);
 
     let capFilters = getProviderCapabilityFilter(d.capabilities || {});
 
@@ -112,6 +121,15 @@ class providerDeploymentServiceImpl {
                 search ? { id: { in: search.map(r => r.documentId) } } : undefined!,
                 providers ? { providerOid: providers.in } : undefined!,
                 versions ? { currentVersion: { lockedVersionOid: versions.in } } : undefined!,
+                actors
+                  ? { identityCredentials: { some: { identity: { actor: actors.oidIn } } } }
+                  : undefined!,
+                identities
+                  ? { identityCredentials: { some: { identityOid: identities.in } } }
+                  : undefined!,
+                identityCredentials
+                  ? { identityCredentials: { some: identityCredentials.oidIn } }
+                  : undefined!,
                 d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
                 d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!,
                 capFilters ? { provider: { type: capFilters } } : undefined!

--- a/src/systems/subspace/packages/list-utils/src/resources/identity.ts
+++ b/src/systems/subspace/packages/list-utils/src/resources/identity.ts
@@ -20,3 +20,17 @@ export let resolveIdentityActors = createResolver(async ({ ts, ids }) =>
     select: { oid: true }
   })
 );
+
+export let resolveIdentityCredentials = createResolver(async ({ ts, ids }) =>
+  db.identityCredential.findMany({
+    where: {
+      id: { in: ids },
+      identity: {
+        tenantOid: ts.tenantOid,
+        solutionOid: ts.solutionOid,
+        environmentOid: ts.environmentOid
+      }
+    },
+    select: { oid: true }
+  })
+);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new query filters and DB relationships that change how identity-linked provider resources and consumers are queried/associated; includes new locking/upsert paths that could affect concurrency and data integrity if misapplied.
> 
> **Overview**
> Adds end-to-end filtering of provider deployments/configs/auth-configs by **actor/consumer/identity/identity-credential**: API controllers accept new query params, subspace services map `consumerIds` to identity `actorIds`, and subspace list queries now join through identity credentials to apply the filters.
> 
> Extends the consumer data model to optionally link `Consumer`, `InstanceConsumer`, and `ConsumerProfile` to `OrganizationMember`/`OrganizationActor`, and updates `ensureConsumerProfile` plus new lock-based `upsertConsumer`/profile creation to avoid races.
> 
> Adds a hidden `consumers.getMemberConsumer` endpoint to upsert/fetch the authenticated member’s consumer (via an internal `cli` surface), and makes small UI layout tweaks in the provider configuration selection modal (including always rendering the Auth Config picker).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 134c6698a9cba4d915a8d02f894c7fff56445bd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->