### PR TITLE
Use auto mode for consumer auth setup

### DIFF
--- a/src/backend/modules/consumer/src/services/consumerProviderDeployment.ts
+++ b/src/backend/modules/consumer/src/services/consumerProviderDeployment.ts
@@ -159,13 +159,16 @@ class ConsumerProviderDeploymentServiceImpl {
         providerContext,
         input: d.input
       });
-      let providerAuthConfigId = await this.createProviderAuthConfig({
+      let providerAuthConfigIdRes = await this.createProviderAuthConfig({
         instance: d.instance,
         context: d.context,
         consumerProfile: d.consumerProfile,
         providerContext,
         input: d.input
       });
+      let providerAuthConfigId = providerAuthConfigIdRes?.authConfigId;
+      if (providerAuthConfigIdRes?.configId)
+        providerConfigId = providerAuthConfigIdRes.configId;
 
       if (consumerActor?.defaultIdentityId) {
         try {
@@ -317,7 +320,10 @@ class ConsumerProviderDeploymentServiceImpl {
         providerSetupSessionId: authInput.providerSetupSessionId
       });
 
-      return setupSession.authConfig!.id;
+      return {
+        authConfigId: setupSession.authConfig!.id,
+        configId: setupSession.config?.id
+      };
     }
 
     if (authInput.type == 'auth_config') {
@@ -337,7 +343,9 @@ class ConsumerProviderDeploymentServiceImpl {
         throw new ServiceError(notFoundError('provider.auth_config'));
       }
 
-      return authConfig.id;
+      return {
+        authConfigId: authConfig.id
+      };
     }
 
     let authMethod = d.providerContext.authMethods.find(method => {
@@ -363,7 +371,9 @@ class ConsumerProviderDeploymentServiceImpl {
       config: authInput.value
     });
 
-    return authConfig.id;
+    return {
+      authConfigId: authConfig.id
+    };
   }
 
   private async rollbackFailedDeployment(d: {

--- a/src/backend/modules/consumer/src/services/consumerProviderSetupSession.ts
+++ b/src/backend/modules/consumer/src/services/consumerProviderSetupSession.ts
@@ -117,7 +117,7 @@ class ConsumerProviderSetupSessionServiceImpl {
       name: providerContext.provider.name,
       description: providerContext.provider.description ?? undefined,
       uiMode: 'metorial_elements',
-      type: 'auth_and_config',
+      type: 'auto',
       ip: d.context.ip,
       ua: d.context.ua ?? '',
       redirectUrl: buildProviderSetupRedirectUrl(portal.slug),

--- a/src/backend/modules/consumer/src/services/consumerProviderSetupSession.ts
+++ b/src/backend/modules/consumer/src/services/consumerProviderSetupSession.ts
@@ -117,7 +117,7 @@ class ConsumerProviderSetupSessionServiceImpl {
       name: providerContext.provider.name,
       description: providerContext.provider.description ?? undefined,
       uiMode: 'metorial_elements',
-      type: 'auth_only',
+      type: 'auth_and_config',
       ip: d.context.ip,
       ua: d.context.ua ?? '',
       redirectUrl: buildProviderSetupRedirectUrl(portal.slug),

--- a/src/backend/modules/subspace/src/proxy/index.ts
+++ b/src/backend/modules/subspace/src/proxy/index.ts
@@ -25,6 +25,7 @@ export let proxyMcpRequestToSubspace = async (
   let subspaceUrl = await getSubspaceMcpUrl(instance, sessionId, inputUrl);
 
   let headers = new Headers(c.req.raw.headers);
+  headers.set('User-Agent', c.req.header('User-Agent') || 'unknown');
 
   let finalHostName = inputUrl.hostname;
   if (

--- a/src/systems/subspace/apps/controller/src/connection/api/mcp.ts
+++ b/src/systems/subspace/apps/controller/src/connection/api/mcp.ts
@@ -154,7 +154,15 @@ export let mcpRouter = createHono().all(`/:key?`, async c => {
       let res = await con.handleMessage(json, {
         waitForResponse: true
       });
-      if (!res) return c.text('No response');
+      if (!res) {
+        // return streamSSE(c, async stream => {
+        //   await delay(100); // ensure the message is sent before closing
+        // });
+
+        // if (!res) return c.text('No response');
+
+        return new Response(null, { status: 204 });
+      }
 
       if (con.connection) {
         c.res.headers.set('mcp-session-id', con.connection.token);

--- a/src/systems/subspace/apps/controller/src/connection/api/mcp.ts
+++ b/src/systems/subspace/apps/controller/src/connection/api/mcp.ts
@@ -161,7 +161,7 @@ export let mcpRouter = createHono().all(`/:key?`, async c => {
 
         // if (!res) return c.text('No response');
 
-        return new Response(null, { status: 204 });
+        return new Response(null, { status: 202 });
       }
 
       if (con.connection) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches provider deployment/auth/config wiring and MCP request/response behavior; mistakes could cause mis-linked configs or client-side handling changes for async MCP calls.
> 
> **Overview**
> Consumer provider setup now uses setup-session `type: 'auto'` instead of `auth_only`, and deployments can reuse a provider `configId` produced during auth setup (e.g., from a completed setup session) rather than only creating config separately.
> 
> `createProviderAuthConfig` now returns an object (`authConfigId` plus optional `configId`) and callers update identity credential + session-template provider creation accordingly. Separately, MCP proxying forces a concrete `User-Agent` header, and the Subspace MCP controller returns `202 Accepted` (instead of an error body) when a POST message yields no immediate response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f1f6dad9bcc6b4b22f6cf066855ecdbb1b87296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->