### PR TITLE
Fix managed cred scopes

### DIFF
--- a/src/systems/subspace/modules/auth/src/lib/managedOAuthScopes.ts
+++ b/src/systems/subspace/modules/auth/src/lib/managedOAuthScopes.ts
@@ -1,5 +1,46 @@
 export type ManagedOAuthScopes = NonNullable<PrismaJson.ProviderAuthMethodValue['scopes']>;
 
+let getManagedOAuthScopeId = (scope: unknown): string | null => {
+  if (typeof scope === 'string') {
+    return scope;
+  }
+
+  if (!scope || typeof scope !== 'object') {
+    return null;
+  }
+
+  if ('id' in scope && typeof scope.id === 'string') {
+    return scope.id;
+  }
+
+  if ('scope' in scope && typeof scope.scope === 'string') {
+    return scope.scope;
+  }
+
+  return null;
+};
+
+export let normalizeManagedOAuthScopeIds = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  let seen = new Set<string>();
+  let scopeIds: string[] = [];
+
+  for (let scope of value) {
+    let scopeId = getManagedOAuthScopeId(scope);
+    if (!scopeId || seen.has(scopeId)) {
+      continue;
+    }
+
+    seen.add(scopeId);
+    scopeIds.push(scopeId);
+  }
+
+  return scopeIds;
+};
+
 export let getManagedOAuthScopeIds = (value: ManagedOAuthScopes): string[] => {
-  return value.map(scope => scope.id);
+  return normalizeManagedOAuthScopeIds(value);
 };

--- a/src/systems/subspace/modules/auth/src/lib/managedProviderAuthCredentialsBacking.ts
+++ b/src/systems/subspace/modules/auth/src/lib/managedProviderAuthCredentialsBacking.ts
@@ -11,6 +11,7 @@ import {
   withTransaction
 } from '@metorial-subspace/db';
 import { getBackend } from '@metorial-subspace/provider';
+import { normalizeManagedOAuthScopeIds } from './managedOAuthScopes';
 import { env } from '../env';
 import {
   providerAuthCredentialsCreatedQueue,
@@ -81,7 +82,7 @@ export let ensureManagedProviderAuthCredentialsBacking = async (d: {
 }) => {
   let provider = getProviderForManagedCredentials(d.managedCredentials);
   let managedCredentialsGlobalOid = getProviderAuthMethodGlobalOid(d.managedCredentials);
-  let managedScopeIds = d.managedCredentials.oauthScopes as unknown as string[];
+  let managedScopeIds = normalizeManagedOAuthScopeIds(d.managedCredentials.oauthScopes);
   let desiredStatus =
     d.managedCredentials.status === 'archived' ? ('archived' as const) : ('active' as const);
   let syncAfter = d.managedCredentials.updatedAt.getTime();
@@ -128,8 +129,10 @@ export let ensureManagedProviderAuthCredentialsBacking = async (d: {
       }
     });
 
-    let desiredScopes = (existing?.scopes ?? managedScopeIds).filter(scope =>
-      managedScopeIds.includes(scope)
+    // Older rows may still contain scope objects instead of scope IDs.
+    let existingScopeIds = normalizeManagedOAuthScopeIds(existing?.scopes);
+    let desiredScopes = (existingScopeIds.length ? existingScopeIds : managedScopeIds).filter(
+      scope => managedScopeIds.includes(scope)
     );
 
     let backendProviderAuthCredentials = await backend.auth.createProviderAuthCredentials({

--- a/src/systems/subspace/modules/auth/src/services/providerAuthCredentials.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthCredentials.ts
@@ -35,6 +35,7 @@ import {
   type ManagedProviderAuthCredentialsBackingSource,
   managedProviderAuthCredentialsBackingSourceInclude
 } from '../lib/managedProviderAuthCredentialsBacking';
+import { normalizeManagedOAuthScopeIds } from '../lib/managedOAuthScopes';
 import {
   providerAuthCredentialsArchivedQueue,
   providerAuthCredentialsCreatedQueue,
@@ -174,6 +175,7 @@ class providerAuthCredentialsServiceImpl {
     let origin = d.origin?.length ? d.origin : defaultListOrigins;
     let includeTenantCreated = origin.includes('tenant_created');
     let includeManagedBacking = origin.includes('managed_backing');
+
     let search = d.search
       ? await voyager.record.search({
           tenantId: d.tenant.id,
@@ -229,7 +231,7 @@ class providerAuthCredentialsServiceImpl {
                         tenant: d.tenant,
                         solution: d.solution,
                         ids: credentialIds,
-                        providerAuthMethodGlobalOids: authMethodsGlobal?.oidIn.oid.in
+                        providerAuthMethodGlobalOids: authMethodsGlobal?.oids
                       })
                     : undefined!
                 ].filter(Boolean)
@@ -347,7 +349,7 @@ class providerAuthCredentialsServiceImpl {
     });
 
     if (d.input.scopes && managedCredentials) {
-      let allowedScopes = new Set(managedCredentials.oauthScopes);
+      let allowedScopes = new Set(normalizeManagedOAuthScopeIds(managedCredentials.oauthScopes));
       let invalidScopes = d.input.scopes.filter(scope => !allowedScopes.has(scope));
       if (invalidScopes.length > 0) {
         throw new ServiceError(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches managed OAuth scope normalization and scope-subset validation when syncing/creating provider auth credentials, which can affect what scopes are persisted and accepted. Low implementation complexity, but mistakes could cause incorrect scope restriction or unexpected scope drops for managed credentials.
> 
> **Overview**
> Fixes managed-credential scope handling by **normalizing scopes into unique string IDs** (accepting legacy shapes like `{id}`/`{scope}` as well as raw strings) via new `normalizeManagedOAuthScopeIds`.
> 
> Managed backing sync now derives `desiredScopes` using normalized existing scopes (for older DB rows) and intersects them with the current managed scope set, and managed-credential updates now validate requested scopes against the normalized managed scope list (instead of assuming it’s already `string[]`).
> 
> Also updates the tenant list filter to pass the resolved auth-method global OIDs via `authMethodsGlobal?.oids`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b2d710aaba09cde8e456406290950514f16ca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->