### PR TITLE
Add credential scope update

### DIFF
--- a/clients/metorial-consumer/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-consumer/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
@@ -37,12 +37,18 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapDashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<DashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/clients/metorial-consumer/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-consumer/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-deployments/auth-credentials/update.ts
@@ -37,12 +37,18 @@ export type ManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<ManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/clients/metorial-consumer/src/gen/src/mt_2025_01_01_dashboard/resources/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-consumer/src/gen/src/mt_2025_01_01_dashboard/resources/provider-deployments/auth-credentials/update.ts
@@ -35,12 +35,18 @@ export type ProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<ProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/clients/metorial-consumer/src/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-consumer/src/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
@@ -37,12 +37,18 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapDashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<DashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/clients/metorial-consumer/src/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-consumer/src/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/update.ts
@@ -37,12 +37,18 @@ export type ManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<ManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/clients/metorial-consumer/src/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-consumer/src/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/update.ts
@@ -35,12 +35,18 @@ export type ProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<ProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/create.ts
@@ -10,6 +10,7 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsCreateOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -27,6 +28,7 @@ export let mapDashboardInstanceProviderDeploymentsAuthCredentialsCreateOutput =
       name: mtMap.objectField('name', mtMap.passthrough()),
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
       providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
       updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/delete.ts
@@ -10,6 +10,7 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsDeleteOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -27,6 +28,7 @@ export let mapDashboardInstanceProviderDeploymentsAuthCredentialsDeleteOutput =
       name: mtMap.objectField('name', mtMap.passthrough()),
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
       providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
       updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/get.ts
@@ -10,6 +10,7 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsGetOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -26,6 +27,7 @@ export let mapDashboardInstanceProviderDeploymentsAuthCredentialsGetOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
     providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/list.ts
