### PR TITLE
Remove identity management flag

### DIFF
--- a/src/backend/apis/core/src/controllers/instance/consumer.ts
+++ b/src/backend/apis/core/src/controllers/instance/consumer.ts
@@ -95,7 +95,7 @@ export let consumerController = Controller.create(
         description: 'Returns a paginated list of consumers for an instance.'
       })
       .use(checkAccess({ possibleScopes: ['instance.portal.consumers:read'] }))
-      .use(hasFlags(['identity-management', 'paid-identity']))
+      .use(hasFlags(['paid-identity']))
       .outputList(consumerPresenter)
       .query(
         'default',
@@ -123,7 +123,7 @@ export let consumerController = Controller.create(
         description: 'Retrieves a consumer by ID.'
       })
       .use(checkAccess({ possibleScopes: ['instance.portal.consumers:read'] }))
-      .use(hasFlags(['identity-management', 'paid-identity']))
+      .use(hasFlags(['paid-identity']))
       .output(consumerPresenter)
       .do(async ctx => consumerPresenter.present({ consumer: ctx.consumer })),
 
@@ -133,7 +133,7 @@ export let consumerController = Controller.create(
         description: 'Creates or links a consumer for an instance.'
       })
       .use(checkAccess({ possibleScopes: ['instance.portal.consumers:write'] }))
-      .use(hasFlags(['identity-management', 'paid-identity']))
+      .use(hasFlags(['paid-identity']))
       .body(
         'default',
         v.object({
@@ -166,7 +166,7 @@ export let consumerController = Controller.create(
         hideInDocs: true
       })
       .use(checkAccess({ possibleScopes: ['instance.portal.consumers:write'] }))
-      .use(hasFlags(['identity-management', 'paid-identity']))
+      .use(hasFlags(['paid-identity']))
       .body(
         'default',
         v.object({
@@ -238,7 +238,7 @@ export let consumerController = Controller.create(
         description: 'Updates a consumer for an instance.'
       })
       .use(checkAccess({ possibleScopes: ['instance.portal.consumers:write'] }))
-      .use(hasFlags(['identity-management', 'paid-identity']))
+      .use(hasFlags(['paid-identity']))
       .body(
         'default',
         v.object({
@@ -265,7 +265,7 @@ export let consumerController = Controller.create(
         description: 'Returns a paginated list of profiles for a consumer in an instance.'
       })
       .use(checkAccess({ possibleScopes: ['instance.portal.consumers:read'] }))
-      .use(hasFlags(['identity-management', 'paid-identity']))
+      .use(hasFlags(['paid-identity']))
       .outputList(consumerProfilePresenter)
       .query('default', Paginator.validate(v.object({})))
       .do(async ctx => {
@@ -298,7 +298,7 @@ export let consumerController = Controller.create(
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.portal.consumers:read'] }))
-      .use(hasFlags(['identity-management', 'paid-identity']))
+      .use(hasFlags(['paid-identity']))
       .output(consumerProfilePresenter)
       .do(async ctx => {
         let assignedConsumerGroups = await consumerProfileService.getGroupsForProfile({

--- a/src/backend/apis/core/src/controllers/instance/consumerSurface.ts
+++ b/src/backend/apis/core/src/controllers/instance/consumerSurface.ts
@@ -40,7 +40,7 @@ export let consumerSurfaceController = Controller.create(
         hideInDocs: true
       })
       .use(checkAccess({ possibleScopes: ['instance.portal.consumers:read'] }))
-      .use(hasFlags(['identity-management', 'paid-identity']))
+      .use(hasFlags(['paid-identity']))
       .outputList(consumerSurfacePresenter)
       .query('default', Paginator.validate(v.object({})))
       .do(async ctx => {
@@ -60,7 +60,7 @@ export let consumerSurfaceController = Controller.create(
         description: 'Retrieves a consumer surface by ID.'
       })
       .use(checkAccess({ possibleScopes: ['instance.portal.consumers:read'] }))
-      .use(hasFlags(['identity-management', 'paid-identity']))
+      .use(hasFlags(['paid-identity']))
       .output(consumerSurfacePresenter)
       .do(async ctx =>
         consumerSurfacePresenter.present({ consumerSurface: ctx.consumerSurface })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes feature entitlement gating for several consumer-related endpoints, which could alter which paid customers can access these APIs. Access is still scope-checked, but flag configuration mistakes could broaden availability unexpectedly.
> 
> **Overview**
> Removes the `identity-management` flag requirement from instance consumer and consumer-surface endpoints (`consumers.*` and `consumerSurfaces.*`), so these routes now only require the `paid-identity` flag in addition to existing `checkAccess` scope checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f43bf48364212e3dcaca253e7f7037727d81d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->