### PR TITLE
Various ui fixes

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/components/runLogs.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/components/runLogs.tsx
@@ -9,6 +9,11 @@ let Wrapper = styled.div`
   background: #1a1a1a;
   overflow: hidden;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+
+  ::selection {
+    background-color: #ffcc00;
+    color: #000;
+  }
 `;
 
 let Header = styled.header`

--- a/src/frontend/apps/dashboard/src/slices/product/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/index.tsx
@@ -1,4 +1,4 @@
-import { PaginationSearchParamsProvider, renderWithLoader } from '@metorial/data-hooks';
+import { renderWithLoader } from '@metorial/data-hooks';
 import { dynamicPage } from '@metorial/dynamic-component';
 import { createSlice } from '@metorial/microfrontend';
 import { NotFound } from '@metorial/pages';
@@ -518,11 +518,7 @@ let ProductWrapper = () => {
     lastInstanceIdStore.set(instance.data.id);
   }, [instance.data]);
 
-  return (
-    <PaginationSearchParamsProvider enabled={true}>
-      <Outlet />
-    </PaginationSearchParamsProvider>
-  );
+  return <Outlet />;
 };
 
 export let productTraceSlice = createSlice([

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(callbacks)/(list)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(callbacks)/(list)/_layout.tsx
@@ -1,3 +1,4 @@
+import { PaginationSearchParamsProvider } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -53,7 +54,9 @@ export let CallbacksListLayout = () => {
         }
       />
 
-      <Outlet />
+      <PaginationSearchParamsProvider enabled={true}>
+        <Outlet />
+      </PaginationSearchParamsProvider>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/(list)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/(list)/_layout.tsx
@@ -1,3 +1,4 @@
+import { PaginationSearchParamsProvider } from '@metorial/data-hooks';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
   useCurrentInstance,
@@ -53,7 +54,11 @@ export let ManagedProvidersListLayout = () => {
                 });
               }}
             >
-              <Button size="2" loading={user.isLoading} disabled={!user.data && !user.isLoading}>
+              <Button
+                size="2"
+                loading={user.isLoading}
+                disabled={!user.data && !user.isLoading}
+              >
                 Create Custom Provider
               </Button>
             </Menu>
@@ -75,7 +80,9 @@ export let ManagedProvidersListLayout = () => {
         }
       />
 
-      <Outlet />
+      <PaginationSearchParamsProvider enabled={true}>
+        <Outlet />
+      </PaginationSearchParamsProvider>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/(list)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/(list)/_layout.tsx
@@ -1,3 +1,4 @@
+import { PaginationSearchParamsProvider } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -15,7 +16,9 @@ export let ProvidersListLayout = () => {
   return (
     <ContentLayout>
       <PageHeader title="Providers" description="Browse and deploy providers on Metorial." />
-      <Outlet />
+      <PaginationSearchParamsProvider enabled={true}>
+        <Outlet />
+      </PaginationSearchParamsProvider>
     </ContentLayout>
   );
 };
@@ -61,7 +64,9 @@ export let SessionTemplatesListLayout = () => {
         }
       />
 
-      <Outlet />
+      <PaginationSearchParamsProvider enabled={true}>
+        <Outlet />
+      </PaginationSearchParamsProvider>
     </ContentLayout>
   );
 };
@@ -97,7 +102,9 @@ export let ProviderSessionsListLayout = () => {
         ]}
       />
 
-      <Outlet />
+      <PaginationSearchParamsProvider enabled={true}>
+        <Outlet />
+      </PaginationSearchParamsProvider>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/(list)/provider-auth-credentials.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/(list)/provider-auth-credentials.tsx
@@ -168,7 +168,18 @@ export let providerAuthCredentialsTable = new DashboardTable<
       isDefault: true,
       header: 'Name',
       render: row => (
-        <Text size="2" weight="strong">
+        <Text
+          size="2"
+          weight="strong"
+          style={{ display: 'inline-flex', alignItems: 'center' }}
+        >
+          {row.isManaged && (
+            <div style={{ marginRight: 5, display: 'inline-flex', verticalAlign: 'middle' }}>
+              <Badge color="blue" size="1">
+                Managed
+              </Badge>
+            </div>
+          )}
           {row.name || '—'}
         </Text>
       )

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/components/scopePicker.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/components/scopePicker.tsx
@@ -1,0 +1,224 @@
+import { Checkbox, Flex, OptionToggle, Text, theme } from '@metorial/ui';
+import { useMemo, useState } from 'react';
+
+type ScopePermissionMode = 'allow' | 'reject' | 'mixed';
+type ScopeSectionId = 'read' | 'write' | 'dangerous';
+
+export type ScopePickerScope = {
+  id?: string;
+  scope: string;
+  name?: string | null;
+  description?: string | null;
+};
+
+let dangerousScopeKeywords = [
+  'admin',
+  'delete',
+  'remove',
+  'destroy',
+  'danger',
+  'manage',
+  'owner',
+  'root',
+  'full_access',
+  'full-access',
+  'full access'
+];
+
+let readOnlyScopeKeywords = [
+  'read',
+  'readonly',
+  'read_only',
+  'read-only',
+  'view',
+  'list',
+  'get'
+];
+
+let getScopeSearchValue = (scope: ScopePickerScope) =>
+  [scope.id, scope.scope, scope.name].filter(Boolean).join(' ').toLowerCase();
+
+let getScopeSectionId = (scope: ScopePickerScope): ScopeSectionId => {
+  let searchValue = getScopeSearchValue(scope);
+
+  if (dangerousScopeKeywords.some(keyword => searchValue.includes(keyword))) {
+    return 'dangerous';
+  }
+
+  if (readOnlyScopeKeywords.some(keyword => searchValue.includes(keyword))) {
+    return 'read';
+  }
+
+  return 'write';
+};
+
+export let ScopePicker = ({
+  scopes,
+  selectedScopes,
+  onSelectedScopesChange,
+  disabled
+}: {
+  scopes: ScopePickerScope[];
+  selectedScopes: string[];
+  onSelectedScopesChange: (scopes: string[]) => void;
+  disabled?: boolean;
+}) => {
+  let [sectionModeOverrides, setSectionModeOverrides] = useState<
+    Partial<Record<ScopeSectionId, ScopePermissionMode>>
+  >({});
+  let normalizedScopes = useMemo(() => {
+    let seen = new Set<string>();
+    return scopes.filter(scope => {
+      if (seen.has(scope.scope)) return false;
+      seen.add(scope.scope);
+      return true;
+    });
+  }, [scopes]);
+  let scopeSections = useMemo(
+    () =>
+      [
+        { id: 'read', title: 'Read-Only Scopes', scopes: [] },
+        { id: 'write', title: 'Write/Custom Scopes', scopes: [] },
+        { id: 'dangerous', title: 'Dangerous Scopes', scopes: [] }
+      ].map(section => ({
+        ...section,
+        scopes: normalizedScopes.filter(scope => getScopeSectionId(scope) === section.id)
+      })) as { id: ScopeSectionId; title: string; scopes: ScopePickerScope[] }[],
+    [normalizedScopes]
+  );
+  let selectedScopeSet = new Set(selectedScopes);
+
+  let updateSelectedScopes = (nextScopes: string[]) => {
+    let allowedScopes = new Set(normalizedScopes.map(scope => scope.scope));
+    onSelectedScopesChange(nextScopes.filter(scope => allowedScopes.has(scope)));
+  };
+
+  let setScopeChecked = (scope: string, checked: boolean) => {
+    let selectedScope = normalizedScopes.find(s => s.scope === scope);
+    if (!selectedScope) return;
+
+    let sectionId = getScopeSectionId(selectedScope);
+    setSectionModeOverrides(prev => ({ ...prev, [sectionId]: undefined }));
+
+    let nextScopes = checked
+      ? [...new Set([...selectedScopes, scope])]
+      : selectedScopes.filter(selectedScope => selectedScope !== scope);
+
+    updateSelectedScopes(nextScopes);
+  };
+
+  let getSectionMode = (sectionScopes: ScopePickerScope[]): ScopePermissionMode => {
+    if (sectionScopes.length === 0) return 'reject';
+
+    let selectedCount = sectionScopes.filter(scope =>
+      selectedScopeSet.has(scope.scope)
+    ).length;
+
+    if (selectedCount === 0) return 'reject';
+    if (selectedCount === sectionScopes.length) return 'allow';
+    return 'mixed';
+  };
+
+  let setSectionMode = (
+    sectionId: ScopeSectionId,
+    sectionScopes: ScopePickerScope[],
+    mode: ScopePermissionMode
+  ) => {
+    if (sectionScopes.length === 0) return;
+    if (mode === 'mixed') {
+      setSectionModeOverrides(prev => ({ ...prev, [sectionId]: 'mixed' }));
+      return;
+    }
+
+    setSectionModeOverrides(prev => ({ ...prev, [sectionId]: undefined }));
+
+    let sectionScopeSet = new Set(sectionScopes.map(scope => scope.scope));
+    updateSelectedScopes(
+      mode === 'allow'
+        ? [...new Set([...selectedScopes, ...sectionScopes.map(scope => scope.scope)])]
+        : selectedScopes.filter(scope => !sectionScopeSet.has(scope))
+    );
+  };
+
+  if (normalizedScopes.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        marginRight: -20,
+        paddingRight: 20
+      }}
+    >
+      <Flex direction="column" gap={12}>
+        {scopeSections
+          .filter(section => section.scopes.length > 0)
+          .map(section => (
+            <div key={section.id} style={{ padding: '6px 0 8px' }}>
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'minmax(120px, 1fr) auto',
+                  gap: 10,
+                  alignItems: 'center'
+                }}
+              >
+                <Text size="2" style={{ fontWeight: 600, lineHeight: 1.2 }}>
+                  {section.title} ({section.scopes.length})
+                </Text>
+                <OptionToggle
+                  size="1"
+                  value={sectionModeOverrides[section.id] ?? getSectionMode(section.scopes)}
+                  disabled={disabled}
+                  onChange={value => {
+                    if (value !== 'allow' && value !== 'reject' && value !== 'mixed') {
+                      return;
+                    }
+
+                    setSectionMode(section.id, section.scopes, value);
+                  }}
+                  items={[
+                    { id: 'allow', label: 'Allow' },
+                    { id: 'reject', label: 'Reject' },
+                    { id: 'mixed', label: 'Mixed' }
+                  ]}
+                />
+              </div>
+
+              <Flex direction="column" gap={0} style={{ marginTop: 12 }}>
+                {section.scopes.map((scope, idx) => (
+                  <div
+                    key={scope.id ?? scope.scope}
+                    style={{
+                      padding: '9px 2px',
+                      borderBottom:
+                        idx === section.scopes.length - 1
+                          ? 'none'
+                          : `1px solid ${theme.colors.gray200}`
+                    }}
+                  >
+                    <Checkbox
+                      checked={selectedScopeSet.has(scope.scope)}
+                      disabled={disabled}
+                      onCheckedChange={checked => setScopeChecked(scope.scope, !!checked)}
+                      label={
+                        <Flex direction="column" gap={2}>
+                          <Text size="2" weight="medium">
+                            {scope.name ?? scope.scope}
+                          </Text>
+                          {scope.description ? (
+                            <Text size="1" color="gray600">
+                              {scope.description}
+                            </Text>
+                          ) : null}
+                        </Flex>
+                      }
+                    />
+                  </div>
+                ))}
+              </Flex>
+            </div>
+          ))}
+      </Flex>
+    </div>
+  );
+};

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/index.tsx
@@ -1,9 +1,16 @@
 import { renderWithLoader } from '@metorial/data-hooks';
-import { useCurrentInstance, useProvider, useProviderAuthCredential } from '@metorial/state';
-import { Attributes, Callout, RenderDate, Spacer } from '@metorial/ui';
+import {
+  useCurrentInstance,
+  useProvider,
+  useProviderAuthCredential,
+  useProviderAuthMethods
+} from '@metorial/state';
+import { Attributes, Button, Callout, RenderDate, Spacer } from '@metorial/ui';
 import { Box, ID } from '@metorial/ui-product';
+import { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { ProviderAuthErrorsTable } from '../../../scenes/providerAuthErrors/table';
+import { ScopePicker } from './components/scopePicker';
 
 export let ProviderAuthCredentialOverviewPage = () => {
   let instance = useCurrentInstance();
@@ -11,12 +18,31 @@ export let ProviderAuthCredentialOverviewPage = () => {
   let { providerAuthCredentialsId } = useParams();
   let credential = useProviderAuthCredential(instance.data?.id, providerAuthCredentialsId);
   let provider = useProvider(instance.data?.id, credential.data?.providerId);
+  let versionId = provider.data?.currentVersion?.id;
+  let authMethods = useProviderAuthMethods(
+    instance.data?.id,
+    versionId ? { providerVersionId: versionId } : null
+  );
+  let availableScopes = useMemo(() => {
+    let oauthMethod = (authMethods.data?.items ?? []).find(m => m.type === 'oauth');
+    return oauthMethod?.scopes ?? [];
+  }, [authMethods.data?.items]);
+  let [selectedScopes, setSelectedScopes] = useState<string[] | null>(null);
+
+  let credentialScopes = credential.data?.scopes;
+  let effectiveScopes =
+    selectedScopes ?? credentialScopes ?? availableScopes.map(s => s.scope);
+  let scopesMutator = credential.useUpdateMutator();
+
+  let saveScopes = async () => {
+    await scopesMutator.mutate({ scopes: effectiveScopes });
+  };
 
   return renderWithLoader({ credential })(({ credential }) => (
     <>
       {credential.data.isManaged && (
         <>
-          <Callout color="blue">Managed by Metorial.</Callout>
+          <Callout color="blue">These auth credentials are managed by Metorial.</Callout>
           <Spacer size={12} />
         </>
       )}
@@ -67,6 +93,38 @@ export let ProviderAuthCredentialOverviewPage = () => {
           linkToDetail
         />
       </Box>
+
+      {availableScopes.length > 0 && (
+        <>
+          <Spacer size={12} />
+
+          <Box
+            title="Scopes"
+            description="Select which OAuth scopes this credential should request."
+          >
+            <ScopePicker
+              scopes={availableScopes}
+              selectedScopes={effectiveScopes}
+              onSelectedScopesChange={setSelectedScopes}
+            />
+
+            <Spacer size={15} />
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <Button
+                size="2"
+                onClick={saveScopes}
+                loading={scopesMutator.isLoading}
+                success={scopesMutator.isSuccess}
+              >
+                Save
+              </Button>
+            </div>
+
+            <scopesMutator.RenderError />
+          </Box>
+        </>
+      )}
     </>
   ));
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/settings.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/settings.tsx
@@ -6,25 +6,13 @@ import {
   useProviderAuthCredential,
   useProviderAuthMethods
 } from '@metorial/state';
-import { Button, Callout, Checkbox, Flex, Input, Spacer, Text } from '@metorial/ui';
+import { Button, Callout, Input, Spacer } from '@metorial/ui';
 import { Box } from '@metorial/ui-product';
 import { useMemo, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import styled from 'styled-components';
 import { DeleteResourceDangerZone } from '../../../scenes/deleteResourceDangerZone';
 import { getFromDeployment } from '../fromDeployment';
-
-let ScopesList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-`;
-
-let ScopeItem = styled.div`
-  display: flex;
-  align-items: flex-start;
-  gap: 4px;
-`;
+import { ScopePicker } from './components/scopePicker';
 
 export let ProviderAuthCredentialSettingsPage = () => {
   let instance = useCurrentInstance();
@@ -45,11 +33,11 @@ export let ProviderAuthCredentialSettingsPage = () => {
     return oauthMethod?.scopes ?? [];
   }, [authMethods.data?.items]);
 
