### PR TITLE
Fix ares admin

### DIFF
--- a/src/systems/ares/service/frontend/admin/vite.config.ts
+++ b/src/systems/ares/service/frontend/admin/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   base: '/metorial-ares-admin',
 
   resolve: {
-    dedupe: ['react', 'react-dom']
+    dedupe: ['react', 'react-dom', 'react-router', 'react-router-dom']
   },
 
   server: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config tweak limited to Vite module resolution; main risk is unexpected bundling/runtime behavior if the app relied on multiple router instances.
> 
> **Overview**
> Updates the Ares admin `vite.config.ts` to *dedupe* `react-router` and `react-router-dom` alongside React, reducing the chance of multiple router copies being bundled and causing hook/context mismatches at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53494fad89a4a9978a307f740e0d4c2da5b08503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->