### PR TITLE
Return empty body for notifications

### DIFF
--- a/src/backend/modules/subspace/src/proxy/index.ts
+++ b/src/backend/modules/subspace/src/proxy/index.ts
@@ -25,6 +25,7 @@ export let proxyMcpRequestToSubspace = async (
   let subspaceUrl = await getSubspaceMcpUrl(instance, sessionId, inputUrl);
 
   let headers = new Headers(c.req.raw.headers);
+  headers.set('User-Agent', c.req.header('User-Agent') || 'unknown');
 
   let finalHostName = inputUrl.hostname;
   if (

--- a/src/systems/subspace/apps/controller/src/connection/api/mcp.ts
+++ b/src/systems/subspace/apps/controller/src/connection/api/mcp.ts
@@ -154,7 +154,15 @@ export let mcpRouter = createHono().all(`/:key?`, async c => {
       let res = await con.handleMessage(json, {
         waitForResponse: true
       });
-      if (!res) return c.text('No response');
+      if (!res) {
+        // return streamSSE(c, async stream => {
+        //   await delay(100); // ensure the message is sent before closing
+        // });
+
+        // if (!res) return c.text('No response');
+
+        return new Response(null, { status: 204 });
+      }
 
       if (con.connection) {
         c.res.headers.set('mcp-session-id', con.connection.token);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes HTTP behavior for MCP POST requests by returning `204 No Content` when no response is produced, which may affect client/proxy expectations. Also forces a `User-Agent` header to be forwarded, impacting downstream request handling/logging.
> 
> **Overview**
> Adjusts MCP request handling so **notification-style POSTs that produce no response now return an empty `204 No Content`** instead of a `"No response"` text body.
> 
> Updates the Subspace MCP proxy to always forward a `User-Agent` header (defaulting to `unknown` when absent) when relaying requests upstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c308a8b7dafd4625cf2d1f3e84bd5b78bba3cbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->