### PR TITLE
Custom providers bug fixes

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/deployments.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/deployments.tsx
@@ -1,28 +1,75 @@
-import { renderWithLoader } from '@metorial/data-hooks';
-import { useCurrentInstance, useCustomProvider } from '@metorial/state';
+import { renderWithLoader, renderWithPagination } from '@metorial/data-hooks';
+import {
+  useCurrentInstance,
+  useCustomProvider,
+  useCustomProviderDeployments
+} from '@metorial/state';
 import { useParams } from 'react-router-dom';
-import { Text } from '@metorial/ui';
-import { ProviderDeploymentsTable } from '../../../scenes/providerDeployments/table';
+import { Badge, RenderDate, Text } from '@metorial/ui';
+import { ID, Table } from '@metorial/ui-product';
 import { ProviderDeploymentTabSection } from '../../../scenes/providerDeployments/tabSection';
 
 export let CustomProviderProviderDeploymentsPage = () => {
   let instance = useCurrentInstance();
   let { customProviderId } = useParams();
   let customProvider = useCustomProvider(instance.data?.id, customProviderId);
+  let deployments = useCustomProviderDeployments(instance.data?.id, customProvider.data?.id, {
+    order: 'desc'
+  });
 
-  return renderWithLoader({ instance, customProvider })(({ instance, customProvider }) => (
-    <ProviderDeploymentTabSection>
-      {customProvider.data.provider?.id ? (
-        <ProviderDeploymentsTable
-          instanceId={instance.data.id}
-          providerId={customProvider.data.provider.id}
-          providerName={customProvider.data.provider.name}
-        />
-      ) : (
+  let deploymentsContent = renderWithPagination(deployments)(deployments => (
+    <>
+      <Table
+        headers={['Status', 'Version', 'Trigger', 'Source', 'Actor', 'Created']}
+        data={deployments.data.items.map(deployment => ({
+          data: [
+            <Badge
+              color={
+                deployment.status === 'succeeded'
+                  ? 'green'
+                  : deployment.status === 'failed'
+                    ? 'red'
+                    : 'orange'
+              }
+            >
+              {deployment.status}
+            </Badge>,
+            deployment.customProviderVersionId ? (
+              <ID color="gray">{deployment.customProviderVersionId}</ID>
+            ) : (
+              <Text size="2" color="gray600">
+                --
+              </Text>
+            ),
+            <Text size="2">{deployment.trigger ?? 'manual'}</Text>,
+            deployment.scmPush ? (
+              <Text size="2">
+                {deployment.scmPush.commit.branch}@{deployment.scmPush.commit.sha.substring(0, 7)}
+              </Text>
+            ) : deployment.commit?.message ? (
+              <Text size="2">{deployment.commit.message}</Text>
+            ) : (
+              <Text size="2" color="gray600">
+                Manual
+              </Text>
+            ),
+            <Text size="2">{deployment.actor?.name ?? 'System'}</Text>,
+            <RenderDate date={deployment.createdAt} />
+          ]
+        }))}
+      />
+
+      {deployments.data.items.length === 0 && (
         <Text size="2" color="gray600" align="center" style={{ marginTop: 10 }}>
-          This custom provider has not been published as a provider yet.
+          No deployments found.
         </Text>
       )}
+    </>
+  ));
+
+  return renderWithLoader({ instance, customProvider })(() => (
+    <ProviderDeploymentTabSection>
+      {deploymentsContent}
     </ProviderDeploymentTabSection>
   ));
 };

--- a/src/systems/origin/apps/service/src/services/changeNotification.ts
+++ b/src/systems/origin/apps/service/src/services/changeNotification.ts
@@ -34,9 +34,7 @@ class ChangeNotificationServiceImpl {
             repoPush: { include: { repo: true } },
             tenant: true
           },
-          orderBy: {
-            createdAt: 'desc'
-          }
+          orderBy: opts.orderBy?.length ? opts.orderBy : [{ createdAt: 'desc' }]
         })
       )
     );

--- a/src/systems/subspace/modules/custom-provider/src/queues/scm/handlePush.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/scm/handlePush.ts
@@ -121,7 +121,7 @@ export let processProviderPushQueueProcessor = processProviderPushQueue.process(
 
         message: `Git push: ${push.commitMessage} (${push.sha.substring(0, 7)})`,
 
-        type: 'create_custom_provider',
+        type: 'create_custom_provider_version',
 
         customProviderOid: provider.oid,
         customProviderDeploymentOid: versionPrep.deployment.oid,

--- a/src/systems/subspace/modules/custom-provider/src/queues/scm/sync.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/scm/sync.ts
@@ -39,40 +39,46 @@ export let scmSyncManyQueueProcessor = scmSyncManyQueue.process(async data =>
     });
     let repoMap = new Map(repos.map(t => [t.id, t]));
 
