### PR TITLE
Set slate auth method correctly

### DIFF
--- a/src/packages/frontend/ui/src/error/index.tsx
+++ b/src/packages/frontend/ui/src/error/index.tsx
@@ -23,6 +23,13 @@ export let Error = ({
 }) => {
   let sizeString = (typeof size == 'number' ? `${size}px` : size) || '14px';
 
+  let inner = children;
+
+  if (typeof children == 'string' && children.startsWith('[') && children.includes(']')) {
+    let endIndex = children.indexOf(']');
+    inner = children.substring(endIndex + 1);
+  }
+
   return (
     <Wrapper
       style={{
@@ -38,7 +45,7 @@ export let Error = ({
         <RiErrorWarningLine size={calc.multiply(sizeString, 1.3)} />
       </span>
 
-      <span>{children}</span>
+      <span>{inner}</span>
     </Wrapper>
   );
 };

--- a/src/systems/slates/apps/hub/src/services/slateAuthConfig.ts
+++ b/src/systems/slates/apps/hub/src/services/slateAuthConfig.ts
@@ -45,6 +45,7 @@ class slateAuthConfigServiceImpl {
       ? fullVersion.specification?.slateAuthMethods.find(
           m =>
             m.authMethod.id === d.input.authMethodId ||
+            m.authMethod.identifier === d.input.authMethodId ||
             m.authMethod.type === d.input.authMethodId ||
             m.authMethod.key === d.input.authMethodId
         )

--- a/src/systems/slates/apps/hub/src/services/slateOAuthSetup.ts
+++ b/src/systems/slates/apps/hub/src/services/slateOAuthSetup.ts
@@ -59,6 +59,7 @@ class slateOAuthSetupServiceImpl {
       ? authMethods.find(
           m =>
             m.id === d.input.authMethodId ||
+            m.identifier === d.input.authMethodId ||
             m.type === d.input.authMethodId ||
             m.key === d.input.authMethodId
         )

--- a/src/systems/subspace/provider-backends/provider-slates/src/impl/auth.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/impl/auth.ts
@@ -189,7 +189,7 @@ export class ProviderAuth extends IProviderAuth {
       tenantId: tenant.id,
       slateId: slate.id,
       slateVersionId: slateVersion.id,
-      authMethodId: data.authMethod.callableId,
+      authMethodId: data.authMethod.specId,
 
       input: data.input,
       redirectUrl: data.redirectUrl,
@@ -239,7 +239,7 @@ export class ProviderAuth extends IProviderAuth {
       tenantId: tenant.id,
       slateId: slate.id,
       slateVersionId: slateVersion.id,
-      authMethodId: data.authMethod.value.callableId,
+      authMethodId: data.authMethod.specId,
       authConfig: data.input
     });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches provider authentication configuration and OAuth setup paths by changing how auth methods are resolved/identified, which could affect login/config flows if IDs don’t match expected values. Scope is small and localized, but impacts auth-related requests.
> 
> **Overview**
> Fixes slate auth method resolution by allowing `authMethodId` inputs to match an auth method’s `identifier` (in addition to `id`/`type`/`key`) in `slateAuthConfig` and `slateOAuthSetup` creation.
> 
> Corrects the auth method ID sent from the provider backend to Slates when creating OAuth setups and auth configs, switching from `callableId` to the spec’s `specId`.
> 
> Separately, the UI `Error` component now strips leading bracketed prefixes (e.g. `[...]`) from string error messages before rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfc16edcced0d1781e36dec83045c8d092a72e25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->