### PR TITLE
Add slate attachments

### DIFF
--- a/src/systems/_clients/slates/package.json
+++ b/src/systems/_clients/slates/package.json
@@ -31,8 +31,7 @@
   },
   "dependencies": {
     "@lowerdeck/rpc-client": "^1.1.3",
-    "@lowerdeck/validation": "^1.0.10",
-    "@slates/proto": "workspace:*"
+    "@lowerdeck/validation": "^1.0.10"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/src/systems/slates/apps/hub/package.json
+++ b/src/systems/slates/apps/hub/package.json
@@ -90,7 +90,7 @@
     "@remixicon/react": "^4.0.0",
     "@sentry/bun": "^10.36.0",
     "@sentry/cli": "^3.2.0",
-    "@slates/proto": "^1.0.0-rc.7",
+    "@slates/proto": "^1.0.0-rc.8",
     "@types/semver": "^7.7.1",
     "@types/unzipper": "^0.10.11",
     "date-fns": "^4.1.0",

--- a/src/systems/slates/apps/hub/prisma/schema/attachment.prisma
+++ b/src/systems/slates/apps/hub/prisma/schema/attachment.prisma
@@ -1,0 +1,14 @@
+model SlateAttachment {
+  oid BigInt @id
+  id  String @unique
+
+  digest Bytes @unique
+
+  createdAt     DateTime @default(now())
+  expiresAt     DateTime
+  lastCreatedAt DateTime @default(now())
+
+  slateInvocationAttachments SlateInvocationAttachment[]
+
+  @@index([expiresAt])
+}

--- a/src/systems/slates/apps/hub/prisma/schema/invocation.prisma
+++ b/src/systems/slates/apps/hub/prisma/schema/invocation.prisma
@@ -28,6 +28,20 @@ model SlateInvocation {
   slateSessionToolCalls         SlateSessionToolCall[]
   slateTriggerInvocations       SlateTriggerInvocation[]
   slateTriggerEvents            SlateTriggerEvent[]
+  slateInvocationAttachment     SlateInvocationAttachment[]
 
   @@index([deploymentOid, createdAt])
+}
+
+model SlateInvocationAttachment {
+  oid BigInt @id
+  id  String @unique
+
+  invocationOid BigInt
+  invocation    SlateInvocation @relation(fields: [invocationOid], references: [oid], onDelete: Cascade)
+
+  attachmentsOid BigInt
+  attachments    SlateAttachment @relation(fields: [attachmentsOid], references: [oid])
+
+  createdAt DateTime @default(now())
 }

--- a/src/systems/slates/apps/hub/src/apis/internal/slateInvocation.ts
+++ b/src/systems/slates/apps/hub/src/apis/internal/slateInvocation.ts
@@ -22,5 +22,5 @@ export let slateInvocationController = app.controller({
         slateInvocationId: v.string()
       })
     )
-    .do(async ctx => slateInvocationPresenter(ctx.slateInvocation))
+    .do(async ctx => await slateInvocationPresenter(ctx.slateInvocation))
 });

--- a/src/systems/slates/apps/hub/src/apis/internal/slateSessionToolCall.ts
+++ b/src/systems/slates/apps/hub/src/apis/internal/slateSessionToolCall.ts
@@ -39,7 +39,7 @@ export let slateSessionToolCallController = app.controller({
 
       let list = await paginator.run(ctx.input);
 
-      return Paginator.presentLight(list, slateSessionToolCallPresenter);
+      return await Paginator.presentLight(list, slateSessionToolCallPresenter);
     }),
 
   call: app
@@ -91,7 +91,7 @@ export let slateSessionToolCallController = app.controller({
         slateSessionToolCallId: v.string()
       })
     )
-    .do(async ctx => slateSessionToolCallPresenter(ctx.slateSessionToolCall)),
+    .do(async ctx => await slateSessionToolCallPresenter(ctx.slateSessionToolCall)),
 
   getLogs: slateSessionToolCallApp
     .handler()
