### PR TITLE
Fix tool pagination

### DIFF
--- a/src/frontend/state/src/lib/autoPaginate.ts
+++ b/src/frontend/state/src/lib/autoPaginate.ts
@@ -1,5 +1,5 @@
 export let autoPaginate = async <T>(
-  cb: (cursor: { after?: string }) => Promise<{
+  cb: (cursor: { after?: string; limit?: number }) => Promise<{
     items: T[];
     pagination: {
       hasMoreAfter: boolean;
@@ -11,7 +11,7 @@ export let autoPaginate = async <T>(
   let after: string | undefined = undefined;
 
   while (true) {
-    let { items: newItems, pagination } = await cb({ after });
+    let { items: newItems, pagination } = await cb({ after, limit: 100 });
 
     items = [...items, ...newItems];
     let lastItem = newItems[newItems.length - 1];

--- a/src/systems/subspace/modules/catalog/src/services/providerTool.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerTool.ts
@@ -33,6 +33,24 @@ class providerToolServiceImpl {
           return [];
         }
 
+        // We need to patch the cursor from the versioned tool to
+        // the global one for pagination to work correctly
+        if (opts.cursor?.id) {
+          let tool = await db.providerTool.findFirst({
+            where: {
+              provider: getProviderTenantFilter(d),
+              OR: [{ id: opts.cursor.id }, { global: { id: opts.cursor.id } }]
+            },
+            include: {
+              global: true
+            }
+          });
+
+          if (tool?.global) {
+            opts.cursor = { id: tool.global.id };
+          }
+        }
+
         let listRes = await db.providerToolGlobal.findMany({
           ...opts,
 

--- a/src/systems/subspace/modules/catalog/src/services/providerTrigger.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerTrigger.ts
@@ -33,6 +33,24 @@ class providerTriggerServiceImpl {
           return [];
         }
 
+        // We need to patch the cursor from the versioned tool to
+        // the global one for pagination to work correctly
+        if (opts.cursor?.id) {
+          let trigger = await db.providerTrigger.findFirst({
+            where: {
+              provider: getProviderTenantFilter(d),
+              OR: [{ id: opts.cursor.id }, { global: { id: opts.cursor.id } }]
+            },
+            include: {
+              global: true
+            }
+          });
+
+          if (trigger?.global) {
+            opts.cursor = { id: trigger.global.id };
+          }
+        }
+
         let listRes = await db.providerTriggerGlobal.findMany({
           ...opts,
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared pagination behavior in both frontend and catalog services; incorrect cursor/limit handling could lead to missing/duplicated results during scrolling/listing.
> 
> **Overview**
> Improves pagination reliability across the app.
> 
> On the frontend, `autoPaginate` now always requests pages with `limit: 100` and expands the callback signature to accept an optional `limit`.
> 
> On the backend, `listProviderTools` and `listProviderTriggers` now remap incoming cursors from versioned rows to the corresponding *global* record ID before calling `findMany`, preventing cursor mismatches that broke pagination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e110304665b0f0654be6081e6b8cae80cffd9987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->