### PR TITLE
Keep multi region connections open

### DIFF
--- a/src/backend/multi-region/src/db/index.ts
+++ b/src/backend/multi-region/src/db/index.ts
@@ -1,9 +1,11 @@
 import { Signer } from '@aws-sdk/rds-signer';
 import { delay } from '@lowerdeck/delay';
 import { PrismaPg } from '@prisma/adapter-pg';
-import type pg from 'pg';
+import pg from 'pg';
 import { PrismaClient } from '../../prisma/generated/client.js';
 export * from '../../prisma/generated/client.js';
+
+let { Pool } = pg;
 
 let getGlobalDatabaseRegion = (url: URL) => {
   let arnRegion = process.env.GLOBAL_DATABASE_ARN?.split(':')[3];
@@ -16,6 +18,29 @@ let getGlobalDatabaseRegion = (url: URL) => {
   return (
     process.env.GLOBAL_DB_REGION ?? process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION
   );
+};
+
+let getGlobalDbPoolSize = (url: URL) => {
+  let rawPoolSize =
+    process.env.GLOBAL_DATABASE_POOL_SIZE ?? url.searchParams.get('connection_limit') ?? '10';
+  let poolSize = Number.parseInt(rawPoolSize, 10);
+
+  if (!Number.isFinite(poolSize) || poolSize < 1) {
+    throw new Error('GLOBAL_DATABASE_POOL_SIZE must be a positive integer');
+  }
+
+  return poolSize;
+};
+
+let getGlobalDbPingIntervalMs = () => {
+  let rawPingInterval = process.env.GLOBAL_DATABASE_PING_INTERVAL_MS ?? '10000';
+  let pingInterval = Number.parseInt(rawPingInterval, 10);
+
+  if (!Number.isFinite(pingInterval) || pingInterval < 1000) {
+    throw new Error('GLOBAL_DATABASE_PING_INTERVAL_MS must be at least 1000');
+  }
+
+  return pingInterval;
 };
 
 let createGlobalDbPoolConfig = (): pg.PoolConfig => {
@@ -32,6 +57,7 @@ let createGlobalDbPoolConfig = (): pg.PoolConfig => {
 
   let username = decodeURIComponent(url.username);
   let port = Number.parseInt(url.port || '5432', 10);
+  let poolSize = getGlobalDbPoolSize(url);
   let signer = new Signer({
     region,
     hostname: url.hostname,
@@ -49,17 +75,84 @@ let createGlobalDbPoolConfig = (): pg.PoolConfig => {
       url.searchParams.get('sslmode') === 'require'
         ? { rejectUnauthorized: false }
         : undefined,
-    max: Number.parseInt(url.searchParams.get('connection_limit') || '10', 10)
+    min: poolSize,
+    max: poolSize,
+    idleTimeoutMillis: 0,
+    connectionTimeoutMillis: 5000,
+    keepAlive: true,
+    keepAliveInitialDelayMillis: 10000
   };
 };
 
+let createGlobalDbPool = () => {
+  let pool = new Pool(createGlobalDbPoolConfig());
+
+  pool.on('error', error => {
+    console.error('Error from idle global database connection:', error);
+  });
+
+  return pool;
+};
+
+let warmGlobalDbPool = async (pool: pg.Pool, size: number) => {
+  let clients: { client: pg.PoolClient; released: boolean }[] = [];
+
+  try {
+    for (let index = 0; index < size; index++) {
+      let client = await pool.connect();
+      clients.push({ client, released: false });
+    }
+
+    await Promise.all(
+      clients.map(async entry => {
+        try {
+          await entry.client.query('SELECT 1');
+        } catch (error) {
+          entry.released = true;
+          entry.client.release(true);
+          throw error;
+        }
+      })
+    );
+  } finally {
+    for (let entry of clients) {
+      if (entry.released) continue;
+      entry.released = true;
+      entry.client.release();
+    }
+  }
+};
+
+let maintainGlobalDbPool = (pool: pg.Pool) => {
+  let targetSize = pool.options.max;
+  let pingInterval = getGlobalDbPingIntervalMs();
+
+  if (!targetSize || targetSize < 1) return;
+
+  void (async () => {
+    while (true) {
+      try {
+        await warmGlobalDbPool(pool, targetSize);
+      } catch (error) {
+        console.error('Error warming global database pool:', error);
+      }
+
+      await delay(pingInterval);
+    }
+  })();
+};
+
 let createClient = () => {
-  let mainAdapter =
+  let globalDbPool =
     process.env.GLOBAL_DATABASE_ARN && process.env.GLOBAL_DATABASE_URL
-      ? new PrismaPg(createGlobalDbPoolConfig())
-      : new PrismaPg({
-          connectionString: process.env.GLOBAL_DATABASE_URL
-        });
+      ? createGlobalDbPool()
+      : undefined;
+
+  let mainAdapter = globalDbPool
+    ? new PrismaPg(globalDbPool)
+    : new PrismaPg({
+        connectionString: process.env.GLOBAL_DATABASE_URL
+      });
 
   let baseClient = new PrismaClient({
     adapter: mainAdapter,
@@ -68,6 +161,10 @@ let createClient = () => {
       timeout: 12000
     }
   });
+
+  if (globalDbPool) {
+    maintainGlobalDbPool(globalDbPool);
+  }
 
   return baseClient;
 };
@@ -81,15 +178,3 @@ export type GlobalDB = typeof globalDB;
 declare global {
   namespace PrismaJson {}
 }
-
-(async () => {
-  while (true) {
-    try {
-      globalDB.$queryRaw`SELECT 1`;
-    } catch (error) {
-      console.error('Error pinging global database:', error);
-    }
-
-    await delay(10_000);
-  }
-})();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how the multi-region service manages Postgres connections by introducing a fixed-size `pg.Pool` and a background pool-warming loop, which can impact connection usage and runtime stability if misconfigured.
> 
> **Overview**
> Updates the multi-region DB client to use an explicit `pg.Pool` (passed to `PrismaPg`) when connecting via `GLOBAL_DATABASE_ARN`, with **fixed min/max pool sizing**, TCP keepalive, and tighter connect/idle settings.
> 
> Replaces the prior Prisma-level `SELECT 1` ping loop with a **pool maintenance loop** that periodically opens and pings up to the target pool size to keep connections warm, and adds new env knobs `GLOBAL_DATABASE_POOL_SIZE` and `GLOBAL_DATABASE_PING_INTERVAL_MS` with validation and error logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc36ae991f8ae280ac1035d5451ce56ea949fbb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->