@@ -119,6 +119,6 @@ export let slateSessionToolCallController = app.controller({
         }
       );
 
-      return slateSessionToolCalls.map(slateSessionToolCallPresenter);
+      return await Promise.all(slateSessionToolCalls.map(slateSessionToolCallPresenter));
     })
 });

--- a/src/systems/slates/apps/hub/src/apis/internal/tests/slateInvocation.e2e.test.ts
+++ b/src/systems/slates/apps/hub/src/apis/internal/tests/slateInvocation.e2e.test.ts
@@ -1,8 +1,44 @@
+import { addDays } from 'date-fns';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { SlateDeploymentStatus, SlateStatus } from '../../../../prisma/generated/client';
+import { getId } from '../../../id';
+import { getStoredAttachmentsStorageKey } from '../../../lib/invocation/store';
+import { invocationsBucketRecord, storage } from '../../../storage';
 import { slatesHubClient } from '../../../test/client';
 import { fixtures } from '../../../test/fixtures';
 import { cleanDatabase, testDb } from '../../../test/setup';
+
+let createStoredAttachment = async (invocationOid: bigint) => {
+  let content = Buffer.from('invocation-attachment');
+  let digest = new Uint8Array(new Bun.CryptoHasher('sha256').update(content).digest());
+  let digestString = Buffer.from(digest).toString('hex');
+
+  await storage.putObject(
+    invocationsBucketRecord.bucket,
+    getStoredAttachmentsStorageKey(digestString),
+    content,
+    'application/octet-stream'
+  );
+
+  let attachment = await testDb.slateAttachment.create({
+    data: {
+      ...getId('slateAttachment'),
+      digest,
+      expiresAt: addDays(new Date(), 7),
+      lastCreatedAt: new Date()
+    }
+  });
+
+  await testDb.slateInvocationAttachment.create({
+    data: {
+      ...getId('slateInvocationAttachment'),
+      invocationOid,
+      attachmentsOid: attachment.oid
+    }
+  });
+
+  return attachment;
+};
 
 describe('slateInvocation:DANGEROUSLY_get E2E', () => {
   const f = fixtures(testDb);
@@ -55,5 +91,72 @@ describe('slateInvocation:DANGEROUSLY_get E2E', () => {
       id: invocation.id,
       status: 'succeeded'
     });
+  });
+
+  it('returns stored attachments for an invocation', async () => {
+    const slate = await f.slate.complete({
+      slateStatus: SlateStatus.active
+    });
+    const provider = await f.deploymentProvider.default();
+    const deployment = await f.slateDeployment.default({
+      slateOid: slate.oid,
+      slateVersionOid: slate.currentVersion.oid,
+      providerOid: provider.oid,
+      overrides: { status: SlateDeploymentStatus.succeeded }
+    });
+    const invocation = await f.slateInvocation.succeeded({
+      deploymentOid: deployment.oid
+    });
+    await createStoredAttachment(invocation.oid);
+
+    const result = await slatesHubClient.slateInvocation.DANGEROUSLY_get({
+      slateInvocationId: invocation.id
+    });
+
+    expect(result.attachments).toEqual([
+      expect.objectContaining({
+        type: 'url',
+        url: expect.any(String),
+        urlExpiresAt: expect.any(Date)
+      })
+    ]);
+  });
+
+  it('removes invocation attachment joins when an invocation is deleted', async () => {
+    const slate = await f.slate.complete({
+      slateStatus: SlateStatus.active
+    });
+    const provider = await f.deploymentProvider.default();
+    const deployment = await f.slateDeployment.default({
+      slateOid: slate.oid,
+      slateVersionOid: slate.currentVersion.oid,
+      providerOid: provider.oid,
+      overrides: { status: SlateDeploymentStatus.succeeded }
+    });
+    const invocation = await f.slateInvocation.succeeded({
+      deploymentOid: deployment.oid
+    });
+    const attachment = await createStoredAttachment(invocation.oid);
+
+    await testDb.slateInvocation.delete({
+      where: {
+        oid: invocation.oid
+      }
+    });
+
+    expect(
+      await testDb.slateInvocationAttachment.findMany({
+        where: {
+          invocationOid: invocation.oid
+        }
+      })
+    ).toHaveLength(0);
+    expect(
+      await testDb.slateAttachment.findUnique({
+        where: {
+          oid: attachment.oid
+        }
+      })
+    ).not.toBeNull();
   });
 });

