### PR TITLE
Add portal multi region sync

### DIFF
--- a/src/backend/db/prisma/schema/cells/organization.prisma
+++ b/src/backend/db/prisma/schema/cells/organization.prisma
@@ -1,0 +1,18 @@
+model CellOrganization {
+  id String @id
+
+  type   OrganizationType
+  status OrganizationStatus
+
+  slug String @unique
+  name String
+
+  isOwnedByDeployment Boolean
+
+  /// [EntityImage]
+  image Json
+
+  deletedAt DateTime?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @default(now()) @updatedAt
+}

--- a/src/backend/db/prisma/schema/cells/portal.prisma
+++ b/src/backend/db/prisma/schema/cells/portal.prisma
@@ -1,0 +1,16 @@
+model CellPortal {
+  id String @id
+
+  status PortalStatus
+
+  name        String
+  description String?
+  slug        String  @unique
+
+  isOwnedByDeployment Boolean
+
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @default(now()) @updatedAt
+  archivedAt DateTime?
+  deletedAt  DateTime?
+}

--- a/src/backend/db/prisma/schema/portal/portal.prisma
+++ b/src/backend/db/prisma/schema/portal/portal.prisma
@@ -23,9 +23,10 @@ model Portal {
   instanceOid BigInt
   instance    Instance @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
 
-  createdAt         DateTime           @default(now())
-  updatedAt         DateTime           @default(now()) @updatedAt
-  archivedAt        DateTime?
-  deletedAt         DateTime?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @default(now()) @updatedAt
+  archivedAt DateTime?
+  deletedAt  DateTime?
+
   portalAuthClients PortalAuthClient[]
 }

--- a/src/backend/modules/organization/src/services/organization.ts
+++ b/src/backend/modules/organization/src/services/organization.ts
@@ -30,7 +30,9 @@ import { organizationMemberService } from './organizationMember';
 import { projectService } from './project';
 
 let getOrgSlug = createSlugGenerator(
-  async slug => !(await db.organization.findFirst({ where: { slug } }))
+  async slug =>
+    !(await db.organization.findFirst({ where: { slug } })) &&
+    !(await db.cellOrganization.findFirst({ where: { slug } }))
 );
 
 class OrganizationService {

--- a/src/backend/modules/portal/src/services/portal.ts
+++ b/src/backend/modules/portal/src/services/portal.ts
@@ -40,9 +40,11 @@ let include = {
   }
 } as const;
 
