### PR TITLE
Fix provider tool pagination

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/tools.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/tools.tsx
@@ -1,5 +1,5 @@
 import { DashboardInstanceProvidersToolsListOutput } from '@metorial/dashboard-sdk';
-import { renderWithLoader, renderWithPagination } from '@metorial/data-hooks';
+import { renderWithLoader } from '@metorial/data-hooks';
 import { useCurrentInstance, useProviderTools } from '@metorial/state';
 import { Badge, Button, Dialog, Flex, Text, showModal, theme } from '@metorial/ui';
 import { Table } from '@metorial/ui-product';
@@ -508,7 +508,7 @@ export let ProviderToolsPage = () => {
     ));
   };
 
-  let toolsContent = renderWithPagination(tools)(tools => (
+  let toolsContent = renderWithLoader({ tools })(({ tools }) => (
     <>
       <Table
         headers={['Name', 'Type', '']}

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/triggers.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/triggers.tsx
@@ -1,5 +1,5 @@
 import type { DashboardInstanceProvidersTriggersListOutput } from '@metorial/dashboard-sdk';
-import { renderWithLoader, renderWithPagination } from '@metorial/data-hooks';
+import { renderWithLoader } from '@metorial/data-hooks';
 import { useCurrentInstance, useProviderTriggers } from '@metorial/state';
 import { Badge, Button, Dialog, Flex, Text, showModal, theme } from '@metorial/ui';
 import { Table } from '@metorial/ui-product';
@@ -498,7 +498,7 @@ export let ProviderTriggersPage = () => {
     ));
   };
 
-  let triggersContent = renderWithPagination(triggers)(triggers => (
+  let triggersContent = renderWithLoader({ triggers })(({ triggers }) => (
     <>
       <Table
         headers={['Name', 'Mode', '']}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/providerConfigurationSelectionModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/providerConfigurationSelectionModal.tsx
@@ -21,11 +21,11 @@ import {
 } from '@metorial/ui';
 import { RiAddLine } from '@remixicon/react';
 import { useEffect, useState, type ReactNode } from 'react';
+import { Stepper } from '../../../../components/stepper';
 import {
   emptyConfigurationSelection,
   type ConfigurationSelection
 } from '../../lib/configSelection';
-import { Stepper } from '../../../../components/stepper';
 import { ProviderAuthConfigCreateButton } from '../providerAuthConfigs/modal';
 import { ProviderConfigurationSelection } from '../providerConfigs/selection';
 import { ProviderDeploymentsList } from '../providerDeployments/list';
@@ -140,10 +140,7 @@ export let ProviderConfigurationSelectionModalContent = ({
       form.setFieldValue('selectedProviderId', providerId);
     }
 
-    if (
-      resolvedProviderName &&
-      form.values.selectedProviderName !== resolvedProviderName
-    ) {
+    if (resolvedProviderName && form.values.selectedProviderName !== resolvedProviderName) {
       form.setFieldValue('selectedProviderName', resolvedProviderName);
     }
   }, [
@@ -265,13 +262,7 @@ export let ProviderConfigurationSelectionModalContent = ({
         }
       ];
 
-  return (
-    <Stepper
-      currentStep={currentStep}
-      setCurrentStep={setCurrentStep}
-      steps={steps}
-    />
-  );
+  return <Stepper currentStep={currentStep} setCurrentStep={setCurrentStep} steps={steps} />;
 };
 
 export let showProviderConfigurationSelectionModal = (p: {

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/toolsTable.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/toolsTable.tsx
@@ -1,4 +1,4 @@
-import { renderWithPagination } from '@metorial/data-hooks';
+import { renderWithLoader } from '@metorial/data-hooks';
 import { useProviderTools } from '@metorial/state';
 import { Text, theme } from '@metorial/ui';
 import { Table } from '@metorial/ui-product';
@@ -12,7 +12,7 @@ export let ProviderToolsTable = ({
 }) => {
   let tools = useProviderTools(instanceId, providerVersionId ? { providerVersionId } : null);
 
-  return renderWithPagination(tools)(tools => (
+  return renderWithLoader({ tools })(({ tools }) => (
     <>
       <Table
         headers={['Name', 'Key', 'Description']}

--- a/src/frontend/state/src/provider/loaders/providerTools.ts
+++ b/src/frontend/state/src/provider/loaders/providerTools.ts
@@ -1,13 +1,15 @@
 import { DashboardInstanceProvidersToolsListQuery } from '@metorial/dashboard-sdk';
 import { createLoader } from '@metorial/data-hooks';
-import { usePaginator } from '../../lib/usePaginator';
+import { autoPaginate } from '../../lib/autoPaginate';
 import { withAuth } from '../../user';
 
 export let providerToolsLoader = createLoader({
   name: 'providerTools',
   parents: [],
   fetch: async (i: { instanceId: string } & DashboardInstanceProvidersToolsListQuery) => {
-    return await withAuth(sdk => sdk.providers.tools.list(i.instanceId, i));
+    return await withAuth(sdk =>
+      autoPaginate(c => sdk.providers.tools.list(i.instanceId, { ...i, ...c }))
+    );
   },
   mutators: {}
 });
@@ -16,19 +18,20 @@ export let useProviderTools = (
   instanceId: string | null | undefined,
   opts: DashboardInstanceProvidersToolsListQuery | null
 ) => {
-  let data = usePaginator(pagination =>
-    providerToolsLoader.use(
-      instanceId && opts
-        ? {
-            instanceId,
-            ...opts,
-            ...pagination
-          }
-        : null
-    )
-  );
+  let data = providerToolsLoader.use(instanceId && opts ? { instanceId, ...opts } : null);
 
-  return data;
+  return {
+    ...data,
+    data: data.data
+      ? {
+          items: data.data,
+          pagination: {
+            hasMoreAfter: false,
+            hasMoreBefore: false
+          }
+        }
+      : null
+  };
 };
 
 export let providerToolLoader = createLoader({

--- a/src/frontend/state/src/provider/loaders/providerTriggers.ts
+++ b/src/frontend/state/src/provider/loaders/providerTriggers.ts
@@ -1,6 +1,6 @@
 import { DashboardInstanceProvidersTriggersListQuery } from '@metorial/dashboard-sdk';
 import { createLoader } from '@metorial/data-hooks';
-import { usePaginator } from '../../lib/usePaginator';
+import { autoPaginate } from '../../lib/autoPaginate';
 import { withAuth } from '../../user';
 
 export let providerTriggersLoader = createLoader({
@@ -12,7 +12,9 @@ export let providerTriggersLoader = createLoader({
       providerVersionId: string;
     } & DashboardInstanceProvidersTriggersListQuery
   ) => {
-    return await withAuth(sdk => sdk.providers.triggers.list(i.instanceId, i));
+    return await withAuth(sdk =>
+      autoPaginate(c => sdk.providers.triggers.list(i.instanceId, { ...i, ...c }))
+    );
   },
   mutators: {}
 });
@@ -21,19 +23,20 @@ export let useProviderTriggers = (
   instanceId: string | null | undefined,
   opts: DashboardInstanceProvidersTriggersListQuery | null
 ) => {
-  let data = usePaginator(pagination =>
-    providerTriggersLoader.use(
-      instanceId && opts
-        ? {
-            instanceId,
-            ...opts,
-            ...pagination
-          }
-        : null
-    )
-  );
+  let data = providerTriggersLoader.use(instanceId && opts ? { instanceId, ...opts } : null);
 
-  return data;
+  return {
+    ...data,
+    data: data.data
+      ? {
+          items: data.data,
+          pagination: {
+            hasMoreAfter: false,
+            hasMoreBefore: false
+          }
+        }
+      : null
+  };
 };
 
 export let providerTriggerLoader = createLoader({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core data-fetching behavior for provider tools/triggers by auto-loading all pages, which could impact performance or memory for very large provider definitions and alters pagination semantics.
> 
> **Overview**
> Fixes provider *tools* and *triggers* listings to reliably return complete results without UI-driven pagination.
> 
> State loaders for `useProviderTools`/`useProviderTriggers` now fetch all pages via `autoPaginate` and adapt the response back into an `items` list with a non-paginating `pagination` shape, and dashboard tables switch from `renderWithPagination` to `renderWithLoader` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f1f8b82bc5b6312d876cd225e6006489ea980db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->