### PR TITLE
Fix schema for custom provider deployments and versions

### DIFF
--- a/src/systems/subspace/db/prisma/schema/backend-shuttle/custom.prisma
+++ b/src/systems/subspace/db/prisma/schema/backend-shuttle/custom.prisma
@@ -15,8 +15,8 @@ model ShuttleCustomServer {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  customProviderDeployment       CustomProviderDeployment?
-  customProviderVersion          CustomProviderVersion?
+  customProviderDeployments      CustomProviderDeployment[]
+  customProviderVersions         CustomProviderVersion[]
   customProvider                 CustomProvider?
   shuttleCustomServerDeployments ShuttleCustomServerDeployment[]
 }

--- a/src/systems/subspace/db/prisma/schema/custom-provider/deployment.prisma
+++ b/src/systems/subspace/db/prisma/schema/custom-provider/deployment.prisma
@@ -39,7 +39,7 @@ model CustomProviderDeployment {
   shuttleServerVersionOid BigInt?               @unique
   shuttleServerVersion    ShuttleServerVersion? @relation(fields: [shuttleServerVersionOid], references: [oid])
 
-  shuttleCustomServerOid BigInt?              @unique
+  shuttleCustomServerOid BigInt?
   shuttleCustomServer    ShuttleCustomServer? @relation(fields: [shuttleCustomServerOid], references: [oid])
 
   shuttleCustomServerDeploymentOid BigInt?                        @unique
@@ -66,4 +66,5 @@ model CustomProviderDeployment {
   @@index([updatedAt])
   @@index([status])
   @@index([trigger])
+  @@index([shuttleCustomServerOid])
 }

--- a/src/systems/subspace/db/prisma/schema/custom-provider/version.prisma
+++ b/src/systems/subspace/db/prisma/schema/custom-provider/version.prisma
@@ -38,7 +38,7 @@ model CustomProviderVersion {
   shuttleServerVersionOid BigInt?               @unique
   shuttleServerVersion    ShuttleServerVersion? @relation(fields: [shuttleServerVersionOid], references: [oid])
 
-  shuttleCustomServerOid BigInt?              @unique
+  shuttleCustomServerOid BigInt?
   shuttleCustomServer    ShuttleCustomServer? @relation(fields: [shuttleCustomServerOid], references: [oid])
 
   shuttleCustomServerDeploymentOid BigInt?                        @unique
@@ -63,4 +63,5 @@ model CustomProviderVersion {
   @@index([createdAt])
   @@index([updatedAt])
   @@index([status])
+  @@index([shuttleCustomServerOid])
 }

--- a/src/systems/subspace/modules/custom-provider/src/queues/scm/handlePush.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/scm/handlePush.ts
@@ -34,7 +34,7 @@ export let handlePushQueueProcessor = handlePushQueue.process(async data => {
     }))
   );
 
-  let lastCodeBucket = codeBuckets.at(-1);
+  let lastCodeBucket = codeBuckets[codeBuckets.length - 1];
   if (!lastCodeBucket) return;
 
   await handlePushQueue.add({

--- a/src/systems/subspace/modules/custom-provider/src/queues/scm/handlePush.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/scm/handlePush.ts
@@ -34,9 +34,12 @@ export let handlePushQueueProcessor = handlePushQueue.process(async data => {
     }))
   );
 
+  let lastCodeBucket = codeBuckets.at(-1);
+  if (!lastCodeBucket) return;
+
   await handlePushQueue.add({
     scmRepoPushId: data.scmRepoPushId,
-    cursor: codeBuckets[codeBuckets.length - 1].id
+    cursor: lastCodeBucket.id
   });
 });
 


### PR DESCRIPTION
Fix schema for custom provider deployments and versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Prisma schema changes alter cardinality/uniqueness for `ShuttleCustomServer` links to deployments/versions, which can impact existing data and migrations. Runtime change is minimal (a defensive check in queue cursor logic).
> 
> **Overview**
> Fixes Prisma relations between `ShuttleCustomServer` and custom provider deployments/versions by changing the back-relations to one-to-many and removing unintended `@unique` constraints on `shuttleCustomServerOid` in both `CustomProviderDeployment` and `CustomProviderVersion`.
> 
> Adds an index on `shuttleCustomServerOid` for deployments/versions, and hardens SCM push queue pagination (`handlePushQueue`) by guarding against an undefined last item before enqueuing the next cursor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d77e371f2b2a5efd78fcd80686a332d94042611d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->