-  let [selectedScopes, setSelectedScopes] = useState<Set<string> | null>(null);
+  let [selectedScopes, setSelectedScopes] = useState<string[] | null>(null);
 
   let credentialScopes = credential.data?.scopes;
   let effectiveScopes =
-    selectedScopes ?? new Set(credentialScopes ?? availableScopes.map(s => s.scope));
+    selectedScopes ?? credentialScopes ?? availableScopes.map(s => s.scope);
 
   let updateMutator = credential.useUpdateMutator();
   let scopesMutator = credential.useUpdateMutator();
@@ -74,19 +62,9 @@ export let ProviderAuthCredentialSettingsPage = () => {
       }) as any
   });
 
-  let toggleScope = (scope: string) => {
-    let next = new Set(effectiveScopes);
-    if (next.has(scope)) {
-      next.delete(scope);
-    } else {
-      next.add(scope);
-    }
-    setSelectedScopes(next);
-  };
-
   let saveScopes = async () => {
     // if (credential.data?.isManaged) return;
-    await scopesMutator.mutate({ scopes: [...effectiveScopes] });
+    await scopesMutator.mutate({ scopes: effectiveScopes });
   };
 
   return renderWithLoader({ credential })(({ credential }) => (
@@ -129,28 +107,11 @@ export let ProviderAuthCredentialSettingsPage = () => {
             title="Scopes"
             description="Select which OAuth scopes this credential should request."
           >
-            <ScopesList>
-              {availableScopes.map(scope => (
-                <ScopeItem key={scope.id}>
-                  <Checkbox
-                    checked={effectiveScopes.has(scope.scope)}
-                    onCheckedChange={() => toggleScope(scope.scope)}
-                    label={
-                      <Flex direction="column" gap={2}>
-                        <Text size="2" weight="medium">
-                          {scope.name}
-                        </Text>
-                        {scope.description && (
-                          <Text size="1" color="gray600">
-                            {scope.description}
-                          </Text>
-                        )}
-                      </Flex>
-                    }
-                  />
-                </ScopeItem>
-              ))}
-            </ScopesList>
+            <ScopePicker
+              scopes={availableScopes}
+              selectedScopes={effectiveScopes}
+              onSelectedScopesChange={setSelectedScopes}
+            />
 
             <Spacer size={15} />
 

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/(list)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/(list)/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { PaginationSearchParamsProvider, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -111,7 +111,9 @@ export let IdentityListLayout = () => {
         ) : !isPaidIdentityEnabled(flags.data.flags) ? (
           getIdentityUpgrade()
         ) : (
-          <Outlet />
+          <PaginationSearchParamsProvider enabled={true}>
+            <Outlet />
+          </PaginationSearchParamsProvider>
         )}
       </ContentLayout>
     )

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/(list)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/(list)/_layout.tsx
@@ -1,3 +1,4 @@
+import { PaginationSearchParamsProvider } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -40,7 +41,9 @@ export let SessionLogsListLayout = () => {
         ]}
       />
 
-      <Outlet />
+      <PaginationSearchParamsProvider enabled={true}>
+        <Outlet />
+      </PaginationSearchParamsProvider>
     </ContentLayout>
   );
 };
