### PR TITLE
Deprecate docker providers

### DIFF
--- a/src/backend/apis/oauth/src/index.ts
+++ b/src/backend/apis/oauth/src/index.ts
@@ -241,6 +241,10 @@ export let oauthApi = createOAuthAppSkeleton({
       return c.json(await oauthOidcService.getOpenIdConfiguration());
     },
 
+    oauthProtectedResourceMetadata: async ({}, c) => {
+      return c.json(await oauthOidcService.getOAuthProtectedResourceMetadata());
+    },
+
     oauthAuthorizationServerMetadata: async ({}, c) => {
       return c.json(await oauthOidcService.getOAuthAuthorizationServerMetadata());
     },

--- a/src/backend/apis/oauth/src/skeleton.ts
+++ b/src/backend/apis/oauth/src/skeleton.ts
@@ -64,6 +64,10 @@ export let createOAuthAppSkeleton = (d: {
       d: { context: ReturnType<typeof useRequestContext> },
       c: Context
     ) => Promise<Response>;
+    oauthProtectedResourceMetadata: (
+      d: { context: ReturnType<typeof useRequestContext> },
+      c: Context
+    ) => Promise<Response>;
     oauthAuthorizationServerMetadata: (
       d: { context: ReturnType<typeof useRequestContext> },
       c: Context
@@ -281,6 +285,10 @@ export let createOAuthAppSkeleton = (d: {
     .get('/.well-known/openid-configuration', async c => {
       let context = useRequestContext(c);
       return await d.oauth.openIdConfiguration({ context }, c);
+    })
+    .get('/.well-known/oauth-protected-resource', async c => {
+      let context = useRequestContext(c);
+      return await d.oauth.oauthProtectedResourceMetadata({ context }, c);
     })
     .get('/.well-known/oauth-authorization-server', async c => {
       let context = useRequestContext(c);

--- a/src/backend/modules/machine-access/src/services/oauthOidc.ts
+++ b/src/backend/modules/machine-access/src/services/oauthOidc.ts
@@ -98,6 +98,18 @@ class OAuthOidcService {
     };
   }
 
+  async getOAuthProtectedResourceMetadata() {
+    let issuer = getConfig().urls.apiUrl;
+
+    return {
+      resource: issuer,
+      authorization_servers: [issuer],
+      bearer_methods_supported: ['header'],
+      token_types_supported: ['access_token'],
+      scopes_supported: [...oidcScopes, ...coreScopes]
+    };
+  }
+
   async getOAuthAuthorizationServerMetadata() {
     return await this.getOpenIdConfiguration();
   }

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthErrors/groupsTable.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthErrors/groupsTable.tsx
@@ -17,23 +17,17 @@ type ErrorGroupsTableStateProps = ErrorGroupsTableProps & {
   instance: ReturnType<typeof useCurrentInstance>;
 };
 
-let ERROR_LABELS: Record<string, string> = {
-  tool_call_failed: 'Tool Call Failed',
-  config_validation_failed: 'Config Validation Failed',
-  auth_processing_failed: 'Auth Processing Failed',
-  oauth_token_refresh_failed: 'OAuth Token Refresh Failed',
-  oauth_setup_failed: 'OAuth Setup Failed',
-  trigger_event_input_failed: 'Trigger Event Input Failed',
-  profile_fetch_failed: 'Profile Fetch Failed'
+let splitMany = (str: string, separators: string[]) => {
+  let regex = new RegExp(separators.map(s => `\\${s}`).join('|'), 'g');
+  return str.split(regex);
 };
 
 let humanizeCode = (code: string) =>
-  code
-    .split('_')
+  splitMany(code, ['_', '-', '.', ' '])
     .map(part => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
 
-let getErrorLabel = (code: string) => ERROR_LABELS[code] ?? humanizeCode(code);
+let getErrorLabel = (code: string) => humanizeCode(code);
 
 let errorGroupsTableState: TableStateProvider<
   ErrorGroupsTableStateProps,
@@ -68,7 +62,7 @@ let providerAuthErrorGroupsTable = new DashboardTable<ErrorGroupsTableStateProps
     {
       id: 'code',
       isDefault: true,
-      header: 'Code',
+      header: 'Name',
       render: group =>
         group.code ? (
           <Badge color="red">{getErrorLabel(group.code)}</Badge>
@@ -79,13 +73,13 @@ let providerAuthErrorGroupsTable = new DashboardTable<ErrorGroupsTableStateProps
     {
       id: 'message',
       isDefault: true,
-      header: 'Message',
+      header: 'Details',
       render: group => <Text size="2">{group.message}</Text>
     },
     {
       id: 'occurrenceCount',
       isDefault: true,
-      header: 'Count',
+      header: 'Occurrences',
       render: group => <Text size="2">{group.occurrenceCount ?? '—'}</Text>
     },
     {

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerErrors/groupsTable.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerErrors/groupsTable.tsx
@@ -21,6 +21,18 @@ type ErrorGroupsTableStateProps = ErrorGroupsTableProps & {
   instance: ReturnType<typeof useCurrentInstance>;
 };
 
+let splitMany = (str: string, separators: string[]) => {
+  let regex = new RegExp(separators.map(s => `\\${s}`).join('|'), 'g');
+  return str.split(regex);
+};
+
+let humanizeCode = (code: string) =>
+  splitMany(code, ['_', '-', '.', ' '])
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+let getErrorLabel = (code: string) => humanizeCode(code);
+
 let getErrorTypeFilterValue = (
   value: FilterPayload | undefined
 ): DashboardInstanceSessionsErrorGroupsListQuery['type'] => {
@@ -63,10 +75,10 @@ let providerErrorGroupsTable = new DashboardTable<ErrorGroupsTableStateProps, Er
     {
       id: 'code',
       isDefault: true,
-      header: 'Code',
+      header: 'Name',
       render: error =>
         error.code ? (
-          <Badge color="red">{error.code}</Badge>
+          <Badge color="red">{getErrorLabel(error.code)}</Badge>
         ) : (
           <Badge color="gray">Unknown</Badge>
         )
@@ -74,13 +86,13 @@ let providerErrorGroupsTable = new DashboardTable<ErrorGroupsTableStateProps, Er
     {
       id: 'message',
       isDefault: true,
-      header: 'Message',
+      header: 'Details',
       render: error => <Text size="2">{error.message}</Text>
     },
     {
       id: 'occurrenceCount',
       isDefault: true,
-      header: 'Count',
+      header: 'Occurrences',
       render: error => <Text size="2">{error.occurrenceCount ?? '—'}</Text>
     },
     {

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/entry.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/entry.tsx
@@ -1,11 +1,6 @@
 import type { DashboardInstanceProviderInvocationsListOutput } from '@metorial/dashboard-sdk';
 import { Badge, Button, RenderDate, theme } from '@metorial/ui';
-import {
-  RiKey2Line,
-  RiPulseLine,
-  RiShieldKeyholeLine,
-  RiToolsLine
-} from '@remixicon/react';
+import { RiKey2Line, RiPulseLine, RiShieldKeyholeLine, RiToolsLine } from '@remixicon/react';
 import type { ReactNode } from 'react';
 import styled from 'styled-components';
 import { RunLogs } from '../../components/runLogs';
@@ -84,13 +79,8 @@ let getInvocationTitle = (invocation: InvocationItem): string => {
   return formatTitleCase(invocation.type);
 };
 
-export let ProviderInvocationEntry = ({
-  invocation
-}: {
-  invocation: InvocationItem;
-}) => {
-  let variant: 'error' | 'default' =
-    invocation.status === 'error' ? 'error' : 'default';
+export let ProviderInvocationEntry = ({ invocation }: { invocation: InvocationItem }) => {
+  let variant: 'error' | 'default' = invocation.status === 'error' ? 'error' : 'default';
 
   return (
     <Wrapper>
@@ -107,12 +97,11 @@ export let ProviderInvocationEntry = ({
         <Actions>
           <Button
             size="2"
-            variant="outline"
             onClick={() =>
               showProviderInvocationPanel({ providerInvocationId: invocation.id })
             }
           >
-            View Details
+            View invocation details
           </Button>
         </Actions>
 

--- a/src/packages/frontend/ui/src/select/index.tsx
+++ b/src/packages/frontend/ui/src/select/index.tsx
@@ -1,9 +1,10 @@
 import * as RadixSelect from '@radix-ui/react-select';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { RiArrowDownSLine, RiArrowUpSLine, RiCheckLine } from '@remixicon/react';
-import React, { useEffect, useId, useMemo } from 'react';
+import React, { useEffect, useId, useMemo, useState } from 'react';
 import { keyframes, styled } from 'styled-components';
 import { ButtonSize, getButtonSize } from '../button/constants';
+import { useDialogZIndex } from '../dialog/state';
 import { Error } from '../error';
 import { InputDescription, InputLabel } from '../input';
 import { theme } from '../theme';
@@ -153,6 +154,9 @@ export let Select = ({
   let sizeStyles = getButtonSize(size);
   let normalizedValue = value === '' ? undefined : value;
 
+  let [isOpen, setIsOpen] = useState(false);
+  let zIndex = useDialogZIndex(isOpen);
+
   let disabledItems = useMemo(
     () =>
       items
@@ -190,7 +194,12 @@ export let Select = ({
 
       {description && <InputDescription>{description}</InputDescription>}
 
-      <RadixSelect.Root value={normalizedValue} onValueChange={onChange}>
+      <RadixSelect.Root
+        value={normalizedValue}
+        onValueChange={onChange}
+        open={isOpen}
+        onOpenChange={setIsOpen}
+      >
         <Trigger
           id={id}
           disabled={disabled}
@@ -206,7 +215,7 @@ export let Select = ({
           </RadixSelect.Icon>
         </Trigger>
         <RadixSelect.Portal>
-          <Content style={{ zIndex: 9999 }}>
+          <Content style={{ zIndex }}>
             <RadixSelect.ScrollUpButton className="SelectScrollButton">
               <RiArrowUpSLine size={14} />
             </RadixSelect.ScrollUpButton>

--- a/src/systems/subspace/apps/controller/src/controllers/provider.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/provider.ts
@@ -29,6 +29,7 @@ export let providerController = app.controller({
           environmentId: v.string(),
 
           ids: v.optional(v.array(v.string())),
+          includeDeprecated: v.optional(v.boolean()),
 
           capabilities: v.optional(
             v.object({
@@ -51,6 +52,7 @@ export let providerController = app.controller({
         solution: ctx.solution,
 
         ids: ctx.input.ids,
+        includeDeprecated: ctx.input.includeDeprecated,
         capabilities: ctx.input.capabilities
       });
 

--- a/src/systems/subspace/apps/controller/src/controllers/providerAuthMethod.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerAuthMethod.ts
@@ -31,7 +31,8 @@ export let providerAuthMethodController = app.controller({
           tenantId: v.optional(v.string()),
           environmentId: v.optional(v.string()),
 
-          providerVersionId: v.string()
+          providerVersionId: v.string(),
+          includeDeprecated: v.optional(v.boolean())
         })
       )
     )
@@ -40,7 +41,8 @@ export let providerAuthMethodController = app.controller({
         providerVersionId: ctx.input.providerVersionId,
         tenant: ctx.tenant,
         environment: ctx.environment,
-        solution: ctx.solution
+        solution: ctx.solution,
+        includeDeprecated: ctx.input.includeDeprecated
       });
 
       let paginator = await providerAuthMethodService.listProviderAuthMethods({
@@ -48,7 +50,8 @@ export let providerAuthMethodController = app.controller({
         environment: ctx.environment,
         solution: ctx.solution,
 
-        providerVersion
+        providerVersion,
+        includeDeprecated: ctx.input.includeDeprecated
       });
 
       let list = await paginator.run(ctx.input);

--- a/src/systems/subspace/apps/controller/src/controllers/providerListing.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerListing.ts
@@ -39,6 +39,7 @@ export let providerListingController = app.controller({
           providerGroupIds: v.optional(v.array(v.string())),
           publisherIds: v.optional(v.array(v.string())),
           ids: v.optional(v.array(v.string())),
+          includeDeprecated: v.optional(v.boolean()),
 
           isPublic: v.optional(v.boolean()),
           onlyFromTenant: v.optional(v.boolean()),
@@ -102,6 +103,7 @@ export let providerListingController = app.controller({
         providerGroupIds: ctx.input.providerGroupIds,
         publisherIds: ctx.input.publisherIds,
         ids: ctx.input.ids,
+        includeDeprecated: ctx.input.includeDeprecated,
 
         capabilities: ctx.input.capabilities,
 

--- a/src/systems/subspace/apps/controller/src/controllers/providerSpecification.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerSpecification.ts
@@ -34,6 +34,7 @@ export let providerSpecificationController = app.controller({
           providerVersionIds: v.optional(v.array(v.string())),
           providerDeploymentIds: v.optional(v.array(v.string())),
           providerConfigIds: v.optional(v.array(v.string())),
+          includeDeprecated: v.optional(v.boolean()),
 
           createdAt: createdAtValidator,
           updatedAt: updatedAtValidator
@@ -51,6 +52,7 @@ export let providerSpecificationController = app.controller({
         providerVersionIds: ctx.input.providerVersionIds,
         providerDeploymentIds: ctx.input.providerDeploymentIds,
         providerConfigIds: ctx.input.providerConfigIds,
+        includeDeprecated: ctx.input.includeDeprecated,
 
         createdAt: ctx.input.createdAt,
         updatedAt: ctx.input.updatedAt

--- a/src/systems/subspace/apps/controller/src/controllers/providerVariant.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerVariant.ts
@@ -26,7 +26,8 @@ export let providerVariantController = app.controller({
       Paginator.validate(
         v.object({
           tenantId: v.optional(v.string()),
-          environmentId: v.optional(v.string())
+          environmentId: v.optional(v.string()),
+          includeDeprecated: v.optional(v.boolean())
         })
       )
     )
@@ -34,7 +35,8 @@ export let providerVariantController = app.controller({
       let paginator = await providerVariantService.listProviderVariants({
         tenant: ctx.tenant,
         environment: ctx.environment,
-        solution: ctx.solution
+        solution: ctx.solution,
+        includeDeprecated: ctx.input.includeDeprecated
       });
 
       let list = await paginator.run(ctx.input);

--- a/src/systems/subspace/apps/controller/src/controllers/providerVersion.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerVersion.ts
@@ -31,6 +31,7 @@ export let providerVersionController = app.controller({
 
           ids: v.optional(v.array(v.string())),
           providerIds: v.optional(v.array(v.string())),
+          includeDeprecated: v.optional(v.boolean()),
 
           createdAt: createdAtValidator,
           updatedAt: updatedAtValidator
@@ -45,6 +46,7 @@ export let providerVersionController = app.controller({
 
         ids: ctx.input.ids,
         providerIds: ctx.input.providerIds,
+        includeDeprecated: ctx.input.includeDeprecated,
 
         createdAt: ctx.input.createdAt,
         updatedAt: ctx.input.updatedAt

--- a/src/systems/subspace/db/prisma/schema/listing/listing.prisma
+++ b/src/systems/subspace/db/prisma/schema/listing/listing.prisma
@@ -8,6 +8,7 @@ model ProviderListing {
   oid    BigInt                @id
   id     String                @unique
   status ProviderListingStatus
+  isDeprecated Boolean @default(false)
 
   isPublic     Boolean @default(true)
   isCustomized Boolean @default(false)
@@ -66,6 +67,7 @@ model ProviderListing {
   @@index([isPublic])
   @@index([rank])
   @@index([status])
+  @@index([isDeprecated])
   @@index([aliases])
 }
 

--- a/src/systems/subspace/db/prisma/schema/provider/provider.prisma
+++ b/src/systems/subspace/db/prisma/schema/provider/provider.prisma
@@ -34,6 +34,7 @@ model Provider {
 
   access ProviderAccess
   status ProviderStatus
+  isDeprecated Boolean @default(false)
 
   hasEnvironments Boolean @default(false)
 
@@ -103,4 +104,5 @@ model Provider {
 
   @@index([status])
   @@index([access])
+  @@index([isDeprecated])
 }

--- a/src/systems/subspace/modules/catalog/src/services/provider.ts
+++ b/src/systems/subspace/modules/catalog/src/services/provider.ts
@@ -29,8 +29,10 @@ export let getProviderTenantFilter = (d: {
   solution: Solution;
   tenant?: Tenant;
   environment?: Environment;
+  includeDeprecated?: boolean;
 }) => ({
   AND: [
+    d.includeDeprecated ? undefined! : { isDeprecated: false },
     {
       OR: [
         { access: 'public' as const },
@@ -94,11 +96,15 @@ class providerServiceImpl {
     solution: Solution;
     tenant?: Tenant;
     environment?: Environment;
+    includeDeprecated?: boolean;
   }) {
     let provider = await db.provider.findFirst({
       where: {
         AND: [
-          getProviderTenantFilter(d),
+          getProviderTenantFilter({
+            ...d,
+            includeDeprecated: true
+          }),
 
           {
             OR: [
@@ -130,8 +136,10 @@ class providerServiceImpl {
 
     ids?: string[];
     capabilities?: ProviderCapabilityFilter;
+    includeDeprecated?: boolean;
   }) {
     let capFilters = getProviderCapabilityFilter(d.capabilities || {});
+    let includeDeprecated = d.includeDeprecated || !!d.ids?.length;
 
     return Paginator.create(({ prisma }) =>
       prisma(
@@ -140,7 +148,10 @@ class providerServiceImpl {
             ...opts,
             where: {
               AND: [
-                getProviderTenantFilter(d),
+                getProviderTenantFilter({
+                  ...d,
+                  includeDeprecated
+                }),
                 {
                   AND: [
                     d.ids

--- a/src/systems/subspace/modules/catalog/src/services/providerAuthMethod.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerAuthMethod.ts
@@ -17,6 +17,7 @@ class providerAuthMethodServiceImpl {
     tenant?: Tenant;
     environment?: Environment;
     providerVersion: ProviderVersion;
+    includeDeprecated?: boolean;
   }) {
     let versionOid = d.providerVersion?.oid;
 
@@ -38,7 +39,10 @@ class providerAuthMethodServiceImpl {
           where: {
             AND: [
               {
-                provider: getProviderTenantFilter(d)
+                provider: getProviderTenantFilter({
+                  ...d,
+                  includeDeprecated: true
+                })
               }
             ],
             providerOid: d.providerVersion.providerOid,
@@ -90,10 +94,14 @@ class providerAuthMethodServiceImpl {
     solution: Solution;
     environment: Environment;
     providerAuthMethodId: string;
+    includeDeprecated?: boolean;
   }) {
     let providerAuthMethod = await db.providerAuthMethod.findFirst({
       where: {
-        provider: getProviderTenantFilter(d),
+        provider: getProviderTenantFilter({
+          ...d,
+          includeDeprecated: true
+        }),
         id: d.providerAuthMethodId
       },
       include: {

--- a/src/systems/subspace/modules/catalog/src/services/providerListing.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerListing.ts
@@ -57,6 +57,7 @@ class ProviderListingService {
     solution: Solution;
     tenant?: Tenant;
     environment?: Environment;
+    includeDeprecated?: boolean;
   }) {
     let providerListing = await db.providerListing.findFirst({
       where: {
@@ -83,7 +84,7 @@ class ProviderListingService {
                 : undefined!
             ].filter(Boolean)
           }
-        ]
+        ].filter(Boolean)
       },
       include: getInclude(d.tenant, d.solution)
     });
@@ -121,10 +122,12 @@ class ProviderListingService {
     orderByUse?: ProviderListingOrderByUse;
 
     capabilities?: ProviderCapabilityFilter;
+    includeDeprecated?: boolean;
   }) {
     let collections = await resolveProviderCollections(d.providerCollectionIds);
     let categories = await resolveProviderCategories(d.providerCategoryIds);
     let publishers = await resolvePublishers(d.publisherIds);
+    let includeDeprecated = d.includeDeprecated || !!d.ids?.length;
 
     let capFilters = getProviderCapabilityFilter(d.capabilities || {});
 
@@ -177,6 +180,7 @@ class ProviderListingService {
             status: 'active',
 
             AND: [
+              includeDeprecated ? undefined! : { isDeprecated: false },
               {
                 OR: [
                   { isPublic: true },

--- a/src/systems/subspace/modules/catalog/src/services/providerSpecification.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerSpecification.ts
@@ -19,7 +19,15 @@ class providerSpecificationServiceImpl {
 
     createdAt?: DateFilter;
     updatedAt?: DateFilter;
+    includeDeprecated?: boolean;
   }) {
+    let includeDeprecated =
+      d.includeDeprecated ||
+      !!d.ids?.length ||
+      !!d.providerIds?.length ||
+      !!d.providerVersionIds?.length ||
+      !!d.providerDeploymentIds?.length ||
+      !!d.providerConfigIds?.length;
     let providers = await resolveProviders(d, d.providerIds);
 
     let versions = d.providerVersionIds
@@ -56,7 +64,10 @@ class providerSpecificationServiceImpl {
             where: {
               AND: [
                 {
-                  provider: getProviderTenantFilter(d)
+                  provider: getProviderTenantFilter({
+                    ...d,
+                    includeDeprecated
+                  })
                 },
 
                 d.ids ? { id: { in: d.ids } } : undefined!,
@@ -83,10 +94,14 @@ class providerSpecificationServiceImpl {
     tenant?: Tenant;
     environment?: Environment;
     providerSpecificationId: string;
+    includeDeprecated?: boolean;
   }) {
     let providerSpecification = await db.providerSpecification.findFirst({
       where: {
-        provider: getProviderTenantFilter(d),
+        provider: getProviderTenantFilter({
+          ...d,
+          includeDeprecated: true
+        }),
 
         id: d.providerSpecificationId
       },

--- a/src/systems/subspace/modules/catalog/src/services/providerTool.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerTool.ts
@@ -29,7 +29,14 @@ let hasVersionWithoutSpecification = (ctx: ListToolsContext) =>
   !!ctx.version && !ctx.version.specificationOid;
 
 let buildToolsWhere = (ctx: ListToolsContext) => ({
-  AND: [{ provider: getProviderTenantFilter(ctx) }],
+  AND: [
+    {
+      provider: getProviderTenantFilter({
+        ...ctx,
+        includeDeprecated: true
+      })
+    }
+  ],
   providerOid: ctx.providerVersion.providerOid,
   ...(ctx.version?.specificationOid
     ? { providerTools: { some: { specificationOid: ctx.version.specificationOid } } }
@@ -57,7 +64,10 @@ let patchGlobalCursor = async (
 
   let tool = await db.providerTool.findFirst({
     where: {
-      provider: getProviderTenantFilter(ctx),
+      provider: getProviderTenantFilter({
+        ...ctx,
+        includeDeprecated: true
+      }),
       OR: [{ id: cursor.id }, { global: { id: cursor.id } }]
     },
     include: {
@@ -213,7 +223,10 @@ class providerToolServiceImpl {
   }) {
     let providerTool = await db.providerTool.findFirst({
       where: {
-        provider: getProviderTenantFilter(d),
+        provider: getProviderTenantFilter({
+          ...d,
+          includeDeprecated: true
+        }),
 
         id: d.providerToolId
       },

--- a/src/systems/subspace/modules/catalog/src/services/providerTrigger.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerTrigger.ts
@@ -38,7 +38,10 @@ class providerTriggerServiceImpl {
         if (opts.cursor?.id) {
           let trigger = await db.providerTrigger.findFirst({
             where: {
-              provider: getProviderTenantFilter(d),
+              provider: getProviderTenantFilter({
+                ...d,
+                includeDeprecated: true
+              }),
               OR: [{ id: opts.cursor.id }, { global: { id: opts.cursor.id } }]
             },
             include: {
@@ -57,7 +60,10 @@ class providerTriggerServiceImpl {
           where: {
             AND: [
               {
-                provider: getProviderTenantFilter(d)
+                provider: getProviderTenantFilter({
+                  ...d,
+                  includeDeprecated: true
+                })
               }
             ],
             providerOid: d.providerVersion.providerOid,
@@ -111,7 +117,10 @@ class providerTriggerServiceImpl {
   }) {
     let providerTrigger = await db.providerTrigger.findFirst({
       where: {
-        provider: getProviderTenantFilter(d),
+        provider: getProviderTenantFilter({
+          ...d,
+          includeDeprecated: true
+        }),
 
         id: d.providerTriggerId
       },

--- a/src/systems/subspace/modules/catalog/src/services/providerVariant.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerVariant.ts
@@ -25,6 +25,7 @@ class providerVariantServiceImpl {
     solution: Solution;
     tenant?: Tenant;
     environment?: Environment;
+    includeDeprecated?: boolean;
   }) {
     return Paginator.create(({ prisma }) =>
       prisma(
@@ -32,7 +33,10 @@ class providerVariantServiceImpl {
           await db.providerVariant.findMany({
             ...opts,
             where: {
-              provider: getProviderTenantFilter(d)
+              provider: getProviderTenantFilter({
+                ...d,
+                includeDeprecated: d.includeDeprecated
+              })
             },
             include
           })
@@ -46,11 +50,15 @@ class providerVariantServiceImpl {
     tenant?: Tenant;
     environment?: Environment;
     provider?: Provider;
+    includeDeprecated?: boolean;
   }) {
     let providerVariant = await db.providerVariant.findFirst({
       where: {
         providerOid: d.provider ? d.provider.oid : undefined,
-        provider: getProviderTenantFilter(d),
+        provider: getProviderTenantFilter({
+          ...d,
+          includeDeprecated: true
+        }),
 
         AND: [
           {

--- a/src/systems/subspace/modules/catalog/src/services/providerVersion.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerVersion.ts
@@ -25,7 +25,9 @@ class providerVersionServiceImpl {
 
     createdAt?: DateFilter;
     updatedAt?: DateFilter;
+    includeDeprecated?: boolean;
   }) {
+    let includeDeprecated = d.includeDeprecated || !!d.ids?.length || !!d.providerIds?.length;
     let providers = await resolveProviders(d, d.providerIds);
 
     return Paginator.create(({ prisma }) =>
@@ -34,7 +36,10 @@ class providerVersionServiceImpl {
           await db.providerVersion.findMany({
             ...opts,
             where: {
-              provider: getProviderTenantFilter(d),
+              provider: getProviderTenantFilter({
+                ...d,
+                includeDeprecated
+              }),
 
               OR: [
                 { isEnvironmentLocked: false },
@@ -65,10 +70,14 @@ class providerVersionServiceImpl {
     solution: Solution;
     tenant?: Tenant;
     environment?: Environment;
+    includeDeprecated?: boolean;
   }) {
     let providerVersion = await db.providerVersion.findFirst({
       where: {
-        provider: getProviderTenantFilter(d),
+        provider: getProviderTenantFilter({
+          ...d,
+          includeDeprecated: true
+        }),
 
         OR: [
           { isEnvironmentLocked: false },

--- a/src/systems/subspace/modules/provider-internal/src/index.ts
+++ b/src/systems/subspace/modules/provider-internal/src/index.ts
@@ -3,6 +3,7 @@ import { cleanupCron } from './cron/cleanup';
 import { deploymentConfigPairQueues } from './queues/deploymentConfigPair';
 import { lifecycleQueues } from './queues/lifecycle';
 import { listingQueues } from './queues/listing';
+import { reconcilerQueues } from './queues/reconciler';
 import { searchQueues } from './queues/search';
 import { versionQueues } from './queues/version';
 
@@ -18,5 +19,6 @@ export let providerInternalQueueProcessor = combineQueueProcessors([
   lifecycleQueues,
   deploymentConfigPairQueues,
   versionQueues,
-  searchQueues
+  searchQueues,
+  reconcilerQueues
 ]);

--- a/src/systems/subspace/modules/provider-internal/src/queues/reconciler/deprecateProvider.ts
+++ b/src/systems/subspace/modules/provider-internal/src/queues/reconciler/deprecateProvider.ts
@@ -1,0 +1,79 @@
+import { createCron } from '@lowerdeck/cron';
+import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { db } from '@metorial-subspace/db';
+import { env } from '../../env';
+import { providerInternalService } from '../../services/provider';
+
+export let deprecateDockerProviderReconcilerCron = createCron(
+  {
+    name: 'sub/pint/reconcile/provider/deprecate/cron',
+    redisUrl: env.service.REDIS_URL,
+    cron: '0 0 * * *'
+  },
+  async () => {
+    await deprecateDockerProviderManyQueue.add({});
+  }
+);
+
+let deprecateDockerProviderManyQueue = createQueue<{ cursor?: string }>({
+  name: 'sub/pint/reconcile/provider/deprecate/many',
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: {
+    concurrency: 1
+  }
+});
+
+export let deprecateDockerProviderManyQueueProcessor =
+  deprecateDockerProviderManyQueue.process(async data => {
+    let providers = await db.provider.findMany({
+      where: {
+        id: data.cursor ? { gt: data.cursor } : undefined,
+        ownerTenantOid: null,
+        isDeprecated: false,
+        type: {
+          OR: [{ attributes: { path: ['backend'], equals: 'mcp.container' } }]
+        }
+      },
+      orderBy: { id: 'asc' },
+      take: 100,
+      select: { id: true }
+    });
+    if (providers.length === 0) return;
+
+    await deprecateDockerProviderSingleQueue.addMany(
+      providers.map(provider => ({
+        providerId: provider.id
+      }))
+    );
+
+    await deprecateDockerProviderManyQueue.add({
+      cursor: providers[providers.length - 1]!.id
+    });
+  });
+
+let deprecateDockerProviderSingleQueue = createQueue<{ providerId: string }>({
+  name: 'sub/pint/reconcile/provider/deprecate/single',
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: {
+    concurrency: 5,
+    limiter: {
+      max: 25,
+      duration: 1000
+    }
+  }
+});
+
+export let deprecateDockerProviderSingleQueueProcessor =
+  deprecateDockerProviderSingleQueue.process(async data => {
+    let provider = await db.provider.findFirst({
+      where: { id: data.providerId },
+      include: { type: true }
+    });
+    if (!provider) throw new QueueRetryError();
+    if (provider.isDeprecated || provider.ownerTenantOid !== null) return;
+
+    let backend = provider.type.attributes.backend;
+    if (backend !== 'mcp.container' && backend !== 'mcp.function') return;
+
+    await providerInternalService.deprecateProvider({ provider });
+  });

--- a/src/systems/subspace/modules/provider-internal/src/queues/reconciler/index.ts
+++ b/src/systems/subspace/modules/provider-internal/src/queues/reconciler/index.ts
@@ -1,0 +1,12 @@
+import { combineQueueProcessors } from '@lowerdeck/queue';
+import {
+  deprecateDockerProviderManyQueueProcessor,
+  deprecateDockerProviderReconcilerCron,
+  deprecateDockerProviderSingleQueueProcessor
+} from './deprecateProvider';
+
+export let reconcilerQueues = combineQueueProcessors([
+  deprecateDockerProviderReconcilerCron,
+  deprecateDockerProviderManyQueueProcessor,
+  deprecateDockerProviderSingleQueueProcessor
+]);

--- a/src/systems/subspace/modules/provider-internal/src/services/provider.ts
+++ b/src/systems/subspace/modules/provider-internal/src/services/provider.ts
@@ -250,6 +250,7 @@ class providerInternalServiceImpl {
 
         let allData = {
           isPublic: provider.access === 'public',
+          isDeprecated: provider.isDeprecated,
           ownerTenantOid: provider.access === 'tenant' ? provider.ownerTenantOid : null,
           ownerSolutionOid: provider.access === 'tenant' ? provider.ownerSolutionOid : null,
 
@@ -378,13 +379,46 @@ class providerInternalServiceImpl {
           readme: d.input.readme,
           skills: d.input.skills,
           image: d.input.image ?? undefined,
-          isPublic: provider.access === 'public'
+          isPublic: provider.access === 'public',
+          isDeprecated: provider.isDeprecated
         }
       });
 
       await addAfterTransactionHook(() =>
         listingUpdatedQueue.add({ providerListingId: listing.id })
       );
+
+      return provider;
+    });
+  }
+
+  async deprecateProvider(d: { provider: Provider }) {
+    // if (d.provider.isDeprecated) return d.provider;
+
+    return withTransaction(async db => {
+      let provider = await db.provider.update({
+        where: { id: d.provider.id },
+        data: { isDeprecated: true }
+      });
+
+      let listing = await db.providerListing.findFirst({
+        where: { providerOid: provider.oid }
+      });
+
+      if (listing) {
+        listing = await db.providerListing.update({
+          where: { providerOid: provider.oid },
+          data: { isDeprecated: true }
+        });
+      }
+
+      await addAfterTransactionHook(async () => {
+        await providerUpdatedQueue.add({ providerId: provider.id });
+
+        if (listing) {
+          await listingUpdatedQueue.add({ providerListingId: listing.id });
+        }
+      });
 
       return provider;
     });

--- a/src/systems/subspace/packages/list-utils/src/resources/provider.ts
+++ b/src/systems/subspace/packages/list-utils/src/resources/provider.ts
@@ -26,8 +26,8 @@ export let resolveProviders = createOptionalResolver(async ({ ts, ids }) =>
                 }
               : undefined!
           ].filter(Boolean)
-        }
-      ]
+        },
+      ].filter(Boolean)
     },
     select: { oid: true }
   })

--- a/src/systems/subspace/packages/presenters/src/provider.ts
+++ b/src/systems/subspace/packages/presenters/src/provider.ts
@@ -47,6 +47,7 @@ export let providerPresenter = (
     id: provider.id,
     access: provider.access,
     status: provider.status,
+    isDeprecated: provider.isDeprecated,
 
     ownerTenant: provider.ownerTenant ? tenantPresenter(provider.ownerTenant) : null,
     publisher: publisherPresenter(provider.publisher),
@@ -101,6 +102,7 @@ export let providerPreviewPresenter = (provider: Provider) => ({
   id: provider.id,
   access: provider.access,
   status: provider.status,
+  isDeprecated: provider.isDeprecated,
 
   tag: provider.tag,
 

--- a/src/systems/subspace/packages/presenters/src/providerListing.ts
+++ b/src/systems/subspace/packages/presenters/src/providerListing.ts
@@ -49,6 +49,7 @@ export let providerListingPresenter = (
   object: 'provider.listing',
 
   id: providerListing.id,
+  isDeprecated: providerListing.isDeprecated,
 
   isPublic: providerListing.isPublic,
   isCustomized: providerListing.isCustomized,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new persisted `isDeprecated` state and changes multiple catalog queries/controllers to filter or include deprecated providers, which can affect provider discovery and listing behavior. Adds a cron/queue reconciler that mutates provider/listing records in bulk, increasing operational risk if the selection criteria are wrong.
> 
> **Overview**
> Adds an `isDeprecated` flag to `Provider` and `ProviderListing`, exposes it via presenters, and threads a new `includeDeprecated` query option through several controller endpoints and catalog services (defaulting to *exclude deprecated* except when explicitly requested or listing by IDs).
> 
> Introduces a new provider-internal reconciler (daily cron + queues) that scans for eligible docker/container providers and marks them (and their listings) as deprecated via a new `providerInternalService.deprecateProvider` flow.
> 
> Also adds the OAuth `.well-known/oauth-protected-resource` metadata endpoint, improves dashboard error-code display by humanizing codes, and fixes UI select dropdown stacking by deriving z-index from dialog state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e51704ee86bc3b5f485d5b303a0de271c502211d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->