### PR TITLE
Custom providers import fix

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/(list)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/(list)/_layout.tsx
@@ -3,14 +3,26 @@ import {
   useCurrentInstance,
   useCurrentOrganization,
   useCurrentProject,
-  useDashboardFlags
+  useDashboardFlags,
+  useUser
 } from '@metorial/state';
 import { Button, Menu } from '@metorial/ui';
 import { Outlet, useLocation } from 'react-router-dom';
 import { showCustomProviderRemoteFormModal } from '../../../scenes/customProvider/modal';
+import { isMetorialInternalEmail } from '../../../scenes/customProvider/utils';
 
 export let ManagedProvidersListLayout = () => {
   let flags = useDashboardFlags();
+  let user = useUser();
+  let shouldStartWithoutRepository = !isMetorialInternalEmail(user.data?.email);
+  let openManagedCreateModal = () => {
+    if (!user.data) return;
+
+    showCustomProviderRemoteFormModal({
+      type: 'managed',
+      startWithoutRepository: shouldStartWithoutRepository
+    });
+  };
 
   return (
     <ContentLayout>
@@ -34,12 +46,19 @@ export let ManagedProvidersListLayout = () => {
                 }
               ]}
               onItemClick={id => {
+                if (id === 'managed') {
+                  openManagedCreateModal();
+                  return;
+                }
+
                 showCustomProviderRemoteFormModal({
-                  type: id as 'docker' | 'managed'
+                  type: 'docker'
                 });
               }}
             >
