### PR TITLE
Fix magic mcp server creation

### DIFF
--- a/clients/metorial-dashboard/src/sdk.ts
+++ b/clients/metorial-dashboard/src/sdk.ts
@@ -27,6 +27,7 @@ import {
   MetorialDashboardInstanceIdentityActorsEndpoint,
   MetorialDashboardInstanceMagicMcpGroupsEndpoint,
   MetorialDashboardInstanceMagicMcpServersEndpoint,
+  MetorialDashboardInstanceMagicMcpServersProviderEndpoint,
   MetorialDashboardInstanceMagicMcpSessionsEndpoint,
   MetorialDashboardInstanceMagicMcpTokensEndpoint,
   MetorialDashboardInstancePortalsAccessRequestsEndpoint,
@@ -183,7 +184,9 @@ export let createMetorialDashboardSDK = sdkBuilder.build(
   }),
 
   magicMcp: {
-    servers: new MetorialDashboardInstanceMagicMcpServersEndpoint(manager),
+    servers: Object.assign(new MetorialDashboardInstanceMagicMcpServersEndpoint(manager), {
+      providers: new MetorialDashboardInstanceMagicMcpServersProviderEndpoint(manager)
+    }),
     sessions: new MetorialDashboardInstanceMagicMcpSessionsEndpoint(manager),
     tokens: new MetorialDashboardInstanceMagicMcpTokensEndpoint(manager),
     groups: new MetorialDashboardInstanceMagicMcpGroupsEndpoint(manager)

--- a/src/backend/multi-region/package.json
+++ b/src/backend/multi-region/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@aws-sdk/rds-signer": "^3.1018.0",
     "@lowerdeck/base62": "^1.0.4",
+    "@lowerdeck/delay": "^1.0.1",
     "@lowerdeck/env": "^1.0.4",
     "@lowerdeck/error": "^1.2.2",
     "@lowerdeck/service": "^1.0.7",
@@ -26,7 +27,9 @@
     "@prisma/adapter-pg": "6.19.0",
     "@prisma/client": "^7.4.1",
     "@prisma/extension-read-replicas": "^0.5.0",
+    "@types/pg": "^8.11.11",
     "@types/bun": "^1.2.12",
+    "pg": "^8.11.3",
     "prisma": "^7.4.1",
     "prisma-json-types-generator": "^4.1.1",
     "stripe": "^18.5.0",

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/_layout.tsx
@@ -74,6 +74,7 @@ export let CustomProviderLayout = () => {
                 </Button>
               </Link>
             )}
+
             <DeployServerButton providerId={customProvider.data?.provider?.id}>
               Deploy Provider
             </DeployServerButton>
@@ -169,6 +170,7 @@ export let DeployServerButton = ({
           label: 'Provider Deployment',
           description: 'More powerful and flexible.'
         },
+
         ...(flags.data?.flags['magic-mcp-enabled']
           ? [
               {

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/magicMcpForm.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/magicMcpForm.tsx
@@ -10,6 +10,7 @@ import { Button, confirm, Input, Spacer, toast } from '@metorial/ui';
 import { Box } from '@metorial/ui-product';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { showAddProviderModal } from '../sessionTemplates/providersManager';
 
 export type MagicMcpServerFormProps =
   | { type: 'update'; magicMcpServerId: string; for?: undefined }
@@ -65,23 +66,34 @@ export let MagicMcpServerForm = (
         name: values.name,
         description: values.description || undefined
       });
-
       if (!res) return;
 
-      if (p.onCreate) {
-        p.onCreate(res);
-        p.close?.();
-        return;
-      }
+      p.close?.();
 
-      navigate(
-        Paths.instance.magicMcp.server(
-          instance.data.organization,
-          instance.data.project,
-          instance.data,
-          res.id
-        )
-      );
+      showAddProviderModal({
+        title: 'Configure Magic MCP Server',
+        description: 'Set up authentication and other settings for this Magic MCP server.',
+        action: 'Create Magic MCP Server',
+
+        instanceId: instance.data.id,
+        sessionTemplateId: res.sessionTemplateId,
+        providerId: p.type === 'create' ? p.for?.providerId : undefined,
+        onComplete: () => {
+          if (p.onCreate) {
+            p.onCreate(res);
+            return;
+          }
+
+          navigate(
+            Paths.instance.magicMcp.server(
+              instance.data.organization,
+              instance.data.project,
+              instance.data,
+              res.id
+            )
+          );
+        }
+      });
     }
   });
 
