### PR TITLE
feat/improve portal pages

### DIFF
--- a/clients/metorial-consumer/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/list.ts
+++ b/clients/metorial-consumer/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/list.ts
@@ -67,39 +67,21 @@ export let mapDashboardInstancePortalsConsumerProfilesListOutput =
                     group: mtMap.objectField(
                       'group',
                       mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
+                        object: mtMap.objectField('object', mtMap.passthrough()),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        status: mtMap.objectField(
-                          'status',
-                          mtMap.passthrough()
-                        ),
+                        status: mtMap.objectField('status', mtMap.passthrough()),
                         name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
+                        description: mtMap.objectField('description', mtMap.passthrough()),
+                        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
                         ssoGroupIds: mtMap.objectField(
                           'sso_group_ids',
                           mtMap.array(mtMap.passthrough())
                         ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
+                        createdAt: mtMap.objectField('created_at', mtMap.date()),
                         updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
                     ),
-                    assignedVia: mtMap.objectField(
-                      'assigned_via',
-                      mtMap.passthrough()
-                    )
+                    assignedVia: mtMap.objectField('assigned_via', mtMap.passthrough())
                   })
                 )
               ),
@@ -113,10 +95,7 @@ export let mapDashboardInstancePortalsConsumerProfilesListOutput =
                   id: mtMap.objectField('id', mtMap.passthrough()),
                   status: mtMap.objectField('status', mtMap.passthrough()),
                   name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
+                  description: mtMap.objectField('description', mtMap.passthrough()),
                   auth: mtMap.objectField(
                     'auth',
                     mtMap.object({
@@ -139,10 +118,7 @@ export let mapDashboardInstancePortalsConsumerProfilesListOutput =
     pagination: mtMap.objectField(
       'pagination',
       mtMap.object({
-        hasMoreBefore: mtMap.objectField(
-          'has_more_before',
-          mtMap.passthrough()
-        ),
+        hasMoreBefore: mtMap.objectField('has_more_before', mtMap.passthrough()),
         hasMoreAfter: mtMap.objectField('has_more_after', mtMap.passthrough())
       })
     )
@@ -154,6 +130,9 @@ export type DashboardInstancePortalsConsumerProfilesListQuery = {
   before?: string | undefined;
   cursor?: string | undefined;
   order?: 'asc' | 'desc' | undefined;
+  search?: string | undefined;
+  id?: string | undefined;
+  consumerGroupId?: string | undefined;
 } & {};
 
 export let mapDashboardInstancePortalsConsumerProfilesListQuery = mtMap.union([
@@ -164,8 +143,10 @@ export let mapDashboardInstancePortalsConsumerProfilesListQuery = mtMap.union([
       after: mtMap.objectField('after', mtMap.passthrough()),
       before: mtMap.objectField('before', mtMap.passthrough()),
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
-      order: mtMap.objectField('order', mtMap.passthrough())
+      order: mtMap.objectField('order', mtMap.passthrough()),
+      search: mtMap.objectField('search', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      consumerGroupId: mtMap.objectField('consumer_group_id', mtMap.passthrough())
     })
   )
 ]);
-

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/access-requests/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/access-requests/list.ts
@@ -55,10 +55,7 @@ export let mapDashboardInstancePortalsAccessRequestsListOutput =
           id: mtMap.objectField('id', mtMap.passthrough()),
           status: mtMap.objectField('status', mtMap.passthrough()),
           message: mtMap.objectField('message', mtMap.passthrough()),
-          resolutionMessage: mtMap.objectField(
-            'resolution_message',
-            mtMap.passthrough()
-          ),
+          resolutionMessage: mtMap.objectField('resolution_message', mtMap.passthrough()),
           consumerProfile: mtMap.objectField(
             'consumer_profile',
             mtMap.object({
@@ -82,14 +79,8 @@ export let mapDashboardInstancePortalsAccessRequestsListOutput =
                       id: mtMap.objectField('id', mtMap.passthrough()),
                       status: mtMap.objectField('status', mtMap.passthrough()),
                       name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
+                      description: mtMap.objectField('description', mtMap.passthrough()),
+                      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
                       providerDeploymentId: mtMap.objectField(
                         'provider_deployment_id',
                         mtMap.passthrough()
@@ -105,10 +96,7 @@ export let mapDashboardInstancePortalsAccessRequestsListOutput =
                       id: mtMap.objectField('id', mtMap.passthrough()),
                       status: mtMap.objectField('status', mtMap.passthrough()),
                       name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      )
+                      description: mtMap.objectField('description', mtMap.passthrough())
                     })
                   )
                 })
@@ -124,10 +112,7 @@ export let mapDashboardInstancePortalsAccessRequestsListOutput =
     pagination: mtMap.objectField(
       'pagination',
       mtMap.object({
-        hasMoreBefore: mtMap.objectField(
-          'has_more_before',
-          mtMap.passthrough()
-        ),
+        hasMoreBefore: mtMap.objectField('has_more_before', mtMap.passthrough()),
         hasMoreAfter: mtMap.objectField('has_more_after', mtMap.passthrough())
       })
     )
@@ -147,6 +132,7 @@ export type DashboardInstancePortalsAccessRequestsListQuery = {
     | ('pending' | 'approved' | 'rejected')[]
     | undefined;
   consumerProfileId?: string | string[] | undefined;
+  search?: string | undefined;
 };
 
 export let mapDashboardInstancePortalsAccessRequestsListQuery = mtMap.union([
@@ -171,8 +157,8 @@ export let mapDashboardInstancePortalsAccessRequestsListQuery = mtMap.union([
             mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
           )
         ])
-      )
+      ),
+      search: mtMap.objectField('search', mtMap.passthrough())
     })
   )
 ]);
