### PR TITLE
Fix details page frontends

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/actor/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/actor/_layout.tsx
@@ -20,16 +20,18 @@ export let IdentityActorLayout = () => {
   let { identityActorId } = useParams();
   let actor = useIdentityActor(instance.data?.id, identityActorId);
 
-  return renderWithLoader({ instance, organization, project, actor })(
-    ({ instance, organization, project, actor }) => (
-      <ContentLayout>
-        <PageHeader
-          title={actor.data.name}
-          description={actor.data.description ?? undefined}
-          actions={
+  return (
+    <ContentLayout>
+      <PageHeader
+        title={actor.data?.name ?? '...'}
+        description={actor.data?.description ?? undefined}
+        actions={
+          actor.data ? (
             <Button
               size="2"
-              onClick={() =>
+              onClick={() => {
+                if (!instance.data) return;
+
                 showIdentityFormModal({
                   instanceId: instance.data.id,
                   actorId: actor.data.id,
@@ -43,60 +45,66 @@ export let IdentityActorLayout = () => {
                         identity.id
                       )
                     )
-                })
-              }
+                });
+              }}
             >
               Create Identity
             </Button>
+          ) : undefined
+        }
+        pagination={[
+          {
+            label: 'Identity Actors',
+            href: Paths.instance.identity.actors(
+              organization.data,
+              project.data,
+              instance.data
+            )
+          },
+          {
+            label: actor.data?.name ?? identityActorId ?? '...',
+            href: Paths.instance.identity.actor(
+              organization.data,
+              project.data,
+              instance.data,
+              actor.data?.id ?? identityActorId
+            )
           }
-          pagination={[
-            {
-              label: 'Identity Actors',
-              href: Paths.instance.identity.actors(
-                organization.data,
-                project.data,
-                instance.data
-              )
-            },
-            {
-              label: actor.data.name,
-              href: Paths.instance.identity.actor(
-                organization.data,
-                project.data,
-                instance.data,
-                actor.data.id
-              )
-            }
-          ]}
-        />
+        ]}
+      />
 
-        <LinkTabs
-          current={location.pathname}
-          links={[
-            {
-              label: 'Overview',
-              to: Paths.instance.identity.actor(
-                organization.data,
-                project.data,
-                instance.data,
-                actor.data.id
-              )
-            },
-            {
-              label: 'Settings',
-              to: Paths.instance.identity.actor(
-                organization.data,
-                project.data,
-                instance.data,
-                actor.data.id,
-                'settings'
-              )
-            }
-          ]}
-        />
+      {renderWithLoader({ instance, organization, project, actor })(
+        ({ instance, organization, project, actor }) => (
+          <>
+            <LinkTabs
+              current={location.pathname}
+              links={[
+                {
+                  label: 'Overview',
+                  to: Paths.instance.identity.actor(
+                    organization.data,
+                    project.data,
+                    instance.data,
+                    actor.data.id
+                  )
+                },
+                {
+                  label: 'Settings',
+                  to: Paths.instance.identity.actor(
+                    organization.data,
+                    project.data,
+                    instance.data,
+                    actor.data.id,
+                    'settings'
+                  )
+                }
+              ]}
+            />
 
-        <Outlet />
-      </ContentLayout>
-    )
+            <Outlet />
+          </>
+        )
+      )}
+    </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/consumer/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/consumer/_layout.tsx
@@ -18,60 +18,64 @@ export let ConsumerLayout = () => {
   let consumer = useConsumer(instance.data?.id, consumerId);
   let pathname = useLocation().pathname;
 
-  return renderWithLoader({ instance, organization, project, consumer })(
-    ({ instance, organization, project, consumer }) => (
-      <ContentLayout>
-        <PageHeader
-          title={consumer.data.name}
-          description={consumer.data.email}
-          pagination={[
-            {
-              label: 'Consumers',
-              href: Paths.instance.identity.consumers(
-                organization.data,
-                project.data,
-                instance.data
-              )
-            },
-            {
-              label: consumer.data.name,
-              href: Paths.instance.identity.consumer(
-                organization.data,
-                project.data,
-                instance.data,
-                consumer.data.id
-              )
-            }
-          ]}
-        />
+  return (
+    <ContentLayout>
+      <PageHeader
+        title={consumer.data?.name ?? '...'}
+        description={consumer.data?.email ?? undefined}
+        pagination={[
+          {
+            label: 'Consumers',
+            href: Paths.instance.identity.consumers(
+              organization.data,
+              project.data,
+              instance.data
+            )
+          },
+          {
+            label: consumer.data?.name ?? '...',
+            href: Paths.instance.identity.consumer(
+              organization.data,
+              project.data,
+              instance.data,
+              consumer.data?.id ?? consumerId
+            )
+          }
+        ]}
+      />
 
-        <LinkTabs
-          current={pathname}
-          links={[
-            {
-              label: 'Overview',
-              to: Paths.instance.identity.consumer(
-                organization.data,
-                project.data,
-                instance.data,
-                consumer.data.id
-              )
-            },
-            {
-              label: 'Settings',
-              to: Paths.instance.identity.consumer(
-                organization.data,
-                project.data,
-                instance.data,
-                consumer.data.id,
-                'settings'
-              )
-            }
-          ]}
-        />
+      {renderWithLoader({ instance, organization, project, consumer })(
+        ({ instance, organization, project, consumer }) => (
+          <>
+            <LinkTabs
+              current={pathname}
+              links={[
+                {
+                  label: 'Overview',
+                  to: Paths.instance.identity.consumer(
+                    organization.data,
+                    project.data,
+                    instance.data,
+                    consumer.data.id
+                  )
+                },
+                {
+                  label: 'Settings',
+                  to: Paths.instance.identity.consumer(
+                    organization.data,
+                    project.data,
+                    instance.data,
+                    consumer.data.id,
+                    'settings'
+                  )
+                }
+              ]}
+            />
 
-        <Outlet />
-      </ContentLayout>
-    )
+            <Outlet />
+          </>
+        )
+      )}
+    </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/delegation-config/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/delegation-config/_layout.tsx
@@ -16,35 +16,35 @@ export let IdentityDelegationConfigLayout = () => {
   let { identityDelegationConfigId } = useParams();
   let config = useIdentityDelegationConfig(instance.data?.id, identityDelegationConfigId);
 
-  return renderWithLoader({ instance, organization, project, config })(
-    ({ instance, organization, project, config }) => (
-      <ContentLayout>
-        <PageHeader
-          title={config.data.name ?? config.data.id}
-          description={config.data.description ?? undefined}
-          pagination={[
-            {
-              label: 'Delegation Configs',
-              href: Paths.instance.identity.delegationConfigs(
-                organization.data,
-                project.data,
-                instance.data
-              )
-            },
-            {
-              label: config.data.name ?? config.data.id,
-              href: Paths.instance.identity.delegationConfig(
-                organization.data,
-                project.data,
-                instance.data,
-                config.data.id
-              )
-            }
-          ]}
-        />
+  return (
+    <ContentLayout>
+      <PageHeader
+        title={config.data?.name ?? config.data?.id ?? '...'}
+        description={config.data?.description ?? undefined}
+        pagination={[
+          {
+            label: 'Delegation Configs',
+            href: Paths.instance.identity.delegationConfigs(
+              organization.data,
+              project.data,
+              instance.data
+            )
+          },
+          {
+            label: config.data?.name ?? config.data?.id ?? identityDelegationConfigId ?? '...',
+            href: Paths.instance.identity.delegationConfig(
+              organization.data,
+              project.data,
+              instance.data,
+              config.data?.id ?? identityDelegationConfigId
+            )
+          }
+        ]}
+      />
 
+      {renderWithLoader({ instance, organization, project, config })(() => (
         <Outlet />
-      </ContentLayout>
-    )
+      ))}
+    </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/delegation/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/delegation/_layout.tsx
@@ -19,42 +19,44 @@ export let IdentityDelegationLayout = () => {
   let owner = delegation.data?.parties.find(party => party.roles.includes('owner'));
   let delegatee = delegation.data?.parties.find(party => party.roles.includes('delegatee'));
 
-  return renderWithLoader({ instance, organization, project, delegation })(
-    ({ instance, organization, project, delegation }) => (
-      <ContentLayout>
-        <PageHeader
-          title={
-            owner?.actor.name && delegatee?.actor.name ? (
-              <>
-                {owner.actor.name} → {delegatee.actor.name}
-              </>
-            ) : (
-              'Identity Delegation'
+  return (
+    <ContentLayout>
+      <PageHeader
+        title={
+          owner?.actor.name && delegatee?.actor.name ? (
+            <>
+              {owner.actor.name} → {delegatee.actor.name}
+            </>
+          ) : delegation.data ? (
+            'Identity Delegation'
+          ) : (
+            '...'
+          )
+        }
+        pagination={[
+          {
+            label: 'Delegations',
+            href: Paths.instance.identity.delegations(
+              organization.data,
+              project.data,
+              instance.data
+            )
+          },
+          {
+            label: delegation.data?.id ?? identityDelegationId ?? '...',
+            href: Paths.instance.identity.delegation(
+              organization.data,
+              project.data,
+              instance.data,
+              delegation.data?.id ?? identityDelegationId
             )
           }
-          pagination={[
-            {
-              label: 'Delegations',
-              href: Paths.instance.identity.delegations(
-                organization.data,
-                project.data,
-                instance.data
-              )
-            },
-            {
-              label: delegation.data.id,
-              href: Paths.instance.identity.delegation(
-                organization.data,
-                project.data,
-                instance.data,
-                delegation.data.id
-              )
-            }
-          ]}
-        />
+        ]}
+      />
 
+      {renderWithLoader({ instance, organization, project, delegation })(() => (
         <Outlet />
-      </ContentLayout>
-    )
+      ))}
+    </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/identity/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/identity/_layout.tsx
@@ -21,13 +21,13 @@ export let IdentityLayout = () => {
   let pathname = useLocation().pathname;
   let navigate = useNavigate();
 
-  return renderWithLoader({ instance, organization, project, identity: _identity })(
-    ({ instance, organization, project, identity }) => (
-      <ContentLayout>
-        <PageHeader
-          title={identity.data.name ?? identity.data.id}
-          description={identity.data.description ?? undefined}
-          actions={
+  return (
+    <ContentLayout>
+      <PageHeader
+        title={_identity.data?.name ?? _identity.data?.id ?? '...'}
+        description={_identity.data?.description ?? undefined}
+        actions={
+          _identity.data ? (
             <Menu
               label="Delegate"
               items={[
@@ -43,11 +43,14 @@ export let IdentityLayout = () => {
                 }
               ]}
               onItemClick={itemId => {
+                if (!_identity.data || !instance.data || !organization.data || !project.data)
+                  return;
+
                 if (itemId === 'delegation') {
                   showIdentityDelegationFormModal({
                     instanceId: instance.data.id,
-                    identityId: identity.data.id,
-                    identityName: identity.data.name,
+                    identityId: _identity.data.id,
+                    identityName: _identity.data.name,
                     onCreate: delegation =>
                       navigate(
                         Paths.instance.identity.delegation(
@@ -63,8 +66,8 @@ export let IdentityLayout = () => {
 
                 showIdentityDelegationRequestFormModal({
                   instanceId: instance.data.id,
-                  identityId: identity.data.id,
-                  identityName: identity.data.name,
+                  identityId: _identity.data.id,
+                  identityName: _identity.data.name,
                   onCreate: request =>
                     navigate(
                       Paths.instance.identity.delegation(
@@ -79,75 +82,81 @@ export let IdentityLayout = () => {
             >
               <Button size="2">Delegate</Button>
             </Menu>
+          ) : undefined
+        }
+        pagination={[
+          {
+            label: 'Identities',
+            href: Paths.instance.identity.identities(
+              organization.data,
+              project.data,
+              instance.data
+            )
+          },
+          {
+            label: _identity.data?.name ?? _identity.data?.id ?? identityId ?? '...',
+            href: Paths.instance.identity.identity(
+              organization.data,
+              project.data,
+              instance.data,
+              _identity.data?.id ?? identityId
+            )
           }
-          pagination={[
-            {
-              label: 'Identities',
-              href: Paths.instance.identity.identities(
-                organization.data,
-                project.data,
-                instance.data
-              )
-            },
-            {
-              label: identity.data.name ?? identity.data.id,
-              href: Paths.instance.identity.identity(
-                organization.data,
-                project.data,
-                instance.data,
-                identity.data.id
-              )
-            }
-          ]}
-        />
+        ]}
+      />
 
-        <LinkTabs
-          current={pathname}
-          links={[
-            {
-              label: 'Overview',
-              to: Paths.instance.identity.identity(
-                organization.data,
-                project.data,
-                instance.data,
-                identity.data.id
-              )
-            },
-            {
-              label: 'Delegations',
-              to: Paths.instance.identity.identity(
-                organization.data,
-                project.data,
-                instance.data,
-                identity.data.id,
-                'delegations'
-              )
-            },
-            {
-              label: 'Delegation Requests',
-              to: Paths.instance.identity.identity(
-                organization.data,
-                project.data,
-                instance.data,
-                identity.data.id,
-                'delegation-requests'
-              )
-            },
-            {
-              label: 'Settings',
-              to: Paths.instance.identity.identity(
-                organization.data,
-                project.data,
-                instance.data,
-                identity.data.id,
-                'settings'
-              )
-            }
-          ]}
-        />
+      {renderWithLoader({ instance, organization, project, identity: _identity })(
+        ({ instance, organization, project, identity }) => (
+          <>
+            <LinkTabs
+              current={pathname}
+              links={[
+                {
+                  label: 'Overview',
+                  to: Paths.instance.identity.identity(
+                    organization.data,
+                    project.data,
+                    instance.data,
+                    identity.data.id
+                  )
+                },
+                {
+                  label: 'Delegations',
+                  to: Paths.instance.identity.identity(
+                    organization.data,
+                    project.data,
+                    instance.data,
+                    identity.data.id,
+                    'delegations'
+                  )
+                },
+                {
+                  label: 'Delegation Requests',
+                  to: Paths.instance.identity.identity(
+                    organization.data,
+                    project.data,
+                    instance.data,
+                    identity.data.id,
+                    'delegation-requests'
+                  )
+                },
+                {
+                  label: 'Settings',
+                  to: Paths.instance.identity.identity(
+                    organization.data,
+                    project.data,
+                    instance.data,
+                    identity.data.id,
+                    'settings'
+                  )
+                }
+              ]}
+            />
 
-        <Outlet />
-      </ContentLayout>
-    )
+            <Outlet />
+          </>
+        )
+      )}
+    </ContentLayout>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly UI/control-flow changes, but moving `PageHeader` and breadcrumb generation outside the loader could surface new runtime issues if `organization/project/instance` data isn’t guaranteed when those paths are built.
> 
> **Overview**
> Identity detail layouts for *actors, consumers, identities, delegations, and delegation configs* now render their `ContentLayout`/`PageHeader` outside `renderWithLoader`, using placeholder titles (`'...'`) and ID fallbacks so pages don’t crash while entity data is still loading.
> 
> Actions and navigation that require loaded data (e.g. `Create Identity`, `Delegate` menu) are now gated behind `*.data` checks/early returns, and the `LinkTabs`/`Outlet` content remains loader-protected so routes only render once required data is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6196246be4479b97e56193f500addf70317fd235. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->