### PR TITLE
Set up chat system

### DIFF
--- a/src/systems/subspace/db/prisma/schema/agents/agent.prisma
+++ b/src/systems/subspace/db/prisma/schema/agents/agent.prisma
@@ -33,5 +33,7 @@ model Agent {
   updatedAt  DateTime  @default(now()) @updatedAt
   archivedAt DateTime?
 
+  chatSenders ChatSender[]
+
   @@unique([environmentOid, slug])
 }

--- a/src/systems/subspace/db/prisma/schema/chat/provider.prisma
+++ b/src/systems/subspace/db/prisma/schema/chat/provider.prisma
@@ -1,0 +1,14 @@
+model ChatProvider {
+  oid BigInt @id
+  id  String @unique
+
+  identifier  String  @unique
+  name        String
+  description String?
+
+  tag    String      @unique
+  tagRef ProviderTag @relation(fields: [tag], references: [tag])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+}

--- a/src/systems/subspace/db/prisma/schema/chat/sender.prisma
+++ b/src/systems/subspace/db/prisma/schema/chat/sender.prisma
@@ -1,0 +1,23 @@
+model ChatSender {
+  oid BigInt @id
+  id  String @unique
+
+  name        String
+  description String?
+  metadata    Json?
+
+  agentOid BigInt?
+  agent    Agent?  @relation(fields: [agentOid], references: [oid], onDelete: Cascade)
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid], onDelete: Cascade)
+
+  environmentOid BigInt
+  environment    Environment @relation(fields: [environmentOid], references: [oid], onDelete: Cascade)
+
+  solutionOid Int
+  solution    Solution @relation(fields: [solutionOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+}

--- a/src/systems/subspace/db/prisma/schema/identity/delegatedIdentity.prisma
+++ b/src/systems/subspace/db/prisma/schema/identity/delegatedIdentity.prisma
@@ -2,9 +2,9 @@ model DelegatedIdentity {
   oid BigInt @id
   id  String @unique
 
-  permissions IdentityDelegationPermissions[]
+  permissions     IdentityDelegationPermissions[]
   delegationLevel Int
-  isActive    Boolean
+  isActive        Boolean
 
   identityOid BigInt
   identity    Identity @relation(fields: [identityOid], references: [oid], onDelete: Cascade)

--- a/src/systems/subspace/db/prisma/schema/provider/tag.prisma
+++ b/src/systems/subspace/db/prisma/schema/provider/tag.prisma
@@ -10,4 +10,5 @@ model ProviderTag {
   providerVersions ProviderVersion[]
   providers        Provider[]
   publisher        Publisher[]
+  chatProvider     ChatProvider?
 }

--- a/src/systems/subspace/db/prisma/schema/solution.prisma
+++ b/src/systems/subspace/db/prisma/schema/solution.prisma
@@ -55,4 +55,5 @@ model Solution {
   identityDelegationConfigs                IdentityDelegationConfig[]
   identityDelegations                      IdentityDelegation[]
   identityDelegationRequests               IdentityDelegationRequest[]
+  chatSenders                              ChatSender[]
 }

--- a/src/systems/subspace/db/prisma/schema/tenant.prisma
+++ b/src/systems/subspace/db/prisma/schema/tenant.prisma
@@ -86,6 +86,7 @@ model Tenant {
   identityDelegationConfigs                IdentityDelegationConfig[]
   identityDelegations                      IdentityDelegation[]
   identityDelegationRequests               IdentityDelegationRequest[]
+  chatSenders                              ChatSender[]
 }
 
 enum EnvironmentType {
@@ -146,6 +147,7 @@ model Environment {
   identityDelegationConfigs                IdentityDelegationConfig[]
   identityDelegations                      IdentityDelegation[]
   identityDelegationRequests               IdentityDelegationRequest[]
+  chatSenders                              ChatSender[]
 }
 
 enum TenantActorType {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new Prisma models and relations that will require database migrations and could affect existing queries/constraints around `ProviderTag`, `Agent`, and tenant/environment scoping. Risk is moderate because it’s schema-level change but isolated to new chat entities plus additive relations.
> 
> **Overview**
> Adds initial database schema for the chat system by introducing new Prisma models `ChatProvider` (linked 1:1 to `ProviderTag` via a unique `tag`) and `ChatSender` (scoped to `Tenant`/`Environment`/`Solution`, optionally linked to an `Agent`).
> 
> Wires `ChatSender` relations into `Agent`, `Solution`, `Tenant`, and `Environment`, and extends `ProviderTag` with an optional `chatProvider` back-reference. Includes a small formatting-only adjustment in `DelegatedIdentity` field alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10fb0ef5b9b05c86ecd6887195ed00936298cc2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->