--- a/src/systems/slates/apps/hub/src/apis/internal/tests/slateSessionToolCall.e2e.test.ts
+++ b/src/systems/slates/apps/hub/src/apis/internal/tests/slateSessionToolCall.e2e.test.ts
@@ -1,8 +1,44 @@
+import { addDays } from 'date-fns';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { SlateSessionToolCallStatus } from '../../../../prisma/generated/client';
+import { getId } from '../../../id';
+import { getStoredAttachmentsStorageKey } from '../../../lib/invocation/store';
+import { invocationsBucketRecord, storage } from '../../../storage';
 import { slatesHubClient } from '../../../test/client';
 import { fixtures } from '../../../test/fixtures';
 import { cleanDatabase, testDb } from '../../../test/setup';
+
+let createStoredAttachment = async (invocationOid: bigint) => {
+  let content = Buffer.from('tool-call-attachment');
+  let digest = new Uint8Array(new Bun.CryptoHasher('sha256').update(content).digest());
+  let digestString = Buffer.from(digest).toString('hex');
+
+  await storage.putObject(
+    invocationsBucketRecord.bucket,
+    getStoredAttachmentsStorageKey(digestString),
+    content,
+    'application/octet-stream'
+  );
+
+  let attachment = await testDb.slateAttachment.create({
+    data: {
+      ...getId('slateAttachment'),
+      digest,
+      expiresAt: addDays(new Date(), 7),
+      lastCreatedAt: new Date()
+    }
+  });
+
+  await testDb.slateInvocationAttachment.create({
+    data: {
+      ...getId('slateInvocationAttachment'),
+      invocationOid,
+      attachmentsOid: attachment.oid
+    }
+  });
+
+  return attachment;
+};
 
 describe('slateSessionToolCall:list E2E', () => {
   const f = fixtures(testDb);
@@ -90,6 +126,26 @@ describe('slateSessionToolCall:get E2E', () => {
     expect(result).toMatchObject({
       id: toolCall.id
     });
+  });
+
+  it('returns stored attachments for a tool call', async () => {
+    const { toolCall, invocation, tenant } = await f.slateSessionToolCall.complete({
+      status: SlateSessionToolCallStatus.succeeded
+    });
+    await createStoredAttachment(invocation.oid);
+
+    const result = await slatesHubClient.slateSessionToolCall.get({
+      tenantId: tenant.id,
+      slateSessionToolCallId: toolCall.id
+    });
+
+    expect(result.attachments).toEqual([
+      expect.objectContaining({
+        type: 'url',
+        url: expect.any(String),
+        urlExpiresAt: expect.any(Date)
+      })
+    ]);
   });
 });
 

--- a/src/systems/slates/apps/hub/src/id.ts
+++ b/src/systems/slates/apps/hub/src/id.ts
@@ -48,7 +48,10 @@ export let ID = createIdGenerator({
   changeNotification: idType.sorted('shcn'),
 
   adminUser: idType.sorted('shadu'),
-  adminSession: idType.sorted('shads')
+  adminSession: idType.sorted('shads'),
+
+  slateAttachment: idType.sorted('shsa'),
+  slateInvocationAttachment: idType.sorted('shsia')
 });
 
 let workerIdBits = 12;

