### PR TITLE
Safari sucks so it cannot have animations

### DIFF
--- a/src/packages/frontend/ui/src/animateHeight/index.tsx
+++ b/src/packages/frontend/ui/src/animateHeight/index.tsx
@@ -2,8 +2,16 @@ import { motion } from 'framer-motion';
 import React from 'react';
 import { useMeasure } from 'react-use';
 
+let isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
 export let AnimateHeight = (props: { children: React.ReactNode }) => {
   let [ref, { height }] = useMeasure();
+
+  if (isSafari) {
+    // Safari has a weird bug where it doesn't properly animate height when the content changes.
+    // This is a workaround that forces Safari to re-render the component when the content changes.
+    return <div>{props.children}</div>;
+  }
 
   return (
     <motion.div


### PR DESCRIPTION
@RahmeKarim @miki-debicki 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime behavior for Safari users by bypassing `framer-motion` height animation, which could affect layout/UX and may be sensitive if this component is rendered in non-browser/SSR contexts due to `navigator` usage.
> 
> **Overview**
> Adds Safari user-agent detection to `AnimateHeight` and **skips the `framer-motion` height animation on Safari**, rendering children in a plain `div` instead.
> 
> This is a targeted workaround for a Safari-specific height animation bug when content changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0af0a0bba0abf7ab723580ba54d2dea9c8976da7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->