### PR TITLE
Add magic mcp session refresh

### DIFF
--- a/src/backend/apis/core/src/controllers/management/project.ts
+++ b/src/backend/apis/core/src/controllers/management/project.ts
@@ -12,6 +12,10 @@ import {
 } from '../../middleware/organizationGroup';
 import { projectBrandPresenter, projectPresenter } from '../../presenters';
 
+let magicMcpSessionDurationMinutesValidator = v.optional(
+  v.number({ modifiers: [v.positive(), v.integer(), v.minValue(15), v.maxValue(108000)] })
+);
+
 export let projectManagementController = Controller.create(
   {
     name: 'Project',
@@ -117,14 +121,16 @@ export let projectManagementController = Controller.create(
       .body(
         'default',
         v.object({
-          name: v.string()
+          name: v.string(),
+          magic_mcp_session_duration_minutes: magicMcpSessionDurationMinutesValidator
         })
       )
       .output(projectPresenter)
       .do(async ctx => {
         let project = await projectService.createProject({
           input: {
-            name: ctx.body.name
+            name: ctx.body.name,
+            magicMcpSessionDurationMinutes: ctx.body.magic_mcp_session_duration_minutes
           },
           organization: ctx.organization,
           context: ctx.context,
@@ -176,7 +182,8 @@ export let projectManagementController = Controller.create(
       .body(
         'default',
         v.object({
-          name: v.optional(v.string())
+          name: v.optional(v.string()),
+          magic_mcp_session_duration_minutes: magicMcpSessionDurationMinutesValidator
         })
       )
       .output(projectPresenter)
@@ -200,7 +207,8 @@ export let projectManagementController = Controller.create(
           project,
           organization: ctx.organization,
           input: {
-            name: ctx.body.name
+            name: ctx.body.name,
+            magicMcpSessionDurationMinutes: ctx.body.magic_mcp_session_duration_minutes
           },
           context: ctx.context,
           performedBy: ctx.actor

--- a/src/backend/apis/core/src/presenters/implementation/project.ts
+++ b/src/backend/apis/core/src/presenters/implementation/project.ts
@@ -11,6 +11,7 @@ export let v1ProjectPresenter = Presenter.create(projectType)
     slug: project.slug,
     name: project.name,
     organization_id: project.organization.id,
+    magic_mcp_session_duration_minutes: project.magicMcpSessionDurationMinutes,
     created_at: project.createdAt,
     updated_at: project.updatedAt
   }))
@@ -43,6 +44,11 @@ export let v1ProjectPresenter = Presenter.create(projectType)
         name: 'organization_id',
         description: `The organization's unique identifier`,
         examples: ['org_7hNkPqRsTuVwXyZa']
+      }),
+      magic_mcp_session_duration_minutes: v.number({
+        name: 'magic_mcp_session_duration_minutes',
+        description: 'How long magic MCP sessions last before they are rotated',
+        examples: [1440]
       }),
       created_at: v.date({
         name: 'created_at',

--- a/src/backend/apis/core/src/presenters/implementation/provider/magicMcpSession.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/magicMcpSession.ts
@@ -19,6 +19,7 @@ export let v1MagicMcpSessionPresenter = Presenter.create(magicMcpSessionType)
           .run()
       : null,
     session_id: magicMcpSession.subspaceSessionId,
+    expires_at: magicMcpSession.expiresAt ?? null,
 
     created_at: magicMcpSession.createdAt,
     updated_at: magicMcpSession.updatedAt
@@ -30,6 +31,7 @@ export let v1MagicMcpSessionPresenter = Presenter.create(magicMcpSessionType)
       magic_mcp_server: v.nullable(v1MagicMcpServerPresenter.schema),
       magic_mcp_endpoint: v.nullable(v1MagicMcpEndpointPresenter.schema),
       session_id: v.string(),
+      expires_at: v.nullable(v.date()),
       created_at: v.date(),
       updated_at: v.date()
     })

--- a/src/backend/apis/oauth/src/index.ts
+++ b/src/backend/apis/oauth/src/index.ts
@@ -241,6 +241,10 @@ export let oauthApi = createOAuthAppSkeleton({
       return c.json(await oauthOidcService.getOpenIdConfiguration());
     },
 
+    oauthProtectedResourceMetadata: async ({}, c) => {
+      return c.json(await oauthOidcService.getOAuthProtectedResourceMetadata());
+    },
+
     oauthAuthorizationServerMetadata: async ({}, c) => {
       return c.json(await oauthOidcService.getOAuthAuthorizationServerMetadata());
     },

--- a/src/backend/apis/oauth/src/skeleton.ts
+++ b/src/backend/apis/oauth/src/skeleton.ts
@@ -64,6 +64,10 @@ export let createOAuthAppSkeleton = (d: {
       d: { context: ReturnType<typeof useRequestContext> },
       c: Context
     ) => Promise<Response>;
+    oauthProtectedResourceMetadata: (
+      d: { context: ReturnType<typeof useRequestContext> },
+      c: Context
+    ) => Promise<Response>;
     oauthAuthorizationServerMetadata: (
       d: { context: ReturnType<typeof useRequestContext> },
       c: Context
@@ -281,6 +285,10 @@ export let createOAuthAppSkeleton = (d: {
     .get('/.well-known/openid-configuration', async c => {
       let context = useRequestContext(c);
       return await d.oauth.openIdConfiguration({ context }, c);
+    })
+    .get('/.well-known/oauth-protected-resource', async c => {
+      let context = useRequestContext(c);
+      return await d.oauth.oauthProtectedResourceMetadata({ context }, c);
     })
     .get('/.well-known/oauth-authorization-server', async c => {
       let context = useRequestContext(c);

--- a/src/backend/db/prisma/schema/magic/subspaceConnection.prisma
+++ b/src/backend/db/prisma/schema/magic/subspaceConnection.prisma
@@ -15,6 +15,7 @@ model MagicMcpSubspaceSessionConnection {
 
   subspaceSessionId         String
   subspaceSessionTemplateId String
+  expiresAt                 DateTime?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt

--- a/src/backend/db/prisma/schema/organization/project.prisma
+++ b/src/backend/db/prisma/schema/organization/project.prisma
@@ -13,6 +13,7 @@ model Project {
   name String
 
   onlyAllowTrustedProviders Boolean @default(false)
+  magicMcpSessionDurationMinutes Int @default(1440)
 
   organizationOid BigInt
   organization    Organization @relation(fields: [organizationOid], references: [oid], onDelete: Cascade)

--- a/src/backend/modules/machine-access/src/services/oauthOidc.ts
+++ b/src/backend/modules/machine-access/src/services/oauthOidc.ts
@@ -98,6 +98,18 @@ class OAuthOidcService {
     };
   }
 
+  async getOAuthProtectedResourceMetadata() {
+    let issuer = getConfig().urls.apiUrl;
+
+    return {
+      resource: issuer,
+      authorization_servers: [issuer],
+      bearer_methods_supported: ['header'],
+      token_types_supported: ['access_token'],
+      scopes_supported: [...oidcScopes, ...coreScopes]
+    };
+  }
+
   async getOAuthAuthorizationServerMetadata() {
     return await this.getOpenIdConfiguration();
   }

--- a/src/backend/modules/magic/src/lib/ensureSession.ts
+++ b/src/backend/modules/magic/src/lib/ensureSession.ts
@@ -78,6 +78,20 @@ let getConfigurationHash = (templateProviders: EffectiveTemplateProvider[]) => {
   return createHash('sha256').update(JSON.stringify(descriptors)).digest('hex');
 };
 
+let getMagicMcpSessionName = (name: string, now: Date) => {
+  return `Magic MCP ${name} - ${now.toISOString().slice(0, 10)}`;
+};
+
+let getMagicMcpSessionExpiresAt = async (instance: Instance, now: Date) => {
+  let project = await db.project.findUniqueOrThrow({
+    where: { oid: instance.projectOid },
+    select: { magicMcpSessionDurationMinutes: true }
+  });
+  let durationMinutes = project?.magicMcpSessionDurationMinutes;
+
+  return new Date(now.getTime() + durationMinutes * 60 * 1000);
+};
+
 let ensureMagicMcpEndpointTemplate = async (magicMcpEndpoint: MagicMcpEndpointForSession) => {
   let rawTemplateTargets = magicMcpEndpoint.servers
     .map(server => {
@@ -203,7 +217,7 @@ let getMagicMcpTargetInfo = async (d: MagicMcpResolvedTarget) => {
         magicMcpServerOid: d.target.oid
       },
       sessionTemplateId: d.target.subspaceSessionTemplateId,
-      name: d.target.name ?? `Magic MCP ${d.target.id}`,
+      name: d.target.name ?? d.target.id,
       description: d.target.description ?? undefined
     };
   }
@@ -223,7 +237,7 @@ let getMagicMcpTargetInfo = async (d: MagicMcpResolvedTarget) => {
       magicMcpEndpointOid: magicMcpEndpoint.oid
     },
     sessionTemplateId,
-    name: magicMcpEndpoint.name ?? `Magic MCP Endpoint ${magicMcpEndpoint.id}`,
+    name: magicMcpEndpoint.name ?? magicMcpEndpoint.id,
     description: magicMcpEndpoint.description ?? undefined
   };
 };
@@ -246,24 +260,34 @@ let getExistingMapping = async (d: Awaited<ReturnType<typeof getMagicMcpTargetIn
   });
 };
 
-let deleteExistingMapping = async (d: Awaited<ReturnType<typeof getMagicMcpTargetInfo>>) => {
-  if (d.targetType === 'server') {
-    await db.magicMcpSubspaceSessionConnection.updateMany({
-      where: { magicMcpServerOid: d.mappingWhere.magicMcpServerOid },
-      data: { isActive: true }
-    });
-
-    return;
-  }
-
-  await db.magicMcpSubspaceSessionConnection.updateMany({
-    where: { magicMcpEndpointOid: d.mappingWhere.magicMcpEndpointOid },
-    data: { isActive: true }
-  });
-};
-
 let getWinnerMapping = async (d: Awaited<ReturnType<typeof getMagicMcpTargetInfo>>) => {
   return await getExistingMapping(d);
+};
+
+let isReusableMapping = (
+  mapping: Awaited<ReturnType<typeof getExistingMapping>>,
+  target: Awaited<ReturnType<typeof getMagicMcpTargetInfo>>,
+  now: Date
+) => {
+  if (!mapping) return false;
+  if (mapping.subspaceSessionTemplateId !== target.sessionTemplateId) return false;
+  if (!mapping.expiresAt) return false;
+  if (mapping.expiresAt <= now) return false;
+
+  return true;
+};
+
+let deleteSubspaceSessionSafe = async (d: {
+  instance: Instance;
+  subspaceSessionId: string;
+}) => {
+  try {
+    await subspaceSessionService.delete({
+      instance: d.instance,
+      sessionId: d.subspaceSessionId,
+      _allowMagicMcpDelete: true
+    });
+  } catch {}
 };
 
 let getSubspaceProviders = async (d: { instance: Instance; sessionTemplateId: string }) => {
@@ -303,33 +327,68 @@ let getSubspaceProviders = async (d: { instance: Instance; sessionTemplateId: st
 export let ensureMagicMcpSubspaceSession = async (magicMcpTarget: MagicMcpResolvedTarget) => {
   let target = await getMagicMcpTargetInfo(magicMcpTarget);
   let mapping = await getExistingMapping(target);
+  let now = new Date();
 
-  if (mapping && mapping.subspaceSessionTemplateId !== target.sessionTemplateId) {
-    await deleteExistingMapping(target);
-    mapping = null;
-  }
-
-  if (mapping) return mapping;
+  if (isReusableMapping(mapping, target, now)) return mapping!;
 
   let providers = await getSubspaceProviders({
     instance: target.instance,
     sessionTemplateId: target.sessionTemplateId
   });
+  let expiresAt = await getMagicMcpSessionExpiresAt(target.instance, now);
 
   let subspaceSession = await subspaceSessionService.create({
     instance: target.instance,
-    name: target.name,
+    name: getMagicMcpSessionName(target.name, now),
     description: target.description,
     providers
   });
 
   try {
+    if (mapping) {
+      let updated = await db.magicMcpSubspaceSessionConnection.updateMany({
+        where: {
+          oid: mapping.oid,
+          subspaceSessionId: mapping.subspaceSessionId
+        },
+        data: {
+          subspaceSessionId: subspaceSession.id,
+          subspaceSessionTemplateId: target.sessionTemplateId,
+          expiresAt,
+          isActive: true
+        }
+      });
+      let winner = await getWinnerMapping(target);
+      if (!winner) {
+        throw new ServiceError(
+          badRequestError({
+            message: 'Failed to persist magic MCP session mapping'
+          })
+        );
+      }
+      if (updated.count === 0 && winner.subspaceSessionId !== subspaceSession.id) {
+        void deleteSubspaceSessionSafe({
+          instance: target.instance,
+          subspaceSessionId: subspaceSession.id
+        });
+      }
+      if (updated.count > 0 && mapping.subspaceSessionId !== winner.subspaceSessionId) {
+        void deleteSubspaceSessionSafe({
+          instance: target.instance,
+          subspaceSessionId: mapping.subspaceSessionId
+        });
+      }
+
+      return winner;
+    }
+
     return await db.magicMcpSubspaceSessionConnection.create({
       data: {
         id: await ID.generateId('magicMcpServerSubspaceSession'),
         instanceOid: target.instance.oid,
         subspaceSessionId: subspaceSession.id,
         subspaceSessionTemplateId: target.sessionTemplateId,
+        expiresAt,
         isActive: true,
         ...target.mappingData
       }
@@ -337,7 +396,15 @@ export let ensureMagicMcpSubspaceSession = async (magicMcpTarget: MagicMcpResolv
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
       let winner = await getWinnerMapping(target);
-      if (winner) return winner;
+      if (winner) {
+        if (winner.subspaceSessionId !== subspaceSession.id) {
+          void deleteSubspaceSessionSafe({
+            instance: target.instance,
+            subspaceSessionId: subspaceSession.id
+          });
+        }
+        return winner;
+      }
     }
 
     throw error;

--- a/src/backend/modules/magic/test/ensureSession.test.ts
+++ b/src/backend/modules/magic/test/ensureSession.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@metorial/db', () => {
+  let db = {
+    project: {
+      findUnique: vi.fn()
+    },
+    magicMcpSubspaceSessionConnection: {
+      findUnique: vi.fn(),
+      updateMany: vi.fn(),
+      create: vi.fn()
+    }
+  };
+
+  return {
+    db,
+    ID: {
+      generateId: vi.fn().mockResolvedValue('magic-session-link-1')
+    },
+    Prisma: {
+      PrismaClientKnownRequestError: class PrismaClientKnownRequestError extends Error {
+        code: string;
+
+        constructor(code: string) {
+          super(code);
+          this.code = code;
+        }
+      }
+    }
+  };
+});
+
+vi.mock('@metorial/module-subspace', () => ({
+  subspaceSessionService: {
+    create: vi.fn(),
+    delete: vi.fn()
+  },
+  subspaceSessionTemplateProviderService: {
+    getMany: vi.fn()
+  },
+  subspaceSessionTemplateService: {
+    create: vi.fn()
+  }
+}));
+
+vi.mock('../src/services', () => ({
+  magicMcpEndpointInclude: {}
+}));
+
+import { db } from '@metorial/db';
+import {
+  subspaceSessionService,
+  subspaceSessionTemplateProviderService
+} from '@metorial/module-subspace';
+import { ensureMagicMcpSubspaceSession } from '../src/lib/ensureSession';
+
+describe('ensureMagicMcpSubspaceSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('reuses a non-expired mapping', async () => {
+    let mapping = {
+      oid: 1n,
+      subspaceSessionId: 'ses_existing',
+      subspaceSessionTemplateId: 'tmpl_1',
+      expiresAt: new Date('2026-04-25T12:00:00.000Z')
+    };
+
+    vi.mocked(db.magicMcpSubspaceSessionConnection.findUnique).mockResolvedValue(
+      mapping as any
+    );
+
+    let result = await ensureMagicMcpSubspaceSession({
+      type: 'server',
+      target: {
+        oid: 10n,
+        id: 'mcp_server_1',
+        name: 'Claude',
+        description: 'Magic MCP server',
+        subspaceSessionTemplateId: 'tmpl_1',
+        instance: {
+          oid: 20n,
+          id: 'ins_1',
+          projectOid: 30n
+        }
+      } as any
+    });
+
+    expect(result).toBe(mapping);
+    expect(subspaceSessionTemplateProviderService.getMany).not.toHaveBeenCalled();
+    expect(subspaceSessionService.create).not.toHaveBeenCalled();
+  });
+
+  it('rotates an expired mapping using the project duration and a friendly name', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-24T09:15:00.000Z'));
+
+    let existingMapping = {
+      oid: 1n,
+      subspaceSessionId: 'ses_old',
+      subspaceSessionTemplateId: 'tmpl_1',
+      expiresAt: new Date('2026-04-24T08:00:00.000Z')
+    };
+    let nextMapping = {
+      ...existingMapping,
+      subspaceSessionId: 'ses_new',
+      expiresAt: new Date('2026-04-24T10:15:00.000Z')
+    };
+
+    vi.mocked(db.magicMcpSubspaceSessionConnection.findUnique)
+      .mockResolvedValueOnce(existingMapping as any)
+      .mockResolvedValueOnce(nextMapping as any);
+    vi.mocked(db.magicMcpSubspaceSessionConnection.updateMany).mockResolvedValue({
+      count: 1
+    } as any);
+    vi.mocked(db.project.findUnique).mockResolvedValue({
+      magicMcpSessionDurationMinutes: 60
+    } as any);
+    vi.mocked(subspaceSessionTemplateProviderService.getMany).mockResolvedValue([]);
+    vi.mocked(subspaceSessionService.create).mockResolvedValue({
+      id: 'ses_new',
+      providers: []
+    } as any);
+    vi.mocked(subspaceSessionService.delete).mockResolvedValue({} as any);
+
+    let result = await ensureMagicMcpSubspaceSession({
+      type: 'server',
+      target: {
+        oid: 10n,
+        id: 'mcp_server_1',
+        name: 'Claude',
+        description: 'Magic MCP server',
+        subspaceSessionTemplateId: 'tmpl_1',
+        instance: {
+          oid: 20n,
+          id: 'ins_1',
+          projectOid: 30n
+        }
+      } as any
+    });
+
+    expect(subspaceSessionService.create).toHaveBeenCalledWith({
+      instance: expect.objectContaining({ id: 'ins_1' }),
+      name: 'Magic MCP Claude - 2026-04-24',
+      description: 'Magic MCP server',
+      providers: []
+    });
+    expect(db.magicMcpSubspaceSessionConnection.updateMany).toHaveBeenCalledWith({
+      where: {
+        oid: 1n,
+        subspaceSessionId: 'ses_old'
+      },
+      data: {
+        subspaceSessionId: 'ses_new',
+        subspaceSessionTemplateId: 'tmpl_1',
+        expiresAt: new Date('2026-04-24T10:15:00.000Z'),
+        isActive: true
+      }
+    });
+    expect(subspaceSessionService.delete).toHaveBeenCalledWith({
+      instance: expect.objectContaining({ id: 'ins_1' }),
+      sessionId: 'ses_old',
+      _allowMagicMcpDelete: true
+    });
+    expect(result).toEqual(nextMapping);
+  });
+});

--- a/src/backend/modules/organization/src/services/project.ts
+++ b/src/backend/modules/organization/src/services/project.ts
@@ -45,6 +45,7 @@ class ProjectService {
     context: Context;
     input: {
       name: string;
+      magicMcpSessionDurationMinutes?: number;
     };
   }) {
     return withTransaction(async db => {
@@ -56,6 +57,7 @@ class ProjectService {
           status: 'active',
           slug: await getProjectSlug({ input: `${d.input.name}-${generateCode(5)}` }),
           name: d.input.name,
+          magicMcpSessionDurationMinutes: d.input.magicMcpSessionDurationMinutes,
           organizationOid: d.organization.oid
         },
         include: {
@@ -97,6 +99,7 @@ class ProjectService {
     input: {
       name?: string;
       onlyAllowTrustedProviders?: boolean;
+      magicMcpSessionDurationMinutes?: number;
     };
   }) {
     await this.ensureProjectActive(d.project);
@@ -108,7 +111,8 @@ class ProjectService {
         where: { oid: d.project.oid },
         data: {
           name: d.input.name,
-          onlyAllowTrustedProviders: d.input.onlyAllowTrustedProviders
+          onlyAllowTrustedProviders: d.input.onlyAllowTrustedProviders,
+          magicMcpSessionDurationMinutes: d.input.magicMcpSessionDurationMinutes
         },
         include: {
           organization: true

--- a/src/backend/modules/organization/test/project.test.ts
+++ b/src/backend/modules/organization/test/project.test.ts
@@ -108,6 +108,7 @@ describe('ProjectService', () => {
         slug: 'test-project',
         name: 'Test Project',
         status: 'active',
+        magicMcpSessionDurationMinutes: 1440,
         organizationOid: 1,
         organization: mockOrg
       };
@@ -156,6 +157,50 @@ describe('ProjectService', () => {
       });
     });
 
+    it('should persist a custom magic MCP session duration', async () => {
+      let mockOrg = { id: 'org-1', oid: 1 };
+      let mockProject = {
+        id: 'proj-1',
+        oid: 1,
+        slug: 'test-project',
+        name: 'Test Project',
+        status: 'active',
+        magicMcpSessionDurationMinutes: 30,
+        organizationOid: 1,
+        organization: mockOrg
+      };
+      let create = vi.fn().mockResolvedValue(mockProject);
+
+      vi.mocked(ID.generateId).mockResolvedValue('proj-1');
+      vi.mocked(withTransaction).mockImplementation(async callback => {
+        let mockDb = {
+          project: {
+            create
+          }
+        };
+        return callback(mockDb as any);
+      });
+      vi.mocked(instanceService.createInstance).mockResolvedValue({} as any);
+
+      await projectService.createProject({
+        organization: mockOrg as any,
+        performedBy: { id: 'actor-1', oid: 1 } as any,
+        context: {} as any,
+        input: {
+          name: 'Test Project',
+          magicMcpSessionDurationMinutes: 30
+        }
+      });
+
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            magicMcpSessionDurationMinutes: 30
+          })
+        })
+      );
+    });
+
     it('should handle slug generation', async () => {
       let mockProject = { id: 'proj-1', slug: 'test-slug' };
 
@@ -189,7 +234,8 @@ describe('ProjectService', () => {
         id: 'proj-1',
         oid: 1,
         status: 'active',
-        name: 'Old Name'
+        name: 'Old Name',
+        magicMcpSessionDurationMinutes: 1440
       };
       let updatedProject = {
         ...mockProject,
@@ -272,6 +318,47 @@ describe('ProjectService', () => {
       });
 
       expect(Fabric.fire).toHaveBeenCalled();
+    });
+
+    it('should update the magic MCP session duration', async () => {
+      let mockProject = {
+        id: 'proj-1',
+        oid: 1,
+        status: 'active',
+        name: 'Original Name',
+        magicMcpSessionDurationMinutes: 1440
+      };
+      let update = vi.fn().mockResolvedValue({
+        ...mockProject,
+        magicMcpSessionDurationMinutes: 60
+      });
+
+      vi.mocked(withTransaction).mockImplementation(async callback => {
+        let mockDb = {
+          project: {
+            update
+          }
+        };
+        return callback(mockDb as any);
+      });
+
+      await projectService.updateProject({
+        project: mockProject as any,
+        organization: { id: 'org-1', oid: 1 } as any,
+        performedBy: { id: 'actor-1', oid: 1 } as any,
+        context: {} as any,
+        input: {
+          magicMcpSessionDurationMinutes: 60
+        }
+      });
+
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            magicMcpSessionDurationMinutes: 60
+          })
+        })
+      );
     });
   });
 

--- a/src/backend/modules/subspace/src/services/session.ts
+++ b/src/backend/modules/subspace/src/services/session.ts
@@ -1,6 +1,6 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { getSentry } from '@lowerdeck/sentry';
-import { db, Instance } from '@metorial/db';
+import { db, Instance, MagicMcpServer, Prisma } from '@metorial/db';
 import { Fabric } from '@metorial/fabric';
 import { sessionClientSecretReferenceService } from '@metorial/module-access';
 import { usageService } from '@metorial/module-usage';
@@ -11,20 +11,62 @@ import { subspace } from '../subspace';
 let Sentry = getSentry();
 
 type RawSubspaceSession = Awaited<ReturnType<typeof subspace.session.get>>;
+type MagicMcpSubspaceSessionConnectionWithRelations =
+  Prisma.MagicMcpSubspaceSessionConnectionGetPayload<{
+    include: {
+      instance: true;
+      magicMcpEndpoint: true;
+      magicMcpServer: true;
+    };
+  }>;
 
-let enrichSessionWithClientSecret = async (d: {
-  instance: Instance;
-  session: RawSubspaceSession;
-}) => {
-  let reference = await sessionClientSecretReferenceService.getForSession({
-    instance: d.instance as any,
-    sessionId: d.session.id
+let enrichSessions = async (d: { instance: Instance; sessions: RawSubspaceSession[] }) => {
+  if (d.sessions.length === 0) return [];
+
+  let [references, magicMcpConnections] = await Promise.all([
+    sessionClientSecretReferenceService.getForSessions({
+      instance: d.instance as any,
+      sessionIds: d.sessions.map(session => session.id)
+    }),
+    db.magicMcpSubspaceSessionConnection.findMany({
+      where: {
+        instanceOid: d.instance.oid,
+        subspaceSessionId: {
+          in: d.sessions.map(session => session.id)
+        }
+      },
+      include: {
+        instance: true,
+        magicMcpEndpoint: true,
+        magicMcpServer: true
+      }
+    })
+  ]);
+
+  let referenceMap = new Map(
+    references.map(
+      reference => [reference.sessionId, reference.fineGrainedKey.secret] as const
+    )
+  );
+  let magicMcpConnectionMap = new Map(
+    magicMcpConnections.map(connection => [connection.subspaceSessionId, connection] as const)
+  );
+
+  return d.sessions.map(session => ({
+    ...session,
+    clientSecret: referenceMap.get(session.id) ?? null,
+    magicMcpServer: magicMcpConnectionMap.get(session.id)?.magicMcpServer ?? null,
+    magicMcpSubspaceSessionConnection: magicMcpConnectionMap.get(session.id) ?? null
+  }));
+};
+
+let enrichSession = async (d: { instance: Instance; session: RawSubspaceSession }) => {
+  let [session] = await enrichSessions({
+    instance: d.instance,
+    sessions: [d.session]
   });
 
-  return {
-    ...d.session,
-    clientSecret: reference?.fineGrainedKey.secret ?? null
-  };
+  return session!;
 };
 
 export let subspaceSessionService = createSubspaceService(
@@ -34,9 +76,17 @@ export let subspaceSessionService = createSubspaceService(
     get: async (...params: Parameters<typeof inner.get>) => {
       let session = await inner.get(...params);
 
-      return await enrichSessionWithClientSecret({
+      return await enrichSession({
         instance: params[0].instance,
         session
+      });
+    },
+    getMany: async (...params: Parameters<typeof inner.getMany>) => {
+      let sessions = await inner.getMany(...params);
+
+      return await enrichSessions({
+        instance: params[0].instance,
+        sessions
       });
     },
     list: async (
@@ -52,29 +102,12 @@ export let subspaceSessionService = createSubspaceService(
         ids
       });
 
-      return {
-        run: async (query: any) => {
-          let res = await paginator.run(query);
-          let references = await sessionClientSecretReferenceService.getForSessions({
-            instance: input.instance,
-            sessionIds: res.items.map((item: RawSubspaceSession) => item.id)
-          });
-          let referenceMap = new Map(
-            (references as any[]).map(reference => [
-              String(reference.sessionId),
-              String(reference.fineGrainedKey.secret)
-            ])
-          );
-
-          return {
-            ...res,
-            items: res.items.map((item: RawSubspaceSession) => ({
-              ...item,
-              clientSecret: referenceMap.get(item.id) ?? null
-            }))
-          };
-        }
-      };
+      return paginator.map(items =>
+        enrichSessions({
+          instance: input.instance,
+          sessions: items
+        })
+      );
     },
     create: async (...params: Parameters<typeof inner.create>) => {
       let eventBase = toEventBase(params[0]);
@@ -170,7 +203,7 @@ export let subspaceSessionService = createSubspaceService(
         }
       }
 
-      return await enrichSessionWithClientSecret({
+      return await enrichSession({
         instance: params[0].instance,
         session
       });
@@ -197,7 +230,7 @@ export let subspaceSessionService = createSubspaceService(
 
       await Fabric.fire('provider.session.updated:after', { ...eventBase, session });
 
-      return await enrichSessionWithClientSecret({
+      return await enrichSession({
         instance: arg0.instance,
         session
       });
@@ -224,7 +257,7 @@ export let subspaceSessionService = createSubspaceService(
 
       await Fabric.fire('provider.session.deleted:after', { ...eventBase, session });
 
-      return await enrichSessionWithClientSecret({
+      return await enrichSession({
         instance: arg0.instance,
         session
       });
@@ -234,4 +267,6 @@ export let subspaceSessionService = createSubspaceService(
 
 export type SubspaceSession = RawSubspaceSession & {
   clientSecret?: string | null;
+  magicMcpServer?: MagicMcpServer | null;
+  magicMcpSubspaceSessionConnection?: MagicMcpSubspaceSessionConnectionWithRelations | null;
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthErrors/groupsTable.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthErrors/groupsTable.tsx
@@ -17,23 +17,17 @@ type ErrorGroupsTableStateProps = ErrorGroupsTableProps & {
   instance: ReturnType<typeof useCurrentInstance>;
 };
 
-let ERROR_LABELS: Record<string, string> = {
-  tool_call_failed: 'Tool Call Failed',
-  config_validation_failed: 'Config Validation Failed',
-  auth_processing_failed: 'Auth Processing Failed',
-  oauth_token_refresh_failed: 'OAuth Token Refresh Failed',
-  oauth_setup_failed: 'OAuth Setup Failed',
-  trigger_event_input_failed: 'Trigger Event Input Failed',
-  profile_fetch_failed: 'Profile Fetch Failed'
+let splitMany = (str: string, separators: string[]) => {
+  let regex = new RegExp(separators.map(s => `\\${s}`).join('|'), 'g');
+  return str.split(regex);
 };
 
 let humanizeCode = (code: string) =>
-  code
-    .split('_')
+  splitMany(code, ['_', '-', '.', ' '])
     .map(part => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
 
-let getErrorLabel = (code: string) => ERROR_LABELS[code] ?? humanizeCode(code);
+let getErrorLabel = (code: string) => humanizeCode(code);
 
 let errorGroupsTableState: TableStateProvider<
   ErrorGroupsTableStateProps,
@@ -68,7 +62,7 @@ let providerAuthErrorGroupsTable = new DashboardTable<ErrorGroupsTableStateProps
     {
       id: 'code',
       isDefault: true,
-      header: 'Code',
+      header: 'Name',
       render: group =>
         group.code ? (
           <Badge color="red">{getErrorLabel(group.code)}</Badge>
@@ -79,13 +73,13 @@ let providerAuthErrorGroupsTable = new DashboardTable<ErrorGroupsTableStateProps
     {
       id: 'message',
       isDefault: true,
-      header: 'Message',
+      header: 'Details',
       render: group => <Text size="2">{group.message}</Text>
     },
     {
       id: 'occurrenceCount',
       isDefault: true,
-      header: 'Count',
+      header: 'Occurrences',
       render: group => <Text size="2">{group.occurrenceCount ?? '—'}</Text>
     },
     {

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerErrors/groupsTable.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerErrors/groupsTable.tsx
@@ -21,6 +21,18 @@ type ErrorGroupsTableStateProps = ErrorGroupsTableProps & {
   instance: ReturnType<typeof useCurrentInstance>;
 };
 
+let splitMany = (str: string, separators: string[]) => {
+  let regex = new RegExp(separators.map(s => `\\${s}`).join('|'), 'g');
+  return str.split(regex);
+};
+
+let humanizeCode = (code: string) =>
+  splitMany(code, ['_', '-', '.', ' '])
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+let getErrorLabel = (code: string) => humanizeCode(code);
+
 let getErrorTypeFilterValue = (
   value: FilterPayload | undefined
 ): DashboardInstanceSessionsErrorGroupsListQuery['type'] => {
@@ -63,10 +75,10 @@ let providerErrorGroupsTable = new DashboardTable<ErrorGroupsTableStateProps, Er
     {
       id: 'code',
       isDefault: true,
-      header: 'Code',
+      header: 'Name',
       render: error =>
         error.code ? (
-          <Badge color="red">{error.code}</Badge>
+          <Badge color="red">{getErrorLabel(error.code)}</Badge>
         ) : (
           <Badge color="gray">Unknown</Badge>
         )
@@ -74,13 +86,13 @@ let providerErrorGroupsTable = new DashboardTable<ErrorGroupsTableStateProps, Er
     {
       id: 'message',
       isDefault: true,
-      header: 'Message',
+      header: 'Details',
       render: error => <Text size="2">{error.message}</Text>
     },
     {
       id: 'occurrenceCount',
       isDefault: true,
-      header: 'Count',
+      header: 'Occurrences',
       render: error => <Text size="2">{error.occurrenceCount ?? '—'}</Text>
     },
     {

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/entry.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/entry.tsx
@@ -1,11 +1,6 @@
 import type { DashboardInstanceProviderInvocationsListOutput } from '@metorial/dashboard-sdk';
 import { Badge, Button, RenderDate, theme } from '@metorial/ui';
-import {
-  RiKey2Line,
-  RiPulseLine,
-  RiShieldKeyholeLine,
-  RiToolsLine
-} from '@remixicon/react';
+import { RiKey2Line, RiPulseLine, RiShieldKeyholeLine, RiToolsLine } from '@remixicon/react';
 import type { ReactNode } from 'react';
 import styled from 'styled-components';
 import { RunLogs } from '../../components/runLogs';
@@ -84,13 +79,8 @@ let getInvocationTitle = (invocation: InvocationItem): string => {
   return formatTitleCase(invocation.type);
 };
 
-export let ProviderInvocationEntry = ({
-  invocation
-}: {
-  invocation: InvocationItem;
-}) => {
-  let variant: 'error' | 'default' =
-    invocation.status === 'error' ? 'error' : 'default';
+export let ProviderInvocationEntry = ({ invocation }: { invocation: InvocationItem }) => {
+  let variant: 'error' | 'default' = invocation.status === 'error' ? 'error' : 'default';
 
   return (
     <Wrapper>
@@ -107,12 +97,11 @@ export let ProviderInvocationEntry = ({
         <Actions>
           <Button
             size="2"
-            variant="outline"
             onClick={() =>
               showProviderInvocationPanel({ providerInvocationId: invocation.id })
             }
           >
-            View Details
+            View invocation details
           </Button>
         </Actions>
 

--- a/src/packages/frontend/ui/src/select/index.tsx
+++ b/src/packages/frontend/ui/src/select/index.tsx
@@ -1,9 +1,10 @@
 import * as RadixSelect from '@radix-ui/react-select';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { RiArrowDownSLine, RiArrowUpSLine, RiCheckLine } from '@remixicon/react';
-import React, { useEffect, useId, useMemo } from 'react';
+import React, { useEffect, useId, useMemo, useState } from 'react';
 import { keyframes, styled } from 'styled-components';
 import { ButtonSize, getButtonSize } from '../button/constants';
+import { useDialogZIndex } from '../dialog/state';
 import { Error } from '../error';
 import { InputDescription, InputLabel } from '../input';
 import { theme } from '../theme';
@@ -153,6 +154,9 @@ export let Select = ({
   let sizeStyles = getButtonSize(size);
   let normalizedValue = value === '' ? undefined : value;
 
+  let [isOpen, setIsOpen] = useState(false);
+  let zIndex = useDialogZIndex(isOpen);
+
   let disabledItems = useMemo(
     () =>
       items
@@ -190,7 +194,12 @@ export let Select = ({
 
       {description && <InputDescription>{description}</InputDescription>}
 
-      <RadixSelect.Root value={normalizedValue} onValueChange={onChange}>
+      <RadixSelect.Root
+        value={normalizedValue}
+        onValueChange={onChange}
+        open={isOpen}
+        onOpenChange={setIsOpen}
+      >
         <Trigger
           id={id}
           disabled={disabled}
@@ -206,7 +215,7 @@ export let Select = ({
           </RadixSelect.Icon>
         </Trigger>
         <RadixSelect.Portal>
-          <Content style={{ zIndex: 9999 }}>
+          <Content style={{ zIndex }}>
             <RadixSelect.ScrollUpButton className="SelectScrollButton">
               <RiArrowUpSLine size={14} />
             </RadixSelect.ScrollUpButton>

--- a/src/systems/subspace/apps/controller/src/controllers/provider.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/provider.ts
@@ -29,6 +29,7 @@ export let providerController = app.controller({
           environmentId: v.string(),
 
           ids: v.optional(v.array(v.string())),
+          includeDeprecated: v.optional(v.boolean()),
 
           capabilities: v.optional(
             v.object({
@@ -51,6 +52,7 @@ export let providerController = app.controller({
         solution: ctx.solution,
 
         ids: ctx.input.ids,
+        includeDeprecated: ctx.input.includeDeprecated,
         capabilities: ctx.input.capabilities
       });
 

--- a/src/systems/subspace/apps/controller/src/controllers/providerAuthMethod.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerAuthMethod.ts
@@ -31,7 +31,8 @@ export let providerAuthMethodController = app.controller({
           tenantId: v.optional(v.string()),
           environmentId: v.optional(v.string()),
 
-          providerVersionId: v.string()
+          providerVersionId: v.string(),
+          includeDeprecated: v.optional(v.boolean())
         })
       )
     )
@@ -40,7 +41,8 @@ export let providerAuthMethodController = app.controller({
         providerVersionId: ctx.input.providerVersionId,
         tenant: ctx.tenant,
         environment: ctx.environment,
-        solution: ctx.solution
+        solution: ctx.solution,
+        includeDeprecated: ctx.input.includeDeprecated
       });
 
       let paginator = await providerAuthMethodService.listProviderAuthMethods({
@@ -48,7 +50,8 @@ export let providerAuthMethodController = app.controller({
         environment: ctx.environment,
         solution: ctx.solution,
 
-        providerVersion
+        providerVersion,
+        includeDeprecated: ctx.input.includeDeprecated
       });
 
       let list = await paginator.run(ctx.input);

--- a/src/systems/subspace/apps/controller/src/controllers/providerListing.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerListing.ts
@@ -39,6 +39,7 @@ export let providerListingController = app.controller({
           providerGroupIds: v.optional(v.array(v.string())),
           publisherIds: v.optional(v.array(v.string())),
           ids: v.optional(v.array(v.string())),
+          includeDeprecated: v.optional(v.boolean()),
 
           isPublic: v.optional(v.boolean()),
           onlyFromTenant: v.optional(v.boolean()),
@@ -102,6 +103,7 @@ export let providerListingController = app.controller({
         providerGroupIds: ctx.input.providerGroupIds,
         publisherIds: ctx.input.publisherIds,
         ids: ctx.input.ids,
+        includeDeprecated: ctx.input.includeDeprecated,
 
         capabilities: ctx.input.capabilities,
 

--- a/src/systems/subspace/apps/controller/src/controllers/providerSpecification.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerSpecification.ts
@@ -34,6 +34,7 @@ export let providerSpecificationController = app.controller({
           providerVersionIds: v.optional(v.array(v.string())),
           providerDeploymentIds: v.optional(v.array(v.string())),
           providerConfigIds: v.optional(v.array(v.string())),
+          includeDeprecated: v.optional(v.boolean()),
 
           createdAt: createdAtValidator,
           updatedAt: updatedAtValidator
@@ -51,6 +52,7 @@ export let providerSpecificationController = app.controller({
         providerVersionIds: ctx.input.providerVersionIds,
         providerDeploymentIds: ctx.input.providerDeploymentIds,
         providerConfigIds: ctx.input.providerConfigIds,
+        includeDeprecated: ctx.input.includeDeprecated,
 
         createdAt: ctx.input.createdAt,
         updatedAt: ctx.input.updatedAt

--- a/src/systems/subspace/apps/controller/src/controllers/providerVariant.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerVariant.ts
@@ -26,7 +26,8 @@ export let providerVariantController = app.controller({
       Paginator.validate(
         v.object({
           tenantId: v.optional(v.string()),
-          environmentId: v.optional(v.string())
+          environmentId: v.optional(v.string()),
+          includeDeprecated: v.optional(v.boolean())
         })
       )
     )
@@ -34,7 +35,8 @@ export let providerVariantController = app.controller({
       let paginator = await providerVariantService.listProviderVariants({
         tenant: ctx.tenant,
         environment: ctx.environment,
-        solution: ctx.solution
+        solution: ctx.solution,
+        includeDeprecated: ctx.input.includeDeprecated
       });
 
       let list = await paginator.run(ctx.input);

--- a/src/systems/subspace/apps/controller/src/controllers/providerVersion.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerVersion.ts
@@ -31,6 +31,7 @@ export let providerVersionController = app.controller({
 
           ids: v.optional(v.array(v.string())),
           providerIds: v.optional(v.array(v.string())),
+          includeDeprecated: v.optional(v.boolean()),
 
           createdAt: createdAtValidator,
           updatedAt: updatedAtValidator
@@ -45,6 +46,7 @@ export let providerVersionController = app.controller({
 
         ids: ctx.input.ids,
         providerIds: ctx.input.providerIds,
+        includeDeprecated: ctx.input.includeDeprecated,
 
         createdAt: ctx.input.createdAt,
         updatedAt: ctx.input.updatedAt

--- a/src/systems/subspace/db/prisma/schema/listing/listing.prisma
+++ b/src/systems/subspace/db/prisma/schema/listing/listing.prisma
@@ -8,6 +8,7 @@ model ProviderListing {
   oid    BigInt                @id
   id     String                @unique
   status ProviderListingStatus
+  isDeprecated Boolean @default(false)
 
   isPublic     Boolean @default(true)
   isCustomized Boolean @default(false)
@@ -66,6 +67,7 @@ model ProviderListing {
   @@index([isPublic])
   @@index([rank])
   @@index([status])
+  @@index([isDeprecated])
   @@index([aliases])
 }
 

--- a/src/systems/subspace/db/prisma/schema/provider/provider.prisma
+++ b/src/systems/subspace/db/prisma/schema/provider/provider.prisma
@@ -34,6 +34,7 @@ model Provider {
 
   access ProviderAccess
   status ProviderStatus
+  isDeprecated Boolean @default(false)
 
   hasEnvironments Boolean @default(false)
 
@@ -103,4 +104,5 @@ model Provider {
 
   @@index([status])
   @@index([access])
+  @@index([isDeprecated])
 }

--- a/src/systems/subspace/modules/catalog/src/services/provider.ts
+++ b/src/systems/subspace/modules/catalog/src/services/provider.ts
@@ -29,8 +29,10 @@ export let getProviderTenantFilter = (d: {
   solution: Solution;
   tenant?: Tenant;
   environment?: Environment;
+  includeDeprecated?: boolean;
 }) => ({
   AND: [
+    d.includeDeprecated ? undefined! : { isDeprecated: false },
     {
       OR: [
         { access: 'public' as const },
@@ -94,11 +96,15 @@ class providerServiceImpl {
     solution: Solution;
     tenant?: Tenant;
     environment?: Environment;
+    includeDeprecated?: boolean;
   }) {
     let provider = await db.provider.findFirst({
       where: {
         AND: [
-          getProviderTenantFilter(d),
+          getProviderTenantFilter({
+            ...d,
+            includeDeprecated: true
+          }),
 
           {
             OR: [
@@ -130,8 +136,10 @@ class providerServiceImpl {
 
     ids?: string[];
     capabilities?: ProviderCapabilityFilter;
+    includeDeprecated?: boolean;
   }) {
     let capFilters = getProviderCapabilityFilter(d.capabilities || {});
+    let includeDeprecated = d.includeDeprecated || !!d.ids?.length;
 
     return Paginator.create(({ prisma }) =>
       prisma(
@@ -140,7 +148,10 @@ class providerServiceImpl {
             ...opts,
             where: {
               AND: [
-                getProviderTenantFilter(d),
+                getProviderTenantFilter({
+                  ...d,
+                  includeDeprecated
+                }),
                 {
                   AND: [
                     d.ids

--- a/src/systems/subspace/modules/catalog/src/services/providerAuthMethod.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerAuthMethod.ts
@@ -17,6 +17,7 @@ class providerAuthMethodServiceImpl {
     tenant?: Tenant;
     environment?: Environment;
     providerVersion: ProviderVersion;
+    includeDeprecated?: boolean;
   }) {
     let versionOid = d.providerVersion?.oid;
 
@@ -38,7 +39,10 @@ class providerAuthMethodServiceImpl {
           where: {
             AND: [
               {
-                provider: getProviderTenantFilter(d)
+                provider: getProviderTenantFilter({
+                  ...d,
+                  includeDeprecated: true
+                })
               }
             ],
             providerOid: d.providerVersion.providerOid,
@@ -90,10 +94,14 @@ class providerAuthMethodServiceImpl {
     solution: Solution;
     environment: Environment;
     providerAuthMethodId: string;
+    includeDeprecated?: boolean;
   }) {
     let providerAuthMethod = await db.providerAuthMethod.findFirst({
       where: {
-        provider: getProviderTenantFilter(d),
+        provider: getProviderTenantFilter({
+          ...d,
+          includeDeprecated: true
+        }),
         id: d.providerAuthMethodId
       },
       include: {

--- a/src/systems/subspace/modules/catalog/src/services/providerListing.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerListing.ts
@@ -57,6 +57,7 @@ class ProviderListingService {
     solution: Solution;
     tenant?: Tenant;
     environment?: Environment;
+    includeDeprecated?: boolean;
   }) {
     let providerListing = await db.providerListing.findFirst({
       where: {
@@ -83,7 +84,7 @@ class ProviderListingService {
                 : undefined!
             ].filter(Boolean)
           }
-        ]
+        ].filter(Boolean)
       },
       include: getInclude(d.tenant, d.solution)
     });
@@ -121,10 +122,12 @@ class ProviderListingService {
     orderByUse?: ProviderListingOrderByUse;
 
     capabilities?: ProviderCapabilityFilter;
+    includeDeprecated?: boolean;
   }) {
     let collections = await resolveProviderCollections(d.providerCollectionIds);
     let categories = await resolveProviderCategories(d.providerCategoryIds);
     let publishers = await resolvePublishers(d.publisherIds);
+    let includeDeprecated = d.includeDeprecated || !!d.ids?.length;
 
     let capFilters = getProviderCapabilityFilter(d.capabilities || {});
 
@@ -177,6 +180,7 @@ class ProviderListingService {
             status: 'active',
 
             AND: [
+              includeDeprecated ? undefined! : { isDeprecated: false },
               {
                 OR: [
                   { isPublic: true },

--- a/src/systems/subspace/modules/catalog/src/services/providerSpecification.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerSpecification.ts
@@ -19,7 +19,15 @@ class providerSpecificationServiceImpl {
 
     createdAt?: DateFilter;
     updatedAt?: DateFilter;
+    includeDeprecated?: boolean;
   }) {
+    let includeDeprecated =
+      d.includeDeprecated ||
+      !!d.ids?.length ||
+      !!d.providerIds?.length ||
+      !!d.providerVersionIds?.length ||
+      !!d.providerDeploymentIds?.length ||
+      !!d.providerConfigIds?.length;
     let providers = await resolveProviders(d, d.providerIds);
 
     let versions = d.providerVersionIds
@@ -56,7 +64,10 @@ class providerSpecificationServiceImpl {
             where: {
               AND: [
                 {
-                  provider: getProviderTenantFilter(d)
+                  provider: getProviderTenantFilter({
+                    ...d,
+                    includeDeprecated
+                  })
                 },
 
                 d.ids ? { id: { in: d.ids } } : undefined!,
@@ -83,10 +94,14 @@ class providerSpecificationServiceImpl {
     tenant?: Tenant;
     environment?: Environment;
     providerSpecificationId: string;
+    includeDeprecated?: boolean;
   }) {
     let providerSpecification = await db.providerSpecification.findFirst({
       where: {
-        provider: getProviderTenantFilter(d),
+        provider: getProviderTenantFilter({
+          ...d,
+          includeDeprecated: true
+        }),
 
         id: d.providerSpecificationId
       },

--- a/src/systems/subspace/modules/catalog/src/services/providerTool.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerTool.ts
@@ -29,7 +29,14 @@ let hasVersionWithoutSpecification = (ctx: ListToolsContext) =>
   !!ctx.version && !ctx.version.specificationOid;
 
 let buildToolsWhere = (ctx: ListToolsContext) => ({
-  AND: [{ provider: getProviderTenantFilter(ctx) }],
+  AND: [
+    {
+      provider: getProviderTenantFilter({
+        ...ctx,
+        includeDeprecated: true
+      })
+    }
+  ],
   providerOid: ctx.providerVersion.providerOid,
   ...(ctx.version?.specificationOid
     ? { providerTools: { some: { specificationOid: ctx.version.specificationOid } } }
@@ -57,7 +64,10 @@ let patchGlobalCursor = async (
 
   let tool = await db.providerTool.findFirst({
     where: {
-      provider: getProviderTenantFilter(ctx),
+      provider: getProviderTenantFilter({
+        ...ctx,
+        includeDeprecated: true
+      }),
       OR: [{ id: cursor.id }, { global: { id: cursor.id } }]
     },
     include: {
@@ -213,7 +223,10 @@ class providerToolServiceImpl {
   }) {
     let providerTool = await db.providerTool.findFirst({
       where: {
-        provider: getProviderTenantFilter(d),
+        provider: getProviderTenantFilter({
+          ...d,
+          includeDeprecated: true
+        }),
 
         id: d.providerToolId
       },

--- a/src/systems/subspace/modules/catalog/src/services/providerTrigger.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerTrigger.ts
@@ -38,7 +38,10 @@ class providerTriggerServiceImpl {
         if (opts.cursor?.id) {
           let trigger = await db.providerTrigger.findFirst({
             where: {
-              provider: getProviderTenantFilter(d),
+              provider: getProviderTenantFilter({
+                ...d,
+                includeDeprecated: true
+              }),
               OR: [{ id: opts.cursor.id }, { global: { id: opts.cursor.id } }]
             },
             include: {
@@ -57,7 +60,10 @@ class providerTriggerServiceImpl {
           where: {
             AND: [
               {
-                provider: getProviderTenantFilter(d)
+                provider: getProviderTenantFilter({
+                  ...d,
+                  includeDeprecated: true
+                })
               }
             ],
             providerOid: d.providerVersion.providerOid,
@@ -111,7 +117,10 @@ class providerTriggerServiceImpl {
   }) {
     let providerTrigger = await db.providerTrigger.findFirst({
       where: {
-        provider: getProviderTenantFilter(d),
+        provider: getProviderTenantFilter({
+          ...d,
+          includeDeprecated: true
+        }),
 
         id: d.providerTriggerId
       },

--- a/src/systems/subspace/modules/catalog/src/services/providerVariant.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerVariant.ts
@@ -25,6 +25,7 @@ class providerVariantServiceImpl {
     solution: Solution;
     tenant?: Tenant;
     environment?: Environment;
+    includeDeprecated?: boolean;
   }) {
     return Paginator.create(({ prisma }) =>
       prisma(
@@ -32,7 +33,10 @@ class providerVariantServiceImpl {
           await db.providerVariant.findMany({
             ...opts,
             where: {
-              provider: getProviderTenantFilter(d)
+              provider: getProviderTenantFilter({
+                ...d,
+                includeDeprecated: d.includeDeprecated
+              })
             },
             include
           })
@@ -46,11 +50,15 @@ class providerVariantServiceImpl {
     tenant?: Tenant;
     environment?: Environment;
     provider?: Provider;
+    includeDeprecated?: boolean;
   }) {
     let providerVariant = await db.providerVariant.findFirst({
       where: {
         providerOid: d.provider ? d.provider.oid : undefined,
-        provider: getProviderTenantFilter(d),
+        provider: getProviderTenantFilter({
+          ...d,
+          includeDeprecated: true
+        }),
 
         AND: [
           {

--- a/src/systems/subspace/modules/catalog/src/services/providerVersion.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerVersion.ts
@@ -25,7 +25,9 @@ class providerVersionServiceImpl {
 
     createdAt?: DateFilter;
     updatedAt?: DateFilter;
+    includeDeprecated?: boolean;
   }) {
+    let includeDeprecated = d.includeDeprecated || !!d.ids?.length || !!d.providerIds?.length;
     let providers = await resolveProviders(d, d.providerIds);
 
     return Paginator.create(({ prisma }) =>
@@ -34,7 +36,10 @@ class providerVersionServiceImpl {
           await db.providerVersion.findMany({
             ...opts,
             where: {
-              provider: getProviderTenantFilter(d),
+              provider: getProviderTenantFilter({
+                ...d,
+                includeDeprecated
+              }),
 
               OR: [
                 { isEnvironmentLocked: false },
@@ -65,10 +70,14 @@ class providerVersionServiceImpl {
     solution: Solution;
     tenant?: Tenant;
     environment?: Environment;
+    includeDeprecated?: boolean;
   }) {
     let providerVersion = await db.providerVersion.findFirst({
       where: {
-        provider: getProviderTenantFilter(d),
+        provider: getProviderTenantFilter({
+          ...d,
+          includeDeprecated: true
+        }),
 
         OR: [
           { isEnvironmentLocked: false },

--- a/src/systems/subspace/modules/provider-internal/src/index.ts
+++ b/src/systems/subspace/modules/provider-internal/src/index.ts
@@ -3,6 +3,7 @@ import { cleanupCron } from './cron/cleanup';
 import { deploymentConfigPairQueues } from './queues/deploymentConfigPair';
 import { lifecycleQueues } from './queues/lifecycle';
 import { listingQueues } from './queues/listing';
+import { reconcilerQueues } from './queues/reconciler';
 import { searchQueues } from './queues/search';
 import { versionQueues } from './queues/version';
 
@@ -18,5 +19,6 @@ export let providerInternalQueueProcessor = combineQueueProcessors([
   lifecycleQueues,
   deploymentConfigPairQueues,
   versionQueues,
-  searchQueues
+  searchQueues,
+  reconcilerQueues
 ]);

--- a/src/systems/subspace/modules/provider-internal/src/queues/reconciler/deprecateProvider.ts
+++ b/src/systems/subspace/modules/provider-internal/src/queues/reconciler/deprecateProvider.ts
@@ -1,0 +1,79 @@
+import { createCron } from '@lowerdeck/cron';
+import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { db } from '@metorial-subspace/db';
+import { env } from '../../env';
+import { providerInternalService } from '../../services/provider';
+
+export let deprecateDockerProviderReconcilerCron = createCron(
+  {
+    name: 'sub/pint/reconcile/provider/deprecate/cron',
+    redisUrl: env.service.REDIS_URL,
+    cron: '0 0 * * *'
+  },
+  async () => {
+    await deprecateDockerProviderManyQueue.add({});
+  }
+);
+
+let deprecateDockerProviderManyQueue = createQueue<{ cursor?: string }>({
+  name: 'sub/pint/reconcile/provider/deprecate/many',
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: {
+    concurrency: 1
+  }
+});
+
+export let deprecateDockerProviderManyQueueProcessor =
+  deprecateDockerProviderManyQueue.process(async data => {
+    let providers = await db.provider.findMany({
+      where: {
+        id: data.cursor ? { gt: data.cursor } : undefined,
+        ownerTenantOid: null,
+        isDeprecated: false,
+        type: {
+          OR: [{ attributes: { path: ['backend'], equals: 'mcp.container' } }]
+        }
+      },
+      orderBy: { id: 'asc' },
+      take: 100,
+      select: { id: true }
+    });
+    if (providers.length === 0) return;
+
+    await deprecateDockerProviderSingleQueue.addMany(
+      providers.map(provider => ({
+        providerId: provider.id
+      }))
+    );
+
+    await deprecateDockerProviderManyQueue.add({
+      cursor: providers[providers.length - 1]!.id
+    });
+  });
+
+let deprecateDockerProviderSingleQueue = createQueue<{ providerId: string }>({
+  name: 'sub/pint/reconcile/provider/deprecate/single',
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: {
+    concurrency: 5,
+    limiter: {
+      max: 25,
+      duration: 1000
+    }
+  }
+});
+
+export let deprecateDockerProviderSingleQueueProcessor =
+  deprecateDockerProviderSingleQueue.process(async data => {
+    let provider = await db.provider.findFirst({
+      where: { id: data.providerId },
+      include: { type: true }
+    });
+    if (!provider) throw new QueueRetryError();
+    if (provider.isDeprecated || provider.ownerTenantOid !== null) return;
+
+    let backend = provider.type.attributes.backend;
+    if (backend !== 'mcp.container' && backend !== 'mcp.function') return;
+
+    await providerInternalService.deprecateProvider({ provider });
+  });

--- a/src/systems/subspace/modules/provider-internal/src/queues/reconciler/index.ts
+++ b/src/systems/subspace/modules/provider-internal/src/queues/reconciler/index.ts
@@ -1,0 +1,12 @@
+import { combineQueueProcessors } from '@lowerdeck/queue';
+import {
+  deprecateDockerProviderManyQueueProcessor,
+  deprecateDockerProviderReconcilerCron,
+  deprecateDockerProviderSingleQueueProcessor
+} from './deprecateProvider';
+
+export let reconcilerQueues = combineQueueProcessors([
+  deprecateDockerProviderReconcilerCron,
+  deprecateDockerProviderManyQueueProcessor,
+  deprecateDockerProviderSingleQueueProcessor
+]);

--- a/src/systems/subspace/modules/provider-internal/src/services/provider.ts
+++ b/src/systems/subspace/modules/provider-internal/src/services/provider.ts
@@ -250,6 +250,7 @@ class providerInternalServiceImpl {
 
         let allData = {
           isPublic: provider.access === 'public',
+          isDeprecated: provider.isDeprecated,
           ownerTenantOid: provider.access === 'tenant' ? provider.ownerTenantOid : null,
           ownerSolutionOid: provider.access === 'tenant' ? provider.ownerSolutionOid : null,
 
@@ -378,13 +379,46 @@ class providerInternalServiceImpl {
           readme: d.input.readme,
           skills: d.input.skills,
           image: d.input.image ?? undefined,
-          isPublic: provider.access === 'public'
+          isPublic: provider.access === 'public',
+          isDeprecated: provider.isDeprecated
         }
       });
 
       await addAfterTransactionHook(() =>
         listingUpdatedQueue.add({ providerListingId: listing.id })
       );
+
+      return provider;
+    });
+  }
+
+  async deprecateProvider(d: { provider: Provider }) {
+    // if (d.provider.isDeprecated) return d.provider;
+
+    return withTransaction(async db => {
+      let provider = await db.provider.update({
+        where: { id: d.provider.id },
+        data: { isDeprecated: true }
+      });
+
+      let listing = await db.providerListing.findFirst({
+        where: { providerOid: provider.oid }
+      });
+
+      if (listing) {
+        listing = await db.providerListing.update({
+          where: { providerOid: provider.oid },
+          data: { isDeprecated: true }
+        });
+      }
+
+      await addAfterTransactionHook(async () => {
+        await providerUpdatedQueue.add({ providerId: provider.id });
+
+        if (listing) {
+          await listingUpdatedQueue.add({ providerListingId: listing.id });
+        }
+      });
 
       return provider;
     });

--- a/src/systems/subspace/packages/list-utils/src/resources/provider.ts
+++ b/src/systems/subspace/packages/list-utils/src/resources/provider.ts
@@ -26,8 +26,8 @@ export let resolveProviders = createOptionalResolver(async ({ ts, ids }) =>
                 }
               : undefined!
           ].filter(Boolean)
-        }
-      ]
+        },
+      ].filter(Boolean)
     },
     select: { oid: true }
   })

--- a/src/systems/subspace/packages/presenters/src/provider.ts
+++ b/src/systems/subspace/packages/presenters/src/provider.ts
@@ -47,6 +47,7 @@ export let providerPresenter = (
     id: provider.id,
     access: provider.access,
     status: provider.status,
+    isDeprecated: provider.isDeprecated,
 
     ownerTenant: provider.ownerTenant ? tenantPresenter(provider.ownerTenant) : null,
     publisher: publisherPresenter(provider.publisher),
@@ -101,6 +102,7 @@ export let providerPreviewPresenter = (provider: Provider) => ({
   id: provider.id,
   access: provider.access,
   status: provider.status,
+  isDeprecated: provider.isDeprecated,
 
   tag: provider.tag,
 

--- a/src/systems/subspace/packages/presenters/src/providerListing.ts
+++ b/src/systems/subspace/packages/presenters/src/providerListing.ts
@@ -49,6 +49,7 @@ export let providerListingPresenter = (
   object: 'provider.listing',
 
   id: providerListing.id,
+  isDeprecated: providerListing.isDeprecated,
 
   isPublic: providerListing.isPublic,
   isCustomized: providerListing.isCustomized,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches DB schemas and session-lifecycle logic (magic MCP session rotation + mapping updates), which can affect active provider sessions if expiry/duration handling is wrong. Also expands catalog query behavior around deprecated providers, which may change what results API consumers see.
> 
> **Overview**
> **Magic MCP sessions now have expiry/rotation.** `MagicMcpSubspaceSessionConnection` gains `expiresAt`, `ensureMagicMcpSubspaceSession` reuses mappings only if unexpired and otherwise creates a new Subspace session, updates the mapping, and best-effort deletes the replaced session; the API presenter now returns `expires_at`.
> 
> **Projects can configure session rotation duration.** `Project` adds `magicMcpSessionDurationMinutes` (default `1440`), exposed via management create/update with validation and returned by the project presenter.
> 
> **OAuth and Subspace catalog enhancements.** OAuth adds `/.well-known/oauth-protected-resource` via `oauthOidcService.getOAuthProtectedResourceMetadata()`. Subspace adds `isDeprecated` on `Provider`/`ProviderListing`, threads `includeDeprecated` through list/get flows (default filtering deprecated out unless explicitly included/IDs provided), adds presenters fields, and introduces a daily reconciler queue/cron to auto-deprecate certain MCP container/function providers.
> 
> **Minor dashboard/UI tweaks.** Error group tables display humanized error names and updated column labels, and `Select` now uses dialog-aware z-index while open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d2cda4615eb5f95b981045e07b9b85580602b53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->