### PR TITLE
Fix subspace tenant creation delay

### DIFF
--- a/src/backend/modules/organization/src/services/instance.ts
+++ b/src/backend/modules/organization/src/services/instance.ts
@@ -9,6 +9,7 @@ import { Service } from '@lowerdeck/service';
 import { createSlugGenerator } from '@lowerdeck/slugify';
 import { Context } from '@metorial/context';
 import {
+  addAfterTransactionHook,
   db,
   ID,
   Instance,
@@ -22,6 +23,7 @@ import {
 } from '@metorial/db';
 import { Fabric } from '@metorial/fabric';
 import { generateCode } from '@metorial/id';
+import { getTenantForSubspace } from '@metorial/module-subspace';
 import { differenceInMinutes } from 'date-fns';
 
 let getInstanceSlug = createSlugGenerator(
@@ -73,6 +75,8 @@ class InstanceService {
         instance,
         performedBy: d.performedBy
       });
+
+      await addAfterTransactionHook(() => getTenantForSubspace(instance));
 
       return instance;
     });

--- a/src/backend/modules/subspace/src/subspace.ts
+++ b/src/backend/modules/subspace/src/subspace.ts
@@ -31,22 +31,22 @@ export let subspace: ReturnType<typeof createSubspaceControllerClient> =
     endpoint: env.subspace.SUBSPACE_URL
   });
 
+  let retryDelay = 500;
+
   while (true) {
     try {
-      console.log('Trying to create subspace solution');
-
       let sol = await client.solution.upsert({
         name: 'Metorial Platform',
         identifier: env.subspace.SUBSPACE_SOLUTION
       });
       solutionProm.resolve(sol);
-      console.log('Created subspace solution: ', sol.id);
       return;
     } catch (err) {
       console.log('Failed to create subspace solution ... retrying', err);
     }
 
-    await delay(5000);
+    await delay(retryDelay);
+    retryDelay = Math.min(retryDelay * 2, 5000);
   }
 })();
 
