### PR TITLE
Fix root redirect

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/index/pages/rootRedirect.tsx
+++ b/src/frontend/apps/dashboard/src/slices/index/pages/rootRedirect.tsx
@@ -3,6 +3,9 @@ import { lastInstanceIdStore, useBoot } from '@metorial/state';
 import { useLayoutEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
+let joinPaths = (...paths: (string | number | undefined)[]) =>
+  paths.filter(Boolean).join('/').replace(/\/+/g, '/');
+
 export let RootRedirect = () => {
   let boot = useBoot();
   let navigate = useNavigate();
@@ -68,7 +71,10 @@ export let RootRedirect = () => {
         if (intent === 'organization_settings')
           return Paths.organization.settings(organization);
 
-        return Paths.instance.home(organization, project, instance);
+        let homeBasePath = Paths.instance.home(organization, project, instance);
+        if (!path) return homeBasePath;
+
+        return joinPaths(homeBasePath, path);
       })
       .then(async path => {
         if (navigatedRef.current) return;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, isolated change to dashboard root redirect URL construction; main risk is unintended path joining behavior for edge-case inputs (leading slashes/double slashes).
> 
> **Overview**
> `RootRedirect` now honors an optional `path` query parameter by appending it to the computed instance home URL (using a new `joinPaths` helper that normalizes slashes) instead of always redirecting to the base home route.
> 
> The `organization_settings` intent behavior is unchanged; only the default redirect target construction is extended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4236198d9c6499e1a683f80f34446fa3e45cd8c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->