### PR TITLE
Harden provider sync

### DIFF
--- a/src/systems/subspace/db/src/transaction.ts
+++ b/src/systems/subspace/db/src/transaction.ts
@@ -17,7 +17,7 @@ let afterQueue = new PQueue({ concurrency: Number.POSITIVE_INFINITY });
 
 export let withTransaction = async <T>(
   cb: (tdb: TransactionDB) => Promise<T>,
-  opts?: { ifExists?: boolean }
+  opts?: { ifExists?: boolean; timeout?: number; maxWait?: number }
 ): Promise<T> => {
   let tdb = tdbStorage.getStore();
 
@@ -26,17 +26,23 @@ export let withTransaction = async <T>(
   } else {
     let afterHooks: Array<() => Promise<undefined | any>> = [];
 
-    let res = await db.$transaction(async tdb => {
-      return await tdbStorage.run(
-        {
-          tdb,
-          afterHooks
-        },
-        async () => {
-          return await cb(tdb);
-        }
-      );
-    });
+    let res = await db.$transaction(
+      async tdb => {
+        return await tdbStorage.run(
+          {
+            tdb,
+            afterHooks
+          },
+          async () => {
+            return await cb(tdb);
+          }
+        );
+      },
+      {
+        timeout: opts?.timeout,
+        maxWait: opts?.maxWait
+      }
+    );
 
     afterQueue.add(async () => {
       let inner = async () => await Promise.all(afterHooks.map(hook => hook()));

--- a/src/systems/subspace/modules/provider-internal/src/services/provider.ts
+++ b/src/systems/subspace/modules/provider-internal/src/services/provider.ts
@@ -103,224 +103,230 @@ class providerInternalServiceImpl {
       attributes: PrismaJson.ProviderTypeAttributes;
     };
   }) {
-    return withTransaction(async db => {
-      let identifier = `provider::${d.source.type}::`;
+    return withTransaction(
+      async db => {
+        let identifier = `provider::${d.source.type}::`;
 
-      if (d.source.type === 'slates') {
-        identifier += `${d.source.slate.oid}`;
-      } else if (d.source.type === 'shuttle') {
-        identifier += `${d.source.shuttleServer.oid}`;
-      } else if (d.source.type === 'native') {
-        identifier += d.source.integrationIdentifier;
-      } else {
-        throw new Error('Unknown provider source type');
-      }
-
-      let providerEntryData = {
-        identifier: `${identifier}::entry`,
-        name: d.info.name,
-        description: d.info.description,
-        publisherOid: d.publisher.oid
-      };
-      let entry = await db.providerEntry.upsert({
-        where: {
-          identifier: providerEntryData.identifier
-        },
-        create: {
-          ...getId('providerEntry'),
-          ...providerEntryData
-        },
-        update: providerEntryData
-      });
-
-      let type = await ensureProviderType(d.type.name, d.type.attributes);
-
-      let providerData = {
-        identifier: `${identifier}::provider`,
-
-        ...(d.owner
-          ? {
-              access: 'tenant' as const,
-              ownerTenantOid: d.owner.tenant.oid,
-              ownerSolutionOid: d.owner.solution?.oid
-            }
-          : {
-              access: 'public' as const
-            }),
-
-        status: 'active' as const,
-
-        name: d.info.name,
-        description: d.info.description,
-
-        entryOid: entry.oid,
-        publisherOid: d.publisher.oid,
-        typeOid: type.oid,
-
-        globalIdentifier: d.info.globalIdentifier
-      };
-      let existingProvider = await db.provider.findFirst({
-        where: {
-          OR: [
-            { identifier: providerData.identifier },
-            providerData.globalIdentifier
-              ? { globalIdentifier: providerData.globalIdentifier }
-              : undefined!
-          ].filter(Boolean)
+        if (d.source.type === 'slates') {
+          identifier += `${d.source.slate.oid}`;
+        } else if (d.source.type === 'shuttle') {
+          identifier += `${d.source.shuttleServer.oid}`;
+        } else if (d.source.type === 'native') {
+          identifier += d.source.integrationIdentifier;
+        } else {
+          throw new Error('Unknown provider source type');
         }
-      });
 
-      let newProviderId = getId('provider');
-      let provider = existingProvider
-        ? await db.provider.update({
-            where: { oid: existingProvider.oid },
-            data: providerData
-          })
-        : await db.provider.upsert({
-            where: {
-              identifier: providerData.identifier
-            },
-            create: {
-              ...newProviderId,
-              ...providerData,
-              slug: d.info.slug,
-              tag: await createTag()
-            },
-            update: providerData
-          });
+        let providerEntryData = {
+          identifier: `${identifier}::entry`,
+          name: d.info.name,
+          description: d.info.description,
+          publisherOid: d.publisher.oid
+        };
+        let entry = await db.providerEntry.upsert({
+          where: {
+            identifier: providerEntryData.identifier
+          },
+          create: {
+            ...getId('providerEntry'),
+            ...providerEntryData
+          },
+          update: providerEntryData
+        });
 
-      let variantData = {
-        identifier: `${identifier}::variant`,
+        let type = await ensureProviderType(d.type.name, d.type.attributes);
 
-        isDefault: true,
+        let providerData = {
+          identifier: `${identifier}::provider`,
 
-        name: d.info.name,
-        description: d.info.description,
+          ...(d.owner
+            ? {
+                access: 'tenant' as const,
+                ownerTenantOid: d.owner.tenant.oid,
+                ownerSolutionOid: d.owner.solution?.oid
+              }
+            : {
+                access: 'public' as const
+              }),
 
-        backendOid: d.source.backend.oid,
-        providerOid: provider.oid,
-        publisherOid: d.publisher.oid,
-
-        slateOid: d.source.type === 'slates' ? d.source.slate.oid : null,
-        shuttleServerOid: d.source.type === 'shuttle' ? d.source.shuttleServer.oid : null
-      };
-
-      let existingVariant = await db.providerVariant.findFirst({
-        where: { identifier: variantData.identifier }
-      });
-
-      let variant = existingVariant
-        ? await db.providerVariant.update({
-            where: { identifier: variantData.identifier },
-            data: variantData
-          })
-        : await db.providerVariant.upsert({
-            where: { identifier: variantData.identifier },
-            create: {
-              ...getId('providerVariant'),
-              ...variantData,
-              tag: await createTag()
-            },
-            update: variantData
-          });
-
-      await db.provider.updateMany({
-        where: { oid: provider.oid },
-        data: { defaultVariantOid: variant.oid }
-      });
-
-      let listing = await db.providerListing.findFirst({
-        where: { providerOid: provider.oid }
-      });
-
-      let allData = {
-        isPublic: provider.access === 'public',
-        ownerTenantOid: provider.access === 'tenant' ? provider.ownerTenantOid : null,
-        ownerSolutionOid: provider.access === 'tenant' ? provider.ownerSolutionOid : null,
-
-        publisherOid: provider.publisherOid,
-        providerOid: provider.oid,
-
-        typeOid: provider.typeOid
-      };
-
-      let newListingId = getId('providerListing');
-      if (!listing?.isCustomized) {
-        let inner = {
-          ...allData,
+          status: 'active' as const,
 
           name: d.info.name,
           description: d.info.description,
-          slug: d.info.slug,
 
-          image: d.info.image ?? { type: 'default' as const },
+          entryOid: entry.oid,
+          publisherOid: d.publisher.oid,
+          typeOid: type.oid,
 
-          readme: d.info.readme,
+          globalIdentifier: d.info.globalIdentifier
+        };
+        let existingProvider = await db.provider.findFirst({
+          where: {
+            OR: [
+              { identifier: providerData.identifier },
+              providerData.globalIdentifier
+                ? { globalIdentifier: providerData.globalIdentifier }
+                : undefined!
+            ].filter(Boolean)
+          }
+        });
 
-          skills: d.info.skills || [],
+        let newProviderId = getId('provider');
+        let provider = existingProvider
+          ? await db.provider.update({
+              where: { oid: existingProvider.oid },
+              data: providerData
+            })
+          : await db.provider.upsert({
+              where: {
+                identifier: providerData.identifier
+              },
+              create: {
+                ...newProviderId,
+                ...providerData,
+                slug: d.info.slug,
+                tag: await createTag()
+              },
+              update: providerData
+            });
 
-          isCustomized: false,
+        let variantData = {
+          identifier: `${identifier}::variant`,
 
-          isMetorial: d.publisher.type === 'metorial',
-          isVerified: d.publisher.type === 'metorial',
-          isOfficial: false
+          isDefault: true,
+
+          name: d.info.name,
+          description: d.info.description,
+
+          backendOid: d.source.backend.oid,
+          providerOid: provider.oid,
+          publisherOid: d.publisher.oid,
+
+          slateOid: d.source.type === 'slates' ? d.source.slate.oid : null,
+          shuttleServerOid: d.source.type === 'shuttle' ? d.source.shuttleServer.oid : null
         };
 
-        listing = await db.providerListing.upsert({
-          where: { providerOid: provider.oid },
-          create: {
-            ...newListingId,
-            ...inner,
-            status: 'active'
-          },
-          update: inner
+        let existingVariant = await db.providerVariant.findFirst({
+          where: { identifier: variantData.identifier }
         });
-      } else {
-        listing = await db.providerListing.update({
-          where: { providerOid: provider.oid },
-          data: allData
-        });
-      }
 
-      if (d.info.categories) {
-        let categories = await db.providerListingCategory.findMany({
-          where: {
-            slug: { in: d.info.categories }
-          }
+        let variant = existingVariant
+          ? await db.providerVariant.update({
+              where: { identifier: variantData.identifier },
+              data: variantData
+            })
+          : await db.providerVariant.upsert({
+              where: { identifier: variantData.identifier },
+              create: {
+                ...getId('providerVariant'),
+                ...variantData,
+                tag: await createTag()
+              },
+              update: variantData
+            });
+
+        await db.provider.updateMany({
+          where: { oid: provider.oid },
+          data: { defaultVariantOid: variant.oid }
         });
-        await db.providerListing.update({
-          where: { id: listing.id },
-          data: {
-            categories: {
-              set: categories.map(c => ({ oid: c.oid }))
+
+        let listing = await db.providerListing.findFirst({
+          where: { providerOid: provider.oid }
+        });
+
+        let allData = {
+          isPublic: provider.access === 'public',
+          ownerTenantOid: provider.access === 'tenant' ? provider.ownerTenantOid : null,
+          ownerSolutionOid: provider.access === 'tenant' ? provider.ownerSolutionOid : null,
+
+          publisherOid: provider.publisherOid,
+          providerOid: provider.oid,
+
+          typeOid: provider.typeOid
+        };
+
+        let newListingId = getId('providerListing');
+        if (!listing?.isCustomized) {
+          let inner = {
+            ...allData,
+
+            name: d.info.name,
+            description: d.info.description,
+            slug: d.info.slug,
+
+            image: d.info.image ?? { type: 'default' as const },
+
+            readme: d.info.readme,
+
+            skills: d.info.skills || [],
+
+            isCustomized: false,
+
+            isMetorial: d.publisher.type === 'metorial',
+            isVerified: d.publisher.type === 'metorial',
+            isOfficial: false
+          };
+
+          listing = await db.providerListing.upsert({
+            where: { providerOid: provider.oid },
+            create: {
+              ...newListingId,
+              ...inner,
+              status: 'active'
+            },
+            update: inner
+          });
+        } else {
+          listing = await db.providerListing.update({
+            where: { providerOid: provider.oid },
+            data: allData
+          });
+        }
+
+        if (d.info.categories) {
+          let categories = await db.providerListingCategory.findMany({
+            where: {
+              slug: { in: d.info.categories }
             }
+          });
+          await db.providerListing.update({
+            where: { id: listing.id },
+            data: {
+              categories: {
+                set: categories.map(c => ({ oid: c.oid }))
+              }
+            }
+          });
+        }
+
+        await addAfterTransactionHook(async () => {
+          if (provider.id === newProviderId.id) {
+            await providerCreatedQueue.add({ providerId: provider.id });
+          } else {
+            await providerUpdatedQueue.add({ providerId: provider.id });
           }
         });
+
+        await addAfterTransactionHook(async () => {
+          if (listing.id === newListingId.id) {
+            await listingCreatedQueue.add({ providerListingId: listing.id });
+          } else {
+            await listingUpdatedQueue.add({ providerListingId: listing.id });
+          }
+        });
+
+        return await db.provider.findFirstOrThrow({
+          where: { oid: provider.oid },
+          include: {
+            defaultVariant: true
+          }
+        });
+      },
+      {
+        timeout: 20000,
+        maxWait: 20000
       }
-
-      await addAfterTransactionHook(async () => {
-        if (provider.id === newProviderId.id) {
-          await providerCreatedQueue.add({ providerId: provider.id });
-        } else {
-          await providerUpdatedQueue.add({ providerId: provider.id });
-        }
-      });
-
-      await addAfterTransactionHook(async () => {
-        if (listing.id === newListingId.id) {
-          await listingCreatedQueue.add({ providerListingId: listing.id });
-        } else {
-          await listingUpdatedQueue.add({ providerListingId: listing.id });
-        }
-      });
-
-      return await db.provider.findFirstOrThrow({
-        where: { oid: provider.oid },
-        include: {
-          defaultVariant: true
-        }
-      });
-    });
+    );
   }
 
   async updateProvider(d: {

--- a/src/systems/subspace/modules/provider-internal/src/services/providerVersion.ts
+++ b/src/systems/subspace/modules/provider-internal/src/services/providerVersion.ts
@@ -100,88 +100,99 @@ class providerVersionInternalServiceImpl {
     return versionCreateLock.usingLock(
       [String(d.variant.oid), String(d.variant.slateOid)],
       () =>
-        withTransaction(async db => {
-          let identifier = `provider::${d.source.type}::`;
-          if (d.source.type === 'slates') {
-            identifier += `${d.source.slate.oid}::${d.source.slateVersion.oid}`;
-          } else if (d.source.type === 'shuttle') {
-            identifier += `${d.source.shuttleServer.oid}::${d.source.shuttleServerVersion.oid}`;
-          } else if (d.source.type === 'native') {
-            identifier += `${d.source.integrationIdentifier}::version`;
-          } else {
-            throw new Error('Unknown provider source type');
-          }
-
-          let currentVariant = await db.providerVariant.findFirst({
-            where: { oid: d.variant.oid }
-          });
-
-          let versionData = {
-            identifier,
-
-            name: d.info.name,
-            backendOid: d.source.backend.oid,
-            providerOid: d.variant.providerOid,
-            providerVariantOid: d.variant.oid,
-
-            typeOid: type.oid,
-
-            slateOid: d.source.type === 'slates' ? d.source.slate.oid : null,
-            slateVersionOid: d.source.type === 'slates' ? d.source.slateVersion.oid : null,
-
-            shuttleServerOid: d.source.type === 'shuttle' ? d.source.shuttleServer.oid : null,
-            shuttleServerVersionOid:
-              d.source.type === 'shuttle' ? d.source.shuttleServerVersion.oid : null,
-
-            isCurrent: d.isCurrent
-          };
-
-          let existingVersion = await db.providerVersion.findFirst({
-            where: { identifier: versionData.identifier }
-          });
-
-          let newId = getId('providerVersion');
-          let providerVersion = existingVersion
-            ? await db.providerVersion.update({
-                where: { identifier: versionData.identifier },
-                data: versionData
-              })
-            : await db.providerVersion.upsert({
-                where: { identifier: versionData.identifier },
-                create: {
-                  ...newId,
-                  ...versionData,
-                  specificationDiscoveryStatus: 'discovering',
-                  previousVersionOid: currentVariant?.currentVersionOid,
-                  tag: await createTag()
-                },
-                update: versionData
-              });
-
-          if (d.isCurrent) {
-            await db.providerVariant.updateMany({
-              where: { oid: d.variant.oid },
-              data: { currentVersionOid: providerVersion.oid }
-            });
-            await db.providerVersion.updateMany({
-              where: {
-                providerVariantOid: d.variant.oid,
-                oid: { not: providerVersion.oid }
-              },
-              data: { isCurrent: false }
-            });
-          }
-
-          await addAfterTransactionHook(async () => {
-            if (providerVersion.id === newId.id) {
-              await providerVersionCreatedQueue.add({ providerVersionId: providerVersion.id });
+        withTransaction(
+          async db => {
+            let identifier = `provider::${d.source.type}::`;
+            if (d.source.type === 'slates') {
+              identifier += `${d.source.slate.oid}::${d.source.slateVersion.oid}`;
+            } else if (d.source.type === 'shuttle') {
+              identifier += `${d.source.shuttleServer.oid}::${d.source.shuttleServerVersion.oid}`;
+            } else if (d.source.type === 'native') {
+              identifier += `${d.source.integrationIdentifier}::version`;
             } else {
-              await providerVersionUpdatedQueue.add({ providerVersionId: providerVersion.id });
+              throw new Error('Unknown provider source type');
             }
-          });
 
-          return providerVersion;
-        })
+            let currentVariant = await db.providerVariant.findFirst({
+              where: { oid: d.variant.oid }
+            });
+
+            let versionData = {
+              identifier,
+
+              name: d.info.name,
+              backendOid: d.source.backend.oid,
+              providerOid: d.variant.providerOid,
+              providerVariantOid: d.variant.oid,
+
+              typeOid: type.oid,
+
+              slateOid: d.source.type === 'slates' ? d.source.slate.oid : null,
+              slateVersionOid: d.source.type === 'slates' ? d.source.slateVersion.oid : null,
+
+              shuttleServerOid:
+                d.source.type === 'shuttle' ? d.source.shuttleServer.oid : null,
+              shuttleServerVersionOid:
+                d.source.type === 'shuttle' ? d.source.shuttleServerVersion.oid : null,
+
+              isCurrent: d.isCurrent
+            };
+
+            let existingVersion = await db.providerVersion.findFirst({
+              where: { identifier: versionData.identifier }
+            });
+
+            let newId = getId('providerVersion');
+            let providerVersion = existingVersion
+              ? await db.providerVersion.update({
+                  where: { identifier: versionData.identifier },
+                  data: versionData
+                })
+              : await db.providerVersion.upsert({
+                  where: { identifier: versionData.identifier },
+                  create: {
+                    ...newId,
+                    ...versionData,
+                    specificationDiscoveryStatus: 'discovering',
+                    previousVersionOid: currentVariant?.currentVersionOid,
+                    tag: await createTag()
+                  },
+                  update: versionData
+                });
+
+            if (d.isCurrent) {
+              await db.providerVariant.updateMany({
+                where: { oid: d.variant.oid },
+                data: { currentVersionOid: providerVersion.oid }
+              });
+              await db.providerVersion.updateMany({
+                where: {
+                  providerVariantOid: d.variant.oid,
+                  oid: { not: providerVersion.oid }
+                },
+                data: { isCurrent: false }
+              });
+            }
+
+            await addAfterTransactionHook(async () => {
+              if (providerVersion.id === newId.id) {
+                await providerVersionCreatedQueue.add({
+                  providerVersionId: providerVersion.id
+                });
+              } else {
+                await providerVersionUpdatedQueue.add({
+                  providerVersionId: providerVersion.id
+                });
+              }
+            });
+
+            return providerVersion;
+          },
+          {
+            timeout: 20000,
+            maxWait: 20000
+          }
+        )
     );
   }
 }

--- a/src/systems/subspace/provider-backends/provider-shuttle/src/lib/upsertShuttleVersion.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/lib/upsertShuttleVersion.ts
@@ -47,7 +47,7 @@ let getBackendForServerType = (
   }
 };
 
-export let upsertShuttleServerVersion = ({
+export let upsertShuttleServerVersion = async ({
   publisherId,
   globalIdentifier,
 
@@ -72,145 +72,149 @@ export let upsertShuttleServerVersion = ({
     categories: string[];
     readme?: string;
   };
-}) =>
-  withTransaction(async db => {
-    let publisher: Publisher | null = null;
-    let owner: { tenant: Tenant } | null = null;
+}) => {
+  return await withTransaction(
+    async db => {
+      let publisher: Publisher | null = null;
+      let owner: { tenant: Tenant } | null = null;
 
-    if (server.tenantId) {
-      let tenant = await db.tenant.findFirst({
-        where: { shuttleTenantId: server.tenantId }
-      });
-
-      if (tenant) {
-        publisher = await publisherInternalService.upsertPublisherForTenant({
-          tenant
+      if (server.tenantId) {
+        let tenant = await db.tenant.findFirst({
+          where: { shuttleTenantId: server.tenantId }
         });
-        owner = { tenant };
-      }
-    }
 
-    if (!publisher && publisherId) {
-      publisher = await db.publisher.findFirst({
-        where: { OR: [{ id: publisherId }, { identifier: publisherId }] }
-      });
-    }
-
-    if (!publisher) {
-      if (server.type === 'container') {
-        if (
-          version.repositoryVersion &&
-          (version.repositoryVersion.repository.registry.url === 'https://ghcr.io' ||
-            version.repositoryVersion.repository.registry.url === 'ghcr.io') &&
-          version.repositoryVersion.repository.name.startsWith('metorial/mcp-container--')
-        ) {
-          publisher = await publisherInternalService.upsertPublisherForExternal({
-            identifier: `shuttle::registry::metorial.com/mcp-container`,
-            name: 'Metorial MCP Containers'
+        if (tenant) {
+          publisher = await publisherInternalService.upsertPublisherForTenant({
+            tenant
           });
-        } else if (
-          version.repositoryVersion &&
-          (version.repositoryVersion.repository.registry.url === 'https://ghcr.io' ||
-            version.repositoryVersion.repository.registry.url === 'ghcr.io') &&
-          version.repositoryVersion.repository.name.startsWith('metorial/')
-        ) {
-          publisher = await publisherInternalService.upsertPublisherForMetorial();
-        } else {
+          owner = { tenant };
+        }
+      }
+
+      if (!publisher && publisherId) {
+        publisher = await db.publisher.findFirst({
+          where: { OR: [{ id: publisherId }, { identifier: publisherId }] }
+        });
+      }
+
+      if (!publisher) {
+        if (server.type === 'container') {
+          if (
+            version.repositoryVersion &&
+            (version.repositoryVersion.repository.registry.url === 'https://ghcr.io' ||
+              version.repositoryVersion.repository.registry.url === 'ghcr.io') &&
+            version.repositoryVersion.repository.name.startsWith('metorial/mcp-container--')
+          ) {
+            publisher = await publisherInternalService.upsertPublisherForExternal({
+              identifier: `shuttle::registry::metorial.com/mcp-container`,
+              name: 'Metorial MCP Containers'
+            });
+          } else if (
+            version.repositoryVersion &&
+            (version.repositoryVersion.repository.registry.url === 'https://ghcr.io' ||
+              version.repositoryVersion.repository.registry.url === 'ghcr.io') &&
+            version.repositoryVersion.repository.name.startsWith('metorial/')
+          ) {
+            publisher = await publisherInternalService.upsertPublisherForMetorial();
+          } else {
+            publisher = await publisherInternalService.upsertPublisherForExternal({
+              identifier: `shuttle::registry::${version.repositoryVersion?.repository.registry.id}`,
+              name:
+                version.repositoryVersion?.repository.registry.name ??
+                version.repositoryVersion?.repository.registry.url ??
+                'Unknown Registry'
+            });
+          }
+        } else if (server.type === 'remote') {
           publisher = await publisherInternalService.upsertPublisherForExternal({
-            identifier: `shuttle::registry::${version.repositoryVersion?.repository.registry.id}`,
-            name:
-              version.repositoryVersion?.repository.registry.name ??
-              version.repositoryVersion?.repository.registry.url ??
-              'Unknown Registry'
+            identifier: `shuttle::remote::${version.remoteUrl}`,
+            name: `MCP Remote (${version.remoteUrl ?? 'unknown'})`
           });
         }
-      } else if (server.type === 'remote') {
-        publisher = await publisherInternalService.upsertPublisherForExternal({
-          identifier: `shuttle::remote::${version.remoteUrl}`,
-          name: `MCP Remote (${version.remoteUrl ?? 'unknown'})`
-        });
       }
-    }
 
-    if (!publisher) {
-      publisher = await publisherInternalService.upsertUnknownPublisher();
-    }
+      if (!publisher) {
+        publisher = await publisherInternalService.upsertUnknownPublisher();
+      }
 
-    let hasConfig = !!normalizeJsonSchema(getConfigSchema(version.configSchema));
-    let providerBackend = getBackendForServerType(server.type);
+      let hasConfig = !!normalizeJsonSchema(getConfigSchema(version.configSchema));
+      let providerBackend = getBackendForServerType(server.type);
 
-    let type = {
-      name: `MCP`,
+      let type = {
+        name: `MCP`,
 
-      attributes: {
-        provider: 'metorial-shuttle',
-        backend: providerBackend,
+        attributes: {
+          provider: 'metorial-shuttle',
+          backend: providerBackend,
 
-        triggers: { status: 'disabled' },
+          triggers: { status: 'disabled' },
 
-        auth: server.oauthConfig
-          ? {
-              status: 'enabled',
-
-              oauth: {
+          auth: server.oauthConfig
+            ? {
                 status: 'enabled',
-                oauthCallbackUrl: `${env.service.SHUTTLE_PUBLIC_URL}/shuttle-oauth/callback`,
-                oauthAutoRegistration: {
-                  status:
-                    server.oauthConfig?.discovery.status === 'supports_auto_registration'
-                      ? 'supported'
-                      : 'unsupported'
-                }
-              },
 
-              export: { status: 'enabled' },
-              import: { status: 'enabled' }
-            }
-          : { status: 'disabled' },
+                oauth: {
+                  status: 'enabled',
+                  oauthCallbackUrl: `${env.service.SHUTTLE_PUBLIC_URL}/shuttle-oauth/callback`,
+                  oauthAutoRegistration: {
+                    status:
+                      server.oauthConfig?.discovery.status === 'supports_auto_registration'
+                        ? 'supported'
+                        : 'unsupported'
+                  }
+                },
 
-        config: hasConfig
-          ? { status: 'enabled', read: { status: 'disabled' } }
-          : { status: 'disabled' }
-      } satisfies PrismaJson.ProviderTypeAttributes
-    };
+                export: { status: 'enabled' },
+                import: { status: 'enabled' }
+              }
+            : { status: 'disabled' },
 
-    let provider = await providerInternalService.upsertProvider({
-      owner,
-      publisher,
-      source: {
-        type: 'shuttle',
-        shuttleServer: shuttleServerRecord,
-        backend
-      },
-      info: {
-        name: server.name,
-        description: server.description ?? undefined,
-        slug: slugify(`${server.name}-${generateCode(5)}`),
-        globalIdentifier: owner ? null : (globalIdentifier ?? null),
+          config: hasConfig
+            ? { status: 'enabled', read: { status: 'disabled' } }
+            : { status: 'disabled' }
+        } satisfies PrismaJson.ProviderTypeAttributes
+      };
 
-        categories: info?.categories,
-        readme: info?.readme
-      },
-      type
-    });
-    if (!provider?.defaultVariant) {
-      throw new Error(`No default variant after upserting provider for server ${server.id}`);
-    }
+      let provider = await providerInternalService.upsertProvider({
+        owner,
+        publisher,
+        source: {
+          type: 'shuttle',
+          shuttleServer: shuttleServerRecord,
+          backend
+        },
+        info: {
+          name: server.name,
+          description: server.description ?? undefined,
+          slug: slugify(`${server.name}-${generateCode(5)}`),
+          globalIdentifier: owner ? null : (globalIdentifier ?? null),
 
-    let providerVersion = await providerVersionInternalService.upsertVersion({
-      variant: provider.defaultVariant,
-      isCurrent: version.isCurrent,
-      source: {
-        type: 'shuttle',
-        shuttleServer: shuttleServerRecord,
-        shuttleServerVersion: shuttleServerVersionRecord,
-        backend
-      },
-      info: {
-        name: generatePlainId(8)
-      },
-      type
-    });
+          categories: info?.categories,
+          readme: info?.readme
+        },
+        type
+      });
+      if (!provider?.defaultVariant) {
+        throw new Error(`No default variant after upserting provider for server ${server.id}`);
+      }
 
-    return { provider, providerVersion };
-  });
+      let providerVersion = await providerVersionInternalService.upsertVersion({
+        variant: provider.defaultVariant,
+        isCurrent: version.isCurrent,
+        source: {
+          type: 'shuttle',
+          shuttleServer: shuttleServerRecord,
+          shuttleServerVersion: shuttleServerVersionRecord,
+          backend
+        },
+        info: {
+          name: generatePlainId(8)
+        },
+        type
+      });
+
+      return { provider, providerVersion };
+    },
+    { ifExists: true }
+  );
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts Prisma transaction behavior (timeouts/maxWait and conditional reuse) around provider/providerVersion upserts, which can affect data consistency and error rates under load. Risk is moderate because it changes how long-running sync operations interact with the database and transactional hooks.
> 
> **Overview**
> **Hardens provider sync transactions** by extending `withTransaction` to accept Prisma `timeout`/`maxWait` options and passing them through to `db.$transaction`.
> 
> Provider and provider-version upserts now run with explicit 20s transaction limits, and the Shuttle version upsert is made `async` and executes inside an existing transaction when present (`ifExists: true`), reducing nested transaction behavior during sync flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98751299d310e00e3c694ed5f6aaa8db9a10891b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->