-

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/auth/sso-tenants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/auth/sso-tenants/list.ts
@@ -39,10 +39,7 @@ export let mapDashboardInstancePortalsAuthSsoTenantsListOutput =
     pagination: mtMap.objectField(
       'pagination',
       mtMap.object({
-        hasMoreBefore: mtMap.objectField(
-          'has_more_before',
-          mtMap.passthrough()
-        ),
+        hasMoreBefore: mtMap.objectField('has_more_before', mtMap.passthrough()),
         hasMoreAfter: mtMap.objectField('has_more_after', mtMap.passthrough())
       })
     )
@@ -54,7 +51,11 @@ export type DashboardInstancePortalsAuthSsoTenantsListQuery = {
   before?: string | undefined;
   cursor?: string | undefined;
   order?: 'asc' | 'desc' | undefined;
-} & {};
+} & {
+  search?: string | undefined;
+  id?: string | undefined;
+  status?: 'pending' | 'completed' | ('pending' | 'completed')[] | undefined;
+};
 
 export let mapDashboardInstancePortalsAuthSsoTenantsListQuery = mtMap.union([
   mtMap.unionOption(
@@ -64,8 +65,19 @@ export let mapDashboardInstancePortalsAuthSsoTenantsListQuery = mtMap.union([
       after: mtMap.objectField('after', mtMap.passthrough()),
       before: mtMap.objectField('before', mtMap.passthrough()),
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
-      order: mtMap.objectField('order', mtMap.passthrough())
+      order: mtMap.objectField('order', mtMap.passthrough()),
+      search: mtMap.objectField('search', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField(
+        'status',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      )
     })
   )
 ]);
-

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-access/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-access/list.ts
@@ -145,6 +145,8 @@ export type DashboardInstancePortalsConsumerAccessListQuery = {
   cursor?: string | undefined;
   order?: 'asc' | 'desc' | undefined;
 } & {
+  search?: string | undefined;
+  id?: string | undefined;
   consumerGroupId?: string | string[] | undefined;
   providerTemplateId?: string | string[] | undefined;
   magicMcpServerId?: string | string[] | undefined;
@@ -164,6 +166,8 @@ export let mapDashboardInstancePortalsConsumerAccessListQuery = mtMap.union([
       before: mtMap.objectField('before', mtMap.passthrough()),
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
       order: mtMap.objectField('order', mtMap.passthrough()),
+      search: mtMap.objectField('search', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
       consumerGroupId: mtMap.objectField(
         'consumer_group_id',
         mtMap.union([

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-groups/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-groups/list.ts
@@ -27,10 +27,7 @@ export let mapDashboardInstancePortalsConsumerGroupsListOutput =
           name: mtMap.objectField('name', mtMap.passthrough()),
           description: mtMap.objectField('description', mtMap.passthrough()),
           isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          ssoGroupIds: mtMap.objectField(
-            'sso_group_ids',
-            mtMap.array(mtMap.passthrough())
-          ),
+          ssoGroupIds: mtMap.objectField('sso_group_ids', mtMap.array(mtMap.passthrough())),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
           updatedAt: mtMap.objectField('updated_at', mtMap.date())
         })
@@ -39,10 +36,7 @@ export let mapDashboardInstancePortalsConsumerGroupsListOutput =
     pagination: mtMap.objectField(
       'pagination',
       mtMap.object({
-        hasMoreBefore: mtMap.objectField(
-          'has_more_before',
-          mtMap.passthrough()
-        ),
+        hasMoreBefore: mtMap.objectField('has_more_before', mtMap.passthrough()),
         hasMoreAfter: mtMap.objectField('has_more_after', mtMap.passthrough())
       })
     )
@@ -61,6 +55,8 @@ export type DashboardInstancePortalsConsumerGroupsListQuery = {
     | 'deleted'
     | ('active' | 'archived' | 'deleted')[]
     | undefined;
+  search?: string | undefined;
+  id?: string | undefined;
 };
 
 export let mapDashboardInstancePortalsConsumerGroupsListQuery = mtMap.union([
@@ -75,8 +71,9 @@ export let mapDashboardInstancePortalsConsumerGroupsListQuery = mtMap.union([
       status: mtMap.objectField(
         'status',
         mtMap.union([mtMap.unionOption('array', mtMap.union([]))])
-      )
+      ),
+      search: mtMap.objectField('search', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough())
     })
   )
 ]);
-

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/list.ts
@@ -67,39 +67,21 @@ export let mapDashboardInstancePortalsConsumerProfilesListOutput =
                     group: mtMap.objectField(
                       'group',
                       mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
+                        object: mtMap.objectField('object', mtMap.passthrough()),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        status: mtMap.objectField(
-                          'status',
-                          mtMap.passthrough()
-                        ),
+                        status: mtMap.objectField('status', mtMap.passthrough()),
                         name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
+                        description: mtMap.objectField('description', mtMap.passthrough()),
+                        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
                         ssoGroupIds: mtMap.objectField(
                           'sso_group_ids',
                           mtMap.array(mtMap.passthrough())
                         ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
+                        createdAt: mtMap.objectField('created_at', mtMap.date()),
                         updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
                     ),
-                    assignedVia: mtMap.objectField(
-                      'assigned_via',
-                      mtMap.passthrough()
-                    )
+                    assignedVia: mtMap.objectField('assigned_via', mtMap.passthrough())
                   })
                 )
               ),
@@ -113,10 +95,7 @@ export let mapDashboardInstancePortalsConsumerProfilesListOutput =
                   id: mtMap.objectField('id', mtMap.passthrough()),
                   status: mtMap.objectField('status', mtMap.passthrough()),
                   name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
+                  description: mtMap.objectField('description', mtMap.passthrough()),
                   auth: mtMap.objectField(
                     'auth',
                     mtMap.object({
@@ -139,10 +118,7 @@ export let mapDashboardInstancePortalsConsumerProfilesListOutput =
     pagination: mtMap.objectField(
       'pagination',
       mtMap.object({
-        hasMoreBefore: mtMap.objectField(
-          'has_more_before',
-          mtMap.passthrough()
-        ),
+        hasMoreBefore: mtMap.objectField('has_more_before', mtMap.passthrough()),
         hasMoreAfter: mtMap.objectField('has_more_after', mtMap.passthrough())
       })
     )
@@ -154,6 +130,9 @@ export type DashboardInstancePortalsConsumerProfilesListQuery = {
   before?: string | undefined;
   cursor?: string | undefined;
   order?: 'asc' | 'desc' | undefined;
+  search?: string | undefined;
+  id?: string | undefined;
+  consumerGroupId?: string | undefined;
 } & {};
 
 export let mapDashboardInstancePortalsConsumerProfilesListQuery = mtMap.union([
@@ -164,8 +143,10 @@ export let mapDashboardInstancePortalsConsumerProfilesListQuery = mtMap.union([
       after: mtMap.objectField('after', mtMap.passthrough()),
       before: mtMap.objectField('before', mtMap.passthrough()),
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
-      order: mtMap.objectField('order', mtMap.passthrough())
+      order: mtMap.objectField('order', mtMap.passthrough()),
+      search: mtMap.objectField('search', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      consumerGroupId: mtMap.objectField('consumer_group_id', mtMap.passthrough())
     })
   )
 ]);
-

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/auth/sso-tenants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/auth/sso-tenants/list.ts
@@ -39,10 +39,7 @@ export let mapManagementInstancePortalsAuthSsoTenantsListOutput =
     pagination: mtMap.objectField(
       'pagination',
       mtMap.object({
-        hasMoreBefore: mtMap.objectField(
-          'has_more_before',
-          mtMap.passthrough()
-        ),
+        hasMoreBefore: mtMap.objectField('has_more_before', mtMap.passthrough()),
         hasMoreAfter: mtMap.objectField('has_more_after', mtMap.passthrough())
       })
     )
@@ -54,7 +51,11 @@ export type ManagementInstancePortalsAuthSsoTenantsListQuery = {
   before?: string | undefined;
   cursor?: string | undefined;
   order?: 'asc' | 'desc' | undefined;
-} & {};
+} & {
+  search?: string | undefined;
+  id?: string | undefined;
+  status?: 'pending' | 'completed' | ('pending' | 'completed')[] | undefined;
+};
 
 export let mapManagementInstancePortalsAuthSsoTenantsListQuery = mtMap.union([
   mtMap.unionOption(
@@ -64,8 +65,19 @@ export let mapManagementInstancePortalsAuthSsoTenantsListQuery = mtMap.union([
       after: mtMap.objectField('after', mtMap.passthrough()),
       before: mtMap.objectField('before', mtMap.passthrough()),
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
-      order: mtMap.objectField('order', mtMap.passthrough())
+      order: mtMap.objectField('order', mtMap.passthrough()),
+      search: mtMap.objectField('search', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField(
+        'status',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      )
     })
   )
 ]);
-

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-access/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-access/list.ts
@@ -145,6 +145,8 @@ export type ManagementInstancePortalsConsumerAccessListQuery = {
   cursor?: string | undefined;
   order?: 'asc' | 'desc' | undefined;
 } & {
+  search?: string | undefined;
+  id?: string | undefined;
   consumerGroupId?: string | string[] | undefined;
   providerTemplateId?: string | string[] | undefined;
   magicMcpServerId?: string | string[] | undefined;
@@ -164,6 +166,8 @@ export let mapManagementInstancePortalsConsumerAccessListQuery = mtMap.union([
       before: mtMap.objectField('before', mtMap.passthrough()),
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
       order: mtMap.objectField('order', mtMap.passthrough()),
+      search: mtMap.objectField('search', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
       consumerGroupId: mtMap.objectField(
         'consumer_group_id',
         mtMap.union([

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/auth/sso-tenants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/auth/sso-tenants/list.ts
@@ -14,39 +14,35 @@ export type PortalsAuthSsoTenantsListOutput = {
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
-export let mapPortalsAuthSsoTenantsListOutput =
-  mtMap.object<PortalsAuthSsoTenantsListOutput>({
-    items: mtMap.objectField(
-      'items',
-      mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          clientId: mtMap.objectField('client_id', mtMap.passthrough()),
-          counts: mtMap.objectField(
-            'counts',
-            mtMap.object({
-              connections: mtMap.objectField('connections', mtMap.passthrough())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    ),
-    pagination: mtMap.objectField(
-      'pagination',
+export let mapPortalsAuthSsoTenantsListOutput = mtMap.object<PortalsAuthSsoTenantsListOutput>({
+  items: mtMap.objectField(
+    'items',
+    mtMap.array(
       mtMap.object({
-        hasMoreBefore: mtMap.objectField(
-          'has_more_before',
-          mtMap.passthrough()
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+        counts: mtMap.objectField(
+          'counts',
+          mtMap.object({
+            connections: mtMap.objectField('connections', mtMap.passthrough())
+          })
         ),
-        hasMoreAfter: mtMap.objectField('has_more_after', mtMap.passthrough())
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
       })
     )
-  });
+  ),
+  pagination: mtMap.objectField(
+    'pagination',
+    mtMap.object({
+      hasMoreBefore: mtMap.objectField('has_more_before', mtMap.passthrough()),
+      hasMoreAfter: mtMap.objectField('has_more_after', mtMap.passthrough())
+    })
+  )
+});
 
 export type PortalsAuthSsoTenantsListQuery = {
   limit?: number | undefined;
@@ -54,7 +50,11 @@ export type PortalsAuthSsoTenantsListQuery = {
   before?: string | undefined;
   cursor?: string | undefined;
   order?: 'asc' | 'desc' | undefined;
-} & {};
+} & {
+  search?: string | undefined;
+  id?: string | undefined;
+  status?: 'pending' | 'completed' | ('pending' | 'completed')[] | undefined;
+};
 
 export let mapPortalsAuthSsoTenantsListQuery = mtMap.union([
   mtMap.unionOption(
@@ -64,8 +64,19 @@ export let mapPortalsAuthSsoTenantsListQuery = mtMap.union([
       after: mtMap.objectField('after', mtMap.passthrough()),
       before: mtMap.objectField('before', mtMap.passthrough()),
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
-      order: mtMap.objectField('order', mtMap.passthrough())
+      order: mtMap.objectField('order', mtMap.passthrough()),
+      search: mtMap.objectField('search', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField(
+        'status',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      )
     })
   )
 ]);
-

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-access/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-access/list.ts
@@ -145,6 +145,8 @@ export type PortalsConsumerAccessListQuery = {
   cursor?: string | undefined;
   order?: 'asc' | 'desc' | undefined;
 } & {
+  search?: string | undefined;
+  id?: string | undefined;
   consumerGroupId?: string | string[] | undefined;
   providerTemplateId?: string | string[] | undefined;
   magicMcpServerId?: string | string[] | undefined;
@@ -164,6 +166,8 @@ export let mapPortalsConsumerAccessListQuery = mtMap.union([
       before: mtMap.objectField('before', mtMap.passthrough()),
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
       order: mtMap.objectField('order', mtMap.passthrough()),
+      search: mtMap.objectField('search', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
       consumerGroupId: mtMap.objectField(
         'consumer_group_id',
         mtMap.union([

--- a/scripts/dev-tools/src/env/destinations.ts
+++ b/scripts/dev-tools/src/env/destinations.ts
@@ -94,7 +94,7 @@ export let destinations: Destination[] = [
     path: 'systems/horizon/apps/horizon'
   },
 
-  ...['admin', 'dashboard'].map(v => ({
+  ...['admin', 'dashboard', 'portal'].map(v => ({
     type: 'enterprise' as const,
     env: frontendEnv,
     path: `federation/frontend/apps/${v}`

--- a/scripts/dev-tools/src/env/frontend.ts
+++ b/scripts/dev-tools/src/env/frontend.ts
@@ -59,6 +59,11 @@ export let frontendEnv: Env = [
     defaultValue: `http://${HOSTNAME}:4310`,
     isEnterprise: true
   },
+  {
+    key: 'VITE_CORE_API_URL',
+    defaultValue: `http://${HOSTNAME}:4310`,
+    isEnterprise: true
+  },
 
   // {
   //   key: 'VITE_AUTH_API_URL',

--- a/src/backend/apis/core/src/controllers/instance/portalAuth.ts
+++ b/src/backend/apis/core/src/controllers/instance/portalAuth.ts
@@ -6,6 +6,7 @@ import { portalService } from '@metorial/module-portal';
 import { Controller } from '@metorial/rest';
 import { checkAccess } from '../../middleware/checkAccess';
 import { hasFlags } from '../../middleware/hasFlags';
+import { normalizeArrayParam } from '../../lib/normalizeArrayParam';
 import { instancePath } from '../../middleware/instanceGroup';
 import { isDashboardGroup } from '../../middleware/isDashboard';
 import {
@@ -33,6 +34,38 @@ let getPortalAresAppId = (portal: {
   }
 
   return appId;
+};
+
+let paginateSsoTenantList = <T extends { id: string }>(
+  sorted: T[],
+  query: { limit?: number; after?: string; before?: string }
+) => {
+  let limit = Math.min(Math.max(Number(query.limit) || 20, 1), 100);
+  let start = 0;
+  let end = sorted.length;
+
+  if (query.before) {
+    let idx = sorted.findIndex(t => t.id == query.before);
+    if (idx >= 0) {
+      end = idx;
+      start = Math.max(0, end - limit);
+    }
+  } else if (query.after) {
+    let idx = sorted.findIndex(t => t.id == query.after);
+    start = idx >= 0 ? idx + 1 : 0;
+    end = Math.min(sorted.length, start + limit);
+  } else {
+    end = Math.min(sorted.length, start + limit);
+  }
+
+  let items = sorted.slice(start, end);
+  let hasNextPage = end < sorted.length;
+  let hasPreviousPage = start > 0;
+
+  return {
+    items,
+    pagination: { hasNextPage, hasPreviousPage }
+  };
 };
 
 let portalAuthManagementGroup = portalGroup
@@ -88,19 +121,59 @@ export let portalAuthDashboardController = Controller.create(
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.portal.auth:read'] }))
-      .query('default', Paginator.validate(v.object({})))
+      .query(
+        'default',
+        Paginator.validate(
+          v.object({
+            search: v.optional(v.string()),
+            id: v.optional(v.string()),
+            status: v.optional(
+              v.union([
+                v.enumOf(['pending', 'completed']),
+                v.array(v.enumOf(['pending', 'completed']))
+              ])
+            )
+          })
+        )
+      )
       .outputList(portalAuthSsoTenantPresenter)
       .do(async ctx => {
-        let list = await consumerAresService.listSsoTenants({
-          appId: getPortalAresAppId(ctx.portal),
-          limit: ctx.query.limit,
-          after: ctx.query.after,
-          before: ctx.query.before,
-          cursor: ctx.query.cursor,
-          order: ctx.query.order
+        let appId = getPortalAresAppId(ctx.portal);
+        let all = await consumerAresService.listSsoTenantsAll({ appId });
+
+        let search = ctx.query.search?.trim().toLowerCase();
+        let idFilter = ctx.query.id?.trim();
+        let statuses = normalizeArrayParam(ctx.query.status);
+
+        let filtered = all.filter(tenant => {
+          if (idFilter && tenant.id != idFilter) {
+            return false;
+          }
+
+          if (statuses?.length && !statuses.includes(tenant.status)) {
+            return false;
+          }
+
+          if (search) {
+            let hay = [tenant.id, tenant.name, tenant.clientId].join(' ').toLowerCase();
+            if (!hay.includes(search)) {
+              return false;
+            }
+          }
+
+          return true;
         });
 
-        return Paginator.present(list, ssoTenant =>
+        let order = ctx.query.order == 'asc' ? 1 : -1;
+        filtered.sort((a, b) => order * (a.createdAt.getTime() - b.createdAt.getTime()));
+
+        let page = paginateSsoTenantList(filtered, {
+          limit: ctx.query.limit,
+          after: ctx.query.after,
+          before: ctx.query.before
+        });
+
+        return Paginator.present(page, ssoTenant =>
           portalAuthSsoTenantPresenter.present({ ssoTenant })
         );
       }),

--- a/src/backend/apis/core/src/controllers/instance/portalAuth.ts
+++ b/src/backend/apis/core/src/controllers/instance/portalAuth.ts
@@ -6,7 +6,6 @@ import { portalService } from '@metorial/module-portal';
 import { Controller } from '@metorial/rest';
 import { checkAccess } from '../../middleware/checkAccess';
 import { hasFlags } from '../../middleware/hasFlags';
-import { normalizeArrayParam } from '../../lib/normalizeArrayParam';
 import { instancePath } from '../../middleware/instanceGroup';
 import { isDashboardGroup } from '../../middleware/isDashboard';
 import {
@@ -34,38 +33,6 @@ let getPortalAresAppId = (portal: {
   }
 
   return appId;
-};
-
-let paginateSsoTenantList = <T extends { id: string }>(
-  sorted: T[],
-  query: { limit?: number; after?: string; before?: string }
-) => {
-  let limit = Math.min(Math.max(Number(query.limit) || 20, 1), 100);
-  let start = 0;
-  let end = sorted.length;
-
-  if (query.before) {
-    let idx = sorted.findIndex(t => t.id == query.before);
-    if (idx >= 0) {
-      end = idx;
-      start = Math.max(0, end - limit);
-    }
-  } else if (query.after) {
-    let idx = sorted.findIndex(t => t.id == query.after);
-    start = idx >= 0 ? idx + 1 : 0;
-    end = Math.min(sorted.length, start + limit);
-  } else {
-    end = Math.min(sorted.length, start + limit);
-  }
-
-  let items = sorted.slice(start, end);
-  let hasNextPage = end < sorted.length;
-  let hasPreviousPage = start > 0;
-
-  return {
-    items,
-    pagination: { hasNextPage, hasPreviousPage }
-  };
 };
 
 let portalAuthManagementGroup = portalGroup
@@ -121,59 +88,19 @@ export let portalAuthDashboardController = Controller.create(
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.portal.auth:read'] }))
-      .query(
-        'default',
-        Paginator.validate(
-          v.object({
-            search: v.optional(v.string()),
-            id: v.optional(v.string()),
-            status: v.optional(
-              v.union([
-                v.enumOf(['pending', 'completed']),
-                v.array(v.enumOf(['pending', 'completed']))
-              ])
-            )
-          })
-        )
-      )
+      .query('default', Paginator.validate(v.object({})))
       .outputList(portalAuthSsoTenantPresenter)
       .do(async ctx => {
-        let appId = getPortalAresAppId(ctx.portal);
-        let all = await consumerAresService.listSsoTenantsAll({ appId });
-
-        let search = ctx.query.search?.trim().toLowerCase();
-        let idFilter = ctx.query.id?.trim();
-        let statuses = normalizeArrayParam(ctx.query.status);
-
-        let filtered = all.filter(tenant => {
-          if (idFilter && tenant.id != idFilter) {
-            return false;
-          }
-
-          if (statuses?.length && !statuses.includes(tenant.status)) {
-            return false;
-          }
-
-          if (search) {
-            let hay = [tenant.id, tenant.name, tenant.clientId].join(' ').toLowerCase();
-            if (!hay.includes(search)) {
-              return false;
-            }
-          }
-
-          return true;
-        });
-
-        let order = ctx.query.order == 'asc' ? 1 : -1;
-        filtered.sort((a, b) => order * (a.createdAt.getTime() - b.createdAt.getTime()));
-
-        let page = paginateSsoTenantList(filtered, {
+        let list = await consumerAresService.listSsoTenants({
+          appId: getPortalAresAppId(ctx.portal),
           limit: ctx.query.limit,
           after: ctx.query.after,
-          before: ctx.query.before
+          before: ctx.query.before,
+          cursor: ctx.query.cursor,
+          order: ctx.query.order
         });
 
-        return Paginator.present(page, ssoTenant =>
+        return Paginator.present(list, ssoTenant =>
           portalAuthSsoTenantPresenter.present({ ssoTenant })
         );
       }),

--- a/src/backend/apis/core/src/controllers/instance/portalConsumerAccess.ts
+++ b/src/backend/apis/core/src/controllers/instance/portalConsumerAccess.ts
@@ -53,6 +53,8 @@ export let portalConsumerAccessController = Controller.create(
         'default',
         Paginator.validate(
           v.object({
+            search: v.optional(v.string()),
+            id: v.optional(v.string()),
             consumer_group_id: v.optional(v.union([v.string(), v.array(v.string())])),
             provider_template_id: v.optional(v.union([v.string(), v.array(v.string())])),
             magic_mcp_server_id: v.optional(v.union([v.string(), v.array(v.string())])),
@@ -71,7 +73,9 @@ export let portalConsumerAccessController = Controller.create(
           consumerGroupIds: normalizeArrayParam(ctx.query.consumer_group_id),
           providerTemplateIds: normalizeArrayParam(ctx.query.provider_template_id),
           magicMcpServerIds: normalizeArrayParam(ctx.query.magic_mcp_server_id),
-          types: normalizeArrayParam(ctx.query.type)
+          types: normalizeArrayParam(ctx.query.type),
+          search: ctx.query.search,
+          id: ctx.query.id
         });
         let list = await paginator.run(ctx.query);
 

--- a/src/backend/apis/core/src/controllers/instance/portalConsumerAccessRequest.ts
+++ b/src/backend/apis/core/src/controllers/instance/portalConsumerAccessRequest.ts
@@ -52,7 +52,8 @@ export let portalConsumerAccessRequestController = Controller.create(
                 v.array(v.enumOf(['pending', 'approved', 'rejected']))
               ])
             ),
-            consumer_profile_id: v.optional(v.union([v.string(), v.array(v.string())]))
+            consumer_profile_id: v.optional(v.union([v.string(), v.array(v.string())])),
+            search: v.optional(v.string())
           })
         )
       )
@@ -61,7 +62,8 @@ export let portalConsumerAccessRequestController = Controller.create(
         let paginator = await consumerAccessRequestService.listConsumerAccessRequests({
           consumerSurface: ctx.portal.surface,
           statuses: normalizeArrayParam(ctx.query.status),
-          consumerProfileIds: normalizeArrayParam(ctx.query.consumer_profile_id)
+          consumerProfileIds: normalizeArrayParam(ctx.query.consumer_profile_id),
+          search: ctx.query.search
         });
         let list = await paginator.run(ctx.query);
 

--- a/src/backend/apis/core/src/controllers/instance/portalConsumerGroup.ts
+++ b/src/backend/apis/core/src/controllers/instance/portalConsumerGroup.ts
@@ -52,14 +52,18 @@ export let portalConsumerGroupController = Controller.create(
                 v.enumOf(['active', 'archived', 'deleted']),
                 v.array(v.enumOf(['active', 'archived', 'deleted']))
               ])
-            )
+            ),
+            search: v.optional(v.string()),
+            id: v.optional(v.string())
           })
         )
       )
       .do(async ctx => {
         let paginator = await consumerGroupService.listConsumerGroups({
           consumerSurface: ctx.portal.surface,
-          status: normalizeArrayParam(ctx.query.status)
+          status: normalizeArrayParam(ctx.query.status),
+          search: ctx.query.search,
+          id: ctx.query.id
         });
         let list = await paginator.run(ctx.query);
 

--- a/src/backend/apis/core/src/controllers/instance/portalConsumerProfile.ts
+++ b/src/backend/apis/core/src/controllers/instance/portalConsumerProfile.ts
@@ -45,10 +45,22 @@ export let portalConsumerProfileController = Controller.create(
       .use(checkAccess({ possibleScopes: ['instance.portal.consumers:read'] }))
       .use(hasFlags(['paid-portals', 'portals-access']))
       .outputList(consumerProfilePresenter)
-      .query('default', Paginator.validate(v.object({})))
+      .query(
+        'default',
+        Paginator.validate(
+          v.object({
+            search: v.optional(v.string()),
+            id: v.optional(v.string()),
+            consumer_group_id: v.optional(v.string())
+          })
+        )
+      )
       .do(async ctx => {
         let paginator = await consumerProfileService.listConsumerProfiles({
-          consumerSurface: ctx.portal.surface
+          consumerSurface: ctx.portal.surface,
+          search: ctx.query.search,
+          id: ctx.query.id,
+          consumerGroupId: ctx.query.consumer_group_id
         });
         let list = await paginator.run(ctx.query);
         let assignedConsumerGroupsByProfileId =

--- a/src/backend/modules/consumer/src/services/ares.ts
+++ b/src/backend/modules/consumer/src/services/ares.ts
@@ -114,31 +114,6 @@ class ConsumerAresServiceImpl {
     );
   }
 
-  async listSsoTenantsAll(d: { appId: string; maxItems?: number }) {
-    let maxItems = d.maxItems ?? 2000;
-    let all: ConsumerAresRawSsoTenantList['items'][number][] = [];
-    let after: string | undefined;
-
-    while (all.length < maxItems) {
-      let batch = await this.listSsoTenants({
-        appId: d.appId,
-        limit: 100,
-        after,
-        order: 'asc'
-      });
-
-      all.push(...batch.items);
-
-      if (!batch.pagination.hasNextPage || batch.items.length === 0) {
-        break;
-      }
-
-      after = batch.items[batch.items.length - 1]!.id;
-    }
-
-    return all;
-  }
-
   async getSsoTenant(d: { ssoTenantId: string }) {
     return await this.getClient().sso.getTenant({
       id: d.ssoTenantId

--- a/src/backend/modules/consumer/src/services/ares.ts
+++ b/src/backend/modules/consumer/src/services/ares.ts
@@ -114,6 +114,31 @@ class ConsumerAresServiceImpl {
     );
   }
 
+  async listSsoTenantsAll(d: { appId: string; maxItems?: number }) {
+    let maxItems = d.maxItems ?? 2000;
+    let all: ConsumerAresRawSsoTenantList['items'][number][] = [];
+    let after: string | undefined;
+
+    while (all.length < maxItems) {
+      let batch = await this.listSsoTenants({
+        appId: d.appId,
+        limit: 100,
+        after,
+        order: 'asc'
+      });
+
+      all.push(...batch.items);
+
+      if (!batch.pagination.hasNextPage || batch.items.length === 0) {
+        break;
+      }
+
+      after = batch.items[batch.items.length - 1]!.id;
+    }
+
+    return all;
+  }
+
   async getSsoTenant(d: { ssoTenantId: string }) {
     return await this.getClient().sso.getTenant({
       id: d.ssoTenantId

--- a/src/backend/modules/consumer/src/services/consumerAccess.ts
+++ b/src/backend/modules/consumer/src/services/consumerAccess.ts
@@ -39,7 +39,11 @@ class ConsumerAccessServiceImpl {
     providerTemplateIds?: string[];
     magicMcpServerIds?: string[];
     types?: ConsumerAccessTargetType[];
+    search?: string;
+    id?: string;
   }) {
+    let search = d.search?.trim();
+    let idFilter = d.id?.trim();
     let hasConsumerGroupFilter = !!d.consumerGroupIds?.length;
     let hasProviderTemplateFilter = !!d.providerTemplateIds?.length;
     let hasMagicMcpServerFilter = !!d.magicMcpServerIds?.length;
@@ -90,19 +94,71 @@ class ConsumerAccessServiceImpl {
           ...opts,
           where: {
             surfaceOid: d.consumerSurface.oid,
-            OR: [
+            id: idFilter ? idFilter : undefined,
+            AND: [
               {
-                type: 'provider_template',
-                providerTemplate: {
-                  status: 'active'
-                }
+                OR: [
+                  {
+                    type: 'provider_template',
+                    providerTemplate: {
+                      status: 'active'
+                    }
+                  },
+                  {
+                    type: 'magic_mcp_server',
+                    magicMcpServer: {
+                      status: 'active'
+                    }
+                  }
+                ]
               },
-              {
-                type: 'magic_mcp_server',
-                magicMcpServer: {
-                  status: 'active'
-                }
-              }
+              ...(search
+                ? [
+                    {
+                      OR: [
+                        { id: { contains: search, mode: 'insensitive' as const } },
+                        {
+                          AND: [
+                            { type: 'provider_template' as const },
+                            {
+                              providerTemplate: {
+                                OR: [
+                                  { name: { contains: search, mode: 'insensitive' as const } },
+                                  {
+                                    description: {
+                                      contains: search,
+                                      mode: 'insensitive' as const
+                                    }
+                                  },
+                                  { id: { contains: search, mode: 'insensitive' as const } }
+                                ]
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          AND: [
+                            { type: 'magic_mcp_server' as const },
+                            {
+                              magicMcpServer: {
+                                OR: [
+                                  { name: { contains: search, mode: 'insensitive' as const } },
+                                  {
+                                    description: {
+                                      contains: search,
+                                      mode: 'insensitive' as const
+                                    }
+                                  },
+                                  { id: { contains: search, mode: 'insensitive' as const } }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                : [])
             ],
             type: d.types?.length ? { in: d.types } : undefined,
             consumerGroupOid: hasConsumerGroupFilter

--- a/src/backend/modules/consumer/src/services/consumerAccessRequest.ts
+++ b/src/backend/modules/consumer/src/services/consumerAccessRequest.ts
@@ -100,7 +100,9 @@ class ConsumerAccessRequestServiceImpl {
     providerTemplateIds?: string[];
     magicMcpServerIds?: string[];
     statuses?: ConsumerAccessRequestStatus[];
+    search?: string;
   }) {
+    let search = d.search?.trim();
     let hasConsumerProfileFilter = !!d.consumerProfileIds?.length;
     let hasProviderTemplateFilter = !!d.providerTemplateIds?.length;
     let hasMagicMcpServerFilter = !!d.magicMcpServerIds?.length;
@@ -166,7 +168,23 @@ class ConsumerAccessRequestServiceImpl {
               ? {
                   in: magicMcpServers?.map(magicMcpServer => magicMcpServer.oid) ?? []
                 }
-              : undefined
+              : undefined,
+            ...(search
+              ? {
+                  OR: [
+                    { message: { contains: search, mode: 'insensitive' } },
+                    { id: { contains: search, mode: 'insensitive' } },
+                    {
+                      consumerProfile: {
+                        OR: [
+                          { name: { contains: search, mode: 'insensitive' } },
+                          { email: { contains: search, mode: 'insensitive' } }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              : {})
           },
           include
         });

--- a/src/backend/modules/consumer/src/services/consumerGroup.ts
+++ b/src/backend/modules/consumer/src/services/consumerGroup.ts
@@ -66,7 +66,12 @@ class ConsumerGroupServiceImpl {
   async listConsumerGroups(d: {
     consumerSurface: ConsumerSurface;
     status?: ConsumerGroup['status'][];
+    search?: string;
+    id?: string;
   }) {
+    let search = d.search?.trim();
+    let idFilter = d.id?.trim();
+
     return Paginator.create(({ prisma }) =>
       prisma(async opts => {
         return await db.consumerGroup.findMany({
@@ -74,7 +79,22 @@ class ConsumerGroupServiceImpl {
           where: {
             surfaceOid: d.consumerSurface.oid,
             type: 'default',
-            status: d.status?.length ? { in: d.status } : 'active'
+            status: d.status?.length ? { in: d.status } : 'active',
+            ...(idFilter ? { id: idFilter } : {}),
+            ...(search
+              ? {
+                  OR: [
+                    { name: { contains: search, mode: 'insensitive' } },
+                    {
+                      description: {
+                        contains: search,
+                        mode: 'insensitive'
+                      }
+                    },
+                    { id: { contains: search, mode: 'insensitive' } }
+                  ]
+                }
+              : {})
           }
         });
       })

--- a/src/backend/modules/consumer/src/services/consumerProfile.ts
+++ b/src/backend/modules/consumer/src/services/consumerProfile.ts
@@ -15,6 +15,7 @@ import {
   Instance,
   InstanceConsumer,
   OrganizationMember,
+  Prisma,
   withTransaction
 } from '@metorial/db';
 import { createLock } from '@metorial/lock';
@@ -79,13 +80,79 @@ class ConsumerProfileServiceImpl {
     return consumerProfile;
   }
 
-  async listConsumerProfiles(d: { consumerSurface: ConsumerSurface }) {
+  async listConsumerProfiles(d: {
+    consumerSurface: ConsumerSurface;
+    search?: string;
+    id?: string;
+    consumerGroupId?: string;
+  }) {
+    let search = d.search?.trim();
+    let idFilter = d.id?.trim();
+    let consumerGroupId = d.consumerGroupId?.trim();
+
+    let groupMembershipWhere: Prisma.ConsumerProfileWhereInput | undefined;
+
+    if (consumerGroupId) {
+      let group = await db.consumerGroup.findFirst({
+        where: {
+          id: consumerGroupId,
+          surfaceOid: d.consumerSurface.oid,
+          status: 'active'
+        }
+      });
+
+      if (!group) {
+        groupMembershipWhere = { id: { in: [] } };
+      } else if (group.isDefault) {
+        groupMembershipWhere = undefined;
+      } else {
+        let or: Prisma.ConsumerProfileWhereInput[] = [
+          {
+            groups: {
+              some: {
+                group: {
+                  id: consumerGroupId,
+                  surfaceOid: d.consumerSurface.oid
+                }
+              }
+            }
+          },
+          { personalConsumerGroupOid: group.oid }
+        ];
+
+        if (group.ssoGroupIds.length) {
+          or.push({
+            ssoGroupIds: { hasSome: group.ssoGroupIds }
+          });
+        }
+
+        groupMembershipWhere = { OR: or };
+      }
+    }
+
+    let andParts: Prisma.ConsumerProfileWhereInput[] = [
+      { surfaceOid: d.consumerSurface.oid },
+      ...(idFilter ? [{ id: idFilter }] : []),
+      ...(groupMembershipWhere ? [groupMembershipWhere] : []),
+      ...(search
+        ? [
+            {
+              OR: [
+                { name: { contains: search, mode: 'insensitive' as const } },
+                { email: { contains: search, mode: 'insensitive' as const } },
+                { id: { contains: search, mode: 'insensitive' as const } }
+              ]
+            }
+          ]
+        : [])
+    ];
+
     return Paginator.create(({ prisma }) =>
       prisma(async opts => {
         return await db.consumerProfile.findMany({
           ...opts,
           where: {
-            surfaceOid: d.consumerSurface.oid
+            AND: andParts
           },
           include
         });

--- a/src/packages/frontend/ui/src/textArrayInput/index.tsx
+++ b/src/packages/frontend/ui/src/textArrayInput/index.tsx
@@ -31,7 +31,8 @@ export let TextArrayInput = ({
   error,
   onChange,
   placeholder,
-  autoAdd
+  autoAdd,
+  hideAddButton
 }: {
   label: string;
   description?: string;
@@ -40,6 +41,7 @@ export let TextArrayInput = ({
   error?: (string | undefined)[] | string;
   onChange: (value: string[]) => void;
   autoAdd?: boolean;
+  hideAddButton?: boolean;
 }) => {
   useEffect(() => {
     if (value.length === 0) onChange(['']);
@@ -103,7 +105,7 @@ export let TextArrayInput = ({
           </Item>
         ))}
 
-        {!autoAdd && (
+        {!autoAdd && !hideAddButton && (
           <div
             style={{
               display: 'flex',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new query parameters and non-trivial Prisma `where` logic to multiple portal list endpoints, which could change result sets and query performance if the filters are misapplied. Changes are scoped to portal/consumer listing APIs and a small UI prop addition.
> 
> **Overview**
> Adds **search and direct ID filtering** across portal list endpoints (consumer access rules, access requests, consumer groups, and consumer profiles), and wires these through controller validation into the underlying services.
> 
> Implements corresponding backend query behavior, including text search over related entities (e.g., provider template/MCP server fields) and a **consumer profile filter by `consumer_group_id`** with special handling for default/personal/SSO group membership.
> 
> Updates generated dashboard/management/portal client mappers to accept the new query params, extends dev tooling env/destinations (adds `portal` app + `VITE_CORE_API_URL`), and adds `hideAddButton` support to `TextArrayInput`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aec174b925d021d428869cf1134aae735fb5250b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->