### PR TITLE
Harden queue races

### DIFF
--- a/src/backend/modules/consumer/src/services/consumerIntegration.ts
+++ b/src/backend/modules/consumer/src/services/consumerIntegration.ts
@@ -62,6 +62,21 @@ type ConsumerIntegrationWithRelations = Prisma.ConsumerIntegrationGetPayload<{
   include: typeof consumerIntegrationInclude;
 }>;
 
+let isConsumerIntegrationDuplicateError = (error: unknown) => {
+  let err = error as {
+    code?: string;
+    meta?: { target?: string[] | string };
+    message?: string;
+  };
+  if (err.code !== 'P2002') return false;
+
+  let target = Array.isArray(err.meta?.target) ? err.meta.target.join(',') : err.meta?.target;
+  return (
+    (target?.includes('consumerProfileOid') || err.message?.includes('consumerProfileOid')) &&
+    (target?.includes('magicMcpServerOid') || err.message?.includes('magicMcpServerOid'))
+  );
+};
+
 let assertMagicResourceOwnership = <
   T extends {
     instanceOid: bigint;
@@ -153,28 +168,41 @@ class ConsumerIntegrationServiceImpl {
       resourceType: 'server'
     });
 
-    return await db.consumerIntegration.upsert({
-      where: {
-        consumerProfileOid_magicMcpServerOid: {
-          consumerProfileOid: d.consumerProfile.oid,
-          magicMcpServerOid: d.magicMcpServer.oid
-        }
-      },
-      create: {
-        id: await ID.generateId('consumerIntegration'),
-        instanceOid: d.consumerProfile.instanceOid,
-        consumerOid: d.consumerProfile.consumerOid,
+    let where = {
+      consumerProfileOid_magicMcpServerOid: {
         consumerProfileOid: d.consumerProfile.oid,
-        magicMcpServerOid: d.magicMcpServer.oid,
-        isManaged: d.isManaged
-      },
-      update: {
-        instanceOid: d.consumerProfile.instanceOid,
-        consumerOid: d.consumerProfile.consumerOid,
-        isManaged: d.isManaged ? undefined : false
-      },
-      include: consumerIntegrationInclude
-    });
+        magicMcpServerOid: d.magicMcpServer.oid
+      }
+    };
+    let update = {
+      instanceOid: d.consumerProfile.instanceOid,
+      consumerOid: d.consumerProfile.consumerOid,
+      isManaged: d.isManaged ? undefined : false
+    };
+
+    try {
+      return await db.consumerIntegration.upsert({
+        where,
+        create: {
+          id: await ID.generateId('consumerIntegration'),
+          instanceOid: d.consumerProfile.instanceOid,
+          consumerOid: d.consumerProfile.consumerOid,
+          consumerProfileOid: d.consumerProfile.oid,
+          magicMcpServerOid: d.magicMcpServer.oid,
+          isManaged: d.isManaged
+        },
+        update,
+        include: consumerIntegrationInclude
+      });
+    } catch (error) {
+      if (!isConsumerIntegrationDuplicateError(error)) throw error;
+
+      return await db.consumerIntegration.update({
+        where,
+        data: update,
+        include: consumerIntegrationInclude
+      });
+    }
   }
 
   async upsertConsumerIntegrationEndpoint(d: {

--- a/src/backend/modules/consumer/test/consumerIntegration.test.ts
+++ b/src/backend/modules/consumer/test/consumerIntegration.test.ts
@@ -10,7 +10,8 @@ vi.mock('@metorial/db', () => {
       upsert: vi.fn()
     },
     consumerIntegration: {
-      upsert: vi.fn()
+      upsert: vi.fn(),
+      update: vi.fn()
     },
     consumerIntegrationEndpoint: {
       upsert: vi.fn()
@@ -176,6 +177,46 @@ describe('consumerIntegrationService', () => {
         })
       })
     );
+  });
+
+  it('updates the existing integration when a concurrent upsert wins the insert race', async () => {
+    (db.consumerIntegration.upsert as any).mockRejectedValue({
+      code: 'P2002',
+      meta: {
+        target: ['consumerProfileOid', 'magicMcpServerOid']
+      }
+    });
+    (db.consumerIntegration.update as any).mockResolvedValue({
+      id: 'consumerIntegration-1'
+    } as any);
+
+    await consumerIntegrationService.upsertConsumerIntegration({
+      consumerProfile: {
+        oid: 30n,
+        instanceOid: 10n,
+        consumerOid: 20n
+      },
+      magicMcpServer: {
+        oid: 50n,
+        instanceOid: 10n
+      },
+      isManaged: true
+    });
+
+    expect(db.consumerIntegration.update).toHaveBeenCalledWith({
+      where: {
+        consumerProfileOid_magicMcpServerOid: {
+          consumerProfileOid: 30n,
+          magicMcpServerOid: 50n
+        }
+      },
+      data: {
+        instanceOid: 10n,
+        consumerOid: 20n,
+        isManaged: undefined
+      },
+      include: expect.any(Object)
+    });
   });
 
   it('links auth attempts to an upserted consumer integration endpoint', async () => {

--- a/src/systems/subspace/modules/provider-internal/src/queues/deploymentConfigPair/setSpec.ts
+++ b/src/systems/subspace/modules/provider-internal/src/queues/deploymentConfigPair/setSpec.ts
@@ -8,6 +8,8 @@ import {
 import { env } from '../../env';
 import { providerVersionSetSpecificationQueue } from '../version/setSpec';
 
+let isUniqueConstraintError = (error: any) => error?.code === 'P2002';
+
 export let providerDeploymentConfigPairSetSpecificationQueue = createQueue<{
   providerDeploymentConfigPairOid: bigint;
   versionOid: bigint;
@@ -87,56 +89,76 @@ export let providerDeploymentConfigPairSetSpecificationQueueProcessor =
       };
     }
 
-    let newPairVersion = await withTransaction(async db => {
-      let newPairVersion = await db.providerDeploymentConfigPairProviderVersion.upsert({
-        where: {
-          pairOid_versionOid: filter
-        },
-        create: {
-          ...getId('providerDeploymentConfigPairProviderVersion'),
-          ...filter,
+    let savePairVersion = async (mode: 'upsert' | 'update') =>
+      withTransaction(async db => {
+        let pairVersionData = {
           ...result,
           previousPairVersionOid: previousPairVersion?.oid,
           latestDiscoveryRecordOid: data.result.discoveryRecordOid ?? null
-        },
-        update: {
-          ...result,
-          previousPairVersionOid: previousPairVersion?.oid,
-          latestDiscoveryRecordOid: data.result.discoveryRecordOid ?? null
-        },
-        include: {
-          specification: true
+        };
+
+        let newPairVersion =
+          mode === 'upsert'
+            ? await db.providerDeploymentConfigPairProviderVersion.upsert({
+                where: {
+                  pairOid_versionOid: filter
+                },
+                create: {
+                  ...getId('providerDeploymentConfigPairProviderVersion'),
+                  ...filter,
+                  ...pairVersionData
+                },
+                update: pairVersionData,
+                include: {
+                  specification: true
+                }
+              })
+            : await db.providerDeploymentConfigPairProviderVersion.update({
+                where: {
+                  pairOid_versionOid: filter
+                },
+                data: pairVersionData,
+                include: {
+                  specification: true
+                }
+              });
+
+        if (newPairVersion.specificationOid) {
+          let versionSpec = version.specificationOid
+            ? await db.providerSpecification.findFirst({
+                where: { oid: version.specificationOid }
+              })
+            : null;
+
+          if (versionSpec?.type !== 'full' && newPairVersion.specification?.type === 'full') {
+            // Update the version in this transaction
+            // to avoid eventually consistent issues
+            await db.providerVersion.update({
+              where: { oid: version.oid },
+              data: { specificationOid: newPairVersion.specificationOid }
+            });
+
+            await providerVersionSetSpecificationQueue.add({
+              versionOid: version.oid,
+              result: {
+                status: 'success',
+                specificationOid: newPairVersion.specificationOid,
+                source: 'pair'
+              }
+            });
+          }
         }
+
+        return newPairVersion;
       });
 
-      if (newPairVersion.specificationOid) {
-        let versionSpec = version.specificationOid
-          ? await db.providerSpecification.findFirst({
-              where: { oid: version.specificationOid }
-            })
-          : null;
-
-        if (versionSpec?.type !== 'full' && newPairVersion.specification?.type === 'full') {
-          // Update the version in this transaction
-          // to avoid eventually consistent issues
-          await db.providerVersion.update({
-            where: { oid: version.oid },
-            data: { specificationOid: newPairVersion.specificationOid }
-          });
-
-          await providerVersionSetSpecificationQueue.add({
-            versionOid: version.oid,
-            result: {
-              status: 'success',
-              specificationOid: newPairVersion.specificationOid,
-              source: 'pair'
-            }
-          });
-        }
-      }
-
-      return newPairVersion;
-    });
+    let newPairVersion: Awaited<ReturnType<typeof savePairVersion>>;
+    try {
+      newPairVersion = await savePairVersion('upsert');
+    } catch (error: any) {
+      if (!isUniqueConstraintError(error)) throw error;
+      newPairVersion = await savePairVersion('update');
+    }
 
     if (newPairVersion.specificationOid) {
       if (

--- a/src/systems/subspace/modules/provider-internal/src/services/providerDeploymentConfigPair.ts
+++ b/src/systems/subspace/modules/provider-internal/src/services/providerDeploymentConfigPair.ts
@@ -13,6 +13,7 @@ import {
   type ProviderDeploymentConfigPairProviderVersion,
   type ProviderDeploymentVersion,
   type ProviderVersion,
+  type TransactionDB,
   withTransaction
 } from '@metorial-subspace/db';
 import {
@@ -33,12 +34,14 @@ let getPairIdentifier = (d: PairParts) =>
     d.authConfig ? d.authConfig.currentVersion!.oid.toString(36) : '$'
   }`;
 
+let isUniqueConstraintError = (error: any) => error?.code === 'P2002';
+
 class providerDeploymentConfigPairInternalServiceImpl {
   private async upsertDeploymentConfigPairWithoutCreatingVersion(
     d: PairParts & { version?: ProviderVersion }
   ) {
-    return withTransaction(async db => {
-      let existing = await db.providerDeploymentConfigPair.findUnique({
+    let getExisting = async (pdb: typeof db | TransactionDB = db) => {
+      let existing = await pdb.providerDeploymentConfigPair.findUnique({
         where: { identifier: getPairIdentifier(d) },
         include: {
           versions: d.version
@@ -49,6 +52,7 @@ class providerDeploymentConfigPairInternalServiceImpl {
             : false
         }
       });
+
       if (existing) {
         return {
           pair: existing,
@@ -61,54 +65,70 @@ class providerDeploymentConfigPairInternalServiceImpl {
         };
       }
 
-      let newId = getId('providerDeploymentConfigPair');
-      let pair = await db.providerDeploymentConfigPair.upsert({
-        where: { identifier: getPairIdentifier(d) },
-        create: {
-          ...newId,
+      return null;
+    };
 
-          identifier: getPairIdentifier(d),
+    try {
+      return await withTransaction(async db => {
+        let existing = await getExisting(db);
+        if (existing) return existing;
 
-          providerDeploymentVersionOid: d.deployment.currentVersion!.oid,
-          providerConfigVersionOid: d.config.currentVersion!.oid,
-          providerAuthConfigVersionOid: d.authConfig?.currentVersion?.oid,
+        let newId = getId('providerDeploymentConfigPair');
+        let pair = await db.providerDeploymentConfigPair.upsert({
+          where: { identifier: getPairIdentifier(d) },
+          create: {
+            ...newId,
 
-          tenantOid: d.deployment.tenantOid,
-          environmentOid: d.deployment.environmentOid
-        },
-        update: {}
+            identifier: getPairIdentifier(d),
+
+            providerDeploymentVersionOid: d.deployment.currentVersion!.oid,
+            providerConfigVersionOid: d.config.currentVersion!.oid,
+            providerAuthConfigVersionOid: d.authConfig?.currentVersion?.oid,
+
+            tenantOid: d.deployment.tenantOid,
+            environmentOid: d.deployment.environmentOid
+          },
+          update: {}
+        });
+
+        let created = pair.id === newId.id;
+
+        if (created) {
+          await addAfterTransactionHook(async () =>
+            providerDeploymentConfigPairCreatedQueue.add({
+              providerDeploymentConfigPairId: pair.id
+            })
+          );
+        }
+
+        let version = d.version
+          ? await db.providerDeploymentConfigPairProviderVersion.findFirst({
+              where: {
+                pairOid: pair.oid,
+                versionOid: d.version.oid
+              },
+              include: { latestDiscoveryRecord: true }
+            })
+          : null;
+
+        return {
+          pair,
+          created,
+          version: version ?? undefined
+        };
       });
-
-      let created = pair.id === newId.id;
-
-      if (created) {
-        await addAfterTransactionHook(async () =>
-          providerDeploymentConfigPairCreatedQueue.add({
-            providerDeploymentConfigPairId: pair.id
-          })
-        );
+    } catch (error: any) {
+      if (isUniqueConstraintError(error)) {
+        let existing = await getExisting();
+        if (existing) return existing;
       }
 
-      let version = d.version
-        ? await db.providerDeploymentConfigPairProviderVersion.findFirst({
-            where: {
-              pairOid: pair.oid,
-              versionOid: d.version.oid
-            },
-            include: { latestDiscoveryRecord: true }
-          })
-        : null;
-
-      return {
-        pair,
-        created,
-        version: version ?? undefined
-      };
-    });
+      throw error;
+    }
   }
 
   async upsertDeploymentConfigPair(d: PairParts & { version?: ProviderVersion }) {
-    return withTransaction(async db => {
+    try {
       let res = await this.upsertDeploymentConfigPairWithoutCreatingVersion(d);
 
       if (!d.version) {
@@ -117,6 +137,7 @@ class providerDeploymentConfigPairInternalServiceImpl {
           version: undefined
         };
       }
+      let providerVersion = d.version;
 
       if (res.version) {
         return {
@@ -125,37 +146,74 @@ class providerDeploymentConfigPairInternalServiceImpl {
         };
       }
 
-      let newId = getId('providerDeploymentConfigPairProviderVersion');
-      let version = await db.providerDeploymentConfigPairProviderVersion.upsert({
-        where: {
-          pairOid_versionOid: {
+      return await withTransaction(async db => {
+        let currentVersion = await db.providerDeploymentConfigPairProviderVersion.findFirst({
+          where: {
+            pairOid: res.pair.oid,
+            versionOid: providerVersion.oid
+          },
+          include: { latestDiscoveryRecord: true }
+        });
+
+        if (currentVersion) {
+          return {
+            pair: res.pair,
+            version: currentVersion
+          };
+        }
+
+        let newId = getId('providerDeploymentConfigPairProviderVersion');
+        let version = await db.providerDeploymentConfigPairProviderVersion.upsert({
+          where: {
+            pairOid_versionOid: {
+              pairOid: res.pair.oid,
+              versionOid: providerVersion.oid
+            }
+          },
+          create: {
+            ...newId,
+            pairOid: res.pair.oid,
+            versionOid: providerVersion.oid,
+            specificationDiscoveryStatus: 'discovering'
+          },
+          update: {},
+          include: { latestDiscoveryRecord: true }
+        });
+
+        if (version.id === newId.id) {
+          await addAfterTransactionHook(async () =>
+            providerDeploymentConfigPairVersionCreatedQueue.add({
+              providerDeploymentConfigPairVersionId: version.id
+            })
+          );
+        }
+
+        return {
+          pair: res.pair,
+          version
+        };
+      });
+    } catch (error: any) {
+      if (isUniqueConstraintError(error) && d.version) {
+        let res = await this.upsertDeploymentConfigPairWithoutCreatingVersion(d);
+        let version = await db.providerDeploymentConfigPairProviderVersion.findFirst({
+          where: {
             pairOid: res.pair.oid,
             versionOid: d.version.oid
-          }
-        },
-        create: {
-          ...newId,
-          pairOid: res.pair.oid,
-          versionOid: d.version.oid,
-          specificationDiscoveryStatus: 'discovering'
-        },
-        update: {},
-        include: { latestDiscoveryRecord: true }
-      });
+          },
+          include: { latestDiscoveryRecord: true }
+        });
 
-      if (version.id === newId.id) {
-        await addAfterTransactionHook(async () =>
-          providerDeploymentConfigPairVersionCreatedQueue.add({
-            providerDeploymentConfigPairVersionId: version.id
-          })
-        );
+        if (version) {
+          return {
+            pair: res.pair,
+            version
+          };
+        }
       }
 
-      return {
-        pair: res.pair,
-        version
-      };
-    });
+      throw error;
+    }
   }
 
   async useDeploymentConfigPair(d: PairParts & { version: ProviderVersion }) {

--- a/src/systems/subspace/provider-backends/provider-shuttle/src/queues/sync/changeNotifications.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/queues/sync/changeNotifications.ts
@@ -23,45 +23,77 @@ let lock = createLock({
   redisUrl: env.service.REDIS_URL
 });
 
+let isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value == 'object' && value !== null;
+
+let isLockContentionError = (error: unknown) => {
+  if (!isRecord(error)) return false;
+  if (error.name !== 'ExecutionError') return false;
+
+  let attempts = error.attempts;
+  if (!Array.isArray(attempts)) return false;
+
+  let voteErrors = attempts.flatMap(attempt => {
+    if (!isRecord(attempt)) return [];
+
+    let votesAgainst = attempt.votesAgainst;
+    if (votesAgainst instanceof Map) return [...votesAgainst.values()];
+    if (Array.isArray(votesAgainst)) return votesAgainst;
+
+    return [];
+  });
+
+  return (
+    voteErrors.length > 0 &&
+    voteErrors.every(error => isRecord(error) && error.name === 'ResourceLockedError')
+  );
+};
+
 export let syncChangeNotificationsQueueProcessor = syncChangeNotificationsQueue.process(
-  async data =>
-    lock.usingLock(shuttleBackend.id, async () => {
-      let backend = await db.backend.findFirst({
-        where: { id: shuttleBackend.id },
-        include: { shuttleSyncChangeNotificationCursor: true }
+  async () => {
+    try {
+      await lock.usingLock(shuttleBackend.id, async () => {
+        let backend = await db.backend.findFirst({
+          where: { id: shuttleBackend.id },
+          include: { shuttleSyncChangeNotificationCursor: true }
+        });
+        if (!backend) throw new QueueRetryError();
+
+        let changeNotifications = await shuttle.changeNotification.list({
+          limit: 100,
+          after: backend.shuttleSyncChangeNotificationCursor?.cursor,
+          order: 'asc'
+        });
+        if (!changeNotifications.items.length) return;
+
+        await syncShuttleVersionQueue.addManyWithOps(
+          changeNotifications.items
+            .map(item => ({
+              serverId: item.serverId!,
+              serverVersionId: item.serverVersionId!,
+              tenantId: item.tenantId
+            }))
+            .filter(item => item.serverId && item.serverVersionId)
+            .map(data => ({
+              data,
+              opts: { id: data.serverVersionId }
+            }))
+        );
+
+        let lastItem = changeNotifications.items[changeNotifications.items.length - 1];
+        if (!lastItem) return;
+
+        await db.shuttleSyncChangeNotificationCursor.upsert({
+          where: { backendOid: backend.oid },
+          create: { backendOid: backend.oid, cursor: lastItem.id },
+          update: { cursor: lastItem.id }
+        });
+
+        await syncChangeNotificationsQueue.add({});
       });
-      if (!backend) throw new QueueRetryError();
-
-      let changeNotifications = await shuttle.changeNotification.list({
-        limit: 100,
-        after: backend.shuttleSyncChangeNotificationCursor?.cursor,
-        order: 'asc'
-      });
-      if (!changeNotifications.items.length) return;
-
-      await syncShuttleVersionQueue.addManyWithOps(
-        changeNotifications.items
-          .map(item => ({
-            serverId: item.serverId!,
-            serverVersionId: item.serverVersionId!,
-            tenantId: item.tenantId
-          }))
-          .filter(item => item.serverId && item.serverVersionId)
-          .map(data => ({
-            data,
-            opts: { id: data.serverVersionId }
-          }))
-      );
-
-      let lastItem = changeNotifications.items[changeNotifications.items.length - 1];
-      if (!lastItem) return;
-
-      await db.shuttleSyncChangeNotificationCursor.upsert({
-        where: { backendOid: backend.oid },
-        create: { backendOid: backend.oid, cursor: lastItem.id },
-        update: { cursor: lastItem.id }
-      });
-
-      await syncChangeNotificationsQueue.add({});
-    })
+    } catch (error) {
+      if (isLockContentionError(error)) return;
+      throw error;
+    }
+  }
 );

--- a/src/systems/subspace/provider-backends/provider-shuttle/src/queues/sync/cron.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/queues/sync/cron.ts
@@ -11,7 +11,7 @@ export let syncChangeNotificationsCron = createCron(
     cron: '* * * * *'
   },
   async () => {
-    await syncChangeNotificationsQueue.add({});
+    await syncChangeNotificationsQueue.add({}, { id: 'poll' });
   }
 );
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how several Prisma `upsert` flows recover from unique-constraint races and alters queue processing behavior around locking, which could affect data correctness and job execution if misclassified errors occur.
> 
> **Overview**
> Hardens multiple background flows against concurrency races by **catching Prisma unique-constraint (`P2002`) errors** and falling back to deterministic `update`/re-read paths.
> 
> In `consumerIntegrationService.upsertConsumerIntegration`, an insert-race now retries by updating the existing integration, and tests add coverage for this scenario. In Subspace provider-internal, deployment/config pair creation and pair-version specification persistence are refactored to re-check existing records and retry on `P2002` rather than failing.
> 
> In the Shuttle sync worker, lock contention errors are now explicitly detected and treated as a no-op (instead of surfacing as failures), and the cron enqueues the change-notification poll job with a stable id (`poll`) to reduce duplicate scheduling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 355c953d94dcd91805a32a01cd54888053c9c218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->