@@ -11,6 +11,7 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsListOutput = {
     name: string | null;
     description: string | null;
     metadata: Record<string, any> | null;
+    scopes: string[] | null;
     providerId: string;
     createdAt: Date;
     updatedAt: Date;
@@ -33,6 +34,7 @@ export let mapDashboardInstanceProviderDeploymentsAuthCredentialsListOutput =
           name: mtMap.objectField('name', mtMap.passthrough()),
           description: mtMap.objectField('description', mtMap.passthrough()),
           metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
           providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
           updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
@@ -37,12 +37,18 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapDashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<DashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
@@ -10,6 +10,7 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsUpdateOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -27,6 +28,7 @@ export let mapDashboardInstanceProviderDeploymentsAuthCredentialsUpdateOutput =
       name: mtMap.objectField('name', mtMap.passthrough()),
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
       providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
       updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-deployments/auth-credentials/update.ts
@@ -37,12 +37,18 @@ export type ManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<ManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-deployments/auth-credentials/update.ts
@@ -35,12 +35,18 @@ export type ProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<ProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/create.ts
@@ -10,6 +10,7 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsCreateOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -27,6 +28,7 @@ export let mapDashboardInstanceProviderDeploymentsAuthCredentialsCreateOutput =
       name: mtMap.objectField('name', mtMap.passthrough()),
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
       providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
       updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/delete.ts
@@ -10,6 +10,7 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsDeleteOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -27,6 +28,7 @@ export let mapDashboardInstanceProviderDeploymentsAuthCredentialsDeleteOutput =
       name: mtMap.objectField('name', mtMap.passthrough()),
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
       providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
       updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/get.ts
@@ -10,6 +10,7 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsGetOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -26,6 +27,7 @@ export let mapDashboardInstanceProviderDeploymentsAuthCredentialsGetOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
     providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/list.ts
@@ -11,6 +11,7 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsListOutput = {
     name: string | null;
     description: string | null;
     metadata: Record<string, any> | null;
+    scopes: string[] | null;
     providerId: string;
     createdAt: Date;
     updatedAt: Date;
@@ -33,6 +34,7 @@ export let mapDashboardInstanceProviderDeploymentsAuthCredentialsListOutput =
           name: mtMap.objectField('name', mtMap.passthrough()),
           description: mtMap.objectField('description', mtMap.passthrough()),
           metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
           providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
           updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
@@ -37,12 +37,18 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapDashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<DashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
@@ -10,6 +10,7 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsUpdateOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -27,6 +28,7 @@ export let mapDashboardInstanceProviderDeploymentsAuthCredentialsUpdateOutput =
       name: mtMap.objectField('name', mtMap.passthrough()),
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
       providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
       updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/create.ts
@@ -10,6 +10,7 @@ export type ManagementInstanceProviderDeploymentsAuthCredentialsCreateOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -27,6 +28,7 @@ export let mapManagementInstanceProviderDeploymentsAuthCredentialsCreateOutput =
       name: mtMap.objectField('name', mtMap.passthrough()),
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
       providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
       updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/delete.ts
@@ -10,6 +10,7 @@ export type ManagementInstanceProviderDeploymentsAuthCredentialsDeleteOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -27,6 +28,7 @@ export let mapManagementInstanceProviderDeploymentsAuthCredentialsDeleteOutput =
       name: mtMap.objectField('name', mtMap.passthrough()),
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
       providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
       updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/get.ts
@@ -10,6 +10,7 @@ export type ManagementInstanceProviderDeploymentsAuthCredentialsGetOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -26,6 +27,7 @@ export let mapManagementInstanceProviderDeploymentsAuthCredentialsGetOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
     providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/list.ts
@@ -11,6 +11,7 @@ export type ManagementInstanceProviderDeploymentsAuthCredentialsListOutput = {
     name: string | null;
     description: string | null;
     metadata: Record<string, any> | null;
+    scopes: string[] | null;
     providerId: string;
     createdAt: Date;
     updatedAt: Date;
@@ -33,6 +34,7 @@ export let mapManagementInstanceProviderDeploymentsAuthCredentialsListOutput =
           name: mtMap.objectField('name', mtMap.passthrough()),
           description: mtMap.objectField('description', mtMap.passthrough()),
           metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
           providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
           updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/update.ts
@@ -37,12 +37,18 @@ export type ManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<ManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/update.ts
@@ -10,6 +10,7 @@ export type ManagementInstanceProviderDeploymentsAuthCredentialsUpdateOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -27,6 +28,7 @@ export let mapManagementInstanceProviderDeploymentsAuthCredentialsUpdateOutput =
       name: mtMap.objectField('name', mtMap.passthrough()),
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
       providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
       updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/create.ts
@@ -10,6 +10,7 @@ export type ProviderDeploymentsAuthCredentialsCreateOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -26,6 +27,7 @@ export let mapProviderDeploymentsAuthCredentialsCreateOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
     providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/delete.ts
@@ -10,6 +10,7 @@ export type ProviderDeploymentsAuthCredentialsDeleteOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -26,6 +27,7 @@ export let mapProviderDeploymentsAuthCredentialsDeleteOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
     providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/get.ts
@@ -10,6 +10,7 @@ export type ProviderDeploymentsAuthCredentialsGetOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -26,6 +27,7 @@ export let mapProviderDeploymentsAuthCredentialsGetOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
     providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/list.ts
@@ -11,6 +11,7 @@ export type ProviderDeploymentsAuthCredentialsListOutput = {
     name: string | null;
     description: string | null;
     metadata: Record<string, any> | null;
+    scopes: string[] | null;
     providerId: string;
     createdAt: Date;
     updatedAt: Date;
@@ -33,6 +34,7 @@ export let mapProviderDeploymentsAuthCredentialsListOutput =
           name: mtMap.objectField('name', mtMap.passthrough()),
           description: mtMap.objectField('description', mtMap.passthrough()),
           metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
           providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
           updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/update.ts
@@ -35,12 +35,18 @@ export type ProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<ProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/update.ts
@@ -10,6 +10,7 @@ export type ProviderDeploymentsAuthCredentialsUpdateOutput = {
   name: string | null;
   description: string | null;
   metadata: Record<string, any> | null;
+  scopes: string[] | null;
   providerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -26,6 +27,7 @@ export let mapProviderDeploymentsAuthCredentialsUpdateOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
     providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/src/backend/apis/core/src/controllers/provider/providerAuthCredentials.ts
+++ b/src/backend/apis/core/src/controllers/provider/providerAuthCredentials.ts
@@ -218,7 +218,11 @@ export let providerAuthCredentialsController = Controller.create(
           description: v.optional(v.string()),
           metadata: v.optional(v.record(v.any()), {
             description: 'Custom key-value pairs for storing additional information'
-          })
+          }),
+
+          client_id: v.optional(v.string()),
+          client_secret: v.optional(v.string()),
+          scopes: v.optional(v.array(v.string()))
         })
       )
       .output(providerAuthCredentialsPresenter)
@@ -228,7 +232,10 @@ export let providerAuthCredentialsController = Controller.create(
           providerAuthCredentialsId: ctx.authCredentials.id,
           name: ctx.body.name,
           description: ctx.body.description,
-          metadata: ctx.body.metadata
+          metadata: ctx.body.metadata,
+          clientId: ctx.body.client_id,
+          clientSecret: ctx.body.client_secret,
+          scopes: ctx.body.scopes
         });
 
         return providerAuthCredentialsPresenter.present({

--- a/src/backend/apis/core/src/presenters/implementation/provider/authCredentials.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/authCredentials.ts
@@ -16,6 +16,7 @@ export let v1ProviderAuthCredentialsPresenter = Presenter.create(providerAuthCre
     name: authCredentials.name,
     description: authCredentials.description,
     metadata: authCredentials.metadata,
+    scopes: authCredentials.scopes ?? null,
 
     provider_id: authCredentials.providerId,
 
@@ -62,6 +63,13 @@ export let v1ProviderAuthCredentialsPresenter = Presenter.create(providerAuthCre
           name: 'metadata',
           description: 'Custom key-value pairs for storing additional information',
           examples: [{ app_name: 'My GitHub App', created_by: 'admin@company.com' }]
+        })
+      ),
+      scopes: v.nullable(
+        v.array(v.string(), {
+          name: 'scopes',
+          description: 'OAuth scopes requested by this credential',
+          examples: [['read', 'write']]
         })
       ),
       provider_id: v.string({

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/settings.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/settings.tsx
@@ -1,11 +1,30 @@
 import { renderWithLoader, useForm } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
-import { useCurrentInstance, useProviderAuthCredential } from '@metorial/state';
-import { Button, Callout, Input, Spacer } from '@metorial/ui';
+import {
+  useCurrentInstance,
+  useProvider,
+  useProviderAuthCredential,
+  useProviderAuthMethods
+} from '@metorial/state';
+import { Button, Callout, Checkbox, Flex, Input, Spacer, Text } from '@metorial/ui';
 import { Box } from '@metorial/ui-product';
+import { useMemo, useState } from 'react';
+import styled from 'styled-components';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { DeleteResourceDangerZone } from '../../../scenes/deleteResourceDangerZone';
 import { getFromDeployment } from '../fromDeployment';
+
+let ScopesList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+let ScopeItem = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+`;
 
 export let ProviderAuthCredentialSettingsPage = () => {
   let instance = useCurrentInstance();
@@ -14,7 +33,26 @@ export let ProviderAuthCredentialSettingsPage = () => {
 
   let { providerAuthCredentialsId } = useParams();
   let credential = useProviderAuthCredential(instance.data?.id, providerAuthCredentialsId);
+  let provider = useProvider(instance.data?.id, credential.data?.providerId);
+  let versionId = provider.data?.currentVersion?.id;
+  let authMethods = useProviderAuthMethods(
+    instance.data?.id,
+    versionId ? { providerVersionId: versionId } : null
+  );
+
+  let availableScopes = useMemo(() => {
+    let oauthMethod = (authMethods.data?.items ?? []).find(m => m.type === 'oauth');
+    return oauthMethod?.scopes ?? [];
+  }, [authMethods.data?.items]);
+
+  let [selectedScopes, setSelectedScopes] = useState<Set<string> | null>(null);
+
+  let credentialScopes = credential.data?.scopes;
+  let effectiveScopes =
+    selectedScopes ?? new Set(credentialScopes ?? availableScopes.map(s => s.scope));
+
   let updateMutator = credential.useUpdateMutator();
+  let scopesMutator = credential.useUpdateMutator();
   let deleteMutator = credential.useDeleteMutator();
   let fromDeploymentId = getFromDeployment(location.search);
   let form = useForm({
@@ -37,6 +75,21 @@ export let ProviderAuthCredentialSettingsPage = () => {
         description: yup.string()
       }) as any
   });
+
+  let toggleScope = (scope: string) => {
+    let next = new Set(effectiveScopes);
+    if (next.has(scope)) {
+      next.delete(scope);
+    } else {
+      next.add(scope);
+    }
+    setSelectedScopes(next);
+  };
+
+  let saveScopes = async () => {
+    if (credential.data?.isManaged) return;
+    await scopesMutator.mutate({ scopes: [...effectiveScopes] });
+  };
 
   return renderWithLoader({ credential })(({ credential }) => (
     <>
@@ -77,6 +130,64 @@ export let ProviderAuthCredentialSettingsPage = () => {
           <updateMutator.RenderError />
         </form>
       </Box>
+
+      {availableScopes.length > 0 && (
+        <>
+          <Spacer size={20} />
+
+          <Box
+            title="Scopes"
+            description="Select which OAuth scopes this credential should request."
+          >
+            {credential.data.isManaged && (
+              <>
+                <Callout color="blue">Managed by Metorial.</Callout>
+                <Spacer size={15} />
+              </>
+            )}
+
+            <ScopesList>
+              {availableScopes.map(scope => (
+                <ScopeItem key={scope.id}>
+                  <Checkbox
+                    checked={effectiveScopes.has(scope.scope)}
+                    onCheckedChange={() => toggleScope(scope.scope)}
+                    disabled={credential.data.isManaged}
+                    label={
+                      <Flex direction="column" gap={2}>
+                        <Text size="2" weight="medium">
+                          {scope.name}
+                        </Text>
+                        {scope.description && (
+                          <Text size="1" color="gray600">
+                            {scope.description}
+                          </Text>
+                        )}
+                      </Flex>
+                    }
+                  />
+                </ScopeItem>
+              ))}
+            </ScopesList>
+
+            <Spacer size={15} />
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <Button
+                size="2"
+                onClick={saveScopes}
+                loading={scopesMutator.isLoading}
+                success={scopesMutator.isSuccess}
+                disabled={credential.data.isManaged}
+              >
+                Save
+              </Button>
+            </div>
+
+            <scopesMutator.RenderError />
+          </Box>
+        </>
+      )}
 
       <Spacer size={20} />
 

--- a/src/systems/slates/apps/hub/src/apis/internal/slateOAuthCredentials.ts
+++ b/src/systems/slates/apps/hub/src/apis/internal/slateOAuthCredentials.ts
@@ -82,6 +82,33 @@ export let slateOAuthCredentialsController = app.controller({
     )
     .do(async ctx => slateOAuthCredentialsPresenter(ctx.slateOAuthCredentials)),
 
+  update: slateOAuthCredentialsApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        slateOAuthCredentialsId: v.string(),
+
+        clientId: v.optional(v.string()),
+        clientSecret: v.optional(v.string()),
+        scopes: v.optional(v.array(v.string()))
+      })
+    )
+    .do(async ctx => {
+      let res = await slateOAuthCredentialsService.updateSlateOAuthCredentials({
+        tenant: ctx.tenant,
+        slateOAuthCredentials: ctx.slateOAuthCredentials,
+
+        input: {
+          scopes: ctx.input.scopes,
+          clientId: ctx.input.clientId,
+          clientSecret: ctx.input.clientSecret
+        }
+      });
+
+      return slateOAuthCredentialsPresenter(res);
+    }),
+
   delete: slateOAuthCredentialsApp
     .handler()
     .input(

--- a/src/systems/subspace/apps/controller/src/controllers/providerAuthCredentials.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerAuthCredentials.ts
@@ -105,7 +105,14 @@ export let providerAuthCredentialsController = app.controller({
         allowDeleted: v.optional(v.boolean())
       })
     )
-    .do(async ctx => providerAuthCredentialsPresenter(ctx.providerAuthCredentials)),
+    .do(async ctx => {
+      let [enriched] = await providerAuthCredentialsService.enrichWithScopes({
+        tenant: ctx.tenant,
+        credentials: [ctx.providerAuthCredentials]
+      });
+
+      return providerAuthCredentialsPresenter(enriched!);
+    }),
 
   create: tenantApp
     .handler()

--- a/src/systems/subspace/apps/controller/src/controllers/providerAuthCredentials.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerAuthCredentials.ts
@@ -171,7 +171,11 @@ export let providerAuthCredentialsController = app.controller({
         name: v.optional(v.string()),
         description: v.optional(v.string()),
         metadata: v.optional(v.record(v.any())),
-        privateMetadata: v.optional(v.record(v.any()))
+        privateMetadata: v.optional(v.record(v.any())),
+
+        clientId: v.optional(v.string()),
+        clientSecret: v.optional(v.string()),
+        scopes: v.optional(v.array(v.string()))
       })
     )
     .do(async ctx => {
@@ -186,7 +190,11 @@ export let providerAuthCredentialsController = app.controller({
             name: ctx.input.name,
             description: ctx.input.description,
             metadata: ctx.input.metadata,
-            privateMetadata: ctx.input.privateMetadata
+            privateMetadata: ctx.input.privateMetadata,
+
+            clientId: ctx.input.clientId,
+            clientSecret: ctx.input.clientSecret,
+            scopes: ctx.input.scopes
           }
         });
 

--- a/src/systems/subspace/modules/auth/src/services/providerAuthCredentials.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthCredentials.ts
@@ -301,6 +301,39 @@ class providerAuthCredentialsServiceImpl {
     );
   }
 
+  async enrichWithScopes<T extends ProviderAuthCredentials>(d: {
+    tenant: Tenant;
+    credentials: T[];
+  }): Promise<(T & { scopes: string[] | null })[]> {
+    let byBackend = new Map<bigint, T[]>();
+    for (let cred of d.credentials) {
+      let group = byBackend.get(cred.backendOid) ?? [];
+      group.push(cred);
+      byBackend.set(cred.backendOid, group);
+    }
+
+    let results = await Promise.all(
+      Array.from(byBackend.entries()).map(async ([_, creds]) => {
+        let backend = await getBackend({ entity: creds[0]! });
+        let { scopes } = await backend.auth.getManyProviderAuthCredentialsScopes({
+          tenant: d.tenant,
+          backings: creds.map(c => ({
+            id: c.id,
+            slateCredentialsOid: c.slateCredentialsOid,
+            shuttleCredentialsOid: c.shuttleCredentialsOid
+          }))
+        });
+
+        return creds.map(c => ({
+          ...c,
+          scopes: scopes.get(c.id) ?? null
+        }));
+      })
+    );
+
+    return results.flat();
+  }
+
   async getProviderAuthCredentialsById(d: {
     tenant: Tenant;
     solution: Solution;

--- a/src/systems/subspace/modules/auth/src/services/providerAuthCredentials.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthCredentials.ts
@@ -434,6 +434,10 @@ class providerAuthCredentialsServiceImpl {
       description?: string;
       metadata?: Record<string, any>;
       privateMetadata?: Record<string, any>;
+
+      clientId?: string;
+      clientSecret?: string;
+      scopes?: string[];
     };
   }) {
     checkTenant(d, d.providerAuthCredentials);
@@ -449,6 +453,21 @@ class providerAuthCredentialsServiceImpl {
     }
 
     return withTransaction(async db => {
+      let backend = await getBackend({ entity: d.providerAuthCredentials });
+
+      if (d.input.clientId || d.input.clientSecret || d.input.scopes) {
+        await backend.auth.updateProviderAuthCredentials({
+          tenant: d.tenant,
+          backing: d.providerAuthCredentials,
+          input: {
+            type: 'oauth',
+            clientId: d.input.clientId,
+            clientSecret: d.input.clientSecret,
+            scopes: d.input.scopes
+          }
+        });
+      }
+
       let creds = await db.providerAuthCredentials.update({
         where: {
           oid: d.providerAuthCredentials.oid,

--- a/src/systems/subspace/packages/presenters/src/authCredentials.ts
+++ b/src/systems/subspace/packages/presenters/src/authCredentials.ts
@@ -3,6 +3,7 @@ import type { Provider, ProviderAuthCredentials } from '@metorial-subspace/db';
 export let providerAuthCredentialsPresenter = (
   providerAuthCredentials: ProviderAuthCredentials & {
     provider: Provider;
+    scopes?: string[] | null;
   }
 ) => ({
   object: 'provider.auth_credentials',
@@ -22,6 +23,7 @@ export let providerAuthCredentialsPresenter = (
   description: providerAuthCredentials.description,
   metadata: providerAuthCredentials.metadata,
   privateMetadata: providerAuthCredentials.privateMetadata,
+  scopes: providerAuthCredentials.scopes ?? null,
 
   createdAt: providerAuthCredentials.createdAt,
   updatedAt: providerAuthCredentials.updatedAt

--- a/src/systems/subspace/provider-backends/provider-native/src/impl/auth.ts
+++ b/src/systems/subspace/provider-backends/provider-native/src/impl/auth.ts
@@ -3,14 +3,16 @@ import {
   IProviderAuth,
   type GetDecryptedAuthConfigParam,
   type GetDecryptedAuthConfigRes,
-  type ProviderAuthConfigDeleteParam,
-  type ProviderAuthConfigDeleteRes,
   type ProviderAuthConfigCreateParam,
   type ProviderAuthConfigCreateRes,
-  type ProviderAuthCredentialsDeleteParam,
-  type ProviderAuthCredentialsDeleteRes,
+  type ProviderAuthConfigDeleteParam,
+  type ProviderAuthConfigDeleteRes,
   type ProviderAuthCredentialsCreateParam,
   type ProviderAuthCredentialsCreateRes,
+  type ProviderAuthCredentialsDeleteParam,
+  type ProviderAuthCredentialsDeleteRes,
+  type ProviderAuthCredentialsUpdateParam,
+  type ProviderAuthCredentialsUpdateRes,
   type ProviderOAuthSetupCreateParam,
   type ProviderOAuthSetupCreateRes,
   type ProviderOAuthSetupRetrieveParam,
@@ -28,6 +30,12 @@ export class ProviderAuth extends IProviderAuth {
   override async createProviderAuthCredentials(
     _data: ProviderAuthCredentialsCreateParam
   ): Promise<ProviderAuthCredentialsCreateRes> {
+    throw unsupportedAuthError();
+  }
+
+  override updateProviderAuthCredentials(
+    _data: ProviderAuthCredentialsUpdateParam
+  ): Promise<ProviderAuthCredentialsUpdateRes> {
     throw unsupportedAuthError();
   }
 

--- a/src/systems/subspace/provider-backends/provider-native/src/impl/auth.ts
+++ b/src/systems/subspace/provider-backends/provider-native/src/impl/auth.ts
@@ -33,7 +33,7 @@ export class ProviderAuth extends IProviderAuth {
     throw unsupportedAuthError();
   }
 
-  override updateProviderAuthCredentials(
+  override async updateProviderAuthCredentials(
     _data: ProviderAuthCredentialsUpdateParam
   ): Promise<ProviderAuthCredentialsUpdateRes> {
     throw unsupportedAuthError();

--- a/src/systems/subspace/provider-backends/provider-shuttle/src/impl/auth.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/impl/auth.ts
@@ -12,6 +12,8 @@ import type {
   ProviderAuthCredentialsCreateRes,
   ProviderAuthCredentialsDeleteParam,
   ProviderAuthCredentialsDeleteRes,
+  ProviderAuthCredentialsUpdateParam,
+  ProviderAuthCredentialsUpdateRes,
   ProviderOAuthSetupCreateParam,
   ProviderOAuthSetupCreateRes,
   ProviderOAuthSetupRetrieveParam,
@@ -61,6 +63,16 @@ export class ProviderAuth extends IProviderAuth {
       shuttleOAuthCredentials,
       isAutoRegistration: data.input.type === 'auto_registration'
     };
+  }
+
+  override updateProviderAuthCredentials(
+    _data: ProviderAuthCredentialsUpdateParam
+  ): Promise<ProviderAuthCredentialsUpdateRes> {
+    throw new ServiceError(
+      badRequestError({
+        message: 'This integration does not support authentication configuration'
+      })
+    );
   }
 
   override async deleteProviderAuthCredentials(

--- a/src/systems/subspace/provider-backends/provider-shuttle/src/impl/auth.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/impl/auth.ts
@@ -65,7 +65,7 @@ export class ProviderAuth extends IProviderAuth {
     };
   }
 
-  override updateProviderAuthCredentials(
+  override async updateProviderAuthCredentials(
     _data: ProviderAuthCredentialsUpdateParam
   ): Promise<ProviderAuthCredentialsUpdateRes> {
     throw new ServiceError(

--- a/src/systems/subspace/provider-backends/provider-slates/src/impl/auth.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/impl/auth.ts
@@ -11,6 +11,8 @@ import type {
   ProviderAuthCredentialsCreateRes,
   ProviderAuthCredentialsDeleteParam,
   ProviderAuthCredentialsDeleteRes,
+  ProviderAuthCredentialsScopesParam,
+  ProviderAuthCredentialsScopesRes,
   ProviderAuthCredentialsUpdateParam,
   ProviderAuthCredentialsUpdateRes,
   ProviderOAuthSetupCreateParam,
@@ -116,6 +118,43 @@ export class ProviderAuth extends IProviderAuth {
     });
 
     return {};
+  }
+
+  override async getManyProviderAuthCredentialsScopes(
+    data: ProviderAuthCredentialsScopesParam
+  ): Promise<ProviderAuthCredentialsScopesRes> {
+    let oids = data.backings
+      .filter(b => b.slateCredentialsOid)
+      .map(b => b.slateCredentialsOid!);
+
+    if (oids.length === 0) return { scopes: new Map() };
+
+    let slateRows = await db.slateOAuthCredentials.findMany({
+      where: { oid: { in: oids } }
+    });
+    if (slateRows.length === 0) return { scopes: new Map() };
+
+    let tenant = await getTenantForSlates(data.tenant);
+    let slateCreds = await slates.slateOAuthCredentials.getMany({
+      tenantId: tenant.id,
+      slateOAuthCredentialsIds: slateRows.map(r => r.id)
+    });
+
+    let slateIdToOid = new Map(slateRows.map(r => [r.id, r.oid]));
+    let oidToBackingId = new Map(
+      data.backings.filter(b => b.slateCredentialsOid).map(b => [b.slateCredentialsOid!, b.id])
+    );
+
+    let scopes = new Map<string, string[]>();
+    for (let cred of slateCreds) {
+      let oid = slateIdToOid.get(cred.id);
+      if (!oid) continue;
+      let backingId = oidToBackingId.get(oid);
+      if (!backingId) continue;
+      scopes.set(backingId, cred.scopes);
+    }
+
+    return { scopes };
   }
 
   override async createProviderOAuthSetup(

--- a/src/systems/subspace/provider-backends/provider-slates/src/impl/auth.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/impl/auth.ts
@@ -11,6 +11,8 @@ import type {
   ProviderAuthCredentialsCreateRes,
   ProviderAuthCredentialsDeleteParam,
   ProviderAuthCredentialsDeleteRes,
+  ProviderAuthCredentialsUpdateParam,
+  ProviderAuthCredentialsUpdateRes,
   ProviderOAuthSetupCreateParam,
   ProviderOAuthSetupCreateRes,
   ProviderOAuthSetupRetrieveParam,
@@ -64,6 +66,33 @@ export class ProviderAuth extends IProviderAuth {
       isAutoRegistration: false,
       type: 'oauth'
     };
+  }
+
+  override async updateProviderAuthCredentials(
+    data: ProviderAuthCredentialsUpdateParam
+  ): Promise<ProviderAuthCredentialsUpdateRes> {
+    if (!data.backing.slateCredentialsOid) {
+      return {};
+    }
+
+    let tenant = await getTenantForSlates(data.tenant);
+    let slateOAuthCredentials = await db.slateOAuthCredentials.findUnique({
+      where: { oid: data.backing.slateCredentialsOid }
+    });
+    if (!slateOAuthCredentials) {
+      return {};
+    }
+
+    await slates.slateOAuthCredentials.update({
+      tenantId: tenant.id,
+      slateOAuthCredentialsId: slateOAuthCredentials.id,
+
+      clientId: data.input.clientId,
+      clientSecret: data.input.clientSecret,
+      scopes: data.input.scopes
+    });
+
+    return {};
   }
 
   override async deleteProviderAuthCredentials(

--- a/src/systems/subspace/provider-backends/provider-utils/src/interfaces/providerAuth.ts
+++ b/src/systems/subspace/provider-backends/provider-utils/src/interfaces/providerAuth.ts
@@ -50,6 +50,25 @@ export abstract class IProviderAuth extends IProviderFunctionality {
   abstract getDecryptedAuthConfig(
     data: GetDecryptedAuthConfigParam
   ): Promise<GetDecryptedAuthConfigRes>;
+
+  async getManyProviderAuthCredentialsScopes(
+    data: ProviderAuthCredentialsScopesParam
+  ): Promise<ProviderAuthCredentialsScopesRes> {
+    return { scopes: new Map() };
+  }
+}
+
+export interface ProviderAuthCredentialsScopesParam {
+  tenant: Tenant;
+  backings: {
+    id: string;
+    slateCredentialsOid?: bigint | null;
+    shuttleCredentialsOid?: bigint | null;
+  }[];
+}
+
+export interface ProviderAuthCredentialsScopesRes {
+  scopes: Map<string, string[]>;
 }
 
 export interface ProviderAuthCredentialsCreateParam {

--- a/src/systems/subspace/provider-backends/provider-utils/src/interfaces/providerAuth.ts
+++ b/src/systems/subspace/provider-backends/provider-utils/src/interfaces/providerAuth.ts
@@ -23,6 +23,10 @@ export abstract class IProviderAuth extends IProviderFunctionality {
     data: ProviderAuthCredentialsCreateParam
   ): Promise<ProviderAuthCredentialsCreateRes>;
 
+  abstract updateProviderAuthCredentials(
+    data: ProviderAuthCredentialsUpdateParam
+  ): Promise<ProviderAuthCredentialsUpdateRes>;
+
   abstract deleteProviderAuthCredentials(
     data: ProviderAuthCredentialsDeleteParam
   ): Promise<ProviderAuthCredentialsDeleteRes>;
@@ -68,14 +72,27 @@ export interface ProviderAuthCredentialsCreateRes {
   isAutoRegistration: boolean;
 }
 
-export interface ProviderAuthCredentialsDeleteBacking {
+export interface ProviderAuthCredentialsEditBacking {
   slateCredentialsOid?: bigint | null;
   shuttleCredentialsOid?: bigint | null;
 }
 
+export interface ProviderAuthCredentialsUpdateParam {
+  tenant: Tenant;
+  backing: ProviderAuthCredentialsEditBacking;
+  input: {
+    type: 'oauth';
+    clientId?: string;
+    clientSecret?: string;
+    scopes?: string[];
+  };
+}
+
+export interface ProviderAuthCredentialsUpdateRes {}
+
 export interface ProviderAuthCredentialsDeleteParam {
   tenant: Tenant;
-  backing: ProviderAuthCredentialsDeleteBacking;
+  backing: ProviderAuthCredentialsEditBacking;
 }
 
 export interface ProviderAuthCredentialsDeleteRes {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds end-to-end support for updating OAuth credential `clientId`/`clientSecret` and `scopes`, touching auth-credential APIs and provider backends where secrets are handled. Risk is moderate due to potential integration mismatches across generated clients, backend validation, and backend-specific update support.
> 
> **Overview**
> Adds support to **read and update OAuth scopes on provider auth credentials**.
> 
> Backend `providerAuthCredentials` update now accepts optional `client_id`, `client_secret`, and `scopes`, persists changes via the provider backend (`updateProviderAuthCredentials`), and presenters include `scopes` (including a new `enrichWithScopes` path that fetches scopes from backends). Provider backend interfaces were extended with `updateProviderAuthCredentials` and `getManyProviderAuthCredentialsScopes`, with the Slates backend implementing both and other backends explicitly rejecting unsupported updates.
> 
> Frontend dashboard adds a **Scopes** section to the auth credential settings page to select available OAuth scopes (from provider auth methods) and save them via the existing update mutator. Generated consumer/dashboard client types/mappers were updated to include `scopes` in outputs and the new update fields in request bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bfd9c8d82cc0df5649740f62b030cb68b967e64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->