### PR TITLE
Avoid sending emails for internal api keys

### DIFF
--- a/src/backend/modules/machine-access/src/queues/created/sendApiKeyCreatedEmail.ts
+++ b/src/backend/modules/machine-access/src/queues/created/sendApiKeyCreatedEmail.ts
@@ -20,6 +20,8 @@ export let sendApiKeyCreatedEmailQueueProcessor = sendApiKeyCreatedEmailQueue.pr
     });
     if (!apiKey) throw new QueueRetryError();
 
+    if (apiKey.kind == 'system_internal') return;
+
     let organization = await db.organization.findUnique({
       where: { id: data.organizationId }
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds an early return in the email queue processor to suppress notifications for `system_internal` API keys, without changing data writes or permissions.
> 
> **Overview**
> Prevents API-key creation notification emails from being sent when the created key is marked `system_internal` by adding an early exit in `sendApiKeyCreatedEmailQueueProcessor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0136229106b444db3dbc8d80a887af915966c44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->