### PR TITLE
Various fixes

### DIFF
--- a/src/backend/modules/portal/src/lib/oauth.ts
+++ b/src/backend/modules/portal/src/lib/oauth.ts
@@ -21,10 +21,39 @@ type ParsedPortalAllowedRedirectUrlFilter = {
 let portalAllowedRedirectUrlFilterPattern =
   /^(?<protocol>\*|[a-z][a-z0-9+.-]*):\/\/(?<authority>[^/?#]+)(?<path>\/[^?#]*)?$/i;
 
+let normalizeLoopbackHostname = (hostname: string) => {
+  let normalizedHostname = hostname.toLowerCase();
+  let unwrappedHostname = normalizedHostname.replace(/^\[(.*)\]$/, '$1');
+
+  if (unwrappedHostname == 'localhost' || unwrappedHostname == '::1') {
+    return 'localhost';
+  }
+
+  let ipv4Parts = unwrappedHostname.split('.');
+  if (
+    ipv4Parts.length == 4 &&
+    ipv4Parts.every(part => /^\d+$/.test(part) && Number(part) >= 0 && Number(part) <= 255) &&
+    Number(ipv4Parts[0]) == 127
+  ) {
+    return 'localhost';
+  }
+
+  return normalizedHostname;
+};
+
+let normalizeUrlForComparison = (url: URL) => {
+  return {
+    protocol: url.protocol.replace(/:$/, '').toLowerCase(),
+    hostname: normalizeLoopbackHostname(url.hostname),
+    port: url.port,
+    pathname: url.pathname
+  };
+};
+
 export let urlsMatch = (url1: string, url2: string) => {
   try {
-    let u1 = new URL(url1);
-    let u2 = new URL(url2);
+    let u1 = normalizeUrlForComparison(new URL(url1));
+    let u2 = normalizeUrlForComparison(new URL(url2));
 
     return (
       u1.protocol == u2.protocol &&
@@ -116,7 +145,7 @@ let parsePortalAllowedRedirectUrlFilter = (
 
   return {
     protocol: match.groups.protocol.toLowerCase(),
-    hostname: hostname.toLowerCase(),
+    hostname: normalizeLoopbackHostname(hostname),
     port,
     path: match.groups.path
   };
@@ -209,6 +238,30 @@ export let validatePortalAllowedRedirectUrlFilters = (
   }
 };
 
+export let portalAllowedRedirectUrlFiltersEqual = (
+  filters1: PortalAllowedRedirectUrlFilter[],
+  filters2: PortalAllowedRedirectUrlFilter[]
+) => {
+  if (filters1.length != filters2.length) return false;
+
+  let normalizeFilter = (filter: PortalAllowedRedirectUrlFilter) => {
+    let parsedFilter = parsePortalAllowedRedirectUrlFilter(
+      filter.url,
+      'allowed_redirect_url_filters.url'
+    );
+
+    return `${parsedFilter.protocol}://${parsedFilter.hostname}${
+      parsedFilter.port ? `:${parsedFilter.port}` : ''
+    }${parsedFilter.path ?? ''}`;
+  };
+
+  let normalizedFilters1 = new Set(filters1.map(normalizeFilter));
+  let normalizedFilters2 = new Set(filters2.map(normalizeFilter));
+  if (normalizedFilters1.size != normalizedFilters2.size) return false;
+
+  return [...normalizedFilters1].every(filter => normalizedFilters2.has(filter));
+};
+
 export let portalAllowedRedirectUrlFilterMatches = (
   filter: PortalAllowedRedirectUrlFilter,
   redirectUri: string
@@ -219,48 +272,83 @@ export let portalAllowedRedirectUrlFilterMatches = (
     filter.url,
     'allowed_redirect_url_filters.url'
   );
-  let redirectUrl = new URL(redirectUri);
+  let redirectUrl = normalizeUrlForComparison(new URL(redirectUri));
 
   return (
     matchesPortalAllowedRedirectUrlFilterProtocol(
       parsedFilter.protocol,
-      redirectUrl.protocol.replace(/:$/, '').toLowerCase()
+      redirectUrl.protocol
     ) &&
     matchesPortalAllowedRedirectUrlFilterHostname(
       parsedFilter.hostname,
-      redirectUrl.hostname.toLowerCase()
+      redirectUrl.hostname
     ) &&
     matchesPortalAllowedRedirectUrlFilterPort(parsedFilter.port, redirectUrl.port) &&
     matchesPortalAllowedRedirectUrlFilterPath(parsedFilter.path, redirectUrl.pathname)
   );
 };
 
+export let portalRedirectUriMatchesAllowedFilters = (d: {
+  redirectUri: string;
+  allowedRedirectUrlFilters?: PortalAllowedRedirectUrlFilter[] | null;
+}) => {
+  validateUrlString(d.redirectUri, 'redirect_uri');
+
+  let allowedRedirectUrlFilters = getPortalAllowedRedirectUrlFilters(
+    d.allowedRedirectUrlFilters
+  );
+  return allowedRedirectUrlFilters.some(filter =>
+    portalAllowedRedirectUrlFilterMatches(filter, d.redirectUri)
+  );
+};
+
+export let validatePortalRedirectUriAgainstAllowedFilters = (d: {
+  redirectUri: string;
+  allowedRedirectUrlFilters?: PortalAllowedRedirectUrlFilter[] | null;
+}) => {
+  if (
+    !portalRedirectUriMatchesAllowedFilters({
+      redirectUri: d.redirectUri,
+      allowedRedirectUrlFilters: d.allowedRedirectUrlFilters
+    })
+  ) {
+    throw new ServiceError(
+      badRequestError({
+        message: 'redirect_uri is not allowed for this portal',
+        oauth: {
+          error: 'invalid_request',
+          errorMessage: 'redirect_uri is not allowed for this portal'
+        }
+      })
+    );
+  }
+};
+
 export let validatePortalRedirectUrisAgainstAllowedFilters = (d: {
   redirectUris: string[];
   allowedRedirectUrlFilters?: PortalAllowedRedirectUrlFilter[] | null;
 }) => {
-  let allowedRedirectUrlFilters = getPortalAllowedRedirectUrlFilters(
-    d.allowedRedirectUrlFilters
-  );
-
   for (let redirectUri of d.redirectUris) {
     validateUrlString(redirectUri, 'redirect_uri');
+  }
 
-    if (
-      !allowedRedirectUrlFilters.some(filter =>
-        portalAllowedRedirectUrlFilterMatches(filter, redirectUri)
-      )
-    ) {
-      throw new ServiceError(
-        badRequestError({
-          message: 'redirect_uri is not allowed for this portal',
-          oauth: {
-            error: 'invalid_request',
-            errorMessage: 'redirect_uri is not allowed for this portal'
-          }
-        })
-      );
-    }
+  if (
+    !d.redirectUris.some(redirectUri =>
+      portalRedirectUriMatchesAllowedFilters({
+        redirectUri,
+        allowedRedirectUrlFilters: d.allowedRedirectUrlFilters
+      })
+    )
+  ) {
+    throw new ServiceError(
+      badRequestError({
+        message: 'redirect_uri is not allowed for this portal',
+        oauth: {
+          error: 'invalid_request',
+          errorMessage: 'redirect_uri is not allowed for this portal'
+        }
+      })
+    );
   }
 };
 

--- a/src/backend/modules/portal/src/lib/oauth.ts
+++ b/src/backend/modules/portal/src/lib/oauth.ts
@@ -21,6 +21,49 @@ type ParsedPortalAllowedRedirectUrlFilter = {
 let portalAllowedRedirectUrlFilterPattern =
   /^(?<protocol>\*|[a-z][a-z0-9+.-]*):\/\/(?<authority>[^/?#]+)(?<path>\/[^?#]*)?$/i;
 
+let blockedPortalRedirectProtocols = new Set([
+  'about',
+  'blob',
+  'chrome',
+  'chrome-extension',
+  'data',
+  'file',
+  'ftp',
+  'ftps',
+  'gopher',
+  'http+unix',
+  'imap',
+  'irc',
+  'ircs',
+  'ldap',
+  'ldaps',
+  'mailto',
+  'news',
+  'nntp',
+  'sftp',
+  'sms',
+  'ssh',
+  'tel',
+  'telnet',
+  'urn',
+  'ws',
+  'wss'
+]);
+
+let validatePortalRedirectProtocol = (protocol: string, field: string) => {
+  if (!blockedPortalRedirectProtocols.has(protocol)) return;
+
+  throw new ServiceError(
+    badRequestError({
+      message: `${field} uses a blocked redirect protocol`,
+      oauth: {
+        error: 'invalid_request',
+        errorMessage: `${field} uses a blocked redirect protocol`
+      }
+    })
+  );
+};
+
 let normalizeLoopbackHostname = (hostname: string) => {
   let normalizedHostname = hostname.toLowerCase();
   let unwrappedHostname = normalizedHostname.replace(/^\[(.*)\]$/, '$1');
@@ -143,6 +186,10 @@ let parsePortalAllowedRedirectUrlFilter = (
     );
   }
 
+  if (match.groups.protocol != '*') {
+    validatePortalRedirectProtocol(match.groups.protocol.toLowerCase(), field);
+  }
+
   return {
     protocol: match.groups.protocol.toLowerCase(),
     hostname: normalizeLoopbackHostname(hostname),
@@ -156,7 +203,7 @@ let matchesPortalAllowedRedirectUrlFilterProtocol = (
   protocol: string
 ) => {
   if (protocolPattern == '*') {
-    return protocol != 'http' && protocol != 'https';
+    return protocol != 'http' && protocol != 'https' && !blockedPortalRedirectProtocols.has(protocol);
   }
 
   return protocolPattern == protocol;
@@ -201,8 +248,11 @@ let matchesPortalAllowedRedirectUrlFilterPath = (
 
 export let validateUrlString = (value: string, field: string) => {
   try {
-    new URL(value);
-  } catch {
+    let url = new URL(value);
+    validatePortalRedirectProtocol(url.protocol.replace(/:$/, '').toLowerCase(), field);
+  } catch (error) {
+    if (error instanceof ServiceError) throw error;
+
     throw new ServiceError(
       badRequestError({
         message: `${field} must be a valid URL`,

--- a/src/backend/modules/portal/src/services/consumerOAuth.ts
+++ b/src/backend/modules/portal/src/services/consumerOAuth.ts
@@ -38,6 +38,7 @@ import {
   createCodeChallenge,
   getPortalAllowedRedirectUrlFilters,
   urlsMatch,
+  validatePortalRedirectUriAgainstAllowedFilters,
   validatePortalRedirectUrisAgainstAllowedFilters,
   validateRedirectUri,
   validateUrlString
@@ -418,6 +419,14 @@ class ConsumerOAuthServiceImpl {
         d.magicMcpTarget?.type === 'endpoint' ? d.magicMcpTarget.target.oid : undefined
     });
     validateRedirectUri(d.input.redirectUri, client.redirectUris);
+    if (d.portal) {
+      validatePortalRedirectUriAgainstAllowedFilters({
+        redirectUri: d.input.redirectUri,
+        allowedRedirectUrlFilters: getPortalAllowedRedirectUrlFilters(
+          d.portal.allowedRedirectUrlFilters
+        )
+      });
+    }
 
     let attempt = await db.consumerAuthAttempt.create({
       data: {

--- a/src/backend/modules/portal/src/services/portal.ts
+++ b/src/backend/modules/portal/src/services/portal.ts
@@ -3,7 +3,7 @@ import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import { createSlugGenerator } from '@lowerdeck/slugify';
 import { Context } from '@metorial/context';
-import { db, ID, Instance, Organization, Portal, withTransaction } from '@metorial/db';
+import { db, ID, Instance, Organization, Portal, Prisma, withTransaction } from '@metorial/db';
 import { Fabric } from '@metorial/fabric';
 import {
   consumerSurfaceService,
@@ -12,8 +12,9 @@ import {
 import { env } from '../env';
 import {
   getPortalAllowedRedirectUrlFilters,
-  type PortalAllowedRedirectUrlFilter,
-  validatePortalAllowedRedirectUrlFilters
+  portalAllowedRedirectUrlFiltersEqual,
+  validatePortalAllowedRedirectUrlFilters,
+  type PortalAllowedRedirectUrlFilter
 } from '../lib/oauth';
 import { buildPortalUrlFromTemplate, parsePortalIdFromTemplate } from '../portalUrlTemplate';
 
@@ -70,10 +71,24 @@ type PortalSurface = ConsumerSurfaceWithPublishableApiKey;
 let resolvePortalAllowedRedirectUrlFilters = (
   input?: PortalAllowedRedirectUrlFilter[] | null
 ) => {
-  let allowedRedirectUrlFilters = getPortalAllowedRedirectUrlFilters(input);
-  validatePortalAllowedRedirectUrlFilters(allowedRedirectUrlFilters);
+  if (input == null) return null;
 
-  return allowedRedirectUrlFilters;
+  validatePortalAllowedRedirectUrlFilters(input);
+
+  if (portalAllowedRedirectUrlFiltersEqual(input, getPortalAllowedRedirectUrlFilters())) {
+    return null;
+  }
+
+  return input;
+};
+
+let toNullablePortalAllowedRedirectUrlFilters = (
+  value: PortalAllowedRedirectUrlFilter[] | null | undefined
+) => {
+  if (value === undefined) return undefined;
+  if (value === null) return Prisma.DbNull;
+
+  return value;
 };
 
 class PortalServiceImpl {
@@ -194,8 +209,8 @@ class PortalServiceImpl {
             name: d.input.name,
             description: d.input.description,
             slug,
-            allowedRedirectUrlFilters: resolvePortalAllowedRedirectUrlFilters(
-              d.input.allowedRedirectUrlFilters
+            allowedRedirectUrlFilters: toNullablePortalAllowedRedirectUrlFilters(
+              resolvePortalAllowedRedirectUrlFilters(d.input.allowedRedirectUrlFilters)
             ),
             organizationOid: d.organization.oid,
             surfaceOid: surface.oid,
@@ -262,7 +277,9 @@ class PortalServiceImpl {
           description: d.input.description,
           allowedRedirectUrlFilters:
             d.input.allowedRedirectUrlFilters !== undefined
-              ? resolvePortalAllowedRedirectUrlFilters(d.input.allowedRedirectUrlFilters)
+              ? toNullablePortalAllowedRedirectUrlFilters(
+                  resolvePortalAllowedRedirectUrlFilters(d.input.allowedRedirectUrlFilters)
+                )
               : undefined
         },
         include

--- a/src/backend/modules/portal/test/oauth.test.ts
+++ b/src/backend/modules/portal/test/oauth.test.ts
@@ -6,7 +6,8 @@ import {
   validatePortalRedirectUriAgainstAllowedFilters,
   validatePortalAllowedRedirectUrlFilters,
   validatePortalRedirectUrisAgainstAllowedFilters,
-  validateRedirectUri
+  validateRedirectUri,
+  validateUrlString
 } from '../src/lib/oauth';
 
 describe('portal oauth redirect filters', () => {
@@ -84,6 +85,9 @@ describe('portal oauth redirect filters', () => {
     expect(() =>
       validatePortalAllowedRedirectUrlFilters([{ url: 'http://loc*alhost:*/*' }])
     ).toThrow('unsupported hostname wildcard');
+    expect(() => validatePortalAllowedRedirectUrlFilters([{ url: 'ssh://*' }])).toThrow(
+      'blocked redirect protocol'
+    );
   });
 
   it('allows client registration when at least one redirect uri matches the portal allowlist', () => {
@@ -108,6 +112,15 @@ describe('portal oauth redirect filters', () => {
     expect(() =>
       validateRedirectUri('http://127.0.0.1:33418/', ['http://localhost:33418/'])
     ).not.toThrow();
+  });
+
+  it('rejects blocked well known redirect protocols', () => {
+    expect(() => validateUrlString('ftp://example.com/callback', 'redirect_uri')).toThrow(
+      'blocked redirect protocol'
+    );
+    expect(() =>
+      portalAllowedRedirectUrlFilterMatches({ url: '*://*' }, 'ssh://example.com/callback')
+    ).toThrow('blocked redirect protocol');
   });
 
   it('normalizes the default filters back to null storage', () => {

--- a/src/backend/modules/portal/test/oauth.test.ts
+++ b/src/backend/modules/portal/test/oauth.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   defaultPortalAllowedRedirectUrlFilters,
+  portalAllowedRedirectUrlFiltersEqual,
   portalAllowedRedirectUrlFilterMatches,
+  validatePortalRedirectUriAgainstAllowedFilters,
   validatePortalAllowedRedirectUrlFilters,
-  validatePortalRedirectUrisAgainstAllowedFilters
+  validatePortalRedirectUrisAgainstAllowedFilters,
+  validateRedirectUri
 } from '../src/lib/oauth';
 
 describe('portal oauth redirect filters', () => {
@@ -39,6 +42,12 @@ describe('portal oauth redirect filters', () => {
         'http://localhost:4310/callback'
       )
     ).toBe(false);
+    expect(
+      portalAllowedRedirectUrlFilterMatches(
+        { url: 'http://localhost:*/*' },
+        'http://127.0.0.1:4310/callback'
+      )
+    ).toBe(true);
     expect(
       portalAllowedRedirectUrlFilterMatches({ url: 'https://*/*' }, 'https://example.com/test')
     ).toBe(true);
@@ -77,12 +86,41 @@ describe('portal oauth redirect filters', () => {
     ).toThrow('unsupported hostname wildcard');
   });
 
-  it('rejects client redirect uris outside the portal allowlist', () => {
+  it('allows client registration when at least one redirect uri matches the portal allowlist', () => {
     expect(() =>
       validatePortalRedirectUrisAgainstAllowedFilters({
-        redirectUris: ['https://example.com/callback'],
+        redirectUris: ['https://example.com/callback', 'http://127.0.0.1:33418/'],
+        allowedRedirectUrlFilters: [{ url: 'http://localhost:*/*' }]
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects authorization redirect uris outside the portal allowlist', () => {
+    expect(() =>
+      validatePortalRedirectUriAgainstAllowedFilters({
+        redirectUri: 'https://example.com/callback',
         allowedRedirectUrlFilters: [{ url: 'http://localhost:*/*' }]
       })
     ).toThrow('redirect_uri is not allowed for this portal');
+  });
+
+  it('treats loopback hosts as equivalent during redirect uri matching', () => {
+    expect(() =>
+      validateRedirectUri('http://127.0.0.1:33418/', ['http://localhost:33418/'])
+    ).not.toThrow();
+  });
+
+  it('normalizes the default filters back to null storage', () => {
+    expect(
+      portalAllowedRedirectUrlFiltersEqual(
+        [
+          { url: 'https://*/*' },
+          { url: '*://*' },
+          { url: 'http://*.localhost:*/*' },
+          { url: 'http://127.0.0.1:*/*' }
+        ],
+        defaultPortalAllowedRedirectUrlFilters
+      )
+    ).toBe(true);
   });
 });

--- a/src/backend/modules/subspace/src/proxy/index.ts
+++ b/src/backend/modules/subspace/src/proxy/index.ts
@@ -25,6 +25,21 @@ export let proxyMcpRequestToSubspace = async (
   let subspaceUrl = await getSubspaceMcpUrl(instance, sessionId, inputUrl);
 
   let headers = new Headers(c.req.raw.headers);
+
+  let finalHostName = inputUrl.hostname;
+  if (
+    finalHostName.endsWith('.metorial.com') &&
+    (finalHostName.startsWith('api-') ||
+      finalHostName.startsWith('connect-') ||
+      finalHostName.startsWith('mcp-'))
+  ) {
+    let parts = finalHostName.split('.');
+    let fistPart = parts[0];
+    let identifier = fistPart.split('-')[0];
+
+    finalHostName = `${identifier}.metorial.com`;
+  }
+
   headers.set(
     'Metorial-Proxy-URL',
     process.env.NODE_ENV == 'production'

--- a/src/frontend/layout/src/applicationLayout/switcher/actions/createProject.tsx
+++ b/src/frontend/layout/src/applicationLayout/switcher/actions/createProject.tsx
@@ -27,8 +27,14 @@ export let createProject = (
         let [res] = await create.mutate(values);
 
         if (res) {
-          if (!opts?.noRedirect) window.location.href = Paths.project(org, res);
-          close();
+          if (!opts?.noRedirect) {
+            setTimeout(() => {
+              close();
+              window.location.href = Paths.project(org, res);
+            }, 5000);
+          } else {
+            close();
+          }
         }
       },
       schema: yup =>
@@ -53,7 +59,7 @@ export let createProject = (
               fullWidth
               type="submit"
               loading={create.isLoading}
-              success={create.isSuccess}
+              success={create.isSuccessPermanent}
             >
               Create
             </Button>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect OAuth redirect URI validation and portal allowlisting, which are security-sensitive and could break existing integrations if filters/protocols were previously accepted.
> 
> **Overview**
> **Portal OAuth redirect validation is tightened and normalized.** Redirect URIs and allowed-filter patterns now reject a list of *blocked protocols* (e.g. `ftp`, `ssh`, `data`) and treat loopback hosts (`localhost`, `127.0.0.1/8`, `::1`) as equivalent when comparing/matching URLs.
> 
> **Allowlist enforcement semantics change.** Client registration now passes as long as *at least one* `redirectUri` matches the portal allowlist, while the authorization flow validates the single `redirect_uri` against the allowlist via a new `validatePortalRedirectUriAgainstAllowedFilters` helper.
> 
> **Portal persistence of redirect filters is simplified.** `allowedRedirectUrlFilters` is stored as `null` when it matches the default set (using `portalAllowedRedirectUrlFiltersEqual`) and uses `Prisma.DbNull` for explicit nulls.
> 
> Also adds hostname-rewrite logic scaffolding in subspace MCP proxying and tweaks the project-create modal to show permanent success and delay redirect/close by 5s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92822e018e6d581905c7d4dbee0f1a72744a530d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->