@@ -57,66 +57,73 @@ let lock = createLock({
 let getSubspaceTenantIdentifier = (project: Project) => `mte-pro-${project.oid}`;
 let getSubspaceEnvironmentIdentifier = (instance: Instance) => `mte-ins-${instance.oid}`;
 
-export let getTenantForSubspace = async (
+let needsSubspaceSync = (
   instance: Instance & { organization?: Organization; project?: Project }
 ) => {
-  let solution = await solutionProm.promise;
-
-  if (
+  return (
     !instance.subspaceTenantId ||
     !instance.subspaceEnvironmentId ||
     (instance.organization && !instance.organization.subspaceTenantIds.length) ||
     !instance.lastSubspaceSyncAt ||
     Date.now() - instance.lastSubspaceSyncAt.getTime() > 1000 * 60 * 60 * 24
-  ) {
-    instance = await lock.usingLock(String(instance.organizationOid), async () => {
-      let currentInstance = await db.instance.findUniqueOrThrow({
-        where: { oid: instance.oid },
-        include: { project: { include: { instances: true } } }
+  );
+};
+
+export let getTenantForSubspace = async (
+  instance: Instance & { organization?: Organization; project?: Project }
+) => {
+  let solution = await solutionProm.promise;
+
+  if (needsSubspaceSync(instance)) {
+    let currentInstance = await db.instance.findUniqueOrThrow({
+      where: { oid: instance.oid },
+      include: {
+        organization: true,
+        project: { include: { instances: true } }
+      }
+    });
+
+    let subspaceTenant = await syncSubspaceTenantForProject(currentInstance.project, {
+      subspaceTenantIdentifier: currentInstance.subspaceTenantIdentifier
+    });
+
+    let subspaceEnvironment = await subspace.environment.upsert({
+      tenantId: subspaceTenant.id,
+      name: currentInstance.name,
+      type: currentInstance.type,
+      identifier:
+        currentInstance.subspaceEnvironmentIdentifier ??
+        getSubspaceEnvironmentIdentifier(currentInstance)
+    });
+
+    return await withTransaction(async db => {
+      instance = await db.instance.update({
+        where: { oid: currentInstance.oid },
+        data: {
+          subspaceTenantId: subspaceTenant.id,
+          subspaceTenantIdentifier: subspaceTenant.identifier,
+          subspaceEnvironmentId: subspaceEnvironment.id,
+          subspaceEnvironmentIdentifier: subspaceEnvironment.identifier,
+          lastSubspaceSyncAt: new Date()
+        }
       });
 
-      let subspaceTenant = await syncSubspaceTenantForProject(currentInstance.project, {
-        subspaceTenantIdentifier: currentInstance.subspaceTenantIdentifier
+      await db.project.update({
+        where: { oid: currentInstance.projectOid },
+        data: {
+          subspaceTenantId: subspaceTenant.id,
+          subspaceTenantIdentifier: subspaceTenant.identifier
+        }
       });
 
-      let subspaceEnvironment = await subspace.environment.upsert({
-        tenantId: subspaceTenant.id,
-        name: currentInstance.name,
-        type: currentInstance.type,
-        identifier:
-          currentInstance.subspaceEnvironmentIdentifier ??
-          getSubspaceEnvironmentIdentifier(currentInstance)
+      await db.organization.update({
+        where: { oid: currentInstance.organizationOid },
+        data: {
+          subspaceTenantIds: { push: subspaceTenant.id }
+        }
       });
 
-      return await withTransaction(async db => {
-        instance = await db.instance.update({
-          where: { oid: currentInstance.oid },
-          data: {
-            subspaceTenantId: subspaceTenant.id,
-            subspaceTenantIdentifier: subspaceTenant.identifier,
-            subspaceEnvironmentId: subspaceEnvironment.id,
-            subspaceEnvironmentIdentifier: subspaceEnvironment.identifier,
-            lastSubspaceSyncAt: new Date()
-          }
-        });
-
-        await db.project.update({
-          where: { oid: currentInstance.projectOid },
-          data: {
-            subspaceTenantId: subspaceTenant.id,
-            subspaceTenantIdentifier: subspaceTenant.identifier
-          }
-        });
-
-        await db.organization.update({
-          where: { oid: currentInstance.organizationOid },
-          data: {
-            subspaceTenantIds: { push: subspaceTenant.id }
-          }
-        });
-
-        return instance;
-      });
+      return instance;
     });
   }
 

--- a/src/systems/slates/apps/hub/src/lib/invocation/store.ts
+++ b/src/systems/slates/apps/hub/src/lib/invocation/store.ts
@@ -109,6 +109,14 @@ export let storeSlateInvocation = (
         return m;
       });
 
+      let requestTraces = (d.responseMessages ?? []).flatMap(m => {
+        let result = 'result' in m ? m.result : undefined;
+        if (!result) return [];
+
+        let requestTraces = 'requestTraces' in result ? result.requestTraces : undefined;
+        return requestTraces ?? [];
+      });
+
       // Handle error case where invocationResult.id may be undefined
       if (!d.invocationResult.id) {
         let storageKey = getStoredInvocationStorageKey(d.record);
@@ -120,7 +128,8 @@ export let storeSlateInvocation = (
             requests: sanitizedRequests as any,
             responses: (sanitizedResponses ?? []) as any,
             provider: { error: (d.invocationResult as any).error } as any,
-            logs: []
+            logs: [],
+            requestTraces
           } satisfies StoredSlateInvocation)
         );
 
@@ -152,7 +161,8 @@ export let storeSlateInvocation = (
           requests: sanitizedRequests as any,
           responses: (sanitizedResponses ?? []) as any,
           provider: { ...invocationResult, logs: undefined } as any,
-          logs: invocationResult.logs.map(log => [log.timestamp, log.message] as const)
+          logs: invocationResult.logs.map(log => [log.timestamp, log.message] as const),
+          requestTraces
         } satisfies StoredSlateInvocation)
       );
 

--- a/src/systems/slates/apps/hub/src/lib/invocation/types.ts
+++ b/src/systems/slates/apps/hub/src/lib/invocation/types.ts
@@ -2,6 +2,7 @@ import type {
   SlatesNotifications,
   SlatesParticipant,
   SlatesRequests,
+  slatesRequestTrace,
   SlatesResponses,
   slatesResponsesByMethod
 } from '@slates/proto';
@@ -16,6 +17,7 @@ export interface SlateInvocationBaseParams {
 
 export type SlatesRequest = SlatesNotifications | SlatesRequests;
 export type SlatesResponse = SlatesNotifications | SlatesResponses;
+export type SlatesRequestTrace = z.infer<typeof slatesRequestTrace>;
 
 export interface InvocationError {
   code: string;
@@ -41,4 +43,5 @@ export interface StoredSlateInvocation {
   responses: SlatesResponse[];
   logs: [number, string][];
   provider?: Omit<SlateInvocationResult, 'logs'>;
+  requestTraces?: SlatesRequestTrace[];
 }

--- a/src/systems/slates/apps/hub/src/presenters/slateInvocation.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateInvocation.ts
@@ -72,6 +72,7 @@ export let slateInvocationLitePresenter = async (inv: InvocationWithStoredAttach
 
     requests: output.requests,
     responses: output.responses,
+    requestTraces: output.requestTraces,
     error: output.provider?.error,
     logs: (output.logs ?? []).map(([timestamp, message]) => ({
       timestamp,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches async provisioning of external Subspace tenants/environments and when it runs relative to DB commits; regressions could cause missing or duplicate sync state under concurrency. Also changes the persisted invocation payload shape consumed by the hub (adds `requestTraces`), which could affect downstream readers expecting the old format.
> 
> **Overview**
> **Subspace provisioning behavior is adjusted to happen more reliably and sooner.** Instance creation now registers an `addAfterTransactionHook` to call `getTenantForSubspace(instance)` after the DB transaction commits, and Subspace solution bootstrapping switches to exponential backoff (500ms up to 5s) instead of a fixed 5s delay.
> 
> `getTenantForSubspace` is refactored to centralize “needs sync” checks, always re-load the instance with `organization` and `project` before syncing, and then upsert the Subspace environment and persist tenant/environment identifiers + `lastSubspaceSyncAt` back to instance/project/org.
> 
> **Slate invocation storage/output gains request tracing.** The hub now extracts `requestTraces` from response message results, stores them alongside logs in `StoredSlateInvocation`, and exposes them via the `slateInvocation` presenter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c71f1a9cdd731ec509a58a7a1d0645f4b80b9741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->