### PR TITLE
fix function bay build

### DIFF
--- a/src/systems/function-bay/packages/nodejs/package.json
+++ b/src/systems/function-bay/packages/nodejs/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@function-bay/build": "^1.0.0",
+    "@function-bay/utils": "^1.0.0",
     "@function-bay/types": "^1.0.0",
     "@lowerdeck/validation": "^1.0.10",
     "@types/bun": "^1.3.5"

--- a/src/systems/function-bay/packages/nodejs/src/index.ts
+++ b/src/systems/function-bay/packages/nodejs/src/index.ts
@@ -1,4 +1,5 @@
-import { Function, Runtime, tempDir } from '@function-bay/build';
+import { Function, Runtime } from '@function-bay/build';
+import { tempDir } from '@function-bay/utils';
 import { v, ValidationTypeValue } from '@lowerdeck/validation';
 import { $ as _$ } from 'bun';
 import fs from 'fs/promises';

--- a/src/systems/function-bay/packages/nodejs/tsconfig.json
+++ b/src/systems/function-bay/packages/nodejs/tsconfig.json
@@ -9,6 +9,11 @@
   ],
   "compilerOptions": {
     "outDir": "dist",
-    "types": ["bun"]
+    "types": ["bun"],
+    "baseUrl": ".",
+    "paths": {
+      "@function-bay/build": ["../build/src/index.ts"],
+      "@function-bay/utils": ["../utils/src/index.ts"]
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because this is a small dependency/import and TypeScript config adjustment; main risk is build-time module resolution changing in the `@function-bay/nodejs` package.
> 
> **Overview**
> Fixes the `@function-bay/nodejs` package build by moving the `tempDir` import from `@function-bay/build` to `@function-bay/utils` and adding `@function-bay/utils` as a runtime dependency.
> 
> Updates `tsconfig.json` to add local `paths` mappings for `@function-bay/build` and `@function-bay/utils`, improving TypeScript resolution during development/build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b82e05ba019a3427319d9e59e2ba20bf685380b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->