### PR TITLE
feat/improve-callbacks-frontend

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/scenes/callbacks/deploymentPicker.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/callbacks/deploymentPicker.tsx
@@ -1,0 +1,300 @@
+import * as RadixToggleGroup from '@radix-ui/react-toggle-group';
+import { Input, RenderDate, Text, theme } from '@metorial/ui';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+import { useDebounced } from '../../../../hooks/useDebounced';
+
+export type CallbackDeploymentPickerItem = {
+  id: string;
+  name: string | null;
+  createdAt: Date | string;
+};
+
+let PickerBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  width: 100%;
+`;
+
+let Shell = styled.div`
+  border-radius: 20px;
+  background: ${theme.colors.background};
+  box-shadow: inset 0 0 0 1px ${theme.colors.gray300};
+  overflow: hidden;
+  width: 100%;
+`;
+
+let SearchHeader = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  padding: 10px 10px;
+  background: ${theme.colors.background};
+  border-bottom: 1px solid ${theme.colors.gray300};
+`;
+
+let ScrollArea = styled.div`
+  max-height: calc(100vh - 420px);
+  min-height: 120px;
+  overflow: auto;
+`;
+
+let DeploymentsRoot = styled(RadixToggleGroup.Root)`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border: 0;
+  background: transparent;
+`;
+
+let DeploymentItem = styled(RadixToggleGroup.Item)`
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) auto;
+  column-gap: 14px;
+  align-items: center;
+  width: 100%;
+  position: relative;
+  text-align: left;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 14px 18px;
+  cursor: pointer;
+  outline: none;
+  box-shadow: none;
+  transition:
+    background 0.18s ease,
+    box-shadow 0.18s ease;
+
+  & + & {
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 1px;
+      background: ${theme.colors.gray300};
+    }
+  }
+
+  &:hover {
+    background: ${theme.colors.gray100};
+  }
+
+  &:focus-visible {
+    outline: none;
+  }
+
+  &[data-state='on'] {
+    position: relative;
+    z-index: 1;
+    background: ${theme.colors.gray200};
+    box-shadow: inset 0 0 0 1px ${theme.colors.gray300};
+  }
+
+  &[data-state='on']::before {
+    opacity: 0;
+  }
+
+  &[data-state='on'] + &::before {
+    opacity: 0;
+  }
+`;
+
+let Indicator = styled.span`
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  border: 1.5px solid ${theme.colors.gray500};
+  background: ${theme.colors.background};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    border-color 0.18s ease,
+    background 0.18s ease;
+
+  &::after {
+    content: '';
+    width: 7px;
+    height: 7px;
+    border-radius: 999px;
+    background: ${theme.colors.primary};
+    opacity: 0;
+    transform: scale(0.6);
+    transition:
+      opacity 0.18s ease,
+      transform 0.18s ease;
+  }
+
+  ${DeploymentItem}[data-state='on'] & {
+    border-color: ${theme.colors.primary};
+  }
+
+  ${DeploymentItem}[data-state='on'] &::after {
+    opacity: 1;
+    transform: scale(1);
+  }
+`;
+
+let Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+`;
+
+let TitleLine = styled.div`
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: ${theme.colors.gray900};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+let Subtitle = styled.div`
+  font-size: 12px;
+  line-height: 1.35;
+  color: ${theme.colors.gray600};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-variant-numeric: tabular-nums;
+`;
+
+let Timestamp = styled.div`
+  font-size: 12px;
+  color: ${theme.colors.gray600};
+  white-space: nowrap;
+  padding-left: 14px;
+`;
+
+let EmptyState = styled.div`
+  padding: 28px 20px;
+  text-align: center;
+`;
+
+let shortenId = (id: string) => {
+  if (id.length <= 16) return id;
+  return `${id.slice(0, 10)}...${id.slice(-4)}`;
+};
+
+export let CallbackDeploymentPicker = (p: {
+  items: CallbackDeploymentPickerItem[];
+  value: string | undefined;
+  onChange: (id: string) => void;
+  searchable?: boolean;
+  ariaLabel?: string;
+  focusOnMount?: boolean;
+}) => {
+  let id = useId();
+  let labelId = `${id}-label`;
+  let [search, setSearch] = useState('');
+  let searchDebounced = useDebounced(search, 200);
+  let itemRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  let hasAutoFocused = useRef(false);
+
+  let filteredItems = useMemo(() => {
+    let query = searchDebounced.trim().toLowerCase();
+    if (!query) return p.items;
+
+    return p.items.filter(item => {
+      let title = (item.name ?? '').toLowerCase();
+      return title.includes(query) || item.id.toLowerCase().includes(query);
+    });
+  }, [p.items, searchDebounced]);
+
+  useEffect(() => {
+    if (!p.focusOnMount) return;
+    if (hasAutoFocused.current) return;
+
+    let targetId = p.value || filteredItems[0]?.id;
+    if (!targetId) return;
+
+    let frame = requestAnimationFrame(() => {
+      itemRefs.current[targetId]?.focus();
+      hasAutoFocused.current = true;
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [p.focusOnMount, p.value, filteredItems]);
+
+  return (
+    <PickerBox>
+      <Shell>
+        {p.searchable && (
+          <SearchHeader>
+            <Input
+              label="Search deployments"
+              hideLabel
+              size="2"
+              placeholder="Search deployments..."
+              value={search}
+              onInput={setSearch}
+            />
+          </SearchHeader>
+        )}
+
+        <ScrollArea>
+          {filteredItems.length === 0 ? (
+            <EmptyState>
+              <Text size="2" color="gray600">
+                {searchDebounced.trim()
+                  ? 'No deployments match your search.'
+                  : 'No deployments found.'}
+              </Text>
+            </EmptyState>
+          ) : (
+            <DeploymentsRoot
+              type="single"
+              orientation="vertical"
+              value={p.value ?? ''}
+              onValueChange={nextValue => {
+                if (!nextValue || nextValue == p.value) return;
+                p.onChange(nextValue);
+              }}
+              onKeyDownCapture={e => {
+                if (e.key !== 'Enter') return;
+                e.preventDefault();
+
+                let form = (e.target as HTMLElement).closest('form');
+                requestAnimationFrame(() => {
+                  form?.requestSubmit();
+                });
+              }}
+              aria-label={p.ariaLabel ?? 'Select a deployment'}
+              aria-labelledby={labelId}
+            >
+              {filteredItems.map(item => (
+                <DeploymentItem
+                  key={item.id}
+                  value={item.id}
+                  ref={element => {
+                    itemRefs.current[item.id] = element;
+                  }}
+                  onFocus={() => {
+                    if (p.value == item.id) return;
+                    p.onChange(item.id);
+                  }}
+                >
+                  <Indicator aria-hidden />
+                  <Content>
+                    <TitleLine>{item.name?.trim() || 'Unnamed deployment'}</TitleLine>
+                    <Subtitle>{shortenId(item.id)}</Subtitle>
+                  </Content>
+                  <Timestamp>
+                    <RenderDate date={item.createdAt} />
+                  </Timestamp>
+                </DeploymentItem>
+              ))}
+            </DeploymentsRoot>
+          )}
+        </ScrollArea>
+      </Shell>
+    </PickerBox>
+  );
+};

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/callbacks/modal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/callbacks/modal.tsx
@@ -1,144 +1,266 @@
 import type { DashboardInstanceCallbacksCreateOutput } from '@metorial/dashboard-sdk';
 import { useForm } from '@metorial/data-hooks';
-import { useCreateCallback, useProvider, useProviderDeployment } from '@metorial/state';
+import {
+  useCreateCallback,
+  useCreateProviderDeployment,
+  useProvider,
+  useProviderDeployments
+} from '@metorial/state';
 import {
   Button,
   Callout,
   CenteredSpinner,
   Dialog,
+  Flex,
   Input,
   Spacer,
-  Text,
-  showModal
+  Text
 } from '@metorial/ui';
-import { type ReactNode, useState } from 'react';
-import { ProviderContextCard } from '../providerContextCard';
-import { ProviderDeploymentsList } from '../providerDeployments/list';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { TableFilterState } from '../../../../components/table/filter';
+import {
+  ProviderCreationPanelShell,
+  showProviderCreationPanel
+} from '../providerCreationPanel';
+import { ProviderListingFilters, useProviderListingFilters } from '../providers/filters';
 import { ProvidersWithDeploymentsSearch } from '../providers/search';
-import { Stepper } from '../../../../components/stepper';
+import { CallbackDeploymentPicker } from './deploymentPicker';
 
-let DIALOG_EXIT_MS = 220;
+let SEARCH_THRESHOLD = 5;
 
-let closeAndThen = (close: () => void, next?: () => void) => {
-  close();
-  if (!next) return;
-  setTimeout(() => next(), DIALOG_EXIT_MS);
+let PickProviderStep = (p: { instanceId: string; onSelect: (providerId: string) => void }) => {
+  let [search, setSearch] = useState('');
+  let [filterState, setFilterState] = useState<TableFilterState[]>([]);
+  let { filters, providerListingsFilter } = useProviderListingFilters({
+    search,
+    filterState
+  });
+
+  return (
+    <Flex direction="column" gap={15}>
+      <ProviderListingFilters
+        searchState={[search, setSearch]}
+        filterState={[filterState, setFilterState]}
+        filters={filters}
+      />
+
+      <ProvidersWithDeploymentsSearch
+        instanceId={p.instanceId}
+        columns={3}
+        limit={30}
+        variant="providerCard"
+        cardSize="compact"
+        includeAllProviders
+        prioritizeProvidersWithDeployments
+        providerListingsFilter={{
+          ...providerListingsFilter,
+          capabilities: {
+            ...(providerListingsFilter.capabilities ?? {}),
+            supportsCallbacks: true
+          }
+        }}
+        hideSearch
+        internalScroll
+        internalScrollHeight="calc(100vh - 360px)"
+        emptyText="No providers with callback support found."
+        onSelect={provider => p.onSelect(provider.id)}
+      />
+    </Flex>
+  );
 };
 
-let PickerDialogScaffold = ({
-  title,
-  description,
-  close,
-  onBack,
-  children
-}: {
-  title: string;
-  description: string;
-  close: () => void;
-  onBack?: () => void;
-  children: ReactNode;
-}) => (
-  <>
-    <Dialog.Title>{title}</Dialog.Title>
-    <Dialog.Description>{description}</Dialog.Description>
+let SelectDeploymentStep = (p: {
+  instanceId: string;
+  providerId: string;
+  selectedDeploymentId: string | undefined;
+  setSelectedDeploymentId: (deploymentId: string | undefined) => void;
+  autoAdvanceArmed: boolean;
+  disarmAutoAdvance: () => void;
+  onBack: () => void;
+  onContinue: () => void;
+}) => {
+  let provider = useProvider(p.instanceId, p.providerId);
+  let deployments = useProviderDeployments(p.instanceId, {
+    providerId: p.providerId,
+    limit: 50
+  });
+  let createDeployment = useCreateProviderDeployment();
 
-    <Spacer size={10} />
+  let deploymentItems = useMemo(
+    () => deployments.data?.items ?? [],
+    [deployments.data?.items]
+  );
 
-    {children}
+  let hasProcessedAutoAdvance = useRef<string | null>(null);
+  let [creationError, setCreationError] = useState<string | null>(null);
+  let [isCreatingDefault, setIsCreatingDefault] = useState(false);
 
-    {onBack && (
+  useEffect(() => {
+    if (!p.autoAdvanceArmed) return;
+    if (deployments.isLoading || provider.isLoading) return;
+    if (hasProcessedAutoAdvance.current === p.providerId) return;
+
+    hasProcessedAutoAdvance.current = p.providerId;
+
+    if (deploymentItems.length >= 2) {
+      p.disarmAutoAdvance();
+      if (!p.selectedDeploymentId) {
+        p.setSelectedDeploymentId(deploymentItems[0]!.id);
+      }
+      return;
+    }
+
+    if (deploymentItems.length === 1) {
+      p.disarmAutoAdvance();
+      p.setSelectedDeploymentId(deploymentItems[0]!.id);
+      p.onContinue();
+      return;
+    }
+
+    let providerName = provider.data?.name ?? undefined;
+    setIsCreatingDefault(true);
+    setCreationError(null);
+
+    (async () => {
+      let [result, err] = await createDeployment.mutate({
+        instanceId: p.instanceId,
+        providerId: p.providerId,
+        ...(providerName ? { name: providerName } : {})
+      });
+
+      setIsCreatingDefault(false);
+
+      if (!result || err) {
+        setCreationError(
+          err?.data?.message ?? 'Could not create a default deployment for this provider.'
+        );
+        return;
+      }
+
+      p.disarmAutoAdvance();
+      p.setSelectedDeploymentId(result.id);
+      p.onContinue();
+    })();
+  }, [
+    p.autoAdvanceArmed,
+    p.providerId,
+    deployments.isLoading,
+    provider.isLoading,
+    deploymentItems
+  ]);
+
+  if (provider.isLoading || deployments.isLoading || isCreatingDefault) {
+    return <CenteredSpinner />;
+  }
+
+  if (creationError) {
+    return (
       <>
-        <Spacer size={10} />
+        <Callout color="red">{creationError}</Callout>
+
+        <Spacer size={15} />
 
         <Dialog.Actions>
+          <Button type="button" variant="outline" onClick={p.onBack}>
+            Back
+          </Button>
           <Button
-            size="2"
-            variant="outline"
+            type="button"
             onClick={() => {
-              closeAndThen(close, onBack);
+              hasProcessedAutoAdvance.current = null;
+              setCreationError(null);
             }}
           >
+            Retry
+          </Button>
+        </Dialog.Actions>
+      </>
+    );
+  }
+
+  if (deploymentItems.length === 0) {
+    return (
+      <>
+        <Callout color="gray">
+          This provider has no deployments yet. Preparing a default deployment...
+        </Callout>
+
+        <Spacer size={15} />
+
+        <Dialog.Actions>
+          <Button type="button" variant="outline" onClick={p.onBack}>
             Back
           </Button>
         </Dialog.Actions>
       </>
-    )}
-  </>
-);
+    );
+  }
 
-let CallbackDeploymentPicker = (p: {
-  providerId: string;
-  close: () => void;
-  onSelect: (deploymentId: string) => void;
-  onBack?: () => void;
-}) => (
-  <PickerDialogScaffold
-    title="Select Deployment"
-    description="Choose a deployment to create a callback for."
-    close={p.close}
-    onBack={p.onBack}
-  >
-    <ProviderDeploymentsList
-      providerId={p.providerId}
-      searchable
-      compact
-      columns={3}
-      limit={18}
-      sectionLabel="Deployments"
-      emptyText="No deployments found for this provider."
-      onDeploymentClick={deployment => {
-        closeAndThen(p.close, () => p.onSelect(deployment.id));
+  let pickerItems = deploymentItems.map(deployment => ({
+    id: deployment.id,
+    name: deployment.name,
+    createdAt: deployment.createdAt
+  }));
+
+  return (
+    <form
+      onSubmit={e => {
+        e.preventDefault();
+        if (!p.selectedDeploymentId) return;
+        p.onContinue();
       }}
-    />
-  </PickerDialogScaffold>
-);
+    >
+      <Text size="2" weight="strong">
+        Deployment
+      </Text>
+      <Text size="1" color="gray600">
+        Choose the deployment this callback should listen to.
+      </Text>
 
-let CallbackProviderPicker = (p: {
-  instanceId: string;
-  close: () => void;
-  onSelect: (providerId: string) => void;
-}) => (
-  <PickerDialogScaffold
-    title="Create Callback"
-    description="Select a provider that already has a deployment."
-    close={p.close}
-  >
-    <ProvidersWithDeploymentsSearch
-      instanceId={p.instanceId}
-      columns={3}
-      limit={18}
-      emptyText="No providers with deployments found. Create a deployment first."
-      onSelect={provider => {
-        closeAndThen(p.close, () => p.onSelect(provider.id));
-      }}
-    />
-  </PickerDialogScaffold>
-);
+      <Spacer size={10} />
 
-let showPickerModal = (children: (d: { close: () => void }) => ReactNode) =>
-  showModal(({ dialogProps, close }) => (
-    <Dialog.Wrapper {...dialogProps} width={550}>
-      {children({ close })}
-    </Dialog.Wrapper>
-  ));
+      <CallbackDeploymentPicker
+        items={pickerItems}
+        value={p.selectedDeploymentId}
+        onChange={p.setSelectedDeploymentId}
+        searchable={pickerItems.length > SEARCH_THRESHOLD}
+        ariaLabel="Select a deployment"
+        focusOnMount
+      />
 
-let CallbackCreateModalContent = (p: {
+      <Spacer size={20} />
+
+      <Dialog.Actions>
+        <Button type="button" variant="outline" onClick={p.onBack}>
+          Back
+        </Button>
+        <Button type="submit" disabled={!p.selectedDeploymentId}>
+          Continue
+        </Button>
+      </Dialog.Actions>
+    </form>
+  );
+};
+
+let CallbackDetailsStep = (p: {
   instanceId: string;
   providerId: string;
   providerDeploymentId: string;
   close: () => void;
+  onBack: () => void;
   onCreate?: (callback: DashboardInstanceCallbacksCreateOutput) => void;
-  onBack?: () => void;
 }) => {
   let createCallback = useCreateCallback();
-  let deployment = useProviderDeployment(p.instanceId, p.providerDeploymentId);
   let provider = useProvider(p.instanceId, p.providerId);
-  let [step, setStep] = useState(0);
+  let providerName = provider.data?.name?.trim() ?? '';
+  let defaultName = providerName ? `${providerName} callback` : 'New callback';
+
   let form = useForm({
     initialValues: {
-      name: '',
+      name: defaultName,
       description: ''
     },
+    updateInitialValues: true,
     onSubmit: async values => {
       let [result] = await createCallback.mutate({
         instanceId: p.instanceId,
@@ -159,159 +281,183 @@ let CallbackCreateModalContent = (p: {
       })
   });
 
-  if (deployment.isLoading || provider.isLoading) {
-    return <CenteredSpinner />;
-  }
+  return (
+    <form onSubmit={form.handleSubmit}>
+      <Text size="2" weight="strong">
+        Callback Details
+      </Text>
+      <Text size="1" color="gray600">
+        Give this callback a recognizable name. Destinations and triggers can be configured
+        after creation.
+      </Text>
 
-  if (!deployment.data || !provider.data) {
-    return (
-      <>
-        <Callout color="gray">
-          Could not resolve the selected provider deployment. Please try again.
-        </Callout>
+      <Spacer size={15} />
 
-        <Spacer size={15} />
+      <Input label="Name" required autoFocus {...form.getFieldProps('name')} />
+      <form.RenderError field="name" />
 
-        <Dialog.Actions>
-          <Button variant="outline" onClick={p.onBack ?? p.close}>
-            Back
-          </Button>
-        </Dialog.Actions>
-      </>
-    );
-  }
+      <Spacer size={10} />
 
-  let providerContext = (
-    <ProviderContextCard
-      providerId={provider.data.id}
-      providerName={provider.data.name}
-      providerImageUrl={provider.data.publisher.imageUrl}
-      deploymentName={deployment.data.name}
-      deploymentDescription={deployment.data.description}
-    />
+      <Input label="Description" {...form.getFieldProps('description')} />
+      <form.RenderError field="description" />
+
+      <createCallback.RenderError />
+
+      <Spacer size={20} />
+
+      <Dialog.Actions>
+        <Button type="button" variant="outline" onClick={p.onBack}>
+          Back
+        </Button>
+        <Button
+          type="submit"
+          loading={createCallback.isLoading}
+          success={createCallback.isSuccess}
+          disabled={!form.values.name.trim()}
+        >
+          Create
+        </Button>
+      </Dialog.Actions>
+    </form>
   );
-
-  let steps = [
-    {
-      title: 'Provider',
-      subtitle: 'Confirm deployment',
-      render: () => (
-        <>
-          {providerContext}
-
-          <Spacer size={15} />
-
-          <Callout color="gray">
-            Create the callback now, then add destinations and triggers from the callback
-            details page.
-          </Callout>
-
-          <Spacer size={15} />
-
-          <Dialog.Actions>
-            <Button variant="outline" onClick={p.onBack ?? p.close}>
-              Back
-            </Button>
-            <Button onClick={() => setStep(1)}>Continue</Button>
-          </Dialog.Actions>
-        </>
-      )
-    },
-    {
-      title: 'Details',
-      subtitle: 'Name and create',
-      render: () => (
-        <form onSubmit={form.handleSubmit}>
-          {providerContext}
-
-          <Spacer size={15} />
-
-          <Input label="Name" required {...form.getFieldProps('name')} />
-          <form.RenderError field="name" />
-
-          <Spacer size={15} />
-
-          <Input label="Description" {...form.getFieldProps('description')} />
-          <form.RenderError field="description" />
-
-          <Spacer size={15} />
-
-          <Text size="1" color="gray600">
-            Destinations and triggers can be configured after the callback is created.
-          </Text>
-
-          <Spacer size={20} />
-
-          <Dialog.Actions>
-            <Button type="button" variant="outline" onClick={() => setStep(0)}>
-              Back
-            </Button>
-            <Button
-              type="submit"
-              loading={createCallback.isLoading}
-              success={createCallback.isSuccess}
-            >
-              Create Callback
-            </Button>
-          </Dialog.Actions>
-
-          <createCallback.RenderError />
-        </form>
-      )
-    }
-  ];
-
-  return <Stepper steps={steps} currentStep={step} setCurrentStep={setStep} />;
 };
 
-let showCallbackCreateModal = (p: {
+let CallbackCreationFlow = (p: {
   instanceId: string;
-  providerId: string;
-  providerDeploymentId: string;
+  close: () => void;
+  setPanelWidth: (width: number) => void;
   onCreate?: (callback: DashboardInstanceCallbacksCreateOutput) => void;
-  onBack?: () => void;
-}) =>
-  showModal(({ dialogProps, close }) => (
-    <Dialog.Wrapper {...dialogProps} width={700}>
-      <Dialog.Title>Create Callback</Dialog.Title>
-      <Dialog.Description>
-        Create a callback for the selected deployed provider. Destinations and triggers can be
-        attached after creation.
-      </Dialog.Description>
+}) => {
+  let [step, setStep] = useState(0);
+  let [providerId, setProviderId] = useState<string | null>(null);
+  let [selectedDeploymentId, setSelectedDeploymentId] = useState<string | undefined>(
+    undefined
+  );
+  let [autoAdvanceArmed, setAutoAdvanceArmed] = useState(false);
 
-      <CallbackCreateModalContent {...p} close={close} />
-    </Dialog.Wrapper>
-  ));
+  useEffect(() => {
+    if (step === 0) {
+      p.setPanelWidth(1050);
+      return;
+    }
+
+    p.setPanelWidth(660);
+  }, [step, p.setPanelWidth]);
+
+  let canAdvanceToDeployment = !!providerId;
+  let canAdvanceToDetails = !!providerId && !!selectedDeploymentId;
+
+  let steps = useMemo(
+    () => [
+      {
+        title: 'Select Provider',
+        render: () => (
+          <PickProviderStep
+            instanceId={p.instanceId}
+            onSelect={nextProviderId => {
+              if (nextProviderId !== providerId) {
+                setSelectedDeploymentId(undefined);
+              }
+              setProviderId(nextProviderId);
+              setAutoAdvanceArmed(true);
+              setStep(1);
+            }}
+          />
+        )
+      },
+      {
+        title: 'Choose Deployment',
+        render: () =>
+          providerId ? (
+            <SelectDeploymentStep
+              instanceId={p.instanceId}
+              providerId={providerId}
+              selectedDeploymentId={selectedDeploymentId}
+              setSelectedDeploymentId={setSelectedDeploymentId}
+              autoAdvanceArmed={autoAdvanceArmed}
+              disarmAutoAdvance={() => setAutoAdvanceArmed(false)}
+              onBack={() => {
+                setAutoAdvanceArmed(false);
+                setStep(0);
+              }}
+              onContinue={() => {
+                setStep(2);
+              }}
+            />
+          ) : (
+            <CenteredSpinner />
+          )
+      },
+      {
+        title: 'Configure Details',
+        render: () =>
+          providerId && selectedDeploymentId ? (
+            <CallbackDetailsStep
+              instanceId={p.instanceId}
+              providerId={providerId}
+              providerDeploymentId={selectedDeploymentId}
+              close={p.close}
+              onBack={() => {
+                setAutoAdvanceArmed(false);
+                setStep(1);
+              }}
+              onCreate={p.onCreate}
+            />
+          ) : (
+            <CenteredSpinner />
+          )
+      }
+    ],
+    [p.instanceId, p.close, p.onCreate, providerId, selectedDeploymentId, autoAdvanceArmed]
+  );
+
+  return (
+    <ProviderCreationPanelShell
+      title="Create Callback"
+      description="Select a provider, choose a deployment, and configure your callback."
+      steps={steps}
+      currentStep={step}
+      setCurrentStep={nextStep => {
+        if (nextStep === 0) {
+          setAutoAdvanceArmed(false);
+          setStep(0);
+          return;
+        }
+
+        if (nextStep === 1 && canAdvanceToDeployment) {
+          setAutoAdvanceArmed(false);
+          setStep(1);
+          return;
+        }
+
+        if (nextStep === 2 && canAdvanceToDetails) {
+          setAutoAdvanceArmed(false);
+          setStep(2);
+        }
+      }}
+      isStepDisabled={nextStep => {
+        if (nextStep === 1) return !canAdvanceToDeployment;
+        if (nextStep === 2) return !canAdvanceToDetails;
+        return false;
+      }}
+      getStepDisabledReason={nextStep => {
+        if (nextStep === 1 && !canAdvanceToDeployment) return 'Select a provider first.';
+        if (nextStep === 2 && !canAdvanceToDetails) return 'Select a deployment first.';
+        return undefined;
+      }}
+    />
+  );
+};
 
 export let showCallbackFormModal = (p: {
   instanceId: string;
   onCreate?: (callback: DashboardInstanceCallbacksCreateOutput) => void;
-}) => {
-  let showDeploymentStep = (providerId: string) =>
-    showPickerModal(({ close }) => (
-      <CallbackDeploymentPicker
-        providerId={providerId}
-        close={close}
-        onBack={() => showCallbackFormModal(p)}
-        onSelect={deploymentId =>
-          showCallbackCreateModal({
-            instanceId: p.instanceId,
-            providerId,
-            providerDeploymentId: deploymentId,
-            onBack: () => showDeploymentStep(providerId),
-            onCreate: p.onCreate
-          })
-        }
-      />
-    ));
-
-  return showPickerModal(({ close }) => (
-    <CallbackProviderPicker
+}) =>
+  showProviderCreationPanel(({ close, setWidth }) => (
+    <CallbackCreationFlow
       instanceId={p.instanceId}
       close={close}
-      onSelect={providerId => {
-        showDeploymentStep(providerId);
-      }}
+      setPanelWidth={setWidth}
+      onCreate={p.onCreate}
     />
   ));
-};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate UI/flow change that also introduces automatic provider-deployment creation; risk is mainly around unexpected side effects, navigation edge cases, and error handling in the new multi-step flow.
> 
> **Overview**
> Refactors callback creation from nested `showModal` dialogs into a single multi-step `showProviderCreationPanel` flow: pick a callback-capable provider (with filters), choose a deployment, then enter callback details.
> 
> Adds a new `CallbackDeploymentPicker` (searchable, keyboard-friendly toggle list) and updates the deployment step to *auto-advance* when only one deployment exists, or automatically create a default deployment when none exist (with retry/error states). Callback details now default the name based on the selected provider and enforce step gating/disabled navigation in the panel stepper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed976628646bcf8bd3c135adc43324ea6d2f0cf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->