### PR TITLE
Fix flow picker setup

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createButton.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createButton.tsx
@@ -29,6 +29,7 @@ export let ProviderAuthConfigCreateButton = (
       providerDeploymentId: p.providerDeploymentId,
       providerId: p.providerId,
       initialAuthMethodId: authMethodId,
+      autoStartManagedCredentialSetup: p.autoStartManagedCredentialSetup,
       onCreate: p.onCreate,
       onBack: p.onBack
     });

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createModal.tsx
@@ -12,6 +12,7 @@ export type ProviderAuthConfigCreateModalProps = {
   providerDeploymentId?: string;
   providerId?: string;
   initialAuthMethodId: string;
+  autoStartManagedCredentialSetup?: boolean;
   onCreate?: (authConfig: { id: string; name?: string | null }) => void;
   onBack?: () => void;
 };
@@ -160,6 +161,7 @@ export let ProviderAuthConfigCreateFlowContent = (
             providerName={providerName}
             providerImageUrl={authCreation.provider.data?.publisher.imageUrl}
             selectedMethod={method}
+            autoStartManagedCredentialSetup={p.autoStartManagedCredentialSetup}
             previewMode={previewMode}
             onPreviewModeChange={setPreviewMode}
             close={p.close}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createSetupFlowModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createSetupFlowModal.tsx
@@ -17,6 +17,7 @@ export let ProviderAuthConfigSetupFlowCreateContent = (p: {
   providerName: string;
   providerImageUrl?: string | null;
   selectedMethod: AuthMethod;
+  autoStartManagedCredentialSetup?: boolean;
   previewMode: PreviewMode;
   onPreviewModeChange: (mode: PreviewMode) => void;
   close: () => void;
@@ -49,7 +50,7 @@ export let ProviderAuthConfigSetupFlowCreateContent = (p: {
             showExternalPreviewSidebar
             collectAuthConfigDetails
             initialAuthConfigDetails={onboardingAuthDetails}
-            autoStartManagedCredentialSetup
+            autoStartManagedCredentialSetup={p.autoStartManagedCredentialSetup}
             onAuthConfigDetailsChange={setAuthPreviewDetails}
             cancelLabel={p.onCancel ? 'Close' : 'Cancel'}
             onWindowOpenCancel={p.close}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/methodPickerModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/methodPickerModal.tsx
@@ -53,6 +53,7 @@ let ProviderAuthConfigMethodPickerModalContent = (
           providerDeploymentId: p.providerDeploymentId,
           providerId: p.providerId,
           initialAuthMethodId: values.authMethodId,
+          autoStartManagedCredentialSetup: p.autoStartManagedCredentialSetup,
           onCreate: p.onCreate,
           onBack: p.onBack
         })
@@ -93,6 +94,7 @@ let ProviderAuthConfigMethodPickerModalContent = (
         providerDeploymentId: p.providerDeploymentId,
         providerId: p.providerId,
         initialAuthMethodId: singleMethodId,
+        autoStartManagedCredentialSetup: p.autoStartManagedCredentialSetup,
         onCreate: onCreateRef.current,
         onBack: onBackRef.current
       })

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
@@ -274,7 +274,11 @@ let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
       form.setFieldValue('selectedConfiguration', { kind: 'config', id: p.initialConfigId });
     }
 
-    if (p.initialAuthConfigId && selectedProviderRequiresAuth && !form.values.selectedAuthConfigId) {
+    if (
+      p.initialAuthConfigId &&
+      selectedProviderRequiresAuth &&
+      !form.values.selectedAuthConfigId
+    ) {
       form.setFieldValue('selectedAuthConfigId', p.initialAuthConfigId);
     }
 
@@ -620,6 +624,7 @@ type ProviderSetupSectionsProps = {
   showToolFilters?: boolean;
   showExistingConfigOptions?: boolean;
   showExistingAuthOptions?: boolean;
+  autoStartManagedCredentialSetup?: boolean;
   emptyState?: ReactNode;
   supplementaryContent?: ReactNode;
   footer?: ReactNode;
@@ -649,6 +654,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
   let showToolFilters = p.showToolFilters ?? true;
   let showExistingConfigOptions = p.showExistingConfigOptions ?? true;
   let showExistingAuthOptions = p.showExistingAuthOptions ?? true;
+  let autoStartManagedCredentialSetup = p.autoStartManagedCredentialSetup ?? false;
   let tools = useProviderTools(
     p.instanceId,
     showToolFilters && providerVersionId ? { providerVersionId } : null
@@ -905,6 +911,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
                 instanceId={p.instanceId}
                 providerDeploymentId={p.providerDeploymentId ?? undefined}
                 providerId={p.providerId}
+                autoStartManagedCredentialSetup={autoStartManagedCredentialSetup}
                 onCreate={async authConfig => {
                   pendingCreatedAuthConfigIdRef.current = authConfig.id;
                   setCreatedAuthConfigSelection({
@@ -990,7 +997,9 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
       setSectionModeOverrides(prev => ({ ...prev, [sectionId]: undefined }));
       let sectionToolKeySet = new Set(sectionTools.map(tool => tool.key));
       if (mode === 'allow') {
-        let nextKeys = [...new Set([...selectedToolKeys, ...sectionTools.map(tool => tool.key)])];
+        let nextKeys = [
+          ...new Set([...selectedToolKeys, ...sectionTools.map(tool => tool.key)])
+        ];
         let isAllSelected =
           normalizedTools.length > 0 &&
           normalizedTools.every(tool => nextKeys.includes(tool.key)) &&
@@ -1171,7 +1180,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
           ) : null}
         </div>
       ) : (
-        p.emptyState ?? null
+        (p.emptyState ?? null)
       )}
 
       {p.supplementaryContent}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: frontend-only prop plumbing that changes whether the managed-credential setup auto-starts in the auth-config setup flow; main risk is unintended UX/flow behavior differences if callers rely on the previous always-on default.
> 
> **Overview**
> Adds an optional `autoStartManagedCredentialSetup` flag to the provider auth-config creation flow and threads it from the create button/method picker through `showProviderAuthConfigCreateModal` into the setup-flow embed (`ProviderSetupSessionEmbed`).
> 
> Updates the session template provider panel (`ProviderSetupSections`) to accept this flag and pass it into `ProviderAuthConfigCreateButton`, with minor formatting-only tweaks elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7433e904cd058e5272d3566965a5fbfe330e384f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->