-    let pushes = await db.scmRepoPush.createManyAndReturn({
-      skipDuplicates: true,
-      select: { id: true },
-      data: changeNotifications.items
-        .map(item => {
-          if (item.type !== 'repo_push' || !item.repoPush?.repo) return undefined!;
-          let repo = repoMap.get(item.repoPush.repo.id);
-          if (!repo) return undefined!;
+    let pushData = changeNotifications.items.flatMap(item => {
+      if (item.type !== 'repo_push' || !item.repoPush?.repo) return [];
+      let repo = repoMap.get(item.repoPush.repo.id);
+      if (!repo) return [];
 
-          return {
-            oid: snowflake.nextId(),
-            id: item.id,
+      return [
+        {
+          oid: snowflake.nextId(),
+          id: item.id,
 
-            pusherName: item.repoPush?.pusherName,
-            pusherEmail: item.repoPush?.pusherEmail,
-            senderIdentifier: item.repoPush?.senderIdentifier,
-            commitMessage: item.repoPush?.commitMessage,
+          pusherName: item.repoPush?.pusherName,
+          pusherEmail: item.repoPush?.pusherEmail,
+          senderIdentifier: item.repoPush?.senderIdentifier,
+          commitMessage: item.repoPush?.commitMessage,
 
-            branchName: item.repoPush?.branchName,
-            sha: item.repoPush?.sha,
+          branchName: item.repoPush?.branchName,
+          sha: item.repoPush?.sha,
 
-            repoOid: repo.oid,
-            tenantOid: repo.tenantOid,
-            solutionOid: repo.solutionOid
-          };
-        })
-        .filter(Boolean)
+          repoOid: repo.oid,
+          tenantOid: repo.tenantOid,
+          solutionOid: repo.solutionOid
+        }
+      ];
     });
 
-    await handlePushQueue.addMany(
-      pushes.map(item => ({
-        scmRepoPushId: item.id
-      }))
-    );
+    let pushes = pushData.length
+      ? await db.scmRepoPush.createManyAndReturn({
+          skipDuplicates: true,
+          select: { id: true },
+          data: pushData
+        })
+      : [];
+
+    if (pushes.length) {
+      await handlePushQueue.addMany(
+        pushes.map(item => ({
+          scmRepoPushId: item.id
+        }))
+      );
+    }
 
     let lastItem = changeNotifications.items[changeNotifications.items.length - 1];
     if (!lastItem) return;

--- a/src/systems/subspace/modules/custom-provider/src/services/customProviderDeployment.ts
+++ b/src/systems/subspace/modules/custom-provider/src/services/customProviderDeployment.ts
@@ -16,6 +16,8 @@ import {
   resolveCustomProviderDeployments,
   resolveCustomProviderEnvironments,
   resolveCustomProviders,
+  resolveProviderVersions,
+  resolveCustomProviderVersions,
   resolveProviders
 } from '@metorial-subspace/list-utils';
 import { getTenantForShuttle, shuttle } from '@metorial-subspace/provider-shuttle/src/client';
@@ -52,12 +54,9 @@ class customProviderDeploymentServiceImpl {
     customProviderEnvironmentIds?: string[];
   }) {
     let providers = await resolveProviders(d, d.providerIds);
-    let providerVersions = await resolveProviders(d, d.providerVersionIds);
+    let providerVersions = await resolveProviderVersions(d, d.providerVersionIds);
     let customProviders = await resolveCustomProviders(d, d.customProviderIds);
-    let customProviderVersions = await resolveCustomProviderDeployments(
-      d,
-      d.customProviderVersionIds
-    );
+    let customProviderVersions = await resolveCustomProviderVersions(d, d.customProviderVersionIds);
     let customProviderEnvironments = await resolveCustomProviderEnvironments(
       d,
       d.customProviderEnvironmentIds

--- a/src/systems/subspace/modules/custom-provider/src/services/customProviderVersion.ts
+++ b/src/systems/subspace/modules/custom-provider/src/services/customProviderVersion.ts
@@ -26,6 +26,7 @@ import {
   resolveCustomProviderDeployments,
   resolveCustomProviderEnvironments,
   resolveCustomProviders,
+  resolveProviderVersions,
   resolveProviders
 } from '@metorial-subspace/list-utils';
 import type { ProviderVersionEnrichment } from '@metorial-subspace/provider-utils';
@@ -175,7 +176,7 @@ class customProviderVersionServiceImpl {
 
           message: d.input.message,
 
-          type: 'create_custom_provider',
+          type: 'create_custom_provider_version',
 
           customProviderOid: d.customProvider.oid,
           customProviderVersionOid: versionPrep.version.oid,
@@ -220,7 +221,7 @@ class customProviderVersionServiceImpl {
     customProviderEnvironmentIds?: string[];
   }) {
     let providers = await resolveProviders(d, d.providerIds);
-    let providerVersions = await resolveProviders(d, d.providerVersionIds);
+    let providerVersions = await resolveProviderVersions(d, d.providerVersionIds);
     let customProviders = await resolveCustomProviders(d, d.customProviderIds);
     let customProviderDeployments = await resolveCustomProviderDeployments(
       d,


### PR DESCRIPTION
Custom providers bug fixes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches both the dashboard deployments UI and backend SCM/change-notification ingestion, which could affect how deployments are displayed/queued if ordering or filtering is incorrect. Changes are localized but impact operational flows for custom provider version creation.
> 
> **Overview**
> **Custom provider deployments UI now lists actual custom-provider deployments.** The dashboard `deployments` page switches from rendering a provider-level deployments table to fetching `useCustomProviderDeployments` with pagination and displaying a table with status, version ID, trigger, source (SCM branch/sha or commit message), actor, and created date, plus an empty-state message.
> 
> **Backend fixes for custom provider SCM/version flows.** Upcoming entries created from SCM pushes and manual version creation are retyped to `create_custom_provider_version`, change-notification listing now defaults to `createdAt desc` only when no explicit `orderBy` is provided, SCM sync avoids creating/queuing empty push batches, and deployment/version list filters now correctly resolve `providerVersionIds` and `customProviderVersionIds` via the appropriate resolver functions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60466e59af865a45d3032ec7c2493b65ebed4e2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->