### PR TITLE
Portals deployment fix

### DIFF
--- a/scripts/dev-tools/src/env/frontend.ts
+++ b/scripts/dev-tools/src/env/frontend.ts
@@ -89,7 +89,7 @@ export let frontendEnv: Env = [
 
   {
     key: 'VITE_CUSTOM_PORTAL_API_URL',
-    defaultValue: 'http://localhost:4315'
+    defaultValue: 'http://localhost:4315/portal-api'
   },
   {
     key: 'VITE_MARKETPLACE_API_URL',

--- a/src/backend/apis/custom-portal/src/index.ts
+++ b/src/backend/apis/custom-portal/src/index.ts
@@ -25,7 +25,7 @@ export let customPortalApi = rpcMux(
                 origin
               })
           },
-    path: '/'
+    path: '/portal-api'
   },
   [customPortalRPC]
 );


### PR DESCRIPTION
## Summary

Portals deployment fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the custom portal RPC mount path and the default frontend API URL, which can break routing/deployments if any clients or proxies still expect `/`.
> 
> **Overview**
> Fixes portal deployments by serving the custom portal RPC API under `'/portal-api'` instead of `'/'`.
> 
> Updates the dev-tools default `VITE_CUSTOM_PORTAL_API_URL` to include the new `/portal-api` prefix so frontends call the correct base path by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d78ab062d7825f6333d3e81167d92c05eb6fec11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->