### PR TITLE
Improve tenant management

### DIFF
--- a/src/systems/subspace/apps/controller/src/controllers/tenant.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/tenant.ts
@@ -49,6 +49,7 @@ export let tenantController = app.controller({
         name: v.string(),
         identifier: v.string(),
         onlyAllowTrustedProviders: v.optional(v.boolean()),
+        isWhitelabel: v.optional(v.boolean()),
         logRetentionInDays: v.optional(v.number()),
         environments: v.array(
           v.object({
@@ -66,6 +67,7 @@ export let tenantController = app.controller({
           identifier: ctx.input.identifier,
           environments: ctx.input.environments as any,
           onlyAllowTrustedProviders: ctx.input.onlyAllowTrustedProviders,
+          isWhitelabel: ctx.input.isWhitelabel,
           logRetentionInDays: ctx.input.logRetentionInDays
         }
       });

--- a/src/systems/subspace/apps/public/frontend/src/pages/setupSession/index.tsx
+++ b/src/systems/subspace/apps/public/frontend/src/pages/setupSession/index.tsx
@@ -25,7 +25,7 @@ export let SetupSessionPage = () => {
     return <LoadingPage />;
   }
 
-  let { session, brand, provider } = setupSession.data;
+  let { session, brand, provider, isWhitelabel } = setupSession.data;
   let clientSecret = new URLSearchParams(window.location.search).get('client_secret') || '';
 
   if (session.status === 'completed') {
@@ -45,6 +45,7 @@ export let SetupSessionPage = () => {
         icon={<SuccessIcon />}
         title="Setup Complete"
         description="This setup session has already been completed. You can close this window."
+        isWhitelabel={isWhitelabel}
       />
     );
   }
@@ -55,6 +56,7 @@ export let SetupSessionPage = () => {
         icon={<WarningIcon />}
         title="Session Expired"
         description="This setup session has expired. Please request a new setup link."
+        isWhitelabel={isWhitelabel}
       />
     );
   }
@@ -65,6 +67,7 @@ export let SetupSessionPage = () => {
         icon={<ErrorIcon />}
         title="Setup Failed"
         description="This setup session has failed. Please request a new setup link or contact support."
+        isWhitelabel={isWhitelabel}
       />
     );
   }
@@ -75,6 +78,7 @@ export let SetupSessionPage = () => {
       brand={brand}
       provider={provider}
       clientSecret={clientSecret}
+      isWhitelabel={isWhitelabel}
     />
   );
 };
@@ -174,9 +178,10 @@ interface StatusPageViewProps {
   title: string;
   description: string;
   noPadding?: boolean;
+  isWhitelabel?: boolean;
 }
 
-let StatusPageView = ({ icon, title, description, noPadding }: StatusPageViewProps) => {
+let StatusPageView = ({ icon, title, description, noPadding, isWhitelabel }: StatusPageViewProps) => {
   return (
     <Wrapper>
       <Inner>
@@ -189,9 +194,11 @@ let StatusPageView = ({ icon, title, description, noPadding }: StatusPageViewPro
             <StatusDescription>{description}</StatusDescription>
           </StatusContent>
 
-          <Footer>
-            <SecuredByFooter logoSize={16} isMetorialElement />
-          </Footer>
+          {!isWhitelabel && (
+            <Footer>
+              <SecuredByFooter logoSize={16} isMetorialElement />
+            </Footer>
+          )}
         </Card>
       </Inner>
     </Wrapper>

--- a/src/systems/subspace/apps/public/frontend/src/pages/setupSession/layouts/metorialElementsLayout.tsx
+++ b/src/systems/subspace/apps/public/frontend/src/pages/setupSession/layouts/metorialElementsLayout.tsx
@@ -225,6 +225,7 @@ interface MetorialElementsLayoutProps {
   currentStep?: number;
   stepLabels?: string[];
   variant?: 'box' | 'light';
+  isWhitelabel?: boolean;
 }
 
 export let MetorialElementsLayout = ({
@@ -235,7 +236,8 @@ export let MetorialElementsLayout = ({
   hideHeader = false,
   currentStep = 0,
   stepLabels = [],
-  variant = 'box'
+  variant = 'box',
+  isWhitelabel
 }: MetorialElementsLayoutProps) => {
   return (
     <Wrapper
@@ -332,13 +334,15 @@ export let MetorialElementsLayout = ({
             <Content $hideHeader={hideHeader}>{children}</Content>
           </AnimateHeight>
 
-          <Footer>
-            <span>Secured by</span>
-            <FooterLink href="https://metorial.com" target="_blank" rel="noopener noreferrer">
-              <FooterLogo src={METORIAL_LOGO_URL} alt="Metorial" />
-              Metorial
-            </FooterLink>
-          </Footer>
+          {!isWhitelabel && (
+            <Footer>
+              <span>Secured by</span>
+              <FooterLink href="https://metorial.com" target="_blank" rel="noopener noreferrer">
+                <FooterLogo src={METORIAL_LOGO_URL} alt="Metorial" />
+                Metorial
+              </FooterLink>
+            </Footer>
+          )}
         </Card>
       </Inner>
     </Wrapper>

--- a/src/systems/subspace/apps/public/frontend/src/pages/setupSession/setupSessionFlow.tsx
+++ b/src/systems/subspace/apps/public/frontend/src/pages/setupSession/setupSessionFlow.tsx
@@ -25,6 +25,7 @@ interface SetupSessionFlowProps {
   brand: Brand;
   provider: Provider | null;
   clientSecret: string;
+  isWhitelabel?: boolean;
 }
 
 interface ProviderSelectionPaneProps {
@@ -105,7 +106,8 @@ export let SetupSessionFlow = ({
   session,
   brand,
   clientSecret,
-  provider
+  provider,
+  isWhitelabel
 }: SetupSessionFlowProps) => {
   let [flowSession, setFlowSession] = useState(session);
   let [flowProvider, setFlowProvider] = useState(provider);
@@ -546,6 +548,7 @@ export let SetupSessionFlow = ({
         currentStep={currentStepIndex}
         stepLabels={isCompleted ? [] : stepLabels}
         variant={layoutVariant === 'light' ? 'light' : 'box'}
+        isWhitelabel={isWhitelabel}
       >
         {innerContent}
       </MetorialElementsLayout>

--- a/src/systems/subspace/apps/public/src/api/internal/setupSession.ts
+++ b/src/systems/subspace/apps/public/src/api/internal/setupSession.ts
@@ -60,7 +60,8 @@ export let getFullSession = async (
         }
       : null,
     session: providerSetupSessionPresenter(session),
-    brand: brandPresenter(brand)
+    brand: brandPresenter(brand),
+    isWhitelabel: session.tenant.isWhitelabel
   };
 };
 

--- a/src/systems/subspace/db/prisma/schema/tenant.prisma
+++ b/src/systems/subspace/db/prisma/schema/tenant.prisma
@@ -17,6 +17,7 @@ model Tenant {
   originTenantIdentifier String?
 
   onlyAllowTrustedProviders Boolean @default(false)
+  isWhitelabel              Boolean @default(false)
 
   createdAt DateTime @default(now())
 

--- a/src/systems/subspace/modules/tenant/src/services/tenant.ts
+++ b/src/systems/subspace/modules/tenant/src/services/tenant.ts
@@ -12,6 +12,7 @@ class tenantServiceImpl {
       name: string;
       identifier: string;
       onlyAllowTrustedProviders?: boolean;
+      isWhitelabel?: boolean;
       logRetentionInDays?: number;
       environments: {
         name: string;
@@ -34,6 +35,7 @@ class tenantServiceImpl {
         update: {
           name: d.input.name,
           onlyAllowTrustedProviders: d.input.onlyAllowTrustedProviders,
+          isWhitelabel: d.input.isWhitelabel,
           logRetentionInDays: d.input.logRetentionInDays
         },
         create: {
@@ -41,6 +43,7 @@ class tenantServiceImpl {
           name: d.input.name,
           identifier: d.input.identifier,
           onlyAllowTrustedProviders: d.input.onlyAllowTrustedProviders,
+          isWhitelabel: d.input.isWhitelabel,
           logRetentionInDays: d.input.logRetentionInDays ?? 30,
 
           urlKey: generatePlainId(10).toLowerCase()

--- a/src/systems/subspace/packages/presenters/src/tenant.ts
+++ b/src/systems/subspace/packages/presenters/src/tenant.ts
@@ -9,6 +9,7 @@ export let tenantPresenter = (tenant: Tenant) => ({
   logRetentionInDays: tenant.logRetentionInDays,
 
   onlyAllowTrustedProviders: tenant.onlyAllowTrustedProviders,
+  isWhitelabel: tenant.isWhitelabel,
 
   createdAt: tenant.createdAt
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new persisted `Tenant.isWhitelabel` field and threads it through APIs into the public setup-session UI to conditionally remove branding, which could impact tenant creation/update and setup-session responses if migrations/clients aren’t aligned.
> 
> **Overview**
> Adds a new `Tenant.isWhitelabel` boolean (default `false`) and supports setting it via the tenant `upsert` controller/service, including exposing it through `tenantPresenter`.
> 
> Propagates `isWhitelabel` into the setup-session `getFullSession` API response and updates the public setup-session UI to pass the flag through layouts/status views, hiding the “Secured by Metorial” footer when whitelabel is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 314384f03de1b374ed8d09399e28877ee6573973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->