-let getPortalSlug = createSlugGenerator(async slug => {
-  return !(await db.portal.findFirst({ where: { slug } }));
-});
+let getPortalSlug = createSlugGenerator(
+  async slug =>
+    !(await db.portal.findFirst({ where: { slug } })) &&
+    !(await db.cellPortal.findFirst({ where: { slug } }))
+);
 
 let getPortalRedirectDomains = () => {
   return env.portal.PORTAL_REDIRECT_DOMAINS.split(',')

--- a/src/backend/modules/portal/src/services/portal.ts
+++ b/src/backend/modules/portal/src/services/portal.ts
@@ -1,23 +1,24 @@
-import {
-  notFoundError,
-  preconditionFailedError,
-  ServiceError
-} from '@lowerdeck/error';
+import { notFoundError, preconditionFailedError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import { createSlugGenerator } from '@lowerdeck/slugify';
 import { Context } from '@metorial/context';
-import { db, getOrganizationBrand, ID, Instance, Organization, Portal } from '@metorial/db';
+import {
+  db,
+  getOrganizationBrand,
+  ID,
+  Instance,
+  Organization,
+  Portal,
+  withTransaction
+} from '@metorial/db';
+import { Fabric } from '@metorial/fabric';
 import {
   consumerSurfaceService,
   type ConsumerSurfaceWithPublishableApiKey
 } from '@metorial/module-consumer';
 import { env } from '../env';
-import {
-  buildPortalUrlFromTemplate,
-  getPortalUrlTemplate,
-  parsePortalIdFromTemplate
-} from '../portalUrlTemplate';
+import { buildPortalUrlFromTemplate, parsePortalIdFromTemplate } from '../portalUrlTemplate';
 
 let include = {
   surface: {
@@ -174,18 +175,29 @@ class PortalServiceImpl {
         surface
       });
 
-      return await db.portal.create({
-        data: {
-          id: portalId,
-          status: 'active',
-          name: d.input.name,
-          description: d.input.description,
-          slug,
-          organizationOid: d.organization.oid,
-          surfaceOid: surface.oid,
-          instanceOid: d.instance.oid
-        },
-        include
+      return await withTransaction(async db => {
+        await Fabric.fire('portal.created:before', d);
+
+        let portal = await db.portal.create({
+          data: {
+            id: portalId,
+            status: 'active',
+            name: d.input.name,
+            description: d.input.description,
+            slug,
+            organizationOid: d.organization.oid,
+            surfaceOid: surface.oid,
+            instanceOid: d.instance.oid
+          },
+          include
+        });
+
+        await Fabric.fire('portal.created:after', {
+          ...d,
+          portal
+        });
+
+        return portal;
       });
     } catch (error) {
       await Promise.allSettled([
@@ -225,15 +237,26 @@ class PortalServiceImpl {
       }
     });
 
-    let portal = await db.portal.update({
-      where: {
-        oid: d.portal.oid
-      },
-      data: {
-        name: d.input.name,
-        description: d.input.description
-      },
-      include
+    let portal = await withTransaction(async db => {
+      await Fabric.fire('portal.updated:before', d);
+
+      let portal = await db.portal.update({
+        where: {
+          oid: d.portal.oid
+        },
+        data: {
+          name: d.input.name,
+          description: d.input.description
+        },
+        include
+      });
+
+      await Fabric.fire('portal.updated:after', {
+        ...d,
+        portal
+      });
+
+      return portal;
     });
 
     surface = await this.configurePortalAres({
@@ -265,15 +288,25 @@ class PortalServiceImpl {
       consumerSurface: d.portal.surface
     });
 
-    return await db.portal.update({
-      where: {
-        oid: d.portal.oid
-      },
-      data: {
-        status: 'archived',
-        archivedAt: new Date()
-      },
-      include
+    return await withTransaction(async db => {
+      await Fabric.fire('portal.archived:before', d);
+
+      let portal = await db.portal.update({
+        where: {
+          oid: d.portal.oid
+        },
+        data: {
+          status: 'archived',
+          archivedAt: new Date()
+        },
+        include
+      });
+
+      await Fabric.fire('portal.archived:after', {
+        portal
+      });
+
+      return portal;
     });
   }
 
@@ -299,4 +332,7 @@ class PortalServiceImpl {
   }
 }
 
-export let portalService = Service.create('portalService', () => new PortalServiceImpl()).build();
+export let portalService = Service.create(
+  'portalService',
+  () => new PortalServiceImpl()
+).build();

--- a/src/backend/multi-region/prisma/schema/cell.prisma
+++ b/src/backend/multi-region/prisma/schema/cell.prisma
@@ -9,6 +9,7 @@ model Cell {
   updatedAt DateTime @default(now()) @updatedAt
 
   organizations                     Organization[]
+  portals                           Portal[]
   users                             User[]
   oauthApplications                 OAuthApplication[]
   oauthAuthorizationRequestsCreated OAuthAuthorizationRequest[] @relation("createdBy")

--- a/src/backend/multi-region/prisma/schema/organization.prisma
+++ b/src/backend/multi-region/prisma/schema/organization.prisma
@@ -28,4 +28,5 @@ model Organization {
   updatedAt DateTime  @default(now()) @updatedAt
 
   oauthApplications OAuthApplication[]
+  portals           Portal[]
 }

--- a/src/backend/multi-region/prisma/schema/portal.prisma
+++ b/src/backend/multi-region/prisma/schema/portal.prisma
@@ -1,0 +1,28 @@
+enum PortalStatus {
+  active
+  archived
+  deleted
+}
+
+model Portal {
+  id String @id
+
+  status PortalStatus
+
+  name        String
+  description String?
+  slug        String  @unique
+
+  ownerOid Int
+  owner    Cell @relation(fields: [ownerOid], references: [oid])
+
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  instanceId String
+
+  archivedAt DateTime?
+  deletedAt  DateTime?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @default(now()) @updatedAt
+}

--- a/src/backend/multi-region/src/sync/fromDeployment/index.ts
+++ b/src/backend/multi-region/src/sync/fromDeployment/index.ts
@@ -1,5 +1,4 @@
 import { combineQueueProcessors } from '@lowerdeck/queue';
-
 import {
   syncAppsCron,
   syncAppsManyQueueProcessor,
@@ -10,6 +9,11 @@ import {
   syncOrgSingleQueueProcessor,
   syncOrgsManyQueueProcessor
 } from './organization';
+import {
+  syncPortalsCron,
+  syncPortalSingleQueueProcessor,
+  syncPortalsManyQueueProcessor
+} from './portal';
 import {
   syncUsersCron,
   syncUserSingleQueueProcessor,
@@ -24,6 +28,10 @@ export let fromDeploymentSyncProcessors = combineQueueProcessors([
   syncUsersCron,
   syncUsersManyQueueProcessor,
   syncUserSingleQueueProcessor,
+
+  syncPortalsCron,
+  syncPortalsManyQueueProcessor,
+  syncPortalSingleQueueProcessor,
 
   syncAppsCron,
   syncAppsManyQueueProcessor,

--- a/src/backend/multi-region/src/sync/fromDeployment/portal.ts
+++ b/src/backend/multi-region/src/sync/fromDeployment/portal.ts
@@ -1,0 +1,99 @@
+import { createCron } from '@metorial/cron';
+import { addAfterTransactionHook, db } from '@metorial/db';
+import { Fabric } from '@metorial/fabric';
+import { createQueue } from '@metorial/queue';
+import { cell } from '../../cell';
+import { globalDB } from '../../db';
+
+export let syncPortalsCron = createCron(
+  {
+    name: 'global/sync/from-deployment/portal',
+    cron: process.env.NODE_ENV == 'production' ? '0 * * * *' : '* * * * *'
+  },
+  async () => {
+    await syncPortalsManyQueue.add({});
+  }
+);
+
+let syncPortalsManyQueue = createQueue<{ cursor?: string }>({
+  name: 'global/sync/from-deployment/portal-many'
+});
+
+export let syncPortalsManyQueueProcessor = syncPortalsManyQueue.process(async data => {
+  let portals = await db.portal.findMany({
+    where: {
+      id: { gt: data.cursor }
+    },
+    orderBy: { id: 'asc' },
+    take: 100,
+    select: { id: true }
+  });
+  if (portals.length === 0) return;
+
+  await syncPortalSingleQueue.addMany(portals.map(portal => ({ portalId: portal.id })));
+
+  await syncPortalsManyQueue.add({ cursor: portals[portals.length - 1].id });
+});
+
+let syncPortalSingleQueue = createQueue<{ portalId: string }>({
+  name: 'global/sync/from-deployment/portal-single'
+});
+
+export let syncPortalSingleQueueProcessor = syncPortalSingleQueue.process(async data => {
+  let portal = await db.portal.findUnique({
+    where: { id: data.portalId },
+    include: {
+      organization: {
+        select: {
+          id: true
+        }
+      },
+      instance: {
+        select: {
+          id: true
+        }
+      }
+    }
+  });
+  if (!portal) return;
+
+  let inner = {
+    status: portal.status,
+    name: portal.name,
+    description: portal.description,
+    slug: portal.slug,
+    organizationId: portal.organization.id,
+    instanceId: portal.instance.id,
+    archivedAt: portal.archivedAt,
+    deletedAt: portal.deletedAt,
+    createdAt: portal.createdAt,
+    ownerOid: (await cell).oid
+  };
+
+  await globalDB.portal.upsert({
+    where: { id: portal.id },
+    update: inner,
+    create: {
+      id: portal.id,
+      ...inner
+    }
+  });
+});
+
+Fabric.listen('portal.created:after', async event => {
+  await addAfterTransactionHook(() =>
+    syncPortalSingleQueue.add({ portalId: event.portal.id })
+  );
+});
+
+Fabric.listen('portal.updated:after', async event => {
+  await addAfterTransactionHook(() =>
+    syncPortalSingleQueue.add({ portalId: event.portal.id })
+  );
+});
+
+Fabric.listen('portal.archived:after', async event => {
+  await addAfterTransactionHook(() =>
+    syncPortalSingleQueue.add({ portalId: event.portal.id })
+  );
+});

--- a/src/backend/multi-region/src/sync/toDeployment/index.ts
+++ b/src/backend/multi-region/src/sync/toDeployment/index.ts
@@ -1,12 +1,15 @@
 import { combineQueueProcessors } from '@lowerdeck/queue';
-import { syncCron } from '@metorial-enterprise/federation-payment/src/cron/sync';
 import { syncOAuthAppToDeploymentQueueProcessor } from './oauth';
-import { syncToDeploymentQueueProcessor } from './sync';
+import { syncOrganizationToDeploymentQueueProcessor } from './organization';
+import { syncPortalToDeploymentQueueProcessor } from './portal';
+import { syncCron, syncToDeploymentQueueProcessor } from './sync';
 import { syncUserToDeploymentQueueProcessor } from './user';
 
 export let toDeploymentSyncProcessors = combineQueueProcessors([
   syncToDeploymentQueueProcessor,
   syncUserToDeploymentQueueProcessor,
+  syncOrganizationToDeploymentQueueProcessor,
+  syncPortalToDeploymentQueueProcessor,
   syncOAuthAppToDeploymentQueueProcessor,
   syncCron
 ]);

--- a/src/backend/multi-region/src/sync/toDeployment/organization.ts
+++ b/src/backend/multi-region/src/sync/toDeployment/organization.ts
@@ -1,0 +1,42 @@
+import { db } from '@metorial/db';
+import { createQueue } from '@metorial/queue';
+import { cell } from '../../cell';
+import { Organization } from '../../db';
+
+export let syncOrganizationToDeploymentQueue = createQueue<{
+  organization: Organization;
+}>({
+  name: 'global/sync/to-deployment/organization'
+});
+
+export let syncOrganizationToDeploymentQueueProcessor =
+  syncOrganizationToDeploymentQueue.process(async data => {
+    let organization = data.organization;
+
+    await db.cellOrganization.upsert({
+      where: { id: organization.id },
+      update: {
+        status: organization.status,
+        type: organization.type,
+        slug: organization.slug,
+        name: organization.name,
+        image: organization.image,
+        isOwnedByDeployment: organization.ownerOid === (await cell).oid,
+        deletedAt: organization.deletedAt,
+        createdAt: organization.createdAt,
+        updatedAt: organization.updatedAt
+      },
+      create: {
+        id: organization.id,
+        status: organization.status,
+        type: organization.type,
+        slug: organization.slug,
+        name: organization.name,
+        image: organization.image,
+        isOwnedByDeployment: organization.ownerOid === (await cell).oid,
+        deletedAt: organization.deletedAt,
+        createdAt: organization.createdAt,
+        updatedAt: organization.updatedAt
+      }
+    });
+  });

--- a/src/backend/multi-region/src/sync/toDeployment/portal.ts
+++ b/src/backend/multi-region/src/sync/toDeployment/portal.ts
@@ -1,0 +1,43 @@
+import { db } from '@metorial/db';
+import { createQueue } from '@metorial/queue';
+import { cell } from '../../cell';
+import { Portal } from '../../db';
+
+export let syncPortalToDeploymentQueue = createQueue<{
+  portal: Portal;
+}>({
+  name: 'global/sync/to-deployment/portal'
+});
+
+export let syncPortalToDeploymentQueueProcessor = syncPortalToDeploymentQueue.process(
+  async data => {
+    let portal = data.portal;
+
+    await db.cellPortal.upsert({
+      where: { id: portal.id },
+      update: {
+        status: portal.status,
+        name: portal.name,
+        description: portal.description,
+        slug: portal.slug,
+        isOwnedByDeployment: portal.ownerOid === (await cell).oid,
+        archivedAt: portal.archivedAt,
+        deletedAt: portal.deletedAt,
+        createdAt: portal.createdAt,
+        updatedAt: portal.updatedAt
+      },
+      create: {
+        id: portal.id,
+        status: portal.status,
+        name: portal.name,
+        description: portal.description,
+        slug: portal.slug,
+        isOwnedByDeployment: portal.ownerOid === (await cell).oid,
+        archivedAt: portal.archivedAt,
+        deletedAt: portal.deletedAt,
+        createdAt: portal.createdAt,
+        updatedAt: portal.updatedAt
+      }
+    });
+  }
+);

--- a/src/backend/multi-region/src/sync/toDeployment/sync.ts
+++ b/src/backend/multi-region/src/sync/toDeployment/sync.ts
@@ -3,6 +3,8 @@ import { createQueue } from '@metorial/queue';
 import { cell } from '../../cell';
 import { globalDB } from '../../db';
 import { syncOAuthAppToDeploymentQueue } from './oauth';
+import { syncOrganizationToDeploymentQueue } from './organization';
+import { syncPortalToDeploymentQueue } from './portal';
 import { syncUserToDeploymentQueue } from './user';
 
 let syncToDeploymentQueue = createQueue({
@@ -37,6 +39,42 @@ export let syncToDeploymentQueueProcessor = syncToDeploymentQueue.process(async 
     userCursor = users[users.length - 1].id as string;
   }
 
+  let organizationCursor: string | undefined = undefined;
+  while (true) {
+    let organizations = await globalDB.organization.findMany({
+      where: {
+        id: { gt: organizationCursor },
+        updatedAt: timeRange
+      },
+      orderBy: { id: 'asc' },
+      take: 100
+    });
+    if (organizations.length === 0) break;
+
+    await syncOrganizationToDeploymentQueue.addMany(
+      organizations.map(organization => ({ organization }))
+    );
+
+    organizationCursor = organizations[organizations.length - 1].id as string;
+  }
+
+  let portalCursor: string | undefined = undefined;
+  while (true) {
+    let portals = await globalDB.portal.findMany({
+      where: {
+        id: { gt: portalCursor },
+        updatedAt: timeRange
+      },
+      orderBy: { id: 'asc' },
+      take: 100
+    });
+    if (portals.length === 0) break;
+
+    await syncPortalToDeploymentQueue.addMany(portals.map(portal => ({ portal })));
+
+    portalCursor = portals[portals.length - 1].id as string;
+  }
+
   let oAuthAppCursor: string | undefined = undefined;
   while (true) {
     let oAuthApps = await globalDB.oAuthApplication.findMany({
@@ -64,7 +102,7 @@ export let syncToDeploymentQueueProcessor = syncToDeploymentQueue.process(async 
   await syncToDeploymentQueue.add({}, { delay: 1000, id: 'sync' });
 });
 
-let syncCron = createCron(
+export let syncCron = createCron(
   {
     name: 'global/sync/to-deployment/cron',
     cron: '* * * * *'

--- a/src/packages/backend/fabric/src/types.ts
+++ b/src/packages/backend/fabric/src/types.ts
@@ -15,6 +15,7 @@ import {
   OrganizationInvite,
   OrganizationInviteJoin,
   OrganizationMember,
+  Portal,
   Project,
   ServiceAccount,
   ServiceAccountCredential,
@@ -263,6 +264,13 @@ export interface FabricEvents {
   'machine_access.service_account.archived:after': { serviceAccount: ServiceAccount; oauthApplication: OAuthApplication; organization: Organization; performedBy: OrganizationActor; context: Context; };
   'machine_access.service_account_credential.created:before': { serviceAccount: ServiceAccount; oauthApplication: OAuthApplication; oauthInstallation: OAuthInstallation; oauthAuthorization: OAuthAuthorization; organization: Organization; appActor: OrganizationActor | null; context?: Context; };
   'machine_access.service_account_credential.created:after': { serviceAccount: ServiceAccount; serviceAccountCredential: ServiceAccountCredential; oauthApplication: OAuthApplication; oauthInstallation: OAuthInstallation; oauthAuthorization: OAuthAuthorization; organization: Organization; appActor: OrganizationActor | null; context?: Context; };
+
+  'portal.created:before': { organization: Organization; instance: Instance; context: Context; input: { name: string; description?: string; sessionExpiryTimeInSeconds?: number; } };
+  'portal.created:after': { organization: Organization; instance: Instance; portal: Portal; context: Context; input: { name: string; description?: string; sessionExpiryTimeInSeconds?: number; } };
+  'portal.updated:before': { portal: Portal; input: { name?: string; description?: string; sessionExpiryTimeInSeconds?: number; } };
+  'portal.updated:after': { portal: Portal; input: { name?: string; description?: string; sessionExpiryTimeInSeconds?: number; } };
+  'portal.archived:before': { portal: Portal };
+  'portal.archived:after': { portal: Portal };
 
   'provider.deployment.created:before': ProviderEventBase;
   'provider.deployment.created:after': ProviderEventBase & { deployment: SubspaceProviderDeployment };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new Prisma models and bidirectional multi-region sync for `Portal`, plus event hooks and transactional behavior in portal mutations; issues could lead to replication lag, duplicate slugs, or inconsistent portal state across regions.
> 
> **Overview**
> Adds multi-region replication support for portals by introducing `CellPortal`/`Portal` Prisma models (plus new relations on `Cell`/`Organization`) and wiring new from-deployment and to-deployment sync queues/crons to upsert portal records across regions.
> 
> Updates portal lifecycle operations (`createPortal`, `updatePortal`, `archivePortal`) to run inside `withTransaction` and emit new Fabric events (`portal.*`) used to trigger incremental sync after commit; also extends org/portal slug generation to avoid collisions with `cellOrganization`/`cellPortal` records.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f700e6a60e8c94a1515d3a2b6b7332891e7d80b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->