### PR TITLE
Use setup session ui for portal provider config

### DIFF
--- a/src/backend/modules/consumer/src/services/consumerProviderDeployment.ts
+++ b/src/backend/modules/consumer/src/services/consumerProviderDeployment.ts
@@ -159,13 +159,16 @@ class ConsumerProviderDeploymentServiceImpl {
         providerContext,
         input: d.input
       });
-      let providerAuthConfigId = await this.createProviderAuthConfig({
+      let providerAuthConfigIdRes = await this.createProviderAuthConfig({
         instance: d.instance,
         context: d.context,
         consumerProfile: d.consumerProfile,
         providerContext,
         input: d.input
       });
+      let providerAuthConfigId = providerAuthConfigIdRes?.authConfigId;
+      if (providerAuthConfigIdRes?.configId)
+        providerConfigId = providerAuthConfigIdRes.configId;
 
       if (consumerActor?.defaultIdentityId) {
         try {
@@ -317,7 +320,10 @@ class ConsumerProviderDeploymentServiceImpl {
         providerSetupSessionId: authInput.providerSetupSessionId
       });
 
-      return setupSession.authConfig!.id;
+      return {
+        authConfigId: setupSession.authConfig!.id,
+        configId: setupSession.config?.id
+      };
     }
 
     if (authInput.type == 'auth_config') {
@@ -337,7 +343,9 @@ class ConsumerProviderDeploymentServiceImpl {
         throw new ServiceError(notFoundError('provider.auth_config'));
       }
 
-      return authConfig.id;
+      return {
+        authConfigId: authConfig.id
+      };
     }
 
     let authMethod = d.providerContext.authMethods.find(method => {
@@ -363,7 +371,9 @@ class ConsumerProviderDeploymentServiceImpl {
       config: authInput.value
     });
 
-    return authConfig.id;
+    return {
+      authConfigId: authConfig.id
+    };
   }
 
   private async rollbackFailedDeployment(d: {

--- a/src/backend/modules/consumer/src/services/consumerProviderSetupSession.ts
+++ b/src/backend/modules/consumer/src/services/consumerProviderSetupSession.ts
@@ -117,7 +117,7 @@ class ConsumerProviderSetupSessionServiceImpl {
       name: providerContext.provider.name,
       description: providerContext.provider.description ?? undefined,
       uiMode: 'metorial_elements',
-      type: 'auth_only',
+      type: 'auth_and_config',
       ip: d.context.ip,
       ua: d.context.ua ?? '',
       redirectUrl: buildProviderSetupRedirectUrl(portal.slug),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes provider deployment provisioning to conditionally source config IDs from setup sessions; mismatches could lead to deployments referencing the wrong config/auth pair.
> 
> **Overview**
> Provider deployments can now reuse both *auth* and optional *provider config* produced by a completed `setup_session` instead of only using the auth config.
> 
> This updates `createProviderAuthConfig` in `consumerProviderDeploymentService` to return `{ authConfigId, configId? }` and wires the returned `configId` to override the earlier inline `providerConfigId` when present. Setup sessions started via `consumerProviderSetupSessionService` are switched from `auth_only` to `auth_and_config` so the UI flow can capture configuration during setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7846ee649e28662015291808ae15199a2138447f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->