### PR TITLE
Add magic mcp backing cleanup

### DIFF
--- a/src/backend/modules/magic/src/queues/lifecycle/index.ts
+++ b/src/backend/modules/magic/src/queues/lifecycle/index.ts
@@ -1,5 +1,10 @@
 import { combineQueueProcessors } from '@metorial/queue';
 import {
+  magicMcpEndpointCreatedQueueProcessor,
+  magicMcpEndpointDeletedQueueProcessor,
+  magicMcpEndpointUpdatedQueueProcessor
+} from './magicMcpEndpoint';
+import {
   magicMcpGroupCreatedQueueProcessor,
   magicMcpGroupDeletedQueueProcessor,
   magicMcpGroupUpdatedQueueProcessor
@@ -10,10 +15,14 @@ import {
   magicMcpServerUpdatedQueueProcessor
 } from './magicMcpServer';
 
+export * from './magicMcpEndpoint';
 export * from './magicMcpGroup';
 export * from './magicMcpServer';
 
 export let magicLifecycleQueueProcessor = combineQueueProcessors([
+  magicMcpEndpointCreatedQueueProcessor,
+  magicMcpEndpointUpdatedQueueProcessor,
+  magicMcpEndpointDeletedQueueProcessor,
   magicMcpGroupCreatedQueueProcessor,
   magicMcpGroupUpdatedQueueProcessor,
   magicMcpGroupDeletedQueueProcessor,

--- a/src/backend/modules/magic/src/queues/lifecycle/magicMcpEndpoint.ts
+++ b/src/backend/modules/magic/src/queues/lifecycle/magicMcpEndpoint.ts
@@ -1,0 +1,99 @@
+import { db } from '@metorial/db';
+import {
+  subspaceSessionService,
+  subspaceSessionTemplateService
+} from '@metorial/module-subspace';
+import { createQueue } from '@metorial/queue';
+
+export let magicMcpEndpointCreatedQueue = createQueue<{ magicMcpEndpointId: string }>({
+  name: 'mgc/lc/endpoint/created'
+});
+
+export let magicMcpEndpointCreatedQueueProcessor = magicMcpEndpointCreatedQueue.process(
+  async () => {}
+);
+
+export let magicMcpEndpointUpdatedQueue = createQueue<{ magicMcpEndpointId: string }>({
+  name: 'mgc/lc/endpoint/updated'
+});
+
+export let magicMcpEndpointUpdatedQueueProcessor = magicMcpEndpointUpdatedQueue.process(
+  async () => {}
+);
+
+export let magicMcpEndpointDeletedQueue = createQueue<{ magicMcpEndpointId: string }>({
+  name: 'mgc/lc/endpoint/deleted'
+});
+
+export let magicMcpEndpointDeletedQueueProcessor = magicMcpEndpointDeletedQueue.process(
+  async data => {
+    let magicMcpEndpoint = await db.magicMcpEndpoint.findUnique({
+      where: { id: data.magicMcpEndpointId },
+      include: { instance: true }
+    });
+    if (!magicMcpEndpoint) return;
+
+    let uniqueSubspaceTemplatesRaw = await db.magicMcpSubspaceSessionConnection.findMany({
+      where: { magicMcpEndpointOid: magicMcpEndpoint.oid },
+      select: { subspaceSessionTemplateId: true },
+      distinct: ['subspaceSessionTemplateId']
+    });
+    let uniqueSubspaceTemplateIds = uniqueSubspaceTemplatesRaw
+      .map(record => record.subspaceSessionTemplateId)
+      .filter((value): value is string => !!value);
+
+    let uniqueSubspaceSessionsRaw = await db.magicMcpSubspaceSessionConnection.findMany({
+      where: { magicMcpEndpointOid: magicMcpEndpoint.oid },
+      select: { subspaceSessionId: true },
+      distinct: ['subspaceSessionId']
+    });
+    let uniqueSubspaceSessionIds = uniqueSubspaceSessionsRaw
+      .map(record => record.subspaceSessionId)
+      .filter((value): value is string => !!value);
+
+    await db.magicMcpSubspaceSessionConnection.deleteMany({
+      where: { magicMcpEndpointOid: magicMcpEndpoint.oid }
+    });
+
+    for (let subspaceSessionTemplateId of uniqueSubspaceTemplateIds) {
+      await subspaceSessionTemplateService.delete({
+        instance: magicMcpEndpoint.instance,
+        sessionTemplateId: subspaceSessionTemplateId
+      });
+    }
+
+    for (let subspaceSessionId of uniqueSubspaceSessionIds) {
+      await subspaceSessionService.delete({
+        instance: magicMcpEndpoint.instance,
+        sessionId: subspaceSessionId
+      });
+    }
+  }
+);
+
+export let enqueueMagicMcpEndpointCreated = async (magicMcpEndpointId: string) => {
+  await magicMcpEndpointCreatedQueue.add({ magicMcpEndpointId }).catch(error => {
+    console.error(
+      '[module-magic] Failed to enqueue magic MCP endpoint create lifecycle',
+      error
+    );
+  });
+};
+
+export let enqueueMagicMcpEndpointUpdated = async (magicMcpEndpointId: string) => {
+  await magicMcpEndpointUpdatedQueue.add({ magicMcpEndpointId }).catch(error => {
+    console.error(
+      '[module-magic] Failed to enqueue magic MCP endpoint update lifecycle',
+      error
+    );
+  });
+};
+
+export let enqueueMagicMcpEndpointDeleted = async (magicMcpEndpointId: string) => {
+  await magicMcpEndpointDeletedQueue.add({ magicMcpEndpointId }).catch(error => {
+    console.error(
+      '[module-magic] Failed to enqueue magic MCP endpoint delete lifecycle',
+      error
+    );
+  });
+};

--- a/src/backend/modules/magic/src/queues/lifecycle/magicMcpServer.ts
+++ b/src/backend/modules/magic/src/queues/lifecycle/magicMcpServer.ts
@@ -1,3 +1,5 @@
+import { db } from '@metorial/db';
+import { subspaceSessionTemplateService } from '@metorial/module-subspace';
 import { createQueue } from '@metorial/queue';
 import { indexMagicMcpServerSearchQueue } from '../search/magicMcpServer';
 
@@ -9,25 +11,69 @@ export let magicMcpServerCreatedQueue = createQueue<{ magicMcpServerId: string }
   name: 'mgc/lc/server/created'
 });
 
-export let magicMcpServerCreatedQueueProcessor = magicMcpServerCreatedQueue.process(async data => {
-  await queueMagicMcpServerIndex(data.magicMcpServerId);
-});
+export let magicMcpServerCreatedQueueProcessor = magicMcpServerCreatedQueue.process(
+  async data => {
+    await queueMagicMcpServerIndex(data.magicMcpServerId);
+  }
+);
 
 export let magicMcpServerUpdatedQueue = createQueue<{ magicMcpServerId: string }>({
   name: 'mgc/lc/server/updated'
 });
 
-export let magicMcpServerUpdatedQueueProcessor = magicMcpServerUpdatedQueue.process(async data => {
-  await queueMagicMcpServerIndex(data.magicMcpServerId);
-});
+export let magicMcpServerUpdatedQueueProcessor = magicMcpServerUpdatedQueue.process(
+  async data => {
+    await queueMagicMcpServerIndex(data.magicMcpServerId);
+  }
+);
 
 export let magicMcpServerDeletedQueue = createQueue<{ magicMcpServerId: string }>({
   name: 'mgc/lc/server/deleted'
 });
 
-export let magicMcpServerDeletedQueueProcessor = magicMcpServerDeletedQueue.process(async data => {
-  await queueMagicMcpServerIndex(data.magicMcpServerId);
-});
+export let magicMcpServerDeletedQueueProcessor = magicMcpServerDeletedQueue.process(
+  async data => {
+    let magicMcpServer = await db.magicMcpServer.findUnique({
+      where: { id: data.magicMcpServerId },
+      include: { instance: true }
+    });
+    if (!magicMcpServer) return;
+
+    await queueMagicMcpServerIndex(data.magicMcpServerId);
+
+    let uniqueSubspaceTemplatesRaw = await db.magicMcpSubspaceSessionConnection.findMany({
+      where: { magicMcpServerOid: magicMcpServer.oid },
+      select: { subspaceSessionTemplateId: true },
+      distinct: ['subspaceSessionTemplateId']
+    });
+    let uniqueSubspaceTemplateIds = uniqueSubspaceTemplatesRaw.map(
+      record => record.subspaceSessionTemplateId
+    );
+
+    let uniqueSubspaceSessionsRaw = await db.magicMcpSubspaceSessionConnection.findMany({
+      where: { magicMcpServerOid: magicMcpServer.oid },
+      select: { subspaceSessionId: true },
+      distinct: ['subspaceSessionId']
+    });
+    let uniqueSubspaceSessionIds = uniqueSubspaceSessionsRaw.map(
+      record => record.subspaceSessionId
+    );
+
+    for (let subspaceSessionTemplateId of uniqueSubspaceTemplateIds) {
+      await subspaceSessionTemplateService.delete({
+        instance: magicMcpServer.instance,
+        sessionTemplateId: subspaceSessionTemplateId
+      });
+    }
+
+    for (let subspaceSessionId of uniqueSubspaceSessionIds) {
+      await subspaceSessionTemplateService.delete({
+        instance: magicMcpServer.instance,
+        sessionTemplateId: subspaceSessionId
+      });
+    }
+  }
+);
 
 export let enqueueMagicMcpServerCreated = async (magicMcpServerId: string) => {
   await magicMcpServerCreatedQueue.add({ magicMcpServerId }).catch(error => {

--- a/src/backend/modules/magic/src/services/magicMcpEndpoint.ts
+++ b/src/backend/modules/magic/src/services/magicMcpEndpoint.ts
@@ -22,6 +22,11 @@ import {
   consumerMagicMcpWriteRoles,
   type AnyAccessTagSelector
 } from '@metorial/module-access';
+import {
+  enqueueMagicMcpEndpointCreated,
+  enqueueMagicMcpEndpointDeleted,
+  enqueueMagicMcpEndpointUpdated
+} from '../queues/lifecycle/magicMcpEndpoint';
 import { getAccessTagFilter, getActiveStatusFilter } from './consumerAccess';
 
 let buildSlug = (name?: string | null) => {
@@ -243,7 +248,7 @@ class MagicMcpEndpointImpl {
       : [];
 
     try {
-      return await db.magicMcpEndpoint.create({
+      let magicMcpEndpoint = await db.magicMcpEndpoint.create({
         data: {
           id: await ID.generateId('magicMcpEndpoint'),
           status: 'active',
@@ -268,6 +273,10 @@ class MagicMcpEndpointImpl {
         },
         include: magicMcpEndpointInclude
       });
+
+      await enqueueMagicMcpEndpointCreated(magicMcpEndpoint.id);
+
+      return magicMcpEndpoint;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
         throw new ServiceError(
@@ -290,7 +299,7 @@ class MagicMcpEndpointImpl {
       );
     }
 
-    return await db.magicMcpEndpoint.update({
+    let magicMcpEndpoint = await db.magicMcpEndpoint.update({
       where: {
         id: d.endpoint.id
       },
@@ -300,6 +309,10 @@ class MagicMcpEndpointImpl {
       },
       include: magicMcpEndpointInclude
     });
+
+    await enqueueMagicMcpEndpointDeleted(magicMcpEndpoint.id);
+
+    return magicMcpEndpoint;
   }
 
   async updateMagicMcpEndpoint(d: {
@@ -318,7 +331,7 @@ class MagicMcpEndpointImpl {
       );
     }
 
-    return await db.magicMcpEndpoint.update({
+    let magicMcpEndpoint = await db.magicMcpEndpoint.update({
       where: {
         id: d.endpoint.id
       },
@@ -330,6 +343,10 @@ class MagicMcpEndpointImpl {
       },
       include: magicMcpEndpointInclude
     });
+
+    await enqueueMagicMcpEndpointUpdated(magicMcpEndpoint.id);
+
+    return magicMcpEndpoint;
   }
 
   async addServersToEndpoint(d: {
@@ -374,12 +391,16 @@ class MagicMcpEndpointImpl {
       );
     }
 
-    return await db.magicMcpEndpoint.findUniqueOrThrow({
+    let magicMcpEndpoint = await db.magicMcpEndpoint.findUniqueOrThrow({
       where: {
         id: d.endpoint.id
       },
       include: magicMcpEndpointInclude
     });
+
+    await enqueueMagicMcpEndpointUpdated(magicMcpEndpoint.id);
+
+    return magicMcpEndpoint;
   }
 
   async removeServersFromEndpoint(d: {
@@ -402,12 +423,16 @@ class MagicMcpEndpointImpl {
       });
     }
 
-    return await db.magicMcpEndpoint.findUniqueOrThrow({
+    let magicMcpEndpoint = await db.magicMcpEndpoint.findUniqueOrThrow({
       where: {
         id: d.endpoint.id
       },
       include: magicMcpEndpointInclude
     });
+
+    await enqueueMagicMcpEndpointUpdated(magicMcpEndpoint.id);
+
+    return magicMcpEndpoint;
   }
 
   async listMagicMcpEndpoints(d: {

--- a/src/backend/modules/magic/src/services/magicMcpServer.ts
+++ b/src/backend/modules/magic/src/services/magicMcpServer.ts
@@ -36,6 +36,7 @@ import {
 } from '@metorial/module-subspace';
 import {
   enqueueMagicMcpServerCreated,
+  enqueueMagicMcpServerDeleted,
   enqueueMagicMcpServerUpdated
 } from '../queues/lifecycle/magicMcpServer';
 import { getAccessTagFilter, getActiveStatusFilter } from './consumerAccess';
@@ -271,7 +272,7 @@ class MagicMcpServerImpl {
   }
 
   async archiveMagicMcpServer(d: { server: MagicMcpServer }) {
-    if (d.server.status === 'archived') {
+    if (d.server.status !== 'active') {
       throw new ServiceError(
         preconditionFailedError({
           message: 'The magic MCP server is already archived'
@@ -285,7 +286,7 @@ class MagicMcpServerImpl {
       include
     });
 
-    await enqueueMagicMcpServerUpdated(magicMcpServer.id);
+    await enqueueMagicMcpServerDeleted(magicMcpServer.id);
 
     return magicMcpServer;
   }

--- a/src/backend/modules/subspace/src/services/session.ts
+++ b/src/backend/modules/subspace/src/services/session.ts
@@ -179,7 +179,6 @@ export let subspaceSessionService = createSubspaceService(
       arg0: Parameters<typeof inner.update>[0] & { _allowMagicMcpUpdate?: boolean }
     ) => {
       let eventBase = toEventBase(arg0);
-      await Fabric.fire('provider.session.updated:before', eventBase);
 
       let magicMcpLink = await db.magicMcpSubspaceSessionConnection.findFirst({
         where: { subspaceSessionId: arg0.sessionId }
@@ -191,6 +190,8 @@ export let subspaceSessionService = createSubspaceService(
           })
         );
       }
+
+      await Fabric.fire('provider.session.updated:before', eventBase);
 
       let session = await inner.update(arg0);
 
@@ -205,7 +206,6 @@ export let subspaceSessionService = createSubspaceService(
       arg0: Parameters<typeof inner.delete>[0] & { _allowMagicMcpDelete?: boolean }
     ) => {
       let eventBase = toEventBase(arg0);
-      await Fabric.fire('provider.session.deleted:before', eventBase);
 
       let magicMcpLink = await db.magicMcpSubspaceSessionConnection.findFirst({
         where: { subspaceSessionId: arg0.sessionId }
@@ -217,6 +217,8 @@ export let subspaceSessionService = createSubspaceService(
           })
         );
       }
+
+      await Fabric.fire('provider.session.deleted:before', eventBase);
 
       let session = await inner.delete(arg0);
 

--- a/src/backend/modules/subspace/src/services/sessionTemplate.ts
+++ b/src/backend/modules/subspace/src/services/sessionTemplate.ts
@@ -25,7 +25,6 @@ export let subspaceSessionTemplateService = createSubspaceService(
       arg0: Parameters<typeof inner.update>[0] & { _allowMagicMcpUpdate?: boolean }
     ) => {
       let eventBase = toEventBase(arg0);
-      await Fabric.fire('provider.session_template.updated:before', eventBase);
 
       let magicMcpLink = await db.magicMcpSubspaceSessionConnection.findFirst({
         where: { subspaceSessionTemplateId: arg0.sessionTemplateId }
@@ -37,6 +36,8 @@ export let subspaceSessionTemplateService = createSubspaceService(
           })
         );
       }
+
+      await Fabric.fire('provider.session_template.updated:before', eventBase);
 
       let sessionTemplate = await inner.update(arg0);
 
@@ -51,7 +52,6 @@ export let subspaceSessionTemplateService = createSubspaceService(
       arg0: Parameters<typeof inner.delete>[0] & { _allowMagicMcpDelete?: boolean }
     ) => {
       let eventBase = toEventBase(arg0);
-      await Fabric.fire('provider.session_template.deleted:before', eventBase);
 
       let magicMcpLink = await db.magicMcpSubspaceSessionConnection.findFirst({
         where: { subspaceSessionTemplateId: arg0.sessionTemplateId }
@@ -63,6 +63,8 @@ export let subspaceSessionTemplateService = createSubspaceService(
           })
         );
       }
+
+      await Fabric.fire('provider.session_template.deleted:before', eventBase);
 
       let sessionTemplate = await inner.delete(arg0);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces asynchronous cleanup that deletes Subspace sessions/templates when Magic MCP endpoints/servers are archived, which is data-destructive and easy to get wrong if IDs/services are mismatched.
> 
> **Overview**
> Adds Magic MCP *endpoint* lifecycle queues and wires them into the combined lifecycle processor. Endpoint create/update/archive operations now enqueue lifecycle jobs, and endpoint deletion processing removes related `magicMcpSubspaceSessionConnection` rows and then deletes the associated Subspace session templates and sessions.
> 
> Extends the Magic MCP *server* deleted lifecycle processor to perform similar Subspace cleanup in addition to search reindexing, and updates server archiving to enqueue the deleted lifecycle instead of the updated lifecycle. Separately, `subspace` session and session-template `update`/`delete` hooks now fire their `:before` Fabric events only after rejecting Magic-MCP-linked mutations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57576d1b82bcfa5a02931fcc5d844cd49ab90e28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->