### PR TITLE
Fix transaction issues

### DIFF
--- a/src/backend/modules/organization/src/services/projectBrand.ts
+++ b/src/backend/modules/organization/src/services/projectBrand.ts
@@ -183,29 +183,27 @@ class ProjectBrandService {
     project: Project & { organization: Organization };
     brand: { name: string; image: PrismaJson.EntityImage };
   }) {
-    return withTransaction(async db => {
-      let instance = await db.instance.findFirst({
-        where: { projectOid: d.project.oid, status: 'active' },
-        include: { project: true, organization: true }
-      });
-      if (!instance) return;
+    let instance = await db.instance.findFirst({
+      where: { projectOid: d.project.oid, status: 'active' },
+      include: { project: true, organization: true }
+    });
+    if (!instance) return;
 
-      let { tenant } = await getTenantForSubspace(instance);
+    let { tenant } = await getTenantForSubspace(instance);
 
-      let brand = await subspaceBrandService.upsert({
-        instance,
-        name: d.brand.name,
-        image: d.brand.image,
-        for: {
-          type: 'tenant',
-          tenantId: tenant.id
-        }
-      });
+    let brand = await subspaceBrandService.upsert({
+      instance,
+      name: d.brand.name,
+      image: d.brand.image,
+      for: {
+        type: 'tenant',
+        tenantId: tenant.id
+      }
+    });
 
-      await db.projectBrand.update({
-        where: { projectOid: d.project.oid },
-        data: { subspaceBrandId: brand.id }
-      });
+    await db.projectBrand.update({
+      where: { projectOid: d.project.oid },
+      data: { subspaceBrandId: brand.id }
     });
   }
 }

--- a/src/backend/modules/subspace/src/subspace.ts
+++ b/src/backend/modules/subspace/src/subspace.ts
@@ -1,14 +1,7 @@
 import { delay } from '@lowerdeck/delay';
 import { ProgrammablePromise } from '@lowerdeck/programmable-promise';
 import { createSubspaceControllerClient } from '@metorial-platform-systems/subspace-client';
-import {
-  db,
-  Organization,
-  OrganizationActor,
-  Project,
-  withTransaction,
-  type Instance
-} from '@metorial/db';
+import { db, Organization, OrganizationActor, Project, type Instance } from '@metorial/db';
 import { env } from './env';
 
 let solutionProm = new ProgrammablePromise<
@@ -92,7 +85,7 @@ export let getTenantForSubspace = async (
         getSubspaceEnvironmentIdentifier(currentInstance)
     });
 
-    instance = await withTransaction(async db => {
+    instance = await db.$transaction(async db => {
       instance = await db.instance.update({
         where: { oid: currentInstance.oid },
         data: {

--- a/src/systems/subspace/modules/tenant/src/queues/retention/cleanup.ts
+++ b/src/systems/subspace/modules/tenant/src/queues/retention/cleanup.ts
@@ -278,16 +278,53 @@ let cleanupSessionConnections = async (d: { tenantOid: bigint; cutoffDate: Date 
         where: {
           tenantOid: d.tenantOid,
           createdAt: { lt: d.cutoffDate },
-          state: 'disconnected'
+          state: 'disconnected',
+          providerRuns: { none: {} }
         },
         orderBy: { createdAt: 'asc' },
         take: RETENTION_BATCH_SIZE,
         select: { oid: true }
       }),
-    deleteMany: records =>
-      db.sessionConnection.deleteMany({
-        where: { oid: { in: records.map(record => record.oid) } }
-      })
+    deleteMany: async records => {
+      let connectionOids = records.map(record => record.oid);
+
+      await withTransaction(async tx => {
+        await Promise.all([
+          tx.sessionEvent.updateMany({
+            where: { connectionOid: { in: connectionOids } },
+            data: {
+              connectionOid: null,
+              isParentDeleted: true
+            }
+          }),
+          tx.sessionMessage.updateMany({
+            where: { connectionOid: { in: connectionOids } },
+            data: {
+              connectionOid: null,
+              isParentDeleted: true
+            }
+          }),
+          tx.sessionError.updateMany({
+            where: { connectionOid: { in: connectionOids } },
+            data: {
+              connectionOid: null,
+              isParentDeleted: true
+            }
+          }),
+          tx.sessionWarning.updateMany({
+            where: { connectionOid: { in: connectionOids } },
+            data: {
+              connectionOid: null,
+              isParentDeleted: true
+            }
+          })
+        ]);
+
+        await tx.sessionConnection.deleteMany({
+          where: { oid: { in: connectionOids } }
+        });
+      });
+    }
   });
 };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes touch transactional DB updates and retention deletions; mistakes could cause incomplete cleanup or unexpected nulling of foreign keys on session records.
> 
> **Overview**
> Fixes transaction handling in Subspace syncing by replacing the custom `withTransaction` wrapper with direct `db.$transaction` in `getTenantForSubspace`, and removes an unnecessary transaction wrapper around `syncProjectBrandToSubspace`.
> 
> Hardens retention cleanup for old disconnected `sessionConnection`s by only deleting connections with **no provider runs**, and by nulling `connectionOid` + setting `isParentDeleted` on related session records inside a transaction before deleting the connection rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c1f3446bcc04bf60ec415b64314576e6e5f981. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->