### PR TITLE
Fix magic mcp access + ares redirect domains

### DIFF
--- a/scripts/dev-tools/src/env/backend.ts
+++ b/scripts/dev-tools/src/env/backend.ts
@@ -24,6 +24,10 @@ export let backendEnv: Env = [
     key: 'PORTAL_HOST_TEMPLATE',
     defaultValue: 'http://localhost:4304/{portalId}'
   },
+  {
+    key: 'PORTAL_REDIRECT_DOMAINS',
+    defaultValue: 'localhost'
+  },
 
   {
     key: 'DATABASE_URL',

--- a/src/backend/apis/core/src/controllers/provider/magicMcpToken.ts
+++ b/src/backend/apis/core/src/controllers/provider/magicMcpToken.ts
@@ -2,7 +2,7 @@ import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
 import { MagicMcpTokenStatus } from '@metorial/db';
-import { consumerAccessPolicyService } from '@metorial/module-consumer';
+import { grantConsumerOwnedMagicMcpTokenAccess } from '@metorial/module-consumer';
 import {
   magicMcpGroupService,
   magicMcpServerService,
@@ -171,22 +171,12 @@ export let magicMcpTokenController = Controller.create(
         });
 
         if (ctx.consumerProfile) {
-          for (let permission of [
-            'magic_mcp_read',
-            'magic_mcp_write',
-            'magic_mcp_connect'
-          ] as const) {
-            await consumerAccessPolicyService.grantAccess({
-              organization: ctx.organization,
-              permission,
-              subject: {
-                personalConsumerGroupForProfile: ctx.consumerProfile
-              },
-              resource: {
-                magicMcpToken
-              }
-            });
-          }
+          await grantConsumerOwnedMagicMcpTokenAccess({
+            organization: ctx.organization,
+            consumerProfile: ctx.consumerProfile,
+            consumerGroups: ctx.consumerGroups,
+            magicMcpToken
+          });
         }
 
         return magicMcpTokenPresenter.present({ magicMcpToken });

--- a/src/backend/modules/consumer/src/services/index.ts
+++ b/src/backend/modules/consumer/src/services/index.ts
@@ -11,4 +11,5 @@ export * from './consumerProviderContext';
 export * from './consumerProviderDeployment';
 export * from './consumerProviderSetupSession';
 export * from './consumerSurface';
+export * from './magicMcpTokenAccess';
 export * from './providerTemplate';

--- a/src/backend/modules/consumer/src/services/magicMcpTokenAccess.ts
+++ b/src/backend/modules/consumer/src/services/magicMcpTokenAccess.ts
@@ -1,0 +1,59 @@
+import {
+  ConsumerGroup,
+  ConsumerProfile,
+  MagicMcpToken,
+  Organization
+} from '@metorial/db';
+import { consumerAccessPolicyService } from './accessPolicy';
+
+export let grantConsumerOwnedMagicMcpTokenAccess = async (d: {
+  organization: Organization;
+  consumerProfile: Pick<ConsumerProfile, 'personalConsumerGroupOid'>;
+  consumerGroups?: Array<Pick<ConsumerGroup, 'oid' | 'accessTagOid'>>;
+  magicMcpToken: Pick<MagicMcpToken, 'oid'>;
+}) => {
+  for (let permission of ['magic_mcp_read', 'magic_mcp_write'] as const) {
+    await consumerAccessPolicyService.grantAccess({
+      organization: d.organization,
+      permission,
+      subject: {
+        personalConsumerGroupForProfile: d.consumerProfile
+      },
+      resource: {
+        magicMcpToken: d.magicMcpToken
+      }
+    });
+  }
+
+  let connectGroups = d.consumerGroups?.length
+    ? Array.from(new Map(d.consumerGroups.map(group => [group.oid, group])).values())
+    : [];
+
+  if (!connectGroups.length) {
+    await consumerAccessPolicyService.grantAccess({
+      organization: d.organization,
+      permission: 'magic_mcp_connect',
+      subject: {
+        personalConsumerGroupForProfile: d.consumerProfile
+      },
+      resource: {
+        magicMcpToken: d.magicMcpToken
+      }
+    });
+
+    return;
+  }
+
+  for (let consumerGroup of connectGroups) {
+    await consumerAccessPolicyService.grantAccess({
+      organization: d.organization,
+      permission: 'magic_mcp_connect',
+      subject: {
+        consumerGroup
+      },
+      resource: {
+        magicMcpToken: d.magicMcpToken
+      }
+    });
+  }
+};

--- a/src/backend/modules/portal/src/env.ts
+++ b/src/backend/modules/portal/src/env.ts
@@ -3,6 +3,7 @@ import { v } from '@lowerdeck/validation';
 
 export let env = createValidatedEnv({
   portal: {
-    PORTAL_HOST_TEMPLATE: v.string()
+    PORTAL_HOST_TEMPLATE: v.string(),
+    PORTAL_REDIRECT_DOMAINS: v.string()
   }
 });

--- a/src/backend/modules/portal/src/services/portal.ts
+++ b/src/backend/modules/portal/src/services/portal.ts
@@ -44,14 +44,9 @@ let getPortalSlug = createSlugGenerator(async slug => {
 });
 
 let getPortalRedirectDomains = () => {
-  let template = getPortalUrlTemplate(env.portal.PORTAL_HOST_TEMPLATE);
-  let placeholder = '__portal__';
-  let parsed = new URL(template.replace('{portalId}', placeholder));
-  let hostname = parsed.hostname.includes(placeholder)
-    ? parsed.hostname.replace(placeholder, '*')
-    : parsed.hostname;
-
-  return [hostname];
+  return env.portal.PORTAL_REDIRECT_DOMAINS.split(',')
+    .map(domain => domain.trim())
+    .filter(domain => domain.length > 0);
 };
 
 let buildPortalUrlFromId = (portalId: string) => {


### PR DESCRIPTION
## Summary

Fix magic mcp access + ares redirect domains

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts access-control grants for consumer-created Magic MCP tokens and changes Ares redirect-domain handling, which can impact authorization and SSO redirect safety if misconfigured.
> 
> **Overview**
> Fixes consumer-created Magic MCP token permissions by centralizing the grant logic in `grantConsumerOwnedMagicMcpTokenAccess` and updating token creation to use it; connect access is now granted to the consumer’s groups when available (with de-duping), otherwise to the personal group.
> 
> Makes portal/Ares redirect domains explicitly configurable via a new `PORTAL_REDIRECT_DOMAINS` env var (validated in portal env and defaulted in dev tools), replacing the previous derivation from `PORTAL_HOST_TEMPLATE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33fa97058a06c27fda43640c5b1d864ff23bff2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->