### PR TITLE
Fix/tools filters in session creation

### DIFF
--- a/src/systems/subspace/apps/controller/src/controllers/session.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/session.ts
@@ -127,7 +127,10 @@ export let sessionController = app.controller({
           return {
             ...resolved,
             sessionTemplateId: p.sessionTemplateId,
-            toolFilters: normalizeToolFilters(p.toolFilters),
+            toolFilters:
+              typeof p.toolFilters === 'undefined'
+                ? undefined
+                : normalizeToolFilters(p.toolFilters),
             __allowEphemeral: resolved.hasEphemeral
           };
         })

--- a/src/systems/subspace/modules/session/src/services/sessionProviderInput.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionProviderInput.ts
@@ -86,7 +86,7 @@ class sessionProviderInputServiceImpl {
                   deploymentId: tp.deployment.id,
                   configId: tp.config?.id,
                   authConfigId: tp.authConfig?.id,
-                  toolFilters: s.toolFilters,
+                  toolFilters: s.toolFilters ?? tp.toolFilter,
                   template,
                   templateProvider: tp
                 }));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how `toolFilters` are derived for session providers, which can affect which tools are allowed/blocked for a session. Risk is moderate because mistakes here could unintentionally widen or restrict tool access, but the change is small and targeted.
> 
> **Overview**
> Fixes `toolFilters` handling during session creation so provider inputs no longer always run `normalizeToolFilters` when the field is omitted, preserving `undefined` distinctly from an explicit value.
> 
> When a `sessionTemplateId` is used, provider inputs now default `toolFilters` to the template provider’s `toolFilter` unless the request explicitly supplies `toolFilters`, ensuring template defaults are applied correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 024ddc1f677fa1611975d1f9375e46ac9d2f89b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->