### PR TITLE
feat/fix-callbackUrlOverride

### DIFF
--- a/src/systems/subspace/modules/auth/src/services/providerOAuthSetup.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerOAuthSetup.ts
@@ -226,18 +226,24 @@ class providerOAuthSetupServiceImpl {
         throw new Error('Provider auth credentials are required');
       }
 
-      credentials = await providerAuthCredentialsService.getProviderAuthCredentialsForBackendUse({
-        tenant: d.tenant,
-        solution: d.solution,
-        provider: d.provider,
-        providerAuthCredentials: credentials,
-        providerAuthMethod: authMethod
-      });
+      credentials =
+        await providerAuthCredentialsService.getProviderAuthCredentialsForBackendUse({
+          tenant: d.tenant,
+          solution: d.solution,
+          provider: d.provider,
+          providerAuthCredentials: credentials,
+          providerAuthMethod: authMethod
+        });
 
       let newId = getId('providerOAuthSetup');
       let clientSecret = await ID.generateId('providerOAuthSetup_clientSecret');
 
-      let callbackUrlOverride = getOAuthCallbackUrl(d.provider.type, d.provider, d.tenant);
+      let isManagedCredentials =
+        credentials.origin === 'managed_backing' || credentials.origin === 'managed_public';
+
+      let callbackUrlOverride = isManagedCredentials
+        ? null
+        : getOAuthCallbackUrl(d.provider.type, d.provider, d.tenant);
 
       let backendProviderOAuthSetup = await backend.auth.createProviderOAuthSetup({
         tenant: d.tenant,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes OAuth setup behavior by conditionally suppressing `callbackUrlOverride` for managed credentials, which can affect redirect/callback handling during provider onboarding.
> 
> **Overview**
> Adjusts `createProviderOAuthSetup` to detect *managed* provider credentials (`managed_backing`/`managed_public`) and, in those cases, pass `null` for `callbackUrlOverride` instead of always generating one via `getOAuthCallbackUrl`.
> 
> This changes how the backend OAuth setup is created for managed-credential providers, leaving callback URL selection to the backend/default configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdd534c323a603430ae64da00ca86c09e0fd48d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->