### PR TITLE
Fix table rerender issue

### DIFF
--- a/src/frontend/apps/dashboard/src/components/table/components/query.ts
+++ b/src/frontend/apps/dashboard/src/components/table/components/query.ts
@@ -7,6 +7,8 @@ import {
   serializeToQuery
 } from '../filter';
 
+let emptyFilters: TableFilter<any>[] = [];
+
 let getFilterQueryKeys = (filters: TableFilter<any>[]) => {
   let keys = new Set<string>();
 
@@ -36,7 +38,7 @@ export let useFilterQuery = ({
   debouncedSearch: string;
 }) => {
   let [searchParams, setSearchParams] = useSearchParams();
-  let currentFilters = filters || [];
+  let currentFilters = filters ?? emptyFilters;
   let filterKeys = useMemo(() => getFilterQueryKeys(currentFilters), [currentFilters]);
 
   let lastSetQueryRef = useRef<string | undefined>(undefined);

--- a/src/packages/frontend/ui/src/date/index.tsx
+++ b/src/packages/frontend/ui/src/date/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useReducer } from 'react';
+import React, { useLayoutEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { useInterval } from 'react-use';
 import { shleemy } from 'shleemy';
 import { styled } from 'styled-components';
@@ -21,13 +21,35 @@ let Description = styled('p')`
   }
 `;
 
+let normalizeDate = (date: string | Date | undefined) => {
+  if (!date) return null;
+  return typeof date == 'string' ? new Date(date) : date;
+};
+
+let useStaticDate = (date: string | Date | undefined) => {
+  let [currentDate, setCurrentDate] = useState<Date | null>(() => normalizeDate(date));
+  let currentDateIdentifier = useRef<string>(!date ? 'none' : String(date));
+  let inputDateIdentifier = !date ? 'none' : String(date);
+
+  useLayoutEffect(() => {
+    if (currentDateIdentifier.current === inputDateIdentifier) return;
+
+    currentDateIdentifier.current = inputDateIdentifier;
+    setCurrentDate(normalizeDate(date));
+  }, [inputDateIdentifier]);
+
+  return currentDate;
+};
+
 export let RenderDate = ({ date }: { date: string | Date | undefined }) => {
   let [retriggerIndex, doRetrigger] = useReducer(s => s + 1, 0);
 
-  let result = useMemo(() => {
-    if (!date) return { date: null, utc: '', local: '', pretty: '', timeZone: '' };
+  let normalizedDate = useStaticDate(date);
 
-    let parsed = typeof date == 'string' ? new Date(date) : date;
+  let result = useMemo(() => {
+    if (!normalizedDate) return { date: null, utc: '', local: '', pretty: '', timeZone: '' };
+
+    let parsed = normalizedDate;
     let utc = new Date(parsed.toUTCString().replace('GMT', ''));
 
     let humanOffset = shleemy(parsed).forHumans;
@@ -40,7 +62,7 @@ export let RenderDate = ({ date }: { date: string | Date | undefined }) => {
       pretty: parsed.toLocaleString(),
       timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
     };
-  }, [date, retriggerIndex]);
+  }, [normalizedDate, retriggerIndex]);
 
   useInterval(() => doRetrigger(), 60 * 1000);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-state changes that mainly stabilize hook dependencies to avoid redundant rerenders; potential impact is limited to query param syncing and date display updates.
> 
> **Overview**
> Reduces unnecessary rerenders in the dashboard table query syncing by reusing a stable empty `filters` array when `filters` is undefined, preventing `useMemo`/`useEffect` churn.
> 
> Updates `RenderDate` to normalize and *stabilize* the parsed date via a new `useStaticDate` hook (tracking input identity and updating in `useLayoutEffect`), so memoized formatting work only reruns when the actual date value changes (plus the existing minute retrigger).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6f6b5e22a3e47121c9f6a7c8c53301436268f09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->