@@ -181,7 +193,7 @@ export let MagicMcpServerForm = (
           loading={createMutator.isLoading}
           success={createMutator.isSuccess}
         >
-          Create
+          Continue
         </Button>
       </div>
     </form>

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/providerConfigurationSelectionModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/providerConfigurationSelectionModal.tsx
@@ -57,6 +57,7 @@ type ProviderConfigurationSelectionForm = ReturnType<
 
 export let ProviderConfigurationSelectionModalContent = ({
   instanceId,
+  providerId,
   saving,
   mutationError,
   submitLabel,
@@ -65,6 +66,7 @@ export let ProviderConfigurationSelectionModalContent = ({
   allowConfigVaultSelection = true
 }: {
   instanceId: string;
+  providerId?: string;
   saving: boolean;
   mutationError?: ReactNode;
   submitLabel: string;
@@ -75,10 +77,13 @@ export let ProviderConfigurationSelectionModalContent = ({
   allowConfigVaultSelection?: boolean;
 }) => {
   let [currentStep, setCurrentStep] = useState(0);
+  let selectedProvider = useProvider(instanceId, providerId);
+  let resolvedProviderName =
+    selectedProvider.data?.name ?? selectedProvider.data?.slug ?? providerId ?? '';
   let form = useForm<ProviderConfigurationSelectionFormValues, any>({
     initialValues: {
-      selectedProviderId: '',
-      selectedProviderName: '',
+      selectedProviderId: providerId ?? '',
+      selectedProviderName: resolvedProviderName,
       selectedDeploymentId: '',
       selectedConfiguration: emptyConfigurationSelection(),
       selectedAuthConfigId: '',
@@ -128,6 +133,26 @@ export let ProviderConfigurationSelectionModalContent = ({
       })
   });
 
+  useEffect(() => {
+    if (!providerId) return;
+
+    if (form.values.selectedProviderId !== providerId) {
+      form.setFieldValue('selectedProviderId', providerId);
+    }
+
+    if (
+      resolvedProviderName &&
+      form.values.selectedProviderName !== resolvedProviderName
+    ) {
+      form.setFieldValue('selectedProviderName', resolvedProviderName);
+    }
+  }, [
+    providerId,
+    resolvedProviderName,
+    form.values.selectedProviderId,
+    form.values.selectedProviderName
+  ]);
+
   let resetConfigurationState = () => {
     form.setFieldValue('selectedConfiguration', emptyConfigurationSelection());
     form.setFieldValue('selectedAuthConfigId', '');
@@ -139,11 +164,50 @@ export let ProviderConfigurationSelectionModalContent = ({
     form.setFieldError('selectedAuthConfigId', undefined);
   };
 
-  return (
-    <Stepper
-      currentStep={currentStep}
-      setCurrentStep={setCurrentStep}
-      steps={[
+  let deploymentStepIndex = providerId ? 0 : 1;
+  let configureStepIndex = providerId ? 1 : 2;
+  let steps = providerId
+    ? [
+        {
+          title: 'Deployment',
+          subtitle: 'Select a deployment',
+          render: () => (
+            <PickDeploymentStep
+              instanceId={instanceId}
+              providerId={form.values.selectedProviderId}
+              providerName={form.values.selectedProviderName || resolvedProviderName}
+              onSelect={deploymentId => {
+                form.setFieldValue('selectedDeploymentId', deploymentId);
+                form.setFieldTouched('selectedDeploymentId', false, false);
+                form.setFieldError('selectedDeploymentId', undefined);
+                resetConfigurationState();
+                setCurrentStep(configureStepIndex);
+              }}
+            />
+          )
+        },
+        {
+          title: 'Configure',
+          subtitle: 'Set up the provider',
+          render: () => (
+            <form onSubmit={form.handleSubmit}>
+              <DeploymentConfigureStep
+                form={form}
+                instanceId={instanceId}
+                deploymentId={form.values.selectedDeploymentId}
+                providerId={form.values.selectedProviderId}
+                providerName={form.values.selectedProviderName || resolvedProviderName}
+                saving={saving}
+                mutationError={mutationError}
+                submitLabel={submitLabel}
+                includeToolFilters={includeToolFilters}
+                allowConfigVaultSelection={allowConfigVaultSelection}
+              />
+            </form>
+          )
+        }
+      ]
+    : [
         {
           title: 'Provider',
           subtitle: 'Choose a provider',
@@ -156,7 +220,7 @@ export let ProviderConfigurationSelectionModalContent = ({
                 form.setFieldTouched('selectedDeploymentId', false, false);
                 form.setFieldError('selectedDeploymentId', undefined);
                 resetConfigurationState();
-                setCurrentStep(1);
+                setCurrentStep(deploymentStepIndex);
               }}
             />
           )
@@ -174,7 +238,7 @@ export let ProviderConfigurationSelectionModalContent = ({
                 form.setFieldTouched('selectedDeploymentId', false, false);
                 form.setFieldError('selectedDeploymentId', undefined);
                 resetConfigurationState();
-                setCurrentStep(2);
+                setCurrentStep(configureStepIndex);
               }}
             />
           )
@@ -199,7 +263,13 @@ export let ProviderConfigurationSelectionModalContent = ({
             </form>
           )
         }
-      ]}
+      ];
+
+  return (
+    <Stepper
+      currentStep={currentStep}
+      setCurrentStep={setCurrentStep}
+      steps={steps}
     />
   );
 };
@@ -402,7 +472,7 @@ let DeploymentConfigureStep = ({
     deployment.isLoading ||
     authConfigs.isLoading ||
     (deployment.data && !deployment.data.lockedVersion?.id && provider.isLoading) ||
-    (includeToolFilters && tools.isLoading)
+    (includeToolFilters && !!providerVersionId && tools.isLoading)
   ) {
     return <CenteredSpinner />;
   }

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/providersManager.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/providersManager.tsx
@@ -23,20 +23,25 @@ type SessionTemplateProviderRow =
 let AddProviderModalContent = ({
   instanceId,
   sessionTemplateId,
-  onComplete
+  providerId,
+  onComplete,
+  action
 }: {
   instanceId: string;
   sessionTemplateId: string;
+  providerId?: string;
   onComplete: () => void;
+  action?: string;
 }) => {
   let createMutation = useCreateSessionTemplateProvider();
 
   return (
     <ProviderConfigurationSelectionModalContent
       instanceId={instanceId}
+      providerId={providerId}
       saving={createMutation.isPending}
       mutationError={<createMutation.RenderError />}
-      submitLabel="Add Provider"
+      submitLabel={action || 'Add Provider'}
       includeToolFilters
       onSubmit={async values => {
         let [result, error] = await createMutation.mutate({
@@ -83,14 +88,25 @@ export let showAddProviderModal = (p: {
   instanceId: string;
   sessionTemplateId: string;
   onComplete: () => void;
+  providerId?: string;
+  title?: string;
+  description?: string;
+  action?: string;
 }) =>
   showProviderConfigurationSelectionModal({
-    title: 'Add Provider',
-    description: 'Select a provider to add to this template.',
+    title: p.title ?? 'Add Provider',
+    description:
+      p.description ??
+      (p.providerId
+        ? 'Select a deployment and optional configuration to add to this template.'
+        : 'Select a provider to add to this template.'),
+
     render: close => (
       <AddProviderModalContent
         instanceId={p.instanceId}
         sessionTemplateId={p.sessionTemplateId}
+        providerId={p.providerId}
+        action={p.action}
         onComplete={() => {
           p.onComplete();
           close();

--- a/src/frontend/state/src/custom-provider/loaders/magicMcpServer.ts
+++ b/src/frontend/state/src/custom-provider/loaders/magicMcpServer.ts
@@ -18,7 +18,11 @@ export let magicMcpServersLoader = createLoader({
 
 export let useCreateMagicMcpServer = magicMcpServersLoader.createExternalMutator(
   (i: DashboardInstanceMagicMcpServersCreateBody & { instanceId: string }) =>
-    withAuth(sdk => sdk.magicMcp.servers.create(i.instanceId, i)),
+    withAuth(async sdk => {
+      let server = await sdk.magicMcp.servers.create(i.instanceId, i);
+
+      return server;
+    }),
   {
     disableToast: true
   }

--- a/src/packages/shared/tsconfig/base.json
+++ b/src/packages/shared/tsconfig/base.json
@@ -22,7 +22,6 @@
     "preserveWatchOutput": true,
     "skipLibCheck": true,
     "strict": true,
-    "downlevelIteration": true,
     "resolveJsonModule": true
   },
   "exclude": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the Magic MCP server creation UX to immediately open a provider configuration modal and alters the provider-selection stepper logic, which could affect onboarding flow and form state edge cases. Also adds new SDK surface for Magic MCP server providers and updates backend dependencies, but no core auth/payment logic is touched.
> 
> **Overview**
> Fixes Magic MCP server creation by switching the post-create flow from direct navigation to a guided configuration step: creating a server now closes the form and launches `showAddProviderModal` to select a deployment/config/auth before redirecting.
> 
> Updates the provider configuration selection modal to optionally accept a preselected `providerId`, skip the provider-picking step when provided, and tighten loading behavior for tool filters. Exposes a new `magicMcp.servers.providers` endpoint in the dashboard SDK, and updates `multi-region` backend deps (adds `pg`/`@types/pg` and `@lowerdeck/delay`) plus a small shared `tsconfig` option removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd981a229d6531054e19f46a8757ddd2e60925fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->