### PR TITLE
handle failed setup sessions better

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/index.tsx
@@ -330,6 +330,17 @@ export let ProviderSetupSessionEmbed = ({
     setError(null);
   };
 
+  let clearSetupSessionForRetry = () => {
+    if (setupWindowRef.current && !setupWindowRef.current.closed) {
+      setupWindowRef.current.close();
+    }
+
+    setupWindowRef.current = null;
+    pollingRef.current = false;
+    setSetupSession(null);
+    setSetupWindowBlocked(false);
+  };
+
   let handleMethodChange = (value: string) => {
     methodForm.setFieldValue('selectedMethodId', value);
     autoStartedManagedSetupRef.current = false;
@@ -620,6 +631,7 @@ export let ProviderSetupSessionEmbed = ({
               ? 'Setup session expired. Please start again.'
               : 'Setup session failed. Please try again.'
           );
+          clearSetupSessionForRetry();
           return;
         }
       }
@@ -627,6 +639,7 @@ export let ProviderSetupSessionEmbed = ({
       attempts += 1;
       if (attempts > 120) {
         setError('Authentication timed out. Please try again.');
+        clearSetupSessionForRetry();
         return;
       }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk UI state management change confined to the provider setup session embed flow. Main risk is subtle regressions in popup/polling state if the new reset logic is triggered unexpectedly.
> 
> **Overview**
> Improves the provider deployment auth setup flow by explicitly clearing/closing the setup popup and resetting `setupSession`/polling state when a setup session **fails**, **expires**, or **times out**, allowing the user to retry cleanly without a stuck window or ongoing poll.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c75690f9877e73c4f1a06f65ae0e9d7550ed3da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->