### PR TITLE
Harden magic mcp reconnects

### DIFF
--- a/src/systems/subspace/modules/connection/src/sender/manager.ts
+++ b/src/systems/subspace/modules/connection/src/sender/manager.ts
@@ -100,7 +100,32 @@ export class SenderManager {
     readonly transport: SessionConnectionTransport
   ) {}
 
-  static async create(d: SenderMangerProps): Promise<SenderManager> {
+  private static async resolveSession(d: SenderMangerProps) {
+    if (d.connectionToken) {
+      let connection = await db.sessionConnection.findFirst({
+        where: {
+          token: d.connectionToken,
+          tenant: { OR: [{ id: d.tenantId }, { identifier: d.tenantId }] },
+          solution: { OR: [{ id: d.solutionId }, { identifier: d.solutionId }] }
+        },
+        include: {
+          session: true,
+          participant: true,
+          tenant: true,
+          solution: true
+        }
+      });
+
+      if (connection) {
+        return {
+          ...connection.session,
+          tenant: connection.tenant,
+          solution: connection.solution,
+          connection: connection
+        };
+      }
+    }
+
     let session = await db.session.findFirst({
       where: {
         id: d.sessionId,
@@ -109,21 +134,25 @@ export class SenderManager {
       },
       include: {
         tenant: true,
-        solution: true,
-        connections: d.connectionToken
-          ? {
-              where: { token: d.connectionToken, status: 'active' },
-              include: { participant: true }
-            }
-          : false
+        solution: true
       }
     });
+    if (!session) return null;
+
+    return {
+      ...session,
+      connection: undefined
+    };
+  }
+
+  static async create(d: SenderMangerProps): Promise<SenderManager> {
+    let session = await this.resolveSession(d);
     if (!session) throw new ServiceError(notFoundError('session'));
     if (isRecordDeleted(session)) {
       throw new ServiceError(goneError({ message: 'Session has been archived or deleted' }));
     }
 
-    let connection = session.connections?.[0];
+    let connection = session.connection;
     if (d.connectionToken && !connection) {
       throw new ServiceError(notFoundError('connection'));
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how `SenderManager.create` loads sessions/connections from the DB, which can affect reconnect behavior and error paths for invalid/archived/disabled tokens.
> 
> **Overview**
> **Hardens connection-token reconnect handling in `SenderManager.create`.** Session resolution is refactored into `resolveSession`, which now looks up the `SessionConnection` directly by `connectionToken` (including `session`, `tenant`, `solution`, and `participant`) instead of loading the session and filtering `session.connections`.
> 
> This makes token-based flows return more accurate errors for missing/archived/disabled connections (since non-`active` connections are now found and then validated), while leaving non-token flows to load the session without pulling connection relations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18fd1078f7594f5b6c76e95a2826ecb61359e7e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->