### PR TITLE
feat/fix-provider-auth-config-flow-with-configs

### DIFF
--- a/src/backend/modules/consumer/src/services/consumerProviderCatalog.ts
+++ b/src/backend/modules/consumer/src/services/consumerProviderCatalog.ts
@@ -14,6 +14,7 @@ import {
   subspaceProviderService
 } from '@metorial/module-subspace';
 import {
+  getProviderVersionIdForAuthMethods,
   listProviderAuthMethods,
   type ConsumerProvider,
   type ConsumerProviderAuthMethodList,
@@ -795,7 +796,10 @@ class ConsumerProviderCatalogServiceImpl {
             }),
             listProviderAuthMethods({
               instance: d.instance,
-              providerVersionId: deployment.lockedVersion?.id
+              providerVersionId: getProviderVersionIdForAuthMethods({
+                deployment,
+                provider
+              })
             })
           ]);
 

--- a/src/backend/modules/consumer/src/services/consumerProviderCatalog.ts
+++ b/src/backend/modules/consumer/src/services/consumerProviderCatalog.ts
@@ -788,6 +788,10 @@ class ConsumerProviderCatalogServiceImpl {
           if (!deployment) {
             throw new ServiceError(notFoundError('provider.deployment'));
           }
+          let provider = providerMap.get(deployment.providerId);
+          if (!provider) {
+            throw new ServiceError(notFoundError('provider'));
+          }
 
           let [configSchema, authMethods] = await Promise.all([
             subspaceProviderConfigService.getConfigSchema({

--- a/src/backend/modules/consumer/src/services/consumerProviderContext.ts
+++ b/src/backend/modules/consumer/src/services/consumerProviderContext.ts
@@ -30,6 +30,32 @@ export type ConsumerProviderTemplateContext = {
   configSchema: ConsumerProviderConfigSchema | null;
 };
 
+let getProviderVersionIdForAuthMethods = (d: {
+  deployment: ConsumerProviderDeployment;
+  provider: ConsumerProvider;
+}) => {
+  if (d.deployment.lockedVersion?.id) {
+    return d.deployment.lockedVersion.id;
+  }
+
+  let currentVersion = (d.deployment as any).currentVersion as
+    | {
+        lockedVersionId?: string | null;
+        providerVersionId?: string | null;
+      }
+    | null
+    | undefined;
+
+  if (currentVersion?.lockedVersionId) {
+    return currentVersion.lockedVersionId;
+  }
+  if (currentVersion?.providerVersionId) {
+    return currentVersion.providerVersionId;
+  }
+
+  return d.provider.defaultVariant?.currentVersion?.id ?? null;
+};
+
 let loadBaseTemplateContext = async (d: {
   instance: Instance;
   providerTemplateId: string;
@@ -65,7 +91,10 @@ export let loadTemplateContextForSetup = async (d: {
   let context = await loadBaseTemplateContext(d);
   let authMethods = await listProviderAuthMethods({
     instance: d.instance,
-    providerVersionId: context.deployment.lockedVersion?.id
+    providerVersionId: getProviderVersionIdForAuthMethods({
+      deployment: context.deployment,
+      provider: context.provider
+    })
   });
 
   return {
@@ -81,10 +110,14 @@ export let loadTemplateContextForDeployment = async (d: {
   accessTags: AnyAccessTagSelector;
 }): Promise<ConsumerProviderTemplateContext> => {
   let context = await loadBaseTemplateContext(d);
+  let providerVersionId = getProviderVersionIdForAuthMethods({
+    deployment: context.deployment,
+    provider: context.provider
+  });
   let [authMethods, configSchema] = await Promise.all([
     listProviderAuthMethods({
       instance: d.instance,
-      providerVersionId: context.deployment.lockedVersion?.id
+      providerVersionId
     }),
     subspaceProviderConfigService.getConfigSchema({
       instance: d.instance,
@@ -121,3 +154,5 @@ export let listProviderAuthMethods = async (d: {
 export let getDefaultOauthMethod = (authMethods: ConsumerProviderAuthMethodList) => {
   return authMethods.find(authMethod => authMethod.type == 'oauth') ?? null;
 };
+
+export { getProviderVersionIdForAuthMethods };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/explorer/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/explorer/index.tsx
@@ -368,7 +368,12 @@ export let ExplorerPage = () => {
   let activeProvider = useProvider(instance.data?.id, activeProviderId ?? undefined);
 
   useEffect(() => {
-    if (!selectedProvider && activeProvider.data && selectedDeployment.data?.providerId) {
+    if (
+      !selectedProvider &&
+      !!providerDeploymentId &&
+      activeProvider.data &&
+      selectedDeployment.data?.providerId
+    ) {
       _setSelectedProvider(activeProvider.data);
       setSearch(
         v => {
@@ -378,7 +383,13 @@ export let ExplorerPage = () => {
         { replace: true }
       );
     }
-  }, [selectedProvider, activeProvider.data, selectedDeployment.data, setSearch]);
+  }, [
+    selectedProvider,
+    providerDeploymentId,
+    activeProvider.data,
+    selectedDeployment.data,
+    setSearch
+  ]);
 
   let effectiveVersionIdForAuth =
     selectedDeployment.data?.lockedVersion?.id ?? activeProvider.data?.currentVersion?.id;

--- a/src/frontend/apps/dashboard/src/slices/product/pages/explorer/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/explorer/index.tsx
@@ -268,21 +268,23 @@ export let ExplorerPage = () => {
   providerAuthConfigsRef.current = providerAuthConfigs;
 
   let pendingAuthConfigIdRef = useRef<string | null>(null);
+  let handleAuthConfigCreated = useCallback((authConfig: { id: string }) => {
+    pendingAuthConfigIdRef.current = authConfig.id;
+    setSelectedAuthConfigId(authConfig.id);
+    providerAuthConfigsRef.current.refetch();
+  }, []);
+
   let openAuthConfigCreateModal = useCallback(() => {
     if (!instance.data || !providerDeploymentId) return false;
 
     showProviderAuthConfigMethodPickerModal({
       instanceId: instance.data.id,
       providerDeploymentId,
-      onCreate: authConfig => {
-        pendingAuthConfigIdRef.current = authConfig.id;
-        setSelectedAuthConfigId(authConfig.id);
-        providerAuthConfigsRef.current.refetch();
-      }
+      onCreate: handleAuthConfigCreated
     });
 
     return true;
-  }, [instance.data, providerDeploymentId]);
+  }, [handleAuthConfigCreated, instance.data, providerDeploymentId]);
 
   useEffect(() => {
     let deploymentsForCurrentProvider = deployments.data?.items.filter(

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createModal.tsx
@@ -166,6 +166,7 @@ export let ProviderAuthConfigCreateFlowContent = (
             onCreate={p.onCreate}
             onCancel={p.onBack}
             onWindowOpenStateChange={p.onWindowOpenStateChange}
+            embedded={p.embedded}
           />
         );
       }

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createModal.tsx
@@ -4,7 +4,7 @@ import { type ReactElement, useEffect, useState } from 'react';
 import { useProviderAuthCreationCapabilities } from '../../lib/providerCreationCapabilities';
 import { ProviderAuthConfigManualCreateContent } from './createManualModal';
 import { ProviderAuthConfigSetupFlowCreateContent } from './createSetupFlowModal';
-import { closeAndThen, getAuthMethodHasSchema, isSetupFlowAuthMethod } from './modalHelpers';
+import { closeAndThen, isSetupFlowAuthMethod } from './modalHelpers';
 import { PreviewMode } from './previewSidebar';
 
 export type ProviderAuthConfigCreateModalProps = {
@@ -82,7 +82,7 @@ export let ProviderAuthConfigCreateFlowContent = (
     selectedMethod ??
     (authCreation.authMethodItems.length === 1 ? authCreation.authMethodItems[0] : undefined);
   let [previewMode, setPreviewMode] = useState<PreviewMode>(
-    effectiveAuthMethod?.type === 'oauth' && !getAuthMethodHasSchema(effectiveAuthMethod)
+    effectiveAuthMethod?.type === 'oauth'
       ? authCreation.oauthAutoRegistrationEnabled
         ? 'managed'
         : 'manual_existing'
@@ -90,10 +90,7 @@ export let ProviderAuthConfigCreateFlowContent = (
   );
 
   useEffect(() => {
-    if (
-      effectiveAuthMethod?.type === 'oauth' &&
-      !getAuthMethodHasSchema(effectiveAuthMethod)
-    ) {
+    if (effectiveAuthMethod?.type === 'oauth') {
       setPreviewMode(
         authCreation.oauthAutoRegistrationEnabled ? 'managed' : 'manual_existing'
       );

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createSetupFlowModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createSetupFlowModal.tsx
@@ -1,7 +1,9 @@
+import { instanceProviderAuthConfigsLoader } from '@metorial/state';
+import { Dialog, Spacer } from '@metorial/ui';
+import { useState } from 'react';
 import { ProviderSetupSessionEmbed } from '../providerDeployments/setupSessionEmbed';
 import { AuthMethod } from './modalHelpers';
 import { PreviewMode, SetupFlowLayout, SetupFlowPreviewSidebar } from './previewSidebar';
-import { instanceProviderAuthConfigsLoader } from '@metorial/state';
 
 export let ProviderAuthConfigSetupFlowCreateContent = (p: {
   instanceId: string;
@@ -16,47 +18,66 @@ export let ProviderAuthConfigSetupFlowCreateContent = (p: {
   onCreate?: (authConfig: { id: string }) => void;
   onCancel?: () => void;
   onWindowOpenStateChange?: (isOpen: boolean) => void;
+  embedded?: boolean;
 }) => {
-  return (
-    <SetupFlowLayout $showPreview={true}>
-      <div>
-        <ProviderSetupSessionEmbed
-          instanceId={p.instanceId}
-          providerId={p.providerId}
-          deploymentId={p.providerDeploymentId}
-          initialMethodId={p.selectedMethod.id}
-          hideMethodStep
-          hideCredentialsIntro
-          flattenOAuthCredentialsFlow
-          showExternalPreviewSidebar
-          collectAuthConfigDetails
-          cancelLabel={p.onCancel ? 'Close' : 'Cancel'}
-          onWindowOpenCancel={p.close}
-          windowOpenCancelLabel="Cancel"
-          onWindowOpenStateChange={p.onWindowOpenStateChange}
-          onPreviewModeChange={p.onPreviewModeChange}
-          onPreviewCredentialTypeChange={() => {}}
-          onActiveStepChange={() => {}}
-          onComplete={result => {
-            let authConfigId = result?.authConfig?.id;
-            if (authConfigId) {
-              void instanceProviderAuthConfigsLoader.refetchAll();
-              p.onCreate?.({ id: authConfigId });
-            }
-            p.close();
-          }}
-          onCancel={p.onCancel ?? p.close}
-        />
-      </div>
+  let [authPreviewDetails, setAuthPreviewDetails] = useState({ name: '', description: '' });
 
-      <SetupFlowPreviewSidebar
-        instanceId={p.instanceId}
-        providerName={p.providerName}
-        providerId={p.providerId}
-        providerImageUrl={p.providerImageUrl}
-        showBrandingLink={p.previewMode !== 'managed'}
-        previewMode={p.previewMode}
-      />
-    </SetupFlowLayout>
+  return (
+    <>
+      {!p.embedded && (
+        <>
+          <Dialog.Title>Create Auth Config</Dialog.Title>
+          <Dialog.Description>
+            Set up OAuth credentials, name this connection, and preview how users will see the
+            sign-in experience.
+          </Dialog.Description>
+          <Spacer size={12} />
+        </>
+      )}
+
+      <SetupFlowLayout $showPreview={true}>
+        <div>
+          <ProviderSetupSessionEmbed
+            instanceId={p.instanceId}
+            providerId={p.providerId}
+            deploymentId={p.providerDeploymentId}
+            initialMethodId={p.selectedMethod.id}
+            hideMethodStep
+            hideCredentialsIntro
+            flattenOAuthCredentialsFlow
+            showExternalPreviewSidebar
+            collectAuthConfigDetails
+            onAuthConfigDetailsChange={setAuthPreviewDetails}
+            cancelLabel={p.onCancel ? 'Close' : 'Cancel'}
+            onWindowOpenCancel={p.close}
+            windowOpenCancelLabel="Cancel"
+            onWindowOpenStateChange={p.onWindowOpenStateChange}
+            onPreviewModeChange={p.onPreviewModeChange}
+            onPreviewCredentialTypeChange={() => {}}
+            onActiveStepChange={() => {}}
+            onComplete={result => {
+              let authConfigId = result?.authConfig?.id;
+              if (authConfigId) {
+                void instanceProviderAuthConfigsLoader.refetchAll();
+                p.onCreate?.({ id: authConfigId });
+              }
+              p.close();
+            }}
+            onCancel={p.onCancel ?? p.close}
+          />
+        </div>
+
+        <SetupFlowPreviewSidebar
+          instanceId={p.instanceId}
+          providerName={p.providerName}
+          providerId={p.providerId}
+          providerImageUrl={p.providerImageUrl}
+          showBrandingLink={p.previewMode !== 'managed'}
+          previewMode={p.previewMode}
+          previewAuthName={authPreviewDetails.name}
+          previewAuthDescription={authPreviewDetails.description}
+        />
+      </SetupFlowLayout>
+    </>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/form.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/form.tsx
@@ -43,6 +43,12 @@ let getAuthMethodHasSchema = (method: AuthMethod | undefined) => {
   );
 };
 
+let authConfigDescriptionInputHints = {
+  description:
+    'Optional context for your team about what this connection is used for.',
+  placeholder: 'e.g. Production workspace for the CRM sync'
+};
+
 export type ProviderAuthConfigFormProps =
   | {
       type: 'create';
@@ -421,7 +427,11 @@ export let ProviderAuthConfigForm = (
                 />
                 <form.RenderError field="name" />
 
-                <Input label="Description" {...form.getFieldProps('description')} />
+                <Input
+                  label="Description"
+                  {...authConfigDescriptionInputHints}
+                  {...form.getFieldProps('description')}
+                />
                 <form.RenderError field="description" />
               </FlatCreateSection>
             </FlatCreateSections>
@@ -568,7 +578,11 @@ export let ProviderAuthConfigForm = (
 
           <Spacer size={10} />
 
-          <Input label="Description" {...form.getFieldProps('description')} />
+          <Input
+            label="Description"
+            {...authConfigDescriptionInputHints}
+            {...form.getFieldProps('description')}
+          />
           <form.RenderError field="description" />
 
           <Spacer size={15} />
@@ -631,7 +645,11 @@ export let ProviderAuthConfigForm = (
 
         <Spacer size={10} />
 
-        <Input label="Description" {...form.getFieldProps('description')} />
+        <Input
+          label="Description"
+          {...authConfigDescriptionInputHints}
+          {...form.getFieldProps('description')}
+        />
         <form.RenderError field="description" />
 
         <Spacer size={10} />

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/methodPickerModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/methodPickerModal.tsx
@@ -1,7 +1,7 @@
 import { useForm } from '@metorial/data-hooks';
 import { useProviderDeployment } from '@metorial/state';
 import { Button, CenteredSpinner, Dialog, Spacer, showModal } from '@metorial/ui';
-import { useEffect } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useProviderAuthCreationCapabilities } from '../../lib/providerCreationCapabilities';
 import { AuthMethodPicker } from './authMethodPicker';
 import { closeAndThen, getCreateMethodDescription } from './modalHelpers';
@@ -9,6 +9,8 @@ import {
   ProviderAuthConfigCreateModalProps,
   showProviderAuthConfigCreateModal
 } from './createModal';
+
+let lastSingleMethodAutoAdvance: { key: string; at: number } = { key: '', at: 0 };
 
 let ProviderAuthConfigMethodPickerModalContent = (
   p: Omit<ProviderAuthConfigCreateModalProps, 'initialAuthMethodId'> & {
@@ -22,6 +24,19 @@ let ProviderAuthConfigMethodPickerModalContent = (
     p.providerId ?? deployment.data?.providerId
   );
   let providerName = authCreation.provider.data?.name ?? deployment.data?.name ?? 'provider';
+
+  let onCreateRef = useRef(p.onCreate);
+  let onBackRef = useRef(p.onBack);
+  useEffect(() => {
+    onCreateRef.current = p.onCreate;
+    onBackRef.current = p.onBack;
+  });
+
+  let singleMethodId = useMemo(() => {
+    if (authCreation.authMethodItems.length !== 1) return null;
+    return authCreation.authMethodItems[0]?.id ?? null;
+  }, [authCreation.authMethodItems.length, authCreation.authMethodItems[0]?.id]);
+
   let form = useForm({
     initialValues: {
       authMethodId: ''
@@ -59,28 +74,37 @@ let ProviderAuthConfigMethodPickerModalContent = (
 
   useEffect(() => {
     if (authCreation.isLoading || !authCreation.canCreateAuthConfig) return;
-    if (authCreation.authMethodItems.length !== 1) return;
+    if (!singleMethodId) return;
+
+    let dedupeKey = `${p.instanceId}:${p.providerDeploymentId ?? ''}:${singleMethodId}`;
+    let now = Date.now();
+    if (
+      lastSingleMethodAutoAdvance.key === dedupeKey &&
+      now - lastSingleMethodAutoAdvance.at < 600
+    ) {
+      return;
+    }
+
+    lastSingleMethodAutoAdvance = { key: dedupeKey, at: now };
 
     closeAndThen(p.close, () =>
       showProviderAuthConfigCreateModal({
         instanceId: p.instanceId,
         providerDeploymentId: p.providerDeploymentId,
         providerId: p.providerId,
-        initialAuthMethodId: authCreation.authMethodItems[0]!.id,
-        onCreate: p.onCreate,
-        onBack: p.onBack
+        initialAuthMethodId: singleMethodId,
+        onCreate: onCreateRef.current,
+        onBack: onBackRef.current
       })
     );
   }, [
     authCreation.isLoading,
     authCreation.canCreateAuthConfig,
-    authCreation.authMethodItems,
+    singleMethodId,
     p.close,
     p.instanceId,
     p.providerDeploymentId,
-    p.providerId,
-    p.onCreate,
-    p.onBack
+    p.providerId
   ]);
 
   useEffect(() => {
@@ -94,7 +118,8 @@ let ProviderAuthConfigMethodPickerModalContent = (
   }, [
     authCreation.isLoading,
     authCreation.canCreateAuthConfig,
-    authCreation.authMethodItems,
+    authCreation.authMethodItems.length,
+    authCreation.authMethodItems[0]?.id,
     form.values.authMethodId,
     form.setFieldValue
   ]);

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/modalHelpers.ts
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/modalHelpers.ts
@@ -26,7 +26,7 @@ export let getAuthMethodHasSchema = (method: AuthMethod | undefined) => {
 };
 
 export let isSetupFlowAuthMethod = (method: AuthMethod | undefined) =>
-  method?.type === 'oauth' && !getAuthMethodHasSchema(method);
+  method?.type === 'oauth';
 
 export let getCreateMethodDescription = (method: AuthMethod) => {
   if (isSetupFlowAuthMethod(method)) {

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/modalHelpers.ts
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/modalHelpers.ts
@@ -29,12 +29,8 @@ export let isSetupFlowAuthMethod = (method: AuthMethod | undefined) =>
   method?.type === 'oauth';
 
 export let getCreateMethodDescription = (method: AuthMethod) => {
-  if (isSetupFlowAuthMethod(method)) {
-    return 'OAuth setup flow';
-  }
-
   if (method.type === 'oauth') {
-    return 'Manual credentials';
+    return getAuthMethodHasSchema(method) ? 'Manual credentials' : 'OAuth setup flow';
   }
 
   return 'Manual configuration';

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/previewSidebar.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/previewSidebar.tsx
@@ -277,6 +277,8 @@ export let SetupFlowPreviewSidebar = (p: {
   providerImageUrl?: string | null;
   showBrandingLink?: boolean;
   previewMode?: PreviewMode;
+  previewAuthName?: string;
+  previewAuthDescription?: string;
 }) => {
   let organization = useCurrentOrganization();
   let project = useCurrentProject();
@@ -289,6 +291,12 @@ export let SetupFlowPreviewSidebar = (p: {
   let projectBrandName = projectBrand.data?.name ?? project.data?.name ?? 'Metorial';
   let resolvedProviderImageUrl = providerListing?.imageUrl ?? p.providerImageUrl;
   let previewMode = p.previewMode ?? 'manual_existing';
+  let previewHeadline = p.previewAuthName?.trim()
+    ? p.previewAuthName.trim()
+    : 'Sign in required';
+  let previewSubtext = p.previewAuthDescription?.trim()
+    ? p.previewAuthDescription.trim()
+    : "You'll be redirected to connect your account.";
   let previewBrandImageUrl = projectBrandImageUrl;
   let previewBrandName = projectBrandName;
   let previewBrandInitial = previewBrandName.charAt(0).toUpperCase();
@@ -382,10 +390,10 @@ export let SetupFlowPreviewSidebar = (p: {
 
               <SetupFlowPreviewBody>
                 <Text size="4" weight="strong">
-                  Sign in required
+                  {previewHeadline}
                 </Text>
                 <Text size="2" color="gray600">
-                  You&apos;ll be redirected to connect your account.
+                  {previewSubtext}
                 </Text>
 
                 <Spacer size={15} />

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed.tsx
@@ -216,6 +216,7 @@ export let ProviderSetupSessionEmbed = ({
   flattenOAuthCredentialsFlow = false,
   showExternalPreviewSidebar = false,
   collectAuthConfigDetails = false,
+  onAuthConfigDetailsChange,
   onPreviewCredentialTypeChange,
   onPreviewModeChange,
   onActiveStepChange
@@ -239,6 +240,7 @@ export let ProviderSetupSessionEmbed = ({
   flattenOAuthCredentialsFlow?: boolean;
   showExternalPreviewSidebar?: boolean;
   collectAuthConfigDetails?: boolean;
+  onAuthConfigDetailsChange?: (details: { name: string; description: string }) => void;
   onPreviewCredentialTypeChange?: (type: 'managed' | 'manual') => void;
   onPreviewModeChange?: (mode: 'managed' | 'manual_existing' | 'manual_new') => void;
   onActiveStepChange?: (step: 'method' | 'credentials' | 'connect') => void;
@@ -505,6 +507,20 @@ export let ProviderSetupSessionEmbed = ({
         description: yup.string().ensure()
       })
   });
+
+  useEffect(() => {
+    if (!collectAuthConfigDetails || !onAuthConfigDetailsChange) return;
+
+    onAuthConfigDetailsChange({
+      name: authConfigDetailsForm.values.name,
+      description: authConfigDetailsForm.values.description
+    });
+  }, [
+    collectAuthConfigDetails,
+    onAuthConfigDetailsChange,
+    authConfigDetailsForm.values.name,
+    authConfigDetailsForm.values.description
+  ]);
 
   useEffect(() => {
     if (!onPreviewCredentialTypeChange) return;
@@ -1018,6 +1034,8 @@ export let ProviderSetupSessionEmbed = ({
 
         <Input
           label="Description"
+          description="Optional context for your team about what this connection is used for."
+          placeholder="e.g. Production workspace for the CRM sync"
           {...authConfigDetailsForm.getFieldProps('description')}
           disabled={p.disabled}
         />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes provider-version selection for listing auth methods and refactors the dashboard auth-config creation/setup flow, which could affect which auth methods users see and how OAuth setup proceeds. Risk is moderate due to multi-path UI flow changes and new version fallback logic.
> 
> **Overview**
> **Improves auth-method resolution for deployments** by introducing `getProviderVersionIdForAuthMethods` and using it when listing auth methods (falling back from `deployment.lockedVersion` to deployment current version IDs and finally provider defaults).
> 
> **Refines the dashboard auth-config creation UX**: OAuth methods now consistently use the setup-flow modal, the method picker auto-advances more safely for single-method providers (deduped + stable callbacks), and the setup-flow preview sidebar now reflects the auth config name/description entered during setup. Also adds consistent description field hints and small state/guard fixes in Explorer when selecting providers/deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6106444d9ee42a2dbbe481a368ce9d124be52a34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->