--- a/src/systems/slates/apps/hub/src/lib/invocation/store.ts
+++ b/src/systems/slates/apps/hub/src/lib/invocation/store.ts
@@ -181,3 +181,7 @@ export let storeSlateInvocation = (
 export let getStoredInvocationStorageKey = (invocation: SlateInvocation) => {
   return `invocations/${invocation.id}/logs`;
 };
+
+export let getStoredAttachmentsStorageKey = (digest: string) => {
+  return `attachments/${digest}`;
+};

--- a/src/systems/slates/apps/hub/src/presenters/index.ts
+++ b/src/systems/slates/apps/hub/src/presenters/index.ts
@@ -3,6 +3,7 @@ export * from './registry';
 export * from './secret';
 export * from './slate';
 export * from './slateAction';
+export * from './slateAttachment';
 export * from './slateAuthConfig';
 export * from './slateDeployment';
 export * from './slateDiscoveryBuildOutput';

--- a/src/systems/slates/apps/hub/src/presenters/slateAttachment.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateAttachment.ts
@@ -1,0 +1,58 @@
+import { addDays } from 'date-fns';
+import type { SlateAttachment, SlateInvocation } from '../../prisma/generated/client';
+import { db } from '../db';
+import { getStoredAttachmentsStorageKey } from '../lib/invocation/store';
+import { invocationsBucketRecord, storage } from '../storage';
+
+let ATTACHMENT_PUBLIC_URL_EXPIRATION_DAYS = 7;
+
+type InvocationWithStoredAttachments = SlateInvocation & {
+  slateInvocationAttachment?: { attachments: SlateAttachment }[];
+};
+
+let getStoredAttachments = async (invocation: InvocationWithStoredAttachments) => {
+  if (invocation.slateInvocationAttachment) {
+    return invocation.slateInvocationAttachment.map(record => record.attachments);
+  }
+
+  let records = await db.slateInvocationAttachment.findMany({
+    where: {
+      invocationOid: invocation.oid
+    },
+    include: {
+      attachments: true
+    },
+    orderBy: {
+      createdAt: 'asc'
+    }
+  });
+
+  return records.map(record => record.attachments);
+};
+
+export let slateStoredAttachmentPresenter = async (attachment: SlateAttachment) => {
+  let storageKey = getStoredAttachmentsStorageKey(
+    Buffer.from(attachment.digest).toString('hex')
+  );
+  let url = await storage.getPublicURL(
+    invocationsBucketRecord.bucket,
+    storageKey,
+    ATTACHMENT_PUBLIC_URL_EXPIRATION_DAYS * 24 * 60 * 60
+  );
+
+  return {
+    type: 'url' as const,
+    url: url.url,
+    urlExpiresAt: addDays(new Date(), ATTACHMENT_PUBLIC_URL_EXPIRATION_DAYS)
+  };
+};
+
+export let slateInvocationAttachmentsPresenter = async (
+  invocation: InvocationWithStoredAttachments
+) => {
+  return await Promise.all(
+    (await getStoredAttachments(invocation)).map(attachment =>
+      slateStoredAttachmentPresenter(attachment)
+    )
+  );
+};

--- a/src/systems/slates/apps/hub/src/presenters/slateInvocation.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateInvocation.ts
@@ -1,4 +1,5 @@
 import type {
+  SlateAttachment,
   SlateDeployment,
   SlateInvocation,
   SlateVersion
@@ -7,15 +8,29 @@ import { db } from '../db';
 import { getStoredInvocationStorageKey } from '../lib/invocation/store';
 import type { StoredSlateInvocation } from '../lib/invocation/types';
 import { invocationsBucketRecord, storage } from '../storage';
+import { slateInvocationAttachmentsPresenter } from './slateAttachment';
 
-export let slateInvocationLitePresenter = async (inv: SlateInvocation) => {
+type InvocationWithStoredAttachments = SlateInvocation & {
+  slateInvocationAttachment?: Array<{
+    attachments: SlateAttachment;
+  }>;
+};
+
+export let slateInvocationLitePresenter = async (inv: InvocationWithStoredAttachments) => {
   let i = 0;
   while (inv.isPending) {
     if (i++ > 10) {
     }
 
     let res = await db.slateInvocation.findUniqueOrThrow({
-      where: { oid: inv.oid }
+      where: { oid: inv.oid },
+      include: {
+        slateInvocationAttachment: {
+          include: {
+            attachments: true
+          }
+        }
+      }
     });
     if (!res.isPending) {
       inv = {
@@ -62,6 +77,7 @@ export let slateInvocationLitePresenter = async (inv: SlateInvocation) => {
       timestamp,
       message
     })),
+    attachments: await slateInvocationAttachmentsPresenter(inv),
 
     provider: output.provider
       ? {
@@ -77,7 +93,7 @@ export let slateInvocationLitePresenter = async (inv: SlateInvocation) => {
 };
 
 export let slateInvocationPresenter = async (
-  inv: SlateInvocation & {
+  inv: InvocationWithStoredAttachments & {
     deployment: SlateDeployment & {
       slateVersion: SlateVersion;
     };

--- a/src/systems/slates/apps/hub/src/presenters/slateSessionToolCall.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateSessionToolCall.ts
@@ -1,16 +1,24 @@
 import type { SlateAction } from '../../prisma/generated/browser';
 import type {
+  SlateAttachment,
   SlateInvocation,
   SlateSession,
   SlateSessionToolCall,
   SlateVersion
 } from '../../prisma/generated/client';
+import { slateInvocationAttachmentsPresenter } from './slateAttachment';
 import { slateInvocationLitePresenter } from './slateInvocation';
 
-export let slateSessionToolCallPresenter = (
+type InvocationWithStoredAttachments = SlateInvocation & {
+  slateInvocationAttachment?: Array<{
+    attachments: SlateAttachment;
+  }>;
+};
+
+export let slateSessionToolCallPresenter = async (
   call: SlateSessionToolCall & {
     action: SlateAction;
-    invocation: SlateInvocation;
+    invocation: InvocationWithStoredAttachments;
     session: SlateSession;
     slateVersion: SlateVersion;
   }
@@ -30,6 +38,7 @@ export let slateSessionToolCallPresenter = (
       name: call.action.name
     },
 
+    attachments: await slateInvocationAttachmentsPresenter(call.invocation),
     createdAt: call.createdAt
   };
 };
@@ -37,7 +46,7 @@ export let slateSessionToolCallPresenter = (
 export let slateSessionToolCallLogsPresenter = async (
   call: SlateSessionToolCall & {
     action: SlateAction;
-    invocation: SlateInvocation;
+    invocation: InvocationWithStoredAttachments;
     session: SlateSession;
     slateVersion: SlateVersion;
   }
@@ -57,6 +66,7 @@ export let slateSessionToolCallLogsPresenter = async (
       name: call.action.name
     },
 
+    attachments: await slateInvocationAttachmentsPresenter(call.invocation),
     invocation: await slateInvocationLitePresenter(call.invocation),
 
     createdAt: call.createdAt

--- a/src/systems/slates/apps/hub/src/queues/attachment/cleanup.ts
+++ b/src/systems/slates/apps/hub/src/queues/attachment/cleanup.ts
@@ -1,0 +1,113 @@
+import { createCron } from '@lowerdeck/cron';
+import { createQueue } from '@lowerdeck/queue';
+import { db } from '../../db';
+import { env } from '../../env';
+import { getStoredAttachmentsStorageKey } from '../../lib/invocation/store';
+import { invocationsBucketRecord, storage } from '../../storage';
+import { RETENTION_BATCH_SIZE, retentionStorageCleanupWorkerOpts } from '../retention/_config';
+
+export let slateAttachmentCleanupCron = createCron(
+  {
+    name: 'shub/att/cleanup/cron',
+    redisUrl: env.service.REDIS_URL,
+    cron: '0 0 * * *'
+  },
+  async () => {
+    await slateAttachmentCleanupManyQueue.add({});
+  }
+);
+
+export let slateAttachmentCleanupManyQueue = createQueue<{
+  cursor?: string;
+}>({
+  name: 'shub/att/cleanup/many',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let slateAttachmentCleanupManyQueueProcessor = slateAttachmentCleanupManyQueue.process(
+  async data => {
+    let attachments = await db.slateAttachment.findMany({
+      where: {
+        expiresAt: { lt: new Date() },
+        id: data.cursor ? { gt: data.cursor } : undefined
+      },
+      orderBy: {
+        id: 'asc'
+      },
+      take: RETENTION_BATCH_SIZE,
+      select: {
+        id: true,
+        digest: true
+      }
+    });
+    if (attachments.length === 0) return;
+
+    await slateAttachmentCleanupSingleQueue.addMany(
+      attachments.map(attachment => ({
+        attachmentId: attachment.id,
+        digest: Buffer.from(attachment.digest).toString('hex')
+      }))
+    );
+
+    await slateAttachmentCleanupManyQueue.add({
+      cursor: attachments[attachments.length - 1]!.id
+    });
+  }
+);
+
+export let slateAttachmentCleanupSingleQueue = createQueue<{
+  attachmentId: string;
+  digest: string;
+}>({
+  name: 'shub/att/cleanup/single',
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: retentionStorageCleanupWorkerOpts
+});
+
+export let slateAttachmentCleanupSingleQueueProcessor =
+  slateAttachmentCleanupSingleQueue.process(async data => {
+    let now = new Date();
+    let attachment = await db.slateAttachment.findUnique({
+      where: {
+        id: data.attachmentId
+      }
+    });
+    if (attachment && attachment.expiresAt >= now) return;
+
+    if (attachment) {
+      await db.$transaction(async tx => {
+        let current = await tx.slateAttachment.findUnique({
+          where: {
+            oid: attachment.oid
+          }
+        });
+        if (!current || current.expiresAt >= now) return;
+
+        await tx.slateInvocationAttachment.deleteMany({
+          where: {
+            attachmentsOid: current.oid
+          }
+        });
+        await tx.slateAttachment.delete({
+          where: {
+            oid: current.oid
+          }
+        });
+      });
+    }
+
+    let isDigestStillTracked = await db.slateAttachment.findFirst({
+      where: {
+        digest: Buffer.from(data.digest, 'hex')
+      },
+      select: {
+        oid: true
+      }
+    });
+    if (isDigestStillTracked) return;
+
+    await storage.deleteObject(
+      invocationsBucketRecord.bucket,
+      getStoredAttachmentsStorageKey(data.digest)
+    );
+  });

--- a/src/systems/slates/apps/hub/src/queues/attachment/index.ts
+++ b/src/systems/slates/apps/hub/src/queues/attachment/index.ts
@@ -1,0 +1,12 @@
+import { combineQueueProcessors } from '@lowerdeck/queue';
+import {
+  slateAttachmentCleanupCron,
+  slateAttachmentCleanupManyQueueProcessor,
+  slateAttachmentCleanupSingleQueueProcessor
+} from './cleanup';
+
+export let attachmentQueues = combineQueueProcessors([
+  slateAttachmentCleanupCron,
+  slateAttachmentCleanupManyQueueProcessor,
+  slateAttachmentCleanupSingleQueueProcessor
+]);

--- a/src/systems/slates/apps/hub/src/queues/retention/cleanup.ts
+++ b/src/systems/slates/apps/hub/src/queues/retention/cleanup.ts
@@ -278,9 +278,15 @@ let cleanupTenantInvocations = async (d: { tenantOid: bigint; cutoffDate: Date }
         },
         orderBy: { createdAt: 'asc' },
         take: RETENTION_BATCH_SIZE,
-        select: { id: true }
+        select: { oid: true, id: true }
       }),
     beforeDelete: async records => {
+      await db.slateInvocationAttachment.deleteMany({
+        where: {
+          invocationOid: { in: records.map(record => record.oid) }
+        }
+      });
+
       await enqueueStorageDeletes(records.map(record => `invocations/${record.id}/logs`));
     },
     deleteMany: records =>

--- a/src/systems/slates/apps/hub/src/services/slateInvocation.ts
+++ b/src/systems/slates/apps/hub/src/services/slateInvocation.ts
@@ -9,6 +9,11 @@ let include = {
     include: {
       slateVersion: true
     }
+  },
+  slateInvocationAttachment: {
+    include: {
+      attachments: true
+    }
   }
 };
 

--- a/src/systems/slates/apps/hub/src/services/slateSessionToolCall.ts
+++ b/src/systems/slates/apps/hub/src/services/slateSessionToolCall.ts
@@ -2,20 +2,47 @@ import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import type { SlatesParticipant } from '@slates/proto';
-import { differenceInMinutes } from 'date-fns';
-import type { Tenant } from '../../prisma/generated/client';
+import { addDays, differenceInMinutes } from 'date-fns';
+import { PublicUrlPurpose } from 'object-storage-client';
+import type { SlateInvocation, Tenant } from '../../prisma/generated/client';
 import { db } from '../db';
 import { getId } from '../id';
+import { getStoredAttachmentsStorageKey } from '../lib/invocation/store';
+import { invocationsBucketRecord, storage } from '../storage';
 import { slateAuthHandlerService } from './slateInstanceAuthHandler';
 import { slateInvocationService } from './slateInvocation';
 import { slateSessionService } from './slateSession';
 
 let include = {
   action: true,
-  invocation: true,
+  invocation: {
+    include: {
+      slateInvocationAttachment: {
+        include: {
+          attachments: true
+        }
+      }
+    }
+  },
   session: true,
   slateVersion: true
 };
+
+type SlateToolCallAttachment = {
+  content:
+    | {
+        type: 'url';
+        url: string;
+      }
+    | {
+        type: 'content';
+        encoding: 'base64' | 'utf-8';
+        content: string;
+      };
+  mimeType?: string;
+};
+
+let ATTACHMENT_EXPIRATION_DAYS = 7;
 
 class slateSessionToolCallServiceImpl {
   async createSlateToolCall(d: {
@@ -168,12 +195,92 @@ class slateSessionToolCallServiceImpl {
       };
     }
 
+    let attachments = await Promise.all(
+      (callRes.data.attachments ?? []).map(attachment =>
+        this.ensureAttachment({
+          content: attachment.content,
+          mimeType: attachment.mimeType,
+          invocation: callRes.invocation
+        })
+      )
+    );
+
     return {
       call,
       status: 'success' as const,
 
       output: callRes.data.output,
-      message: callRes.data.message
+      message: callRes.data.message,
+      attachments
+    };
+  }
+
+  private async ensureAttachment(d: {
+    content: SlateToolCallAttachment['content'];
+    mimeType?: string | undefined;
+    invocation: SlateInvocation;
+  }) {
+    if (d.content.type === 'url') {
+      return {
+        type: 'url' as const,
+        url: d.content.url,
+        mimeType: d.mimeType
+      };
+    }
+
+    let contentBuffer = Buffer.from(d.content.content, d.content.encoding);
+    let digest = new Uint8Array(new Bun.CryptoHasher('sha256').update(contentBuffer).digest());
+    let digestString = Buffer.from(digest).toString('hex');
+    let storageKey = getStoredAttachmentsStorageKey(digestString);
+
+    let attachment = await db.slateAttachment.findFirst({
+      where: { digest }
+    });
+    if (!attachment) {
+      await storage.putObject(
+        invocationsBucketRecord.bucket,
+        storageKey,
+        contentBuffer,
+        d.mimeType ?? 'application/octet-stream'
+      );
+    }
+
+    let expiresAt = addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS);
+    let inner = {
+      digest,
+      expiresAt,
+      lastCreatedAt: new Date()
+    };
+
+    attachment = await db.slateAttachment.upsert({
+      where: { digest },
+      create: {
+        ...getId('slateAttachment'),
+        ...inner
+      },
+      update: inner
+    });
+
+    await db.slateInvocationAttachment.createMany({
+      data: {
+        ...getId('slateInvocationAttachment'),
+        invocationOid: d.invocation.oid,
+        attachmentsOid: attachment.oid
+      }
+    });
+
+    let url = await storage.getPublicURL(
+      invocationsBucketRecord.bucket,
+      storageKey,
+      ATTACHMENT_EXPIRATION_DAYS * 24 * 60 * 60,
+      PublicUrlPurpose.Retrieve
+    );
+
+    return {
+      type: 'url' as const,
+      url: url.url,
+      mimeType: d.mimeType,
+      urlExpiresAt: addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS)
     };
   }
 
@@ -240,12 +347,14 @@ class slateSessionToolCallServiceImpl {
                   : []),
 
                 ...(slateInstances
-                  ? [{ session: { slateInstanceOid: { in: slateInstances.map(si => si.oid) } } }]
+                  ? [
+                      {
+                        session: { slateInstanceOid: { in: slateInstances.map(si => si.oid) } }
+                      }
+                    ]
                   : []),
 
-                ...(slates
-                  ? [{ session: { slateOid: { in: slates.map(s => s.oid) } } }]
-                  : []),
+                ...(slates ? [{ session: { slateOid: { in: slates.map(s => s.oid) } } }] : []),
 
                 ...(sessions ? [{ sessionOid: { in: sessions.map(s => s.oid) } }] : [])
               ]

--- a/src/systems/slates/apps/hub/src/worker.ts
+++ b/src/systems/slates/apps/hub/src/worker.ts
@@ -1,13 +1,15 @@
 import { runQueueProcessors } from '@lowerdeck/queue';
+import { attachmentQueues } from './queues/attachment';
 import { cleanupCron } from './queues/cron/cleanup';
 import { deploymentQueues } from './queues/deployment';
 import { discoveryQueues } from './queues/discovery';
 import { instanceQueues } from './queues/instance';
-import { retentionQueues } from './queues/retention';
 import { registryQueues } from './queues/registry';
+import { retentionQueues } from './queues/retention';
 import { triggerQueues } from './queues/trigger';
 
 await runQueueProcessors([
+  attachmentQueues,
   registryQueues,
   deploymentQueues,
   discoveryQueues,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches persistence + object storage lifecycle (new tables, cleanup jobs, and URL generation), so mistakes could leak data or leave orphaned blobs, but changes are localized and covered by new E2E tests.
> 
> **Overview**
> Adds first-class *stored attachments* to the Slates Hub: new Prisma models (`SlateAttachment`, `SlateInvocationAttachment`) link invocations to content-addressed blobs (SHA-256 digest) stored under `attachments/<digest>`, and invocation/tool-call presenters now return an `attachments` array of signed/public URLs.
> 
> Extends tool-call execution to persist inline attachment content (dedupe via digest, upsert + expiry refresh) and introduces daily queues/cron to delete expired attachment records and remove orphaned objects from storage; retention cleanup also deletes invocation→attachment joins when invocations are purged. Includes E2E coverage for attachment presentation and cascade behavior, and bumps `@slates/proto` plus removes an unused `@slates/proto` dependency from the slates client package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7526ca2dcade748b9b4b0440ddeb5a3d6e21453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->