@@ -81,7 +84,9 @@ export let AuthLogsListLayout = () => {
         ]}
       />
 
-      <Outlet />
+      <PaginationSearchParamsProvider enabled={true}>
+        <Outlet />
+      </PaginationSearchParamsProvider>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(session)/(list)/session-templates.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(session)/(list)/session-templates.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { PaginationSearchParamsProvider, renderWithLoader } from '@metorial/data-hooks';
 import { useCurrentInstance } from '@metorial/state';
 import { SessionTemplatesTable } from '../../../scenes/sessionTemplates/table';
 
@@ -6,6 +6,8 @@ export let SessionTemplatesPage = () => {
   let instance = useCurrentInstance();
 
   return renderWithLoader({ instance })(({ instance }) => (
-    <SessionTemplatesTable instanceId={instance.data.id} />
+    <PaginationSearchParamsProvider enabled={true}>
+      <SessionTemplatesTable instanceId={instance.data.id} />
+    </PaginationSearchParamsProvider>
   ));
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/explorer/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/explorer/index.tsx
@@ -43,8 +43,8 @@ import {
 } from '../../lib/configSelection';
 import { ProviderDeploymentsList } from '../../scenes/providerDeployments/list';
 import { ProviderSearch } from '../../scenes/providers/search';
-import { SessionTracingScene } from '../../scenes/sessionTracing';
 import { ProviderSetupSections } from '../../scenes/sessionTemplates/addProviderPanelFlow';
+import { SessionTracingScene } from '../../scenes/sessionTracing';
 
 type ProviderSelection =
   | DashboardInstanceProvidersListOutput['items'][number]
@@ -847,7 +847,10 @@ export let ExplorerPage = () => {
 
         {sessionId &&
           !isCreatingSession &&
-          renderWithLoader({ session: sessionFromQuery })(({ session }) => (
+          renderWithLoader(
+            { session: sessionFromQuery },
+            { spaceTop: 20 }
+          )(({ session }) => (
             <SessionTracingScene
               session={session.data}
               initialExplorerTab

--- a/src/frontend/apps/dashboard/src/slices/product/pages/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/index.tsx
@@ -178,7 +178,7 @@ export let ProjectHomePage = () => {
       {user.data && (
         <PageHeader
           title={`Welcome to Metorial, ${user.data?.name}!`}
-          description="It's a good day to build something amazing."
+          description="It's a good day to build something amazing. Here are your resource at a glance."
         />
       )}
 
@@ -376,6 +376,13 @@ export let ProjectHomePage = () => {
             title="Your Integrations"
             description="Your providers and popular providers on Metorial at a glance."
             size="5"
+            actions={
+              <Link to={Paths.instance.providers(...pathItems)}>
+                <Button size="2" as="span" variant="outline">
+                  View All Providers
+                </Button>
+              </Link>
+            }
           />
 
           <ProvidersGrid limit={9} orderByUse="last_deployment_at" orderByRank />
@@ -386,6 +393,13 @@ export let ProjectHomePage = () => {
             title="Recent Sessions"
             description="Your recent sessions are listed below. Click on a session to view its details."
             size="5"
+            actions={
+              <Link to={Paths.instance.logs(...pathItems)}>
+                <Button size="2" as="span" variant="outline">
+                  View Logs
+                </Button>
+              </Link>
+            }
           />
 
           <ProviderSessionsTable limit={15} />

--- a/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/(list)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/(list)/_layout.tsx
@@ -1,3 +1,4 @@
+import { PaginationSearchParamsProvider } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -78,7 +79,9 @@ export let MagicMcpListLayout = () => {
         ]}
       />
 
-      <Outlet />
+      <PaginationSearchParamsProvider enabled={true}>
+        <Outlet />
+      </PaginationSearchParamsProvider>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/grid.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/grid.tsx
@@ -1,5 +1,5 @@
 import type { DashboardInstanceProviderListingsListQuery } from '@metorial/dashboard-sdk';
-import { renderWithPagination } from '@metorial/data-hooks';
+import { renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { useCurrentInstance, useProviderListings } from '@metorial/state';
 import { Avatar, Badge, Text } from '@metorial/ui';
@@ -29,7 +29,7 @@ export let ProvidersGrid = (filter: DashboardInstanceProviderListingsListQuery) 
   let instance = useCurrentInstance();
   let providers = useProviderListings(instance.data?.id, filter);
 
-  return renderWithPagination(providers)(providers => (
+  return renderWithLoader({ providers })(({ providers }) => (
     <>
       {providers.data.items.length > 0 && (
         <ItemGrid.Root width="300px">

--- a/src/systems/slates/apps/hub/src/aresClient.ts
+++ b/src/systems/slates/apps/hub/src/aresClient.ts
@@ -26,10 +26,12 @@ export let aresAdminApp = aresAdminAppProm.promise;
         slug: 'metorial-slates-hub-admin',
         defaultRedirectUrl: `${env.service.SERVICE_PUBLIC_URL}`,
         redirectDomains: [
+          new URL(env.service.SERVICE_PUBLIC_URL).hostname,
           '*.metorial.com',
           '*.metorial.dev',
           '*.metorial.net',
-          '*.metorial-internal.com'
+          '*.metorial-internal.com',
+          '*.metorial-staging.com'
         ]
       });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new UI for editing OAuth scopes on provider auth credentials and shifts pagination URL-state management to multiple list layouts, which could affect auth credential configuration and list navigation behavior. Also updates Ares admin app redirect domain allowlist, which impacts login/redirect configuration for hub admin.
> 
> **Overview**
> **Dashboard UI/UX improvements across product pages.** Pagination URL state (`PaginationSearchParamsProvider`) is moved from the top-level `ProductWrapper` into specific list layouts (logs, identity, providers/deployments, callbacks, custom providers, magic-mcp, session templates), so only list routes manage pagination params.
> 
> **Provider auth credentials enhancements.** The auth-credentials table now labels managed credentials with a `Managed` badge, and auth credential *overview* and *settings* pages add an OAuth scope editor with a new `ScopePicker` (grouped read/write/dangerous with section-level allow/reject/mixed toggles) plus a Save action that persists selected scopes.
> 
> **Misc UI fixes.** Run logs selection styling is improved, the Explorer session view adds top spacing to the loader render, the home page adds “View All Providers”/“View Logs” actions and tweaks welcome copy, and `ProvidersGrid` switches from `renderWithPagination` to `renderWithLoader`.
> 
> **Hub admin redirect config.** `aresClient` now includes the service hostname and `*.metorial-staging.com` in the Ares admin app `redirectDomains` allowlist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a0f2187368e5bcd424527beb93ca488a38f1e65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->