### PR TITLE
Custom provider fixes

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/(list)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/(list)/_layout.tsx
@@ -9,18 +9,15 @@ import {
 import { Button, Menu } from '@metorial/ui';
 import { Outlet, useLocation } from 'react-router-dom';
 import { showCustomProviderRemoteFormModal } from '../../../scenes/customProvider/modal';
-import { isMetorialInternalEmail } from '../../../scenes/customProvider/utils';
 
 export let ManagedProvidersListLayout = () => {
   let flags = useDashboardFlags();
   let user = useUser();
-  let shouldStartWithoutRepository = !isMetorialInternalEmail(user.data?.email);
   let openManagedCreateModal = () => {
     if (!user.data) return;
 
     showCustomProviderRemoteFormModal({
-      type: 'managed',
-      startWithoutRepository: shouldStartWithoutRepository
+      type: 'managed'
     });
   };
 

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/_layout.tsx
@@ -80,11 +80,9 @@ export let CustomProviderLayout = () => {
               </Link>
             )}
 
-            {!isScmBackedProvider && (
-              <DeployServerButton providerId={customProvider.data?.provider?.id}>
-                Deploy Provider
-              </DeployServerButton>
-            )}
+            <DeployServerButton providerId={customProvider.data?.provider?.id}>
+              Deploy Provider
+            </DeployServerButton>
           </>
         }
       />

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/code.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/code.tsx
@@ -14,6 +14,7 @@ import { motion } from 'framer-motion';
 import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import { getCustomProviderLinkedRepo } from '../../../scenes/customProvider/utils';
 import { SelectRepo } from '../../../scenes/customProvider/selectRepo';
 
 let Wrapper = styled.div`
@@ -83,31 +84,10 @@ export let CustomProviderCodePage = () => {
   let createVersion = useCreateCustomProviderVersion();
   let navigate = useNavigate();
 
-  let linkedRepo = useMemo(() => {
-    let repoFromApi =
-      customProvider.data?.scmRepo ??
-      customProvider.data?.draftBucket?.scmRepoLink?.repository;
-    if (repoFromApi) {
-      return {
-        id: repoFromApi.id,
-        url: repoFromApi.url,
-        defaultBranch: repoFromApi.defaultBranch,
-        path: customProvider.data?.draftBucket?.scmRepoLink?.path ?? undefined
-      };
-    }
-
-    let metadataRepo = customProvider.data?.metadata?.repository as
-      | { url?: string; branch?: string; path?: string }
-      | undefined;
-    if (!metadataRepo?.url) return null;
-
-    return {
-      id: undefined,
-      url: metadataRepo.url,
-      defaultBranch: metadataRepo.branch ?? 'main',
-      path: metadataRepo.path
-    };
-  }, [customProvider.data]);
+  let linkedRepo = useMemo(
+    () => getCustomProviderLinkedRepo(customProvider.data),
+    [customProvider.data]
+  );
   let codeManagementUnavailable =
     Boolean(customProvider.data?.draft?.remoteMcpServer) ||
     Boolean(customProvider.data?.draft?.containerImage);

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/deployments.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/deployments.tsx
@@ -1,75 +1,52 @@
-import { renderWithLoader, renderWithPagination } from '@metorial/data-hooks';
-import {
-  useCurrentInstance,
-  useCustomProvider,
-  useCustomProviderDeployments
-} from '@metorial/state';
+import { renderWithLoader } from '@metorial/data-hooks';
+import { useCurrentInstance, useCustomProvider } from '@metorial/state';
 import { useParams } from 'react-router-dom';
-import { Badge, RenderDate, Text } from '@metorial/ui';
-import { ID, Table } from '@metorial/ui-product';
+import { Input, Text } from '@metorial/ui';
+import { useState } from 'react';
+import { useDebounced } from '../../../../../hooks/useDebounced';
+import { ProviderDeploymentsTableSimple } from '../../../scenes/providerDeployments/tableSimple';
 import { ProviderDeploymentTabSection } from '../../../scenes/providerDeployments/tabSection';
+import { Table } from '@metorial/ui-product';
 
 export let CustomProviderProviderDeploymentsPage = () => {
   let instance = useCurrentInstance();
   let { customProviderId } = useParams();
   let customProvider = useCustomProvider(instance.data?.id, customProviderId);
-  let deployments = useCustomProviderDeployments(instance.data?.id, customProvider.data?.id, {
-    order: 'desc'
+  let [search, setSearch] = useState('');
+  let searchDebounced = useDebounced(search, 500);
+
+  return renderWithLoader({ instance, customProvider })(({ instance, customProvider }) => {
+    let providerId = customProvider.data.provider?.id;
+
+    return (
+      <ProviderDeploymentTabSection
+        search={
+          <Input
+            label="Search"
+            hideLabel
+            placeholder="Search for deployments..."
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+        }
+      >
+        {providerId ? (
+          <ProviderDeploymentsTableSimple
+            instanceId={instance.data.id}
+            providerId={providerId}
+            providerName={customProvider.data.provider?.name ?? customProvider.data.name}
+            search={searchDebounced}
+          />
+        ) : (
+          <>
+            <Table headers={['Name', 'Provider', 'Version', 'Created']} data={[]} />
+
+            <Text size="2" color="gray600" align="center" style={{ marginTop: 10 }}>
+              No deployments for this instance.
+            </Text>
+          </>
+        )}
+      </ProviderDeploymentTabSection>
+    );
   });
-
-  let deploymentsContent = renderWithPagination(deployments)(deployments => (
-    <>
-      <Table
-        headers={['Status', 'Version', 'Trigger', 'Source', 'Actor', 'Created']}
-        data={deployments.data.items.map(deployment => ({
-          data: [
-            <Badge
-              color={
-                deployment.status === 'succeeded'
-                  ? 'green'
-                  : deployment.status === 'failed'
-                    ? 'red'
-                    : 'orange'
-              }
-            >
-              {deployment.status}
-            </Badge>,
-            deployment.customProviderVersionId ? (
-              <ID id={deployment.customProviderVersionId} />
-            ) : (
-              <Text size="2" color="gray600">
-                --
-              </Text>
-            ),
-            <Text size="2">{deployment.trigger ?? 'manual'}</Text>,
-            deployment.scmPush ? (
-              <Text size="2">
-                {deployment.scmPush.commit.branch}@{deployment.scmPush.commit.sha.substring(0, 7)}
-              </Text>
-            ) : deployment.commit?.message ? (
-              <Text size="2">{deployment.commit.message}</Text>
-            ) : (
-              <Text size="2" color="gray600">
-                Manual
-              </Text>
-            ),
-            <Text size="2">{deployment.actor?.name ?? 'System'}</Text>,
-            <RenderDate date={deployment.createdAt} />
-          ]
-        }))}
-      />
-
-      {deployments.data.items.length === 0 && (
-        <Text size="2" color="gray600" align="center" style={{ marginTop: 10 }}>
-          No deployments found.
-        </Text>
-      )}
-    </>
-  ));
-
-  return renderWithLoader({ instance, customProvider })(() => (
-    <ProviderDeploymentTabSection>
-      {deploymentsContent}
-    </ProviderDeploymentTabSection>
-  ));
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/createManagedForm.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/createManagedForm.tsx
@@ -73,7 +73,6 @@ let Form = styled.div`
 
 export let CustomProviderManagedCreateForm = (p: {
   templateId?: string;
-  startWithoutRepository?: boolean;
   close?: () => any;
   onCreate?: (out: CustomProvidersGetOutput) => any;
 }) => {
@@ -93,8 +92,7 @@ export let CustomProviderManagedCreateForm = (p: {
   let navigate = useNavigate();
   let [templateId, setTemplateId] = useState<string | undefined>(undefined);
   let hasTemplates = managedServerTemplates.data.items.length > 0;
-  let finishStep = hasTemplates ? 2 : 1;
-  let [currentStep, setCurrentStep] = useState(p.startWithoutRepository ? finishStep : 0);
+  let [currentStep, setCurrentStep] = useState(0);
 
   let form = useForm({
     initialValues: {
@@ -327,14 +325,6 @@ export let CustomProviderManagedCreateForm = (p: {
 
     setTemplate(p.templateId);
   }, [p.templateId, managedServerTemplates.data, installations.isLoading]);
-
-  useEffect(() => {
-    if (!p.startWithoutRepository) return;
-
-    setSelectedRepo(undefined);
-    setTemplateId(undefined);
-    setCurrentStep(finishStep);
-  }, [finishStep, p.startWithoutRepository]);
 
   if (p.templateId && !templateId) return <CenteredSpinner />;
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/modal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/modal.tsx
@@ -7,7 +7,6 @@ import { CustomProviderRemoteCreateForm } from './createRemoteForm';
 export let showCustomProviderRemoteFormModal = (p: {
   type: 'remote' | 'managed' | 'docker';
   templateId?: string;
-  startWithoutRepository?: boolean;
   onCreate?: (deal: CustomProvidersGetOutput) => any;
 }) =>
   showModal(({ dialogProps, close }) => {
@@ -33,7 +32,6 @@ export let showCustomProviderRemoteFormModal = (p: {
               {...p}
               close={close}
               onCreate={p.onCreate}
-              startWithoutRepository={p.startWithoutRepository}
             />
           </>
         )}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/utils.ts
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/utils.ts
@@ -1,39 +1,32 @@
+import type { DashboardInstanceCustomProvidersGetOutput } from '@metorial/dashboard-sdk';
+
 export type CustomProviderRemoteProtocol = 'sse' | 'streamable_http';
-
-let METORIAL_INTERNAL_EMAIL_DOMAINS = ['@metorial.com', '@metorial.work'];
-
-type CustomProviderScmLike = {
-  scmRepo?: { url?: string | null; defaultBranch?: string | null } | null;
-  draftBucket?: {
-    scmRepoLink?: {
-      repository?: { url?: string | null; defaultBranch?: string | null } | null;
-    } | null;
-  } | null;
-  metadata?: {
-    repository?: {
-      url?: string | null;
-      branch?: string | null;
-    } | null;
-  } | null;
-};
 
 export let normalizeTrackedBranch = (branch: string | null | undefined) => {
   let normalizedBranch = branch?.trim();
   return normalizedBranch ? normalizedBranch : undefined;
 };
 
-export let getCustomProviderScmLink = (
-  provider: CustomProviderScmLike | null | undefined
+export let getCustomProviderLinkedRepo = (
+  provider: DashboardInstanceCustomProvidersGetOutput | null | undefined
 ) => {
-  let scmRepoLink = provider?.draftBucket?.scmRepoLink;
-  let metadataRepo = provider?.metadata?.repository;
-  let repositoryUrl =
-    scmRepoLink?.repository?.url?.trim() ||
-    provider?.scmRepo?.url?.trim() ||
-    metadataRepo?.url?.trim();
-  let branch = normalizeTrackedBranch(
-    scmRepoLink?.repository?.defaultBranch ?? provider?.scmRepo?.defaultBranch ?? metadataRepo?.branch
-  );
+  let repository = provider?.scmRepo ?? provider?.draftBucket?.scmRepoLink?.repository;
+  if (!repository) return null;
+
+  return {
+    id: repository.id,
+    url: repository.url,
+    defaultBranch: repository.defaultBranch,
+    path: provider?.draftBucket?.scmRepoLink?.path ?? undefined
+  };
+};
+
+export let getCustomProviderScmLink = (
+  provider: DashboardInstanceCustomProvidersGetOutput | null | undefined
+) => {
+  let linkedRepo = getCustomProviderLinkedRepo(provider);
+  let repositoryUrl = linkedRepo?.url?.trim();
+  let branch = normalizeTrackedBranch(linkedRepo?.defaultBranch);
 
   if (!repositoryUrl) return null;
 
@@ -44,16 +37,8 @@ export let getCustomProviderScmLink = (
 };
 
 export let isCustomProviderScmBacked = (
-  provider: CustomProviderScmLike | null | undefined
-) => Boolean(getCustomProviderScmLink(provider));
-
-export let isMetorialInternalEmail = (email: string | null | undefined) => {
-  let normalizedEmail = email?.trim().toLowerCase();
-  return Boolean(
-    normalizedEmail &&
-      METORIAL_INTERNAL_EMAIL_DOMAINS.some(domain => normalizedEmail.endsWith(domain))
-  );
-};
+  provider: DashboardInstanceCustomProvidersGetOutput | null | undefined
+) => Boolean(provider?.scmRepo || provider?.draftBucket?.scmRepoLink?.repository);
 
 export let getCustomProviderRemoteProtocolFromUrl = (
   remoteUrl: string | null | undefined

--- a/src/systems/slates/apps/hub/admin/src/pages/slates/SlateList.tsx
+++ b/src/systems/slates/apps/hub/admin/src/pages/slates/SlateList.tsx
@@ -1,6 +1,7 @@
 import { renderWithPagination } from '@metorial-io/data-hooks';
-import { Badge, Flex, Group, Spacer, Text, Title } from '@metorial-io/ui';
+import { Badge, Flex, Group, Input, Spacer, Text, Title } from '@metorial-io/ui';
 import { Table } from '@metorial-io/ui-product';
+import { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import { EmptyState, SlateLogoPlaceholder } from '../../components/styled.js';
 import { versionStatusColors } from '../../constants/statusColors.js';
@@ -13,7 +14,17 @@ let SlateIcon = styled(SlateLogoPlaceholder)`
 `;
 
 export let SlateList = () => {
-  let slates = useSlates();
+  let [search, setSearch] = useState('');
+  let [debouncedSearch, setDebouncedSearch] = useState(search);
+
+  useEffect(() => {
+    let timeout = window.setTimeout(() => setDebouncedSearch(search), 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [search]);
+
+  let searchQuery = debouncedSearch.trim() || undefined;
+  let slates = useSlates(searchQuery);
 
   let emptyState = (
     <EmptyState direction="column" align="center">
@@ -22,14 +33,16 @@ export let SlateList = () => {
       </Title>
       <Spacer size={8} />
       <Text size="2" color="gray600">
-        No slates have been registered in the hub yet.
+        {searchQuery
+          ? `No slates match "${searchQuery}".`
+          : 'No slates have been registered in the hub yet.'}
       </Text>
     </EmptyState>
   );
 
   return (
     <Flex direction="column" gap={32}>
-      <Flex justify="space-between" align="center">
+      <Flex justify="space-between" align="end" gap={16} style={{ flexWrap: 'wrap' }}>
         <div>
           <Title size="6" weight="strong">
             Slates
@@ -38,6 +51,15 @@ export let SlateList = () => {
           <Text size="2" color="gray600">
             All slates registered in the hub. View versions, deployments, and events.
           </Text>
+        </div>
+        <div style={{ width: '100%', maxWidth: 320 }}>
+          <Input
+            label="Search slates"
+            hideLabel
+            placeholder="Search by slate name"
+            value={search}
+            onInput={value => setSearch(value)}
+          />
         </div>
       </Flex>
 

--- a/src/systems/slates/apps/hub/admin/src/state/slates.ts
+++ b/src/systems/slates/apps/hub/admin/src/state/slates.ts
@@ -4,12 +4,12 @@ import { usePaginatedLoader } from './usePaginatedLoader.js';
 
 export let slatesLoader = createLoader({
   name: 'slates',
-  fetch: (params: { after?: string; before?: string }) =>
+  fetch: (params: { after?: string; before?: string; search?: string }) =>
     withAuthRedirect(() => adminClient.slate.list(params)),
   mutators: {}
 });
 
-export let useSlates = () => usePaginatedLoader(slatesLoader, {});
+export let useSlates = (search?: string) => usePaginatedLoader(slatesLoader, { search });
 
 export let slateLoader = createLoader({
   name: 'slate',

--- a/src/systems/slates/apps/hub/admin/src/state/usePaginatedLoader.ts
+++ b/src/systems/slates/apps/hub/admin/src/state/usePaginatedLoader.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 type PaginatedData<T> = {
   items: T[];
@@ -21,6 +21,13 @@ export let usePaginatedLoader = <T extends { id: string }, P>(
   params: Omit<P, 'after' | 'before'> | null
 ) => {
   let [cursor, setCursor] = useState<{ after?: string; before?: string }>({});
+  let serializedParams = JSON.stringify(params ?? null);
+
+  useEffect(() => {
+    setCursor(currentCursor =>
+      currentCursor.after || currentCursor.before ? {} : currentCursor
+    );
+  }, [serializedParams]);
 
   let result = loader.use(params ? ({ ...params, ...cursor } as P) : null);
 

--- a/src/systems/slates/apps/hub/src/apis/admin/controllers/slate.ts
+++ b/src/systems/slates/apps/hub/src/apis/admin/controllers/slate.ts
@@ -18,9 +18,17 @@ export let slateApp = authedApp.use(async ctx => {
 export let slateController = authedApp.controller({
   list: authedApp
     .handler()
-    .input(Paginator.validate(v.object({})))
+    .input(
+      Paginator.validate(
+        v.object({
+          search: v.optional(v.string())
+        })
+      )
+    )
     .do(async ctx => {
-      let paginator = await slateService.listSlates({});
+      let paginator = await slateService.listSlates({
+        search: ctx.input.search
+      });
 
       let list = await paginator.run(ctx.input);
 

--- a/src/systems/slates/apps/hub/src/services/slate.ts
+++ b/src/systems/slates/apps/hub/src/services/slate.ts
@@ -46,14 +46,24 @@ class slateServiceImpl {
     return await res.json();
   }
 
-  async listSlates(_d: {}) {
+  async listSlates(d: { search?: string }) {
+    let search = d.search?.trim();
+
     return Paginator.create(({ prisma }) =>
       prisma(
         async opts =>
           await db.slate.findMany({
             ...opts,
             where: {
-              status: 'active'
+              status: 'active',
+              ...(search
+                ? {
+                    name: {
+                      contains: search,
+                      mode: 'insensitive'
+                    }
+                  }
+                : {})
             },
             include
           })

--- a/src/systems/slates/apps/registry/admin/src/hooks/slates.ts
+++ b/src/systems/slates/apps/registry/admin/src/hooks/slates.ts
@@ -1,19 +1,27 @@
 import { createLoader } from '@metorial-io/data-hooks';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { adminClient, withAuthRedirect } from './client';
 
 export let slatesLoader = createLoader({
   name: 'slates',
-  fetch: (params: { tenantId: string; after?: string; before?: string }) =>
+  fetch: (params: { tenantId: string; after?: string; before?: string; search?: string }) =>
     withAuthRedirect(() => adminClient.slate.list(params)),
-  hash: params => `${params.tenantId}:${params.after ?? ''}:${params.before ?? ''}`,
+  hash: params =>
+    `${params.tenantId}:${params.after ?? ''}:${params.before ?? ''}:${params.search ?? ''}`,
   mutators: {}
 });
 
-export let useSlates = (tenantId: string | undefined) => {
+export let useSlates = (tenantId: string | undefined, search?: string) => {
   let [cursor, setCursor] = useState<{ after?: string; before?: string }>({});
+  let serializedParams = JSON.stringify({ tenantId, search });
 
-  let loader = slatesLoader.use(tenantId ? { tenantId, ...cursor } : null);
+  useEffect(() => {
+    setCursor(currentCursor =>
+      currentCursor.after || currentCursor.before ? {} : currentCursor
+    );
+  }, [serializedParams]);
+
+  let loader = slatesLoader.use(tenantId ? { tenantId, search, ...cursor } : null);
 
   let transformedData = useMemo(() => {
     if (!loader.data) return null;

--- a/src/systems/slates/apps/registry/admin/src/pages/slates/SlateList.tsx
+++ b/src/systems/slates/apps/registry/admin/src/pages/slates/SlateList.tsx
@@ -1,14 +1,25 @@
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { renderWithPagination } from '@metorial-io/data-hooks';
-import { Button, Text, Title, Badge, Flex, Spacer, Group } from '@metorial-io/ui';
+import { Button, Text, Title, Badge, Flex, Spacer, Group, Input } from '@metorial-io/ui';
 import { Table } from '@metorial-io/ui-product';
+import { useEffect, useState } from 'react';
 import { useSlates } from '../../hooks';
 import { EmptyState, SlateLogoImage, SlateLogoPlaceholder } from '../../components/styled';
 
 export let SlateList = () => {
   let navigate = useNavigate();
   let { tenantId } = useParams<{ tenantId: string }>();
-  let slates = useSlates(tenantId);
+  let [search, setSearch] = useState('');
+  let [debouncedSearch, setDebouncedSearch] = useState(search);
+
+  useEffect(() => {
+    let timeout = window.setTimeout(() => setDebouncedSearch(search), 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [search]);
+
+  let searchQuery = debouncedSearch.trim() || undefined;
+  let slates = useSlates(tenantId, searchQuery);
 
   let emptyState = (
     <EmptyState direction="column" align="center">
@@ -17,14 +28,16 @@ export let SlateList = () => {
       </Title>
       <Spacer size={8} />
       <Text size="2" color="gray600">
-        This tenant doesn't have any slates yet.
+        {searchQuery
+          ? `No slates match "${searchQuery}".`
+          : "This tenant doesn't have any slates yet."}
       </Text>
     </EmptyState>
   );
 
   return (
     <Flex direction="column" gap={32}>
-      <Flex justify="space-between" align="center">
+      <Flex justify="space-between" align="center" gap={16} style={{ flexWrap: 'wrap' }}>
         <div>
           <Title size="6" weight="strong">
             Slates
@@ -44,6 +57,16 @@ export let SlateList = () => {
           </Button>
         </Flex>
       </Flex>
+
+      <div style={{ width: '100%', maxWidth: 320 }}>
+        <Input
+          label="Search slates"
+          hideLabel
+          placeholder="Search by slate name"
+          value={search}
+          onInput={value => setSearch(value)}
+        />
+      </div>
 
       {renderWithPagination(slates, { emptyState })(({ data }) => {
         let items = data.items;

--- a/src/systems/slates/apps/registry/src/apis/admin/controllers/slate.ts
+++ b/src/systems/slates/apps/registry/src/apis/admin/controllers/slate.ts
@@ -23,13 +23,15 @@ export let slateController = app.controller({
     .input(
       Paginator.validate(
         v.object({
-          tenantId: v.string()
+          tenantId: v.string(),
+          search: v.optional(v.string())
         })
       )
     )
     .do(async ctx => {
       let paginator = await slateService.listSlates({
-        tenant: ctx.tenant
+        tenant: ctx.tenant,
+        search: ctx.input.search
       });
 
       let list = await paginator.run(ctx.input);

--- a/src/systems/slates/apps/registry/src/services/slate.ts
+++ b/src/systems/slates/apps/registry/src/services/slate.ts
@@ -72,7 +72,9 @@ class slateServiceImpl {
     scopeIds?: string[];
     userIds?: string[];
     workspaceIds?: string[];
+    search?: string;
   }) {
+    let search = d.search?.trim();
     let scopes = d.scopeIds
       ? await db.scope.findMany({
           where: {
@@ -117,6 +119,14 @@ class slateServiceImpl {
               status: 'active',
 
               scopeOid: anyScopeOids ? { in: anyScopeOids } : undefined,
+              ...(search
+                ? {
+                    name: {
+                      contains: search,
+                      mode: 'insensitive'
+                    }
+                  }
+                : {}),
 
               AND: [filterClause]
             },


### PR DESCRIPTION
Custom provider fixes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: adds a new optional `search` parameter to slate list endpoints and resets pagination cursors when query params change, which could affect list behavior and performance under load.
> 
> **Overview**
> **Custom providers:** Simplifies managed provider creation by removing the internal-email `startWithoutRepository` path, always starting the managed create flow from step 0, and refactoring repo-link detection into a shared `getCustomProviderLinkedRepo` helper. The custom provider header now always shows `Deploy Provider`, and the deployments tab switches from custom-provider deployments to provider-based deployments with a debounced search box.
> 
> **Slates:** Adds debounced name search to both hub and registry admin slate list pages, wiring the query through loaders/hooks and backend controllers/services via an optional `search` parameter, and resets pagination cursors when list params change so pagination doesn’t carry across different searches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2eaa64839b7ac96865378de0c58b4d88da21610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->