### PR TITLE
Fix pretty provider slugs

### DIFF
--- a/src/backend/apis/core/src/apiServer.ts
+++ b/src/backend/apis/core/src/apiServer.ts
@@ -1,4 +1,8 @@
-import { consumerApiController, fullDashboardController, magnetarController } from './controllers';
+import {
+  consumerApiController,
+  fullDashboardController,
+  magnetarController
+} from './controllers';
 import { restServer } from './rest';
 
 export let apiServer = restServer.launch({

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/index.tsx
@@ -7,10 +7,11 @@ import {
   useProviderDeployments,
   useProviderListing
 } from '@metorial/state';
-import { Button, Spacer, Text } from '@metorial/ui';
+import { Attributes, Button, Spacer, Text } from '@metorial/ui';
 import { ID, SideBox } from '@metorial/ui-product';
 import dedent from 'dedent';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
 import {
   createJavascriptSdkInstallInstruction,
   createPythonSdkInstallInstruction
@@ -21,6 +22,12 @@ import { useProviderVersionContext } from './_layout';
 import { InstructionItem, Instructions } from './components/instructions';
 import { KeySelector } from './components/keySelector';
 import { Skills } from './components/skills';
+
+let Header = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 20px;
+`;
 
 export let ProviderOverviewPage = () => {
   let instance = useCurrentInstance();
@@ -203,23 +210,39 @@ export let ProviderOverviewPage = () => {
 
   return renderWithLoader({ provider })(({ provider }) => (
     <>
-      <SideBox
-        title="Test this provider"
-        description="Use the Metorial Explorer to test this provider."
-      >
-        <Link
-          to={Paths.instance.explorer(
-            instance.data?.organization,
-            instance.data?.project,
-            instance.data,
-            { provider_id: provider.data?.id }
-          )}
+      <Header>
+        <Attributes
+          itemWidth="200px"
+          attributes={[
+            {
+              label: 'Identifier',
+              content: <ID id={listing.data?.slug ?? provider.data.slug} />
+            },
+            {
+              label: 'Publisher',
+              content: provider.data.publisher.name
+            }
+          ]}
+        />
+
+        <SideBox
+          title="Test this provider"
+          description="Use the Metorial Explorer to test this provider."
         >
-          <Button as="span" size="2">
-            Open Explorer
-          </Button>
-        </Link>
-      </SideBox>
+          <Link
+            to={Paths.instance.explorer(
+              instance.data?.organization,
+              instance.data?.project,
+              instance.data,
+              { provider_id: provider.data?.id }
+            )}
+          >
+            <Button as="span" size="2">
+              Open Explorer
+            </Button>
+          </Link>
+        </SideBox>
+      </Header>
 
       <Spacer height={15} />
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/details.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/details.tsx
@@ -42,7 +42,9 @@ export let ProviderInvocationDetails = ({
                 },
                 {
                   label: 'Type',
-                  value: formatTitleCase(invocation.type)
+                  value: formatTitleCase(
+                    invocation.type === 'unknown' ? 'Provider Call' : invocation.type
+                  )
                 },
                 {
                   label: 'Created',

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/hooks/useConnectionTimeline.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/hooks/useConnectionTimeline.tsx
@@ -83,6 +83,8 @@ export let useConnectionTimeline = ({
   refetchConnectionRef.current = connectionQuery.refetch;
   let refetchProviderInvocationsRef = useRef(providerInvocations.refetch);
   refetchProviderInvocationsRef.current = providerInvocations.refetch;
+  let providerInvocationsLoadingRef = useRef(providerInvocations.isLoading);
+  providerInvocationsLoadingRef.current = providerInvocations.isLoading;
 
   useEffect(() => {
     if (!instanceId) return;
@@ -91,7 +93,9 @@ export let useConnectionTimeline = ({
       refetchMessagesRef.current?.();
       refetchEventsRef.current?.();
       refetchProviderRunsRef.current?.();
-      refetchProviderInvocationsRef.current?.();
+      if (!providerInvocationsLoadingRef.current) {
+        refetchProviderInvocationsRef.current?.();
+      }
     }, 5_000);
     return () => clearInterval(id);
   }, [instanceId, session.id, connection.id]);

--- a/src/systems/origin/apps/code-workspace/setup.sh
+++ b/src/systems/origin/apps/code-workspace/setup.sh
@@ -2,11 +2,16 @@
 
 set -e
 
-ROOT_DIR=$(pwd)
+ROOT_DIR=$(cd "$(dirname "$0")" && pwd)
+cd "$ROOT_DIR"
 
 FORCE_SETUP=${FORCE_SETUP:-false}
 
-IS_SETUP=$(find ./public/vscode -maxdepth 0 -type d | wc -l)
+IS_SETUP=0
+
+if [ -d ./public/vscode ]; then
+  IS_SETUP=1
+fi
 
 if [ "$IS_SETUP" -gt 0 ] && [ "$FORCE_SETUP" = false ]; then
   echo "VS Code workspace is already set up. Use FORCE_SETUP=true to force re-setup."
@@ -20,6 +25,7 @@ mkdir -p ./public/vscode
 
 OSS_NODE_MODULES_PATH=$(realpath ../../../../node_modules || echo "")
 ENTERPRISE_NODE_MODULES_PATH=$(realpath ../../../../../node_modules || echo "")
+ENTERPRISE_NODE_MODULES_PATH_2=$(realpath ../../../../../../node_modules || echo "")
 
 NODE_MODULES_PATH=$OSS_NODE_MODULES_PATH
 
@@ -27,9 +33,20 @@ if [ -d "$ENTERPRISE_NODE_MODULES_PATH" ]; then
   NODE_MODULES_PATH=$ENTERPRISE_NODE_MODULES_PATH
 fi
 
+if [ -d "$ENTERPRISE_NODE_MODULES_PATH_2" ]; then
+  NODE_MODULES_PATH=$ENTERPRISE_NODE_MODULES_PATH_2
+fi
+
 echo "Copying VS Code web files from $NODE_MODULES_PATH/vscode-web/dist to ./public/vscode-web"
 
 cp -r $NODE_MODULES_PATH/vscode-web/dist/** ./public/vscode
+
+# The copied VS Code web bundle includes a package.json with the upstream
+# name "Code - OSS". Because this app lives under the OSS npm workspace globs,
+# npm tries to treat ./public/vscode as a workspace package and fails on that
+# invalid package name during installs. The bundle is served as static assets,
+# so we remove npm metadata after copying.
+rm -f ./public/vscode/package.json ./public/vscode/package-lock.json
 
 mkdir -p ./public/vscode/vscode-textmate/release
 cp $NODE_MODULES_PATH/vscode-textmate/release/main.js ./public/vscode/vscode-textmate/release/
@@ -38,21 +55,41 @@ mkdir -p ./public/vscode/vscode-oniguruma/release
 cp $NODE_MODULES_PATH/vscode-oniguruma/release/main.js ./public/vscode/vscode-oniguruma/release/
 cp $NODE_MODULES_PATH/vscode-oniguruma/release/onig.wasm ./public/vscode/vscode-oniguruma/release/
 
+MEMFS_SOURCE_DIR="$ROOT_DIR/extensions/memfs"
+MEMFS_BUILD_DIR=$(mktemp -d)
 
-cd extensions/memfs
+cleanup() {
+  rm -rf "$MEMFS_BUILD_DIR"
+}
+
+trap cleanup EXIT
+
+echo "Preparing isolated MemFS build in $MEMFS_BUILD_DIR"
+
+cp "$MEMFS_SOURCE_DIR/package.json" "$MEMFS_BUILD_DIR/package.json"
+cp "$MEMFS_SOURCE_DIR/package-lock.json" "$MEMFS_BUILD_DIR/package-lock.json"
+cp "$MEMFS_SOURCE_DIR/tsconfig.json" "$MEMFS_BUILD_DIR/tsconfig.json"
+cp "$MEMFS_SOURCE_DIR/esbuild.js" "$MEMFS_BUILD_DIR/esbuild.js"
+cp "$MEMFS_SOURCE_DIR/eslint.config.mjs" "$MEMFS_BUILD_DIR/eslint.config.mjs"
+cp -R "$MEMFS_SOURCE_DIR/src" "$MEMFS_BUILD_DIR/src"
+
+cd "$MEMFS_BUILD_DIR"
 
 echo "Installing MemFS extension dependencies..."
 npm i
 
 echo "Building MemFS extension..."
-npm run package
+bun run package
 
-cd ../../
+cd "$ROOT_DIR"
 
 echo "Copying MemFS extension files to ./public/extensions/memfs"
 
-cp -r extensions/memfs/dist/** ./public/extensions/memfs
-cp extensions/memfs/package.json ./public/extensions/memfs/package.json
-cp extensions/memfs/package.nls.json ./public/extensions/memfs/package.nls.json
+cp -r "$MEMFS_BUILD_DIR/dist"/** ./public/extensions/memfs
+cp "$MEMFS_SOURCE_DIR/package.json" ./public/extensions/memfs/package.json
 
-cd $ROOT_DIR
+if [ -f "$MEMFS_SOURCE_DIR/package.nls.json" ]; then
+  cp "$MEMFS_SOURCE_DIR/package.nls.json" ./public/extensions/memfs/package.nls.json
+fi
+
+cd "$ROOT_DIR"

--- a/src/systems/shuttle/service/src/lib/function/call.ts
+++ b/src/systems/shuttle/service/src/lib/function/call.ts
@@ -68,8 +68,13 @@ export let callFunction = async <T>(
 export let getFunctionCallLogs = async (d: {
   server: FunctionServer;
   functionCallId: string;
+  waitForLogs?: boolean;
+  attempts?: number;
+  delayMs?: number;
 }) => {
-  for (let i = 0; i < 10; i++) {
+  let attempts = d.waitForLogs ? (d.attempts ?? 10) : 1;
+
+  for (let i = 0; i < attempts; i++) {
     try {
       let out = await functionBay.functionInvocation.get({
         tenantId: d.server.functionBayTenantId,
@@ -77,10 +82,14 @@ export let getFunctionCallLogs = async (d: {
         functionInvocationId: d.functionCallId
       });
 
-      if (out.logs.length > 0) return out.logs;
-    } catch (err) {}
+      if (!d.waitForLogs || out.logs.length > 0) return out.logs;
+    } catch (err) {
+      if (!d.waitForLogs) return [];
+    }
 
-    await delay(1000); // Wait for logs to be available
+    if (i < attempts - 1) {
+      await delay(d.delayMs ?? 1000); // Wait for logs to be available
+    }
   }
 
   return [];

--- a/src/systems/subspace/db/prisma/schema/listing/listing.prisma
+++ b/src/systems/subspace/db/prisma/schema/listing/listing.prisma
@@ -5,10 +5,11 @@ enum ProviderListingStatus {
 }
 
 model ProviderListing {
-  oid    BigInt                @id
-  id     String                @unique
-  status ProviderListingStatus
-  isDeprecated Boolean @default(false)
+  oid BigInt @id
+  id  String @unique
+
+  status       ProviderListingStatus
+  isDeprecated Boolean               @default(false)
 
   isPublic     Boolean @default(true)
   isCustomized Boolean @default(false)
@@ -18,10 +19,9 @@ model ProviderListing {
   isOfficial Boolean @default(false)
 
   name       String
-  slug       String  @unique
-  prettySlug String? @unique
-
-  aliases String[]
+  slug       String   @unique
+  prettySlug String?  @unique
+  aliases    String[]
 
   /// [EntityImage]
   image Json?

--- a/src/systems/subspace/db/prisma/schema/provider/provider.prisma
+++ b/src/systems/subspace/db/prisma/schema/provider/provider.prisma
@@ -32,9 +32,9 @@ model Provider {
   oid BigInt @id
   id  String @unique
 
-  access ProviderAccess
-  status ProviderStatus
-  isDeprecated Boolean @default(false)
+  access       ProviderAccess
+  status       ProviderStatus
+  isDeprecated Boolean        @default(false)
 
   hasEnvironments Boolean @default(false)
 
@@ -43,6 +43,7 @@ model Provider {
   globalIdentifier String? @unique
   name             String
   description      String?
+  prettySlug       String? @unique
 
   metadata Json?
 

--- a/src/systems/subspace/modules/provider-internal/src/services/provider.ts
+++ b/src/systems/subspace/modules/provider-internal/src/services/provider.ts
@@ -110,10 +110,15 @@ class providerInternalServiceImpl {
     let prettySlug = d.info.prettySlug;
     let existingWithPrettySlug = prettySlug
       ? await db.providerListing.findFirst({
-          where: { prettySlug }
+          where: {
+            prettySlug,
+            provider: {
+              slug: { not: d.info.slug },
+              globalIdentifier: { not: d.info.globalIdentifier }
+            }
+          }
         })
       : null;
-
     if (existingWithPrettySlug) prettySlug = `${prettySlug}-${generateCode(5)}`;
 
     return withTransaction(
@@ -167,6 +172,7 @@ class providerInternalServiceImpl {
           name: d.info.name,
           description: d.info.description,
           slug: d.info.slug,
+          prettySlug,
 
           entryOid: entry.oid,
           publisherOid: d.publisher.oid,
@@ -209,8 +215,8 @@ class providerInternalServiceImpl {
 
           isDefault: true,
 
-          name: d.info.name,
-          description: d.info.description,
+          name: provider.name,
+          description: provider.description,
 
           backendOid: d.source.backend.oid,
           providerOid: provider.oid,
@@ -265,11 +271,11 @@ class providerInternalServiceImpl {
           let inner = {
             ...allData,
 
-            name: d.info.name,
-            description: d.info.description,
-            slug: d.info.slug,
+            name: provider.name,
+            description: provider.description,
+            slug: provider.slug,
 
-            prettySlug,
+            prettySlug: provider.prettySlug,
             aliases: [...new Set(d.info.aliases)],
 
             image: d.info.image ?? { type: 'default' as const },

--- a/src/systems/subspace/packages/presenters/src/provider.ts
+++ b/src/systems/subspace/packages/presenters/src/provider.ts
@@ -87,7 +87,7 @@ export let providerPresenter = (
 
     name: provider.name,
     description: provider.description,
-    slug: provider.slug,
+    slug: provider.prettySlug ?? provider.slug,
     globalIdentifier: provider.globalIdentifier,
     metadata: provider.metadata,
 
@@ -108,7 +108,7 @@ export let providerPreviewPresenter = (provider: Provider) => ({
 
   name: provider.name,
   description: provider.description,
-  slug: provider.slug,
+  slug: provider.prettySlug ?? provider.slug,
   metadata: provider.metadata,
 
   createdAt: provider.createdAt,

--- a/src/systems/subspace/packages/presenters/src/providerListing.ts
+++ b/src/systems/subspace/packages/presenters/src/providerListing.ts
@@ -60,7 +60,7 @@ export let providerListingPresenter = (
 
   name: providerListing.name,
   description: providerListing.description,
-  slug: providerListing.prettySlug || providerListing.slug,
+  slug: providerListing.prettySlug ?? providerListing.slug,
   image: providerListing.image,
 
   aliases: providerListing.aliases,

--- a/src/systems/subspace/provider-backends/provider-shuttle/src/impl/providerInvocation.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/impl/providerInvocation.ts
@@ -66,11 +66,17 @@ export class ProviderInvocation extends IProviderInvocation {
   override async listProviderInvocations(
     data: ProviderInvocationListParam
   ): Promise<ProviderInvocationListRes> {
+    console.log('Listing provider invocations with data', data);
+
     let invocationMap = new Map<string, UnifiedProviderInvocation>();
     let queue = new PQueue({ concurrency: 5 });
     let serverConnectionLogsCache = new Map<
       string,
-      Awaited<ReturnType<typeof shuttle.serverConnection.getLogsSync>>
+      Promise<Awaited<ReturnType<typeof shuttle.serverConnection.getLogsSync>>>
+    >();
+    let functionInvocationLogsCache = new Map<
+      string,
+      Promise<Awaited<ReturnType<typeof shuttle.functionServerInvocation.getLogs>>>
     >();
 
     let messageProviderRuns = data.inputs.sessionMessageIds?.length
@@ -129,6 +135,11 @@ export class ProviderInvocation extends IProviderInvocation {
           serverConnectionIds: localConnections.map(connection => connection.id)
         })
       : [];
+    let serverConnectionIdsWithFunctionInvocations = new Set(
+      remoteInvocations
+        .map(invocation => invocation.serverConnectionId)
+        .filter((id): id is string => Boolean(id))
+    );
 
     let providerRunIdByConnectionId = new Map(
       localConnections.map(connection => [connection.id, connection.providerRun.id])
@@ -136,55 +147,82 @@ export class ProviderInvocation extends IProviderInvocation {
 
     let getServerConnectionLogs = async (serverConnectionId: string) => {
       let cached = serverConnectionLogsCache.get(serverConnectionId);
-      if (cached) return cached;
+      if (cached) return await cached;
 
-      let logs = await shuttle.serverConnection.getLogsSync({
-        serverConnectionId
-      });
-      serverConnectionLogsCache.set(serverConnectionId, logs);
+      console.log(`Fetching logs for server connection ${serverConnectionId}`);
+
+      let logsPromise = shuttle.serverConnection.getLogsSync({ serverConnectionId });
+      serverConnectionLogsCache.set(serverConnectionId, logsPromise);
+
+      let logs = await logsPromise;
+
+      console.log(`Fetched ${logs.length} logs for server connection ${serverConnectionId}`);
+
       return logs;
     };
 
-    await queue.addAll(
-      localConnections.map(connection => async () => {
-        let logs = await getServerConnectionLogs(connection.id);
-        let providerRunId = connection.providerRun.id;
+    let getFunctionInvocationLogs = async (functionInvocationId: string) => {
+      let cached = functionInvocationLogsCache.get(functionInvocationId);
+      if (cached) return await cached;
 
-        mergeInvocation(invocationMap, {
-          id: getShuttleServerConnectionProviderInvocationId(connection.id),
-          source: 'shuttle',
-          type: 'tool_call',
-          status: 'unknown',
-          providerRunIds: [providerRunId],
-          sessionMessageIds: sessionMessageIdsByProviderRunId.get(providerRunId) ?? [],
-          authConfigEventIds: [],
-          providerOAuthSetupIds: [],
-          toolCallId: null,
-          action: null,
-          requests: [],
-          responses: [],
-          requestTraces: [],
-          logs: logs.map(log => ({
-            timestamp: log.timestamp,
-            message: log.message,
-            outputType: log.outputType
-          })),
-          attachments: [],
-          error: null,
-          provider: null,
-          metadata: {
-            serverConnectionId: connection.id
-          },
-          createdAt: connection.providerRun.createdAt
-        });
-      })
+      let logsPromise = shuttle.functionServerInvocation.getLogs({ functionInvocationId });
+      functionInvocationLogsCache.set(functionInvocationId, logsPromise);
+
+      return await logsPromise;
+    };
+
+    console.log(
+      `Processing ${localConnections.length} local connections and ${remoteInvocations.length} remote invocations`
     );
 
     await queue.addAll(
+      localConnections
+        .filter(connection => !serverConnectionIdsWithFunctionInvocations.has(connection.id))
+        .map(connection => async () => {
+          let logs = await getServerConnectionLogs(connection.id);
+          let providerRunId = connection.providerRun.id;
+
+          mergeInvocation(invocationMap, {
+            id: getShuttleServerConnectionProviderInvocationId(connection.id),
+            source: 'shuttle',
+            type: 'tool_call',
+            status: 'unknown',
+            providerRunIds: [providerRunId],
+            sessionMessageIds: sessionMessageIdsByProviderRunId.get(providerRunId) ?? [],
+            authConfigEventIds: [],
+            providerOAuthSetupIds: [],
+            toolCallId: null,
+            action: null,
+            requests: [],
+            responses: [],
+            requestTraces: [],
+            logs: logs.map(log => ({
+              timestamp: log.timestamp,
+              message: log.message,
+              outputType: log.outputType
+            })),
+            attachments: [],
+            error: null,
+            provider: null,
+            metadata: {
+              serverConnectionId: connection.id
+            },
+            createdAt: connection.providerRun.createdAt
+          });
+        })
+    );
+
+    console.log(`Finished processing local connections, now processing remote invocations`);
+
+    await queue.addAll(
       remoteInvocations.map(invocation => async () => {
-        let logs = await shuttle.functionServerInvocation.getLogs({
-          functionInvocationId: invocation.id
-        });
+        console.log(
+          `Processing function invocation ${invocation.id} for server connection ${invocation.serverConnectionId}`
+        );
+        let logs = await getFunctionInvocationLogs(invocation.id);
+        console.log(
+          `Fetched ${logs.logs.length} logs for function invocation ${invocation.id}`
+        );
 
         let providerRunId = invocation.serverConnectionId
           ? (providerRunIdByConnectionId.get(invocation.serverConnectionId) ?? null)
@@ -228,6 +266,8 @@ export class ProviderInvocation extends IProviderInvocation {
       })
     );
 
+    console.log(`Finished processing remote invocations, now processing auth config events`);
+
     await queue.addAll(
       authConfigEvents.map(event => async () => {
         let type: UnifiedProviderInvocation['type'] = event.type.includes('oauth_setup')
@@ -244,9 +284,7 @@ export class ProviderInvocation extends IProviderInvocation {
           let invocation = await shuttle.functionServerInvocation.get({
             functionInvocationId: parsedId.sourceId
           });
-          let logs = await shuttle.functionServerInvocation.getLogs({
-            functionInvocationId: parsedId.sourceId
-          });
+          let logs = await getFunctionInvocationLogs(parsedId.sourceId);
 
           mergeInvocation(invocationMap, {
             id: getShuttleFunctionProviderInvocationId(invocation.id),
@@ -290,6 +328,7 @@ export class ProviderInvocation extends IProviderInvocation {
 
         let serverConnectionId = getServerConnectionIdFromPayload(event.payload);
         if (!serverConnectionId) return;
+        if (serverConnectionIdsWithFunctionInvocations.has(serverConnectionId)) return;
 
         let logs = await getServerConnectionLogs(serverConnectionId);
         let providerRunId = providerRunIdByConnectionId.get(serverConnectionId) ?? null;
@@ -333,6 +372,10 @@ export class ProviderInvocation extends IProviderInvocation {
           createdAt: event.createdAt
         });
       })
+    );
+
+    console.log(
+      `Finished processing provider invocations, total unique invocations: ${invocationMap.size}`
     );
 
     return {
@@ -482,8 +525,7 @@ export class ProviderInvocation extends IProviderInvocation {
     )
       ? 'failed'
       : relatedEvents.some(
-            event =>
-              event.type.endsWith('_completed') || event.type.endsWith('_succeeded')
+            event => event.type.endsWith('_completed') || event.type.endsWith('_succeeded')
           )
         ? 'succeeded'
         : 'unknown';

--- a/src/systems/subspace/provider-backends/provider-shuttle/src/impl/providerInvocation.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/impl/providerInvocation.ts
@@ -66,8 +66,6 @@ export class ProviderInvocation extends IProviderInvocation {
   override async listProviderInvocations(
     data: ProviderInvocationListParam
   ): Promise<ProviderInvocationListRes> {
-    console.log('Listing provider invocations with data', data);
-
     let invocationMap = new Map<string, UnifiedProviderInvocation>();
     let queue = new PQueue({ concurrency: 5 });
     let serverConnectionLogsCache = new Map<
@@ -149,14 +147,10 @@ export class ProviderInvocation extends IProviderInvocation {
       let cached = serverConnectionLogsCache.get(serverConnectionId);
       if (cached) return await cached;
 
-      console.log(`Fetching logs for server connection ${serverConnectionId}`);
-
       let logsPromise = shuttle.serverConnection.getLogsSync({ serverConnectionId });
       serverConnectionLogsCache.set(serverConnectionId, logsPromise);
 
       let logs = await logsPromise;
-
-      console.log(`Fetched ${logs.length} logs for server connection ${serverConnectionId}`);
 
       return logs;
     };
@@ -170,10 +164,6 @@ export class ProviderInvocation extends IProviderInvocation {
 
       return await logsPromise;
     };
-
-    console.log(
-      `Processing ${localConnections.length} local connections and ${remoteInvocations.length} remote invocations`
-    );
 
     await queue.addAll(
       localConnections
@@ -212,17 +202,9 @@ export class ProviderInvocation extends IProviderInvocation {
         })
     );
 
-    console.log(`Finished processing local connections, now processing remote invocations`);
-
     await queue.addAll(
       remoteInvocations.map(invocation => async () => {
-        console.log(
-          `Processing function invocation ${invocation.id} for server connection ${invocation.serverConnectionId}`
-        );
         let logs = await getFunctionInvocationLogs(invocation.id);
-        console.log(
-          `Fetched ${logs.logs.length} logs for function invocation ${invocation.id}`
-        );
 
         let providerRunId = invocation.serverConnectionId
           ? (providerRunIdByConnectionId.get(invocation.serverConnectionId) ?? null)
@@ -265,8 +247,6 @@ export class ProviderInvocation extends IProviderInvocation {
         });
       })
     );
-
-    console.log(`Finished processing remote invocations, now processing auth config events`);
 
     await queue.addAll(
       authConfigEvents.map(event => async () => {
@@ -372,10 +352,6 @@ export class ProviderInvocation extends IProviderInvocation {
           createdAt: event.createdAt
         });
       })
-    );
-
-    console.log(
-      `Finished processing provider invocations, total unique invocations: ${invocationMap.size}`
     );
 
     return {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches provider identity fields (adds/uses `prettySlug`) and adjusts shuttle invocation aggregation/caching, which can affect routing/lookup and trace display if assumptions are wrong, but changes are localized and straightforward.
> 
> **Overview**
> Fixes provider “pretty slug” handling end-to-end by adding `prettySlug` to `Provider`, tightening uniqueness checks during provider upsert, and having provider/listing presenters prefer `prettySlug` over `slug` when returning API `slug` values.
> 
> Updates the dashboard provider page to surface identifier/publisher in a new header layout, and improves invocation UX by mapping `type: unknown` to “Provider Call” plus reducing polling churn by skipping provider-invocation refetches while a fetch is already in-flight.
> 
> Improves shuttle invocation/log behavior by making `getFunctionCallLogs` optionally wait/retry, caching log fetch promises, and avoiding duplicate “server_connection” invocations when function invocations exist. Also hardens the `code-workspace` setup script (stable root dir, remove copied VS Code `package.json`, isolated MemFS build in a temp dir, and use `bun` for packaging).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fddd0fef51a779ed8638e5850447b6cfcdecf70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->