### PR TITLE
Build fix

### DIFF
--- a/src/backend/modules/consumer/src/services/providerTemplate.ts
+++ b/src/backend/modules/consumer/src/services/providerTemplate.ts
@@ -40,7 +40,7 @@ class ProviderTemplateServiceImpl {
     instance: Instance;
     providerTemplateId: string;
     accessTags?: AnyAccessTagSelector;
-  }) {
+  }): Promise<EnrichedProviderTemplate> {
     let providerTemplate = await db.providerTemplate.findFirst({
       where: {
         instanceOid: d.instance.oid,
@@ -59,7 +59,7 @@ class ProviderTemplateServiceImpl {
       });
     }
 
-    return (await this.enrich([providerTemplate], d.instance))[0];
+    return await this.enrichOne(providerTemplate, d.instance);
   }
 
   async createProviderTemplate(d: {
@@ -80,7 +80,7 @@ class ProviderTemplateServiceImpl {
           providerDeploymentId?: never;
         }
     );
-  }) {
+  }): Promise<EnrichedProviderTemplate> {
     let providerDeploymentId = await this.getOrCreateProviderDeployment(d);
 
     let existing = await db.providerTemplate.findFirst({
@@ -107,7 +107,7 @@ class ProviderTemplateServiceImpl {
         providerTemplateId: providerTemplate.id
       });
 
-      return providerTemplate;
+      return await this.enrichOne(providerTemplate, d.instance);
     }
 
     if (d.input.toolFilters) {
@@ -133,7 +133,7 @@ class ProviderTemplateServiceImpl {
 
     await providerTemplateCreatedQueue.add({ providerTemplateId: providerTemplate.id });
 
-    return (await this.enrich([providerTemplate], d.instance))[0];
+    return await this.enrichOne(providerTemplate, d.instance);
   }
 
   async updateProviderTemplate(d: {
@@ -145,7 +145,7 @@ class ProviderTemplateServiceImpl {
       metadata?: Record<string, unknown>;
       toolFilters?: any;
     };
-  }) {
+  }): Promise<EnrichedProviderTemplate> {
     if (d.providerTemplate.status != 'active') {
       throw new ServiceError(
         preconditionFailedError({
@@ -175,13 +175,13 @@ class ProviderTemplateServiceImpl {
 
     await providerTemplateUpdatedQueue.add({ providerTemplateId: providerTemplate.id });
 
-    return (await this.enrich([providerTemplate], d.instance))[0];
+    return await this.enrichOne(providerTemplate, d.instance);
   }
 
   async archiveProviderTemplate(d: {
     instance: Instance;
     providerTemplate: ProviderTemplate;
-  }) {
+  }): Promise<EnrichedProviderTemplate> {
     if (d.providerTemplate.status != 'active') {
       throw new ServiceError(
         preconditionFailedError({
@@ -204,7 +204,7 @@ class ProviderTemplateServiceImpl {
 
     await providerTemplateArchivedQueue.add({ providerTemplateId: providerTemplate.id });
 
-    return (await this.enrich([providerTemplate], d.instance))[0];
+    return await this.enrichOne(providerTemplate, d.instance);
   }
 
   async listProviderTemplates(d: {
@@ -315,6 +315,14 @@ class ProviderTemplateServiceImpl {
       ...t,
       providerDeployment: deploymentMap.get(t.providerDeploymentId)!
     }));
+  }
+
+  private async enrichOne(
+    providerTemplate: ProviderTemplate,
+    instance: Instance
+  ): Promise<EnrichedProviderTemplate> {
+    let [enrichedProviderTemplate] = await this.enrich([providerTemplate], instance);
+    return enrichedProviderTemplate!;
   }
 
   private async getOrCreateProviderDeployment(d: {

--- a/src/systems/origin/apps/service/package.json
+++ b/src/systems/origin/apps/service/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "enterprise:dev": "bun --watch ./src/server.ts",
     "start": "bun run server:start",
-    "server:build": "ncc build ./src/server.ts -o ./dist --source-map --transpile-only && bun run sentry:sourcemaps:if-token",
+    "check-types": "tsc --noEmit -p tsconfig.json",
+    "server:build": "bun run check-types && ncc build ./src/server.ts -o ./dist --source-map --transpile-only && bun run sentry:sourcemaps:if-token",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org metorial --project mte-origin ./dist && sentry-cli sourcemaps upload --org metorial --project mte-origin ./dist",
     "sentry:sourcemaps:if-token": "sh -c 'if [ -n \"$SENTRY_AUTH_TOKEN\" ]; then bun run sentry:sourcemaps; else echo \"Skipping Sentry sourcemap upload\"; fi'",
     "server:start": "bun ./dist/index.js",

--- a/src/systems/origin/apps/service/package.json
+++ b/src/systems/origin/apps/service/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "enterprise:dev": "bun --watch ./src/server.ts",
     "start": "bun run server:start",
-    "check-types": "tsc --noEmit -p tsconfig.json",
+    "check-types": "tsc --noEmit -p tsconfig.server.json",
     "server:build": "bun run check-types && ncc build ./src/server.ts -o ./dist --source-map --transpile-only && bun run sentry:sourcemaps:if-token",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org metorial --project mte-origin ./dist && sentry-cli sourcemaps upload --org metorial --project mte-origin ./dist",
     "sentry:sourcemaps:if-token": "sh -c 'if [ -n \"$SENTRY_AUTH_TOKEN\" ]; then bun run sentry:sourcemaps; else echo \"Skipping Sentry sourcemap upload\"; fi'",

--- a/src/systems/origin/apps/service/tsconfig.server.json
+++ b/src/systems/origin/apps/service/tsconfig.server.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/**/tests/**/*",
+    "src/test/**/*"
+  ]
+}

--- a/src/systems/shuttle/service/package.json
+++ b/src/systems/shuttle/service/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start": "bun run server:start",
-    "check-types": "tsc --noEmit -p tsconfig.json",
+    "check-types": "tsc --noEmit -p tsconfig.server.json",
     "server:build": "bun run check-types && ncc build ./src/server.ts -o ./dist --source-map --transpile-only && bun run sentry:sourcemaps:if-token",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org metorial --project mte-shuttle ./dist && sentry-cli sourcemaps upload --org metorial --project mte-shuttle ./dist",
     "sentry:sourcemaps:if-token": "sh -c 'if [ -n \"$SENTRY_AUTH_TOKEN\" ]; then bun run sentry:sourcemaps; else echo \"Skipping Sentry sourcemap upload\"; fi'",
@@ -25,7 +25,7 @@
     "test:unit": "bunx vitest run --config vitest.unit.config.ts",
     "test:e2e": "bunx vitest run --passWithNoTests",
     "test:watch": "bunx vitest watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "bun run check-types"
   },
   "devDependencies": {
     "@lowerdeck/testing-tools": "^1.0.1",
@@ -82,7 +82,7 @@
     "axios": "^1.13.2",
     "date-fns": "^4.1.0",
     "drizzle-orm": "^0.45.1",
-    "hono": "4.10.6",
+    "hono": "^4.11.3",
     "ipaddr.js": "^2.3.0",
     "jsonata": "^2.1.0",
     "jszip": "^3.10.1",

--- a/src/systems/shuttle/service/package.json
+++ b/src/systems/shuttle/service/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "start": "bun run server:start",
-    "server:build": "ncc build ./src/server.ts -o ./dist --source-map --transpile-only && bun run sentry:sourcemaps:if-token",
+    "check-types": "tsc --noEmit -p tsconfig.json",
+    "server:build": "bun run check-types && ncc build ./src/server.ts -o ./dist --source-map --transpile-only && bun run sentry:sourcemaps:if-token",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org metorial --project mte-shuttle ./dist && sentry-cli sourcemaps upload --org metorial --project mte-shuttle ./dist",
     "sentry:sourcemaps:if-token": "sh -c 'if [ -n \"$SENTRY_AUTH_TOKEN\" ]; then bun run sentry:sourcemaps; else echo \"Skipping Sentry sourcemap upload\"; fi'",
     "server:start": "bun ./dist/index.js",

--- a/src/systems/shuttle/service/src/apis/connection/index.ts
+++ b/src/systems/shuttle/service/src/apis/connection/index.ts
@@ -17,6 +17,10 @@ export let connectionApp = createHono().get(
     let tenantId = c.req.param('tenantId');
     let serverConnectionId = c.req.param('connectionId');
 
+    if (!tenantId || !serverConnectionId) {
+      throw new Error('Missing connection route params');
+    }
+
     let tenant = await tenantService.getTenantById({ id: tenantId });
     let connection = await serverConnectionService.getServerConnectionById({
       tenant,

--- a/src/systems/shuttle/service/tsconfig.server.json
+++ b/src/systems/shuttle/service/tsconfig.server.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/**/tests/**/*",
+    "src/test/**/*"
+  ]
+}

--- a/src/systems/slates/apps/hub/package.json
+++ b/src/systems/slates/apps/hub/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "start": "bun run server:start",
-    "server:build": "ncc build ./src/server.ts -o ./dist --source-map --transpile-only && bun run sentry:sourcemaps:if-token",
+    "check-types": "tsc --noEmit -p tsconfig.json",
+    "server:build": "bun run check-types && ncc build ./src/server.ts -o ./dist --source-map --transpile-only && bun run sentry:sourcemaps:if-token",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org metorial --project mte-slates-hub ./dist && sentry-cli sourcemaps upload --org metorial --project mte-slates-hub ./dist",
     "sentry:sourcemaps:if-token": "sh -c 'if [ -n \"$SENTRY_AUTH_TOKEN\" ]; then bun run sentry:sourcemaps; else echo \"Skipping Sentry sourcemap upload\"; fi'",
     "server:start": "bun ./dist/index.js",

--- a/src/systems/slates/apps/hub/package.json
+++ b/src/systems/slates/apps/hub/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start": "bun run server:start",
-    "check-types": "tsc --noEmit -p tsconfig.json",
+    "check-types": "tsc --noEmit -p tsconfig.server.json",
     "server:build": "bun run check-types && ncc build ./src/server.ts -o ./dist --source-map --transpile-only && bun run sentry:sourcemaps:if-token",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org metorial --project mte-slates-hub ./dist && sentry-cli sourcemaps upload --org metorial --project mte-slates-hub ./dist",
     "sentry:sourcemaps:if-token": "sh -c 'if [ -n \"$SENTRY_AUTH_TOKEN\" ]; then bun run sentry:sourcemaps; else echo \"Skipping Sentry sourcemap upload\"; fi'",
@@ -24,7 +24,7 @@
     "db:push": "bun run db:push:dev && bun run db:push:test",
     "test": "bunx vitest run --passWithNoTests",
     "test:watch": "bunx vitest watch",
-    "typecheck": "tsc --noEmit && bun run admin:typecheck",
+    "typecheck": "bun run check-types && bun run admin:typecheck",
     "admin:typecheck": "tsc --noEmit --project admin/tsconfig.json",
     "admin:build": "vite build --config admin/vite.config.ts",
     "admin:dev": "vite --config admin/vite.config.ts"

--- a/src/systems/slates/apps/hub/src/db.ts
+++ b/src/systems/slates/apps/hub/src/db.ts
@@ -37,11 +37,11 @@ export let db = baseClient;
 
 declare global {
   namespace PrismaJson {
-    type SlateJson = {
+    interface SlateJson {
       name: string;
       version: string;
       description?: string;
-    };
+    }
 
     type SlateDeploymentProviderDeploymentInfo = {
       functionId: string;

--- a/src/systems/slates/apps/hub/src/registry.ts
+++ b/src/systems/slates/apps/hub/src/registry.ts
@@ -3,7 +3,6 @@ import { Hash } from '@lowerdeck/hash';
 import { v } from '@lowerdeck/validation';
 import { addMinutes } from 'date-fns';
 import { hc } from 'hono/client';
-import type { registryApp } from '../../../apps/registry/src/apis/public';
 import type { Registry } from '../prisma/generated/client';
 import { db } from './db';
 import { encryption } from './encryption';
@@ -116,13 +115,11 @@ let getReaderToken = async (registry: Registry) => {
   return prom;
 };
 
-export type RegistryAppType = typeof registryApp;
-
-export let createSlatesRegistryClient = (o: { endpoint: string; token?: string }) =>
-  hc<RegistryAppType>(o.endpoint, {
+export let createSlatesRegistryClient = (o: { endpoint: string; token?: string }): RegistryClient =>
+  hc(o.endpoint, {
     headers: o.token ? { Authorization: `Bearer ${o.token}` } : {},
     init: { redirect: 'follow' }
-  });
+  }) as unknown as RegistryClient;
 
 export let getRegistryClient = async (registry: Registry): Promise<RegistryClient> => {
   let token = await getReaderToken(registry);
@@ -130,5 +127,5 @@ export let getRegistryClient = async (registry: Registry): Promise<RegistryClien
   return createSlatesRegistryClient({
     endpoint: registry.url,
     token
-  }) as unknown as RegistryClient;
+  });
 };

--- a/src/systems/slates/apps/hub/tsconfig.server.json
+++ b/src/systems/slates/apps/hub/tsconfig.server.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/**/tests/**/*",
+    "src/test/**/*"
+  ]
+}

--- a/src/systems/slates/apps/registry/package.json
+++ b/src/systems/slates/apps/registry/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "start": "bun run server:start",
-    "server:build": "ncc build ./src/server.ts -o ./dist --source-map --transpile-only && bun run sentry:sourcemaps:if-token",
+    "check-types": "tsc --noEmit -p tsconfig.json",
+    "server:build": "bun run check-types && ncc build ./src/server.ts -o ./dist --source-map --transpile-only && bun run sentry:sourcemaps:if-token",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org metorial --project mte-slates-registry ./dist && sentry-cli sourcemaps upload --org metorial --project mte-slates-registry ./dist",
     "sentry:sourcemaps:if-token": "sh -c 'if [ -n \"$SENTRY_AUTH_TOKEN\" ]; then bun run sentry:sourcemaps; else echo \"Skipping Sentry sourcemap upload\"; fi'",
     "server:start": "bun ./dist/index.js",

--- a/src/systems/slates/apps/registry/src/db.ts
+++ b/src/systems/slates/apps/registry/src/db.ts
@@ -14,11 +14,11 @@ declare global {
       label: string;
     }[];
 
-    type SlateJson = {
+    interface SlateJson {
       name: string;
       version: string;
       description?: string;
-    };
+    }
 
     type FilterExpression = {
       type: 'prefix' | 'scope' | 'slate';


### PR DESCRIPTION
## Summary

Build fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly build/type-safety changes plus a small runtime guard on a websocket route; minimal impact on business logic.
> 
> **Overview**
> Adds a dedicated `check-types` step (via new `tsconfig.server.json` files) and wires it into `server:build` for Origin, Shuttle, Slates Hub, and Slates Registry to fail builds on TypeScript errors.
> 
> Fixes TS issues uncovered by typechecking: `ProviderTemplateService` methods now explicitly return `EnrichedProviderTemplate` and use a new `enrichOne()` helper, Slates’ `PrismaJson.SlateJson` is switched to an `interface`, the Hub registry client drops the cross-package `registryApp` type import in favor of a local `RegistryClient` cast, and Shuttle’s websocket connection route now validates required URL params before use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91f10f03700f0406731c13b021989ea34df6f6d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->