### PR TITLE
Add request traces for slates

### DIFF
--- a/src/systems/slates/apps/hub/src/lib/invocation/store.ts
+++ b/src/systems/slates/apps/hub/src/lib/invocation/store.ts
@@ -109,6 +109,14 @@ export let storeSlateInvocation = (
         return m;
       });
 
+      let requestTraces = (d.responseMessages ?? []).flatMap(m => {
+        let result = 'result' in m ? m.result : undefined;
+        if (!result) return [];
+
+        let requestTraces = 'requestTraces' in result ? result.requestTraces : undefined;
+        return requestTraces ?? [];
+      });
+
       // Handle error case where invocationResult.id may be undefined
       if (!d.invocationResult.id) {
         let storageKey = getStoredInvocationStorageKey(d.record);
@@ -120,7 +128,8 @@ export let storeSlateInvocation = (
             requests: sanitizedRequests as any,
             responses: (sanitizedResponses ?? []) as any,
             provider: { error: (d.invocationResult as any).error } as any,
-            logs: []
+            logs: [],
+            requestTraces
           } satisfies StoredSlateInvocation)
         );
 
@@ -152,7 +161,8 @@ export let storeSlateInvocation = (
           requests: sanitizedRequests as any,
           responses: (sanitizedResponses ?? []) as any,
           provider: { ...invocationResult, logs: undefined } as any,
-          logs: invocationResult.logs.map(log => [log.timestamp, log.message] as const)
+          logs: invocationResult.logs.map(log => [log.timestamp, log.message] as const),
+          requestTraces
         } satisfies StoredSlateInvocation)
       );
 

--- a/src/systems/slates/apps/hub/src/lib/invocation/types.ts
+++ b/src/systems/slates/apps/hub/src/lib/invocation/types.ts
@@ -2,6 +2,7 @@ import type {
   SlatesNotifications,
   SlatesParticipant,
   SlatesRequests,
+  slatesRequestTrace,
   SlatesResponses,
   slatesResponsesByMethod
 } from '@slates/proto';
@@ -16,6 +17,7 @@ export interface SlateInvocationBaseParams {
 
 export type SlatesRequest = SlatesNotifications | SlatesRequests;
 export type SlatesResponse = SlatesNotifications | SlatesResponses;
+export type SlatesRequestTrace = z.infer<typeof slatesRequestTrace>;
 
 export interface InvocationError {
   code: string;
@@ -41,4 +43,5 @@ export interface StoredSlateInvocation {
   responses: SlatesResponse[];
   logs: [number, string][];
   provider?: Omit<SlateInvocationResult, 'logs'>;
+  requestTraces?: SlatesRequestTrace[];
 }

--- a/src/systems/slates/apps/hub/src/presenters/slateInvocation.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateInvocation.ts
@@ -72,6 +72,7 @@ export let slateInvocationLitePresenter = async (inv: InvocationWithStoredAttach
 
     requests: output.requests,
     responses: output.responses,
+    requestTraces: output.requestTraces,
     error: output.provider?.error,
     logs: (output.logs ?? []).map(([timestamp, message]) => ({
       timestamp,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small additive change that stores and surfaces an optional new field; main risk is compatibility with existing stored invocation blobs and any downstream consumers expecting the old shape.
> 
> **Overview**
> Adds support for `requestTraces` on slate invocations by extracting them from `responseMessages` results and persisting them in the stored invocation JSON (including the no-provider-invocation-id error path).
> 
> Extends `StoredSlateInvocation` with an optional `requestTraces` field (typed via `slatesRequestTrace`) and updates the `slateInvocation` presenter to include `requestTraces` in the API output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b95561934113ddcd5d9498313617fd37e890d212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->