-              <Button size="2">Create Custom Provider</Button>
+              <Button size="2" loading={user.isLoading} disabled={!user.data && !user.isLoading}>
+                Create Custom Provider
+              </Button>
             </Menu>
           ) : (
             !!(
@@ -47,11 +66,9 @@ export let ManagedProvidersListLayout = () => {
               flags.data?.flags['paid-custom-providers']
             ) && (
               <Button
-                onClick={() =>
-                  showCustomProviderRemoteFormModal({
-                    type: 'managed'
-                  })
-                }
+                onClick={openManagedCreateModal}
+                loading={user.isLoading}
+                disabled={!user.data && !user.isLoading}
                 size="2"
               >
                 Create Custom Provider

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/_layout.tsx
@@ -14,6 +14,7 @@ import {
   showMagicMcpServerFormModal,
   showProviderDeploymentFormModal
 } from '../../../scenes/providerDeployments/modal';
+import { isCustomProviderScmBacked } from '../../../scenes/customProvider/utils';
 
 export let CustomProviderLayout = () => {
   let instance = useCurrentInstance();
@@ -33,8 +34,12 @@ export let CustomProviderLayout = () => {
   ] as const;
 
   let isExternalProvider = customProvider.data?.type == 'remote';
+  let isScmBackedProvider = isCustomProviderScmBacked(customProvider.data);
   let hasCodeManagement = Boolean(
-    customProvider.data && !isExternalProvider && !customProvider.data.draft?.containerImage
+    customProvider.data &&
+      !isExternalProvider &&
+      !customProvider.data.draft?.containerImage &&
+      !isScmBackedProvider
   );
   let hasVersionManagement = Boolean(customProvider.data);
 
@@ -75,9 +80,11 @@ export let CustomProviderLayout = () => {
               </Link>
             )}
 
-            <DeployServerButton providerId={customProvider.data?.provider?.id}>
-              Deploy Provider
-            </DeployServerButton>
+            {!isScmBackedProvider && (
+              <DeployServerButton providerId={customProvider.data?.provider?.id}>
+                Deploy Provider
+              </DeployServerButton>
+            )}
           </>
         }
       />

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/index.tsx
@@ -5,6 +5,7 @@ import { Attributes, Badge, Button, RenderDate, Spacer } from '@metorial/ui';
 import { Box, ID, SideBox } from '@metorial/ui-product';
 import { useNavigate, useParams } from 'react-router-dom';
 import { CustomProviderEventsTable } from '../../../scenes/customProvider/events';
+import { getCustomProviderScmLink } from '../../../scenes/customProvider/utils';
 import { UsageScene } from '../../../scenes/usage/usage';
 
 export let CustomProviderOverviewPage = () => {
@@ -62,7 +63,30 @@ export let CustomProviderOverviewPage = () => {
           {
             label: 'Custom Provider ID',
             content: <ID id={customProvider.data.id} />
-          }
+          },
+          ...(() => {
+            let scmLink = getCustomProviderScmLink(customProvider.data);
+            if (!scmLink) return [];
+
+            return [
+              {
+                label: 'Repository URL',
+                content: (
+                  <a href={scmLink.repositoryUrl} target="_blank" rel="noreferrer">
+                    {scmLink.repositoryUrl}
+                  </a>
+                )
+              },
+              ...(scmLink.branch
+                ? [
+                    {
+                      label: 'Branch',
+                      content: scmLink.branch
+                    }
+                  ]
+                : [])
+            ];
+          })()
         ]}
       />
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/createManagedForm.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/createManagedForm.tsx
@@ -73,6 +73,7 @@ let Form = styled.div`
 
 export let CustomProviderManagedCreateForm = (p: {
   templateId?: string;
+  startWithoutRepository?: boolean;
   close?: () => any;
   onCreate?: (out: CustomProvidersGetOutput) => any;
 }) => {
@@ -89,11 +90,11 @@ export let CustomProviderManagedCreateForm = (p: {
   >(undefined);
   let selectedRepoId = selectedRepo?.id;
 
-  let [currentStep, setCurrentStep] = useState(0);
-
   let navigate = useNavigate();
   let [templateId, setTemplateId] = useState<string | undefined>(undefined);
   let hasTemplates = managedServerTemplates.data.items.length > 0;
+  let finishStep = hasTemplates ? 2 : 1;
+  let [currentStep, setCurrentStep] = useState(p.startWithoutRepository ? finishStep : 0);
 
   let form = useForm({
     initialValues: {
@@ -326,6 +327,14 @@ export let CustomProviderManagedCreateForm = (p: {
 
     setTemplate(p.templateId);
   }, [p.templateId, managedServerTemplates.data, installations.isLoading]);
+
+  useEffect(() => {
+    if (!p.startWithoutRepository) return;
+
+    setSelectedRepo(undefined);
+    setTemplateId(undefined);
+    setCurrentStep(finishStep);
+  }, [finishStep, p.startWithoutRepository]);
 
   if (p.templateId && !templateId) return <CenteredSpinner />;
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/modal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/modal.tsx
@@ -7,6 +7,7 @@ import { CustomProviderRemoteCreateForm } from './createRemoteForm';
 export let showCustomProviderRemoteFormModal = (p: {
   type: 'remote' | 'managed' | 'docker';
   templateId?: string;
+  startWithoutRepository?: boolean;
   onCreate?: (deal: CustomProvidersGetOutput) => any;
 }) =>
   showModal(({ dialogProps, close }) => {
@@ -28,7 +29,12 @@ export let showCustomProviderRemoteFormModal = (p: {
               Create a new custom MCP provider powered by Metorial.
             </Dialog.Description>
 
-            <CustomProviderManagedCreateForm {...p} close={close} onCreate={p.onCreate} />
+            <CustomProviderManagedCreateForm
+              {...p}
+              close={close}
+              onCreate={p.onCreate}
+              startWithoutRepository={p.startWithoutRepository}
+            />
           </>
         )}
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/utils.ts
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/utils.ts
@@ -1,5 +1,60 @@
 export type CustomProviderRemoteProtocol = 'sse' | 'streamable_http';
 
+let METORIAL_INTERNAL_EMAIL_DOMAINS = ['@metorial.com', '@metorial.work'];
+
+type CustomProviderScmLike = {
+  scmRepo?: { url?: string | null; defaultBranch?: string | null } | null;
+  draftBucket?: {
+    scmRepoLink?: {
+      repository?: { url?: string | null; defaultBranch?: string | null } | null;
+    } | null;
+  } | null;
+  metadata?: {
+    repository?: {
+      url?: string | null;
+      branch?: string | null;
+    } | null;
+  } | null;
+};
+
+export let normalizeTrackedBranch = (branch: string | null | undefined) => {
+  let normalizedBranch = branch?.trim();
+  return normalizedBranch ? normalizedBranch : undefined;
+};
+
+export let getCustomProviderScmLink = (
+  provider: CustomProviderScmLike | null | undefined
+) => {
+  let scmRepoLink = provider?.draftBucket?.scmRepoLink;
+  let metadataRepo = provider?.metadata?.repository;
+  let repositoryUrl =
+    scmRepoLink?.repository?.url?.trim() ||
+    provider?.scmRepo?.url?.trim() ||
+    metadataRepo?.url?.trim();
+  let branch = normalizeTrackedBranch(
+    scmRepoLink?.repository?.defaultBranch ?? provider?.scmRepo?.defaultBranch ?? metadataRepo?.branch
+  );
+
+  if (!repositoryUrl) return null;
+
+  return {
+    repositoryUrl,
+    branch
+  };
+};
+
+export let isCustomProviderScmBacked = (
+  provider: CustomProviderScmLike | null | undefined
+) => Boolean(getCustomProviderScmLink(provider));
+
+export let isMetorialInternalEmail = (email: string | null | undefined) => {
+  let normalizedEmail = email?.trim().toLowerCase();
+  return Boolean(
+    normalizedEmail &&
+      METORIAL_INTERNAL_EMAIL_DOMAINS.some(domain => normalizedEmail.endsWith(domain))
+  );
+};
+
 export let getCustomProviderRemoteProtocolFromUrl = (
   remoteUrl: string | null | undefined
 ): CustomProviderRemoteProtocol => {

--- a/src/systems/origin/apps/service/src/services/scmRepo.ts
+++ b/src/systems/origin/apps/service/src/services/scmRepo.ts
@@ -670,6 +670,8 @@ class scmRepoServiceImpl {
 
         await createHandleRepoPushQueue.add({ pushId: push.id });
       }
+
+      return;
     }
 
     throw new ServiceError(badRequestError({ message: 'Unsupported provider' }));

--- a/src/systems/subspace/modules/custom-provider/package.json
+++ b/src/systems/subspace/modules/custom-provider/package.json
@@ -9,6 +9,7 @@
     "lint": "prettier src/**/*.ts --check"
   },
   "dependencies": {
+    "@lowerdeck/cron": "^1.1.0",
     "@lowerdeck/env": "^1.0.5",
     "@lowerdeck/error": "^1.2.2",
     "@lowerdeck/lock": "^1.0.5",

--- a/src/systems/subspace/modules/custom-provider/src/index.ts
+++ b/src/systems/subspace/modules/custom-provider/src/index.ts
@@ -2,6 +2,7 @@ import { combineQueueProcessors } from '@lowerdeck/queue';
 import { commitQueues } from './queues/commit';
 import { deploymentQueues } from './queues/deployment';
 import { lifecycleQueues } from './queues/lifecycle';
+import { scmQueues } from './queues/scm';
 import { searchQueues } from './queues/search';
 import { upcomingQueues } from './queues/upcoming';
 
@@ -12,6 +13,7 @@ export * from './services';
 export let customProviderQueueProcessor = combineQueueProcessors([
   lifecycleQueues,
   searchQueues,
+  scmQueues,
   deploymentQueues,
   commitQueues,
   upcomingQueues

--- a/src/systems/subspace/modules/custom-provider/src/origin.ts
+++ b/src/systems/subspace/modules/custom-provider/src/origin.ts
@@ -3,7 +3,7 @@ import { createOriginClient } from '@metorial-platform-systems/origin-client';
 import { db, type Tenant } from '@metorial-subspace/db';
 import { env } from './env';
 
-export let origin = createOriginClient({
+export let origin: ReturnType<typeof createOriginClient> = createOriginClient({
   endpoint: env.origin.ORIGIN_URL
 });
 

--- a/src/systems/subspace/modules/custom-provider/src/queues/scm/cron.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/scm/cron.ts
@@ -1,0 +1,14 @@
+import { createCron } from '@lowerdeck/cron';
+import { env } from '../../env';
+import { scmSyncManyQueue } from './sync';
+
+export let scmSyncManyCron = createCron(
+  {
+    name: 'sub/cpr/scm/sync/many/cron',
+    redisUrl: env.service.REDIS_URL,
+    cron: '* * * * *'
+  },
+  async () => {
+    await scmSyncManyQueue.add({});
+  }
+);

--- a/src/systems/subspace/modules/custom-provider/src/queues/scm/handlePush.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/scm/handlePush.ts
@@ -44,7 +44,7 @@ export let processProviderPushQueue = createQueue<{
   scmRepoPushId: string;
   customProviderId: string;
 }>({
-  name: 'sub/cpr/scm/push',
+  name: 'sub/cpr/scm/push/provider',
   redisUrl: env.service.REDIS_URL,
   workerOpts: {
     limiter: {
@@ -107,7 +107,8 @@ export let processProviderPushQueueProcessor = processProviderPushQueue.process(
       environment: env.environment,
       customProvider: provider,
       trigger: 'scm',
-      repoPush: push
+      repoPush: push,
+      payload: provider.payload
     });
 
     let upcoming = await db.upcomingCustomProvider.create({

--- a/src/systems/subspace/modules/custom-provider/src/queues/scm/index.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/scm/index.ts
@@ -1,8 +1,10 @@
 import { combineQueueProcessors } from '@lowerdeck/queue';
+import { scmSyncManyCron } from './cron';
 import { handlePushQueueProcessor, processProviderPushQueueProcessor } from './handlePush';
 import { scmSyncManyQueueProcessor } from './sync';
 
 export let scmQueues = combineQueueProcessors([
+  scmSyncManyCron,
   handlePushQueueProcessor,
   processProviderPushQueueProcessor,
 

--- a/src/systems/subspace/modules/custom-provider/src/queues/scm/sync.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/scm/sync.ts
@@ -1,5 +1,5 @@
 import { createLock } from '@lowerdeck/lock';
-import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { createQueue } from '@lowerdeck/queue';
 import { db, snowflake } from '@metorial-subspace/db';
 import { env } from '../../env';
 import { origin } from '../../origin';
@@ -22,11 +22,10 @@ export let scmSyncManyQueueProcessor = scmSyncManyQueue.process(async data =>
     let changeNotification = await db.originSyncChangeNotificationCursor.findFirst({
       where: { id: CURSOR_ID }
     });
-    if (!changeNotification) throw new QueueRetryError();
 
     let changeNotifications = await origin.changeNotification.list({
       limit: 100,
-      after: changeNotification.cursor,
+      after: changeNotification?.cursor,
       order: 'asc'
     });
     if (!changeNotifications.items.length) return;
@@ -83,5 +82,7 @@ export let scmSyncManyQueueProcessor = scmSyncManyQueue.process(async data =>
       create: { id: CURSOR_ID, cursor: lastItem.id },
       update: { cursor: lastItem.id }
     });
+
+    await scmSyncManyQueue.add({});
   })
 );


### PR DESCRIPTION
Custom providers import fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches custom provider creation flow and SCM sync/queue processing; misclassification of SCM-backed providers or cron/queue recursion could impact deployments and background load.
> 
> **Overview**
> **Custom provider creation and details UI is adjusted for SCM-backed vs file-based providers.** The dashboard now derives an SCM link (`getCustomProviderScmLink`) and shows repository/branch on the overview page, hides `Deploy Provider` for SCM-backed providers, and can start managed-provider creation *without* connecting a repo for non-internal users (with create buttons gated/disabled while `useUser` loads).
> 
> **SCM sync/import reliability is improved in Subspace/Origin.** Origin’s GitHub webhook handler now returns after enqueueing a push, Subspace adds a cron-driven SCM sync (`scmSyncManyCron`) and makes the sync processor tolerate a missing cursor while continuing to re-enqueue work; SCM push processing queue is renamed and now passes provider `payload` into `prepareVersion` when creating versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c7236acea66d18cdd02d4ff32e07ef780d8f0d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->