### PR TITLE
Fix session ui

### DIFF
--- a/src/backend/apis/core/src/apiServer.ts
+++ b/src/backend/apis/core/src/apiServer.ts
@@ -1,4 +1,8 @@
-import { consumerApiController, fullDashboardController, magnetarController } from './controllers';
+import {
+  consumerApiController,
+  fullDashboardController,
+  magnetarController
+} from './controllers';
 import { restServer } from './rest';
 
 export let apiServer = restServer.launch({

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-deployment/auth-methods.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-deployment/auth-methods.tsx
@@ -1,5 +1,4 @@
-import { DashboardInstanceProvidersAuthMethodsListOutput } from '@metorial/dashboard-sdk';
-import { renderWithLoader } from '@metorial/data-hooks';
+import { renderWithLoader, renderWithPagination } from '@metorial/data-hooks';
 import {
   useCurrentInstance,
   useProvider,
@@ -7,169 +6,13 @@ import {
   useProviderDeployment
 } from '@metorial/state';
 import { Badge, Button, Flex, Text } from '@metorial/ui';
-import { Table as DashboardTable } from '../../../../../components/table';
-import { FilterPayload } from '../../../../../components/table/filter';
-import {
-  TableStateProvider,
-  TableStateProviderResult
-} from '../../../../../components/table/type';
+import { ID, Table } from '@metorial/ui-product';
 import { useParams } from 'react-router-dom';
-import { ProviderDeploymentTabSection } from '../../../scenes/providerDeployments/tabSection';
 import {
-  getProviderAuthMethodSchemaFieldCount,
   getProviderAuthMethodTypeColor,
   getProviderAuthMethodTypeLabel,
-  hasProviderAuthMethodSchemaFields,
   showProviderAuthMethodDetailsModal
 } from '../../../scenes/providers/authMethodDetails';
-
-type ProviderDeploymentAuthMethod =
-  DashboardInstanceProvidersAuthMethodsListOutput['items'][number];
-
-type ProviderDeploymentAuthMethodsTableProps = {
-  instanceId: string;
-  effectiveVersionId: string;
-};
-
-let providerDeploymentAuthMethodsTableState: TableStateProvider<
-  ProviderDeploymentAuthMethodsTableProps,
-  ProviderDeploymentAuthMethod,
-  TableStateProviderResult<ProviderDeploymentAuthMethod>
-> = (
-  props: ProviderDeploymentAuthMethodsTableProps,
-  opts: {
-    filter: Record<string, FilterPayload>;
-    search?: string;
-  }
-) => {
-  let authMethods = useProviderAuthMethods(props.instanceId, {
-    providerVersionId: props.effectiveVersionId
-  });
-  let normalizedSearch = opts.search?.trim().toLowerCase() ?? '';
-  let items = (authMethods.data?.items ?? []).filter(method => {
-    if (!normalizedSearch) return true;
-
-    return [method.name, method.description ?? '', getProviderAuthMethodTypeLabel(method.type)]
-      .join(' ')
-      .toLowerCase()
-      .includes(normalizedSearch);
-  });
-
-  return {
-    isLoading: authMethods.isLoading,
-    error: authMethods.error,
-    hasMoreAfter: authMethods.data?.pagination.hasMoreAfter ?? false,
-    hasMoreBefore: authMethods.data?.pagination.hasMoreBefore ?? false,
-    items,
-    loadNext: authMethods.next,
-    loadPrevious: authMethods.previous
-  };
-};
-
-let providerDeploymentAuthMethodsTable = new DashboardTable<
-  ProviderDeploymentAuthMethodsTableProps,
-  ProviderDeploymentAuthMethod
->('provider-deployment-auth-methods')
-  .state(providerDeploymentAuthMethodsTableState)
-  .columns([
-    {
-      id: 'name',
-      isDefault: true,
-      header: 'Name',
-      render: method => {
-        let description =
-          method.description && method.description.length > 110
-            ? `${method.description.slice(0, 110)}...`
-            : (method.description ?? '');
-
-        return (
-          <Flex direction="column" gap={2}>
-            <Text size="2" weight="strong">
-              {method.name}
-            </Text>
-            <Text
-              size="2"
-              color="gray600"
-              style={{
-                display: 'block',
-                maxWidth: '100%',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis'
-              }}
-            >
-              {description}
-            </Text>
-          </Flex>
-        );
-      }
-    },
-    {
-      id: 'type',
-      isDefault: true,
-      header: 'Type',
-      render: method => (
-        <Flex gap={6} style={{ alignItems: 'center', flexWrap: 'wrap' }}>
-          <Badge color={getProviderAuthMethodTypeColor(method.type)} size="1">
-            {getProviderAuthMethodTypeLabel(method.type)}
-          </Badge>
-        </Flex>
-      )
-    },
-    {
-      id: 'details',
-      isDefault: true,
-      header: 'Details',
-      render: method => {
-        let hasInputFields = hasProviderAuthMethodSchemaFields(method.inputSchema);
-        let hasOutputFields = hasProviderAuthMethodSchemaFields(method.outputSchema);
-        let scopeCount = method.type === 'oauth' ? (method.scopes?.length ?? 0) : 0;
-
-        return (
-          <Flex gap={6} style={{ alignItems: 'center', flexWrap: 'wrap' }}>
-            {scopeCount > 0 ? (
-              <Badge color="gray" size="1">
-                {scopeCount} Scopes
-              </Badge>
-            ) : null}
-            {hasInputFields ? (
-              <Badge color="cyan" size="1">
-                {getProviderAuthMethodSchemaFieldCount(method.inputSchema)} Input Fields
-              </Badge>
-            ) : null}
-            {hasOutputFields ? (
-              <Badge color="purple" size="1">
-                {getProviderAuthMethodSchemaFieldCount(method.outputSchema)} Output Fields
-              </Badge>
-            ) : null}
-            {scopeCount === 0 && !hasInputFields && !hasOutputFields ? (
-              <Text size="2" color="gray600">
-                -
-              </Text>
-            ) : null}
-          </Flex>
-        );
-      }
-    },
-    {
-      id: 'action',
-      isDefault: true,
-      header: 'Action',
-      render: method => (
-        <Flex style={{ width: '100%', justifyContent: 'flex-end' }}>
-          <Button
-            size="1"
-            variant="outline"
-            onClick={() => showProviderAuthMethodDetailsModal(method)}
-          >
-            View Details
-          </Button>
-        </Flex>
-      )
-    }
-  ])
-  .search('Search auth methods...')
-  .build();
 
 export let ProviderDeploymentAuthMethodsPage = () => {
   let instance = useCurrentInstance();
@@ -179,21 +22,68 @@ export let ProviderDeploymentAuthMethodsPage = () => {
   let effectiveVersionId =
     deployment.data?.lockedVersion?.id ?? provider.data?.currentVersion?.id;
 
-  return renderWithLoader({ instance, deployment, provider })(() => (
-    <ProviderDeploymentTabSection>
-      {!effectiveVersionId ? (
+  let authMethods = useProviderAuthMethods(
+    instance.data?.id,
+    effectiveVersionId ? { providerVersionId: effectiveVersionId } : null
+  );
+
+  let authMethodsContent = renderWithPagination(authMethods)(authMethods => (
+    <>
+      <Table
+        headers={['Name', 'Type', 'ID', '']}
+        data={authMethods.data.items.map(method => {
+          let description =
+            method.description && method.description.length > 110
+              ? `${method.description.slice(0, 110)}...`
+              : (method.description ?? '');
+
+          return {
+            data: [
+              <Flex direction="column" gap={2}>
+                <Text size="2" weight="strong">
+                  {method.name}
+                </Text>
+                <Text
+                  size="2"
+                  color="gray600"
+                  style={{
+                    display: 'block',
+                    maxWidth: '100%',
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis'
+                  }}
+                >
+                  {description}
+                </Text>
+              </Flex>,
+              <Flex gap={6} style={{ alignItems: 'center', flexWrap: 'wrap' }}>
+                <Badge color={getProviderAuthMethodTypeColor(method.type)} size="1">
+                  {getProviderAuthMethodTypeLabel(method.type)}
+                </Badge>
+              </Flex>,
+              <ID id={method.id} />,
+              <Flex justify="end" style={{ width: '100%' }}>
+                <Button
+                  size="1"
+                  variant="outline"
+                  onClick={() => showProviderAuthMethodDetailsModal(method)}
+                >
+                  View Details
+                </Button>
+              </Flex>
+            ]
+          };
+        })}
+      />
+
+      {authMethods.data.items.length === 0 && (
         <Text size="2" color="gray600" align="center" style={{ marginTop: 10 }}>
-          {provider.data?.type?.auth?.status === 'enabled'
-            ? 'No provider version is available yet, so auth methods cannot be loaded.'
-            : 'This deployment does not require authentication.'}
+          No authentication methods found for this provider.
         </Text>
-      ) : (
-        providerDeploymentAuthMethodsTable({
-          instanceId: instance.data!.id,
-          effectiveVersionId,
-          emptyState: 'No auth methods for this deployment.'
-        })
       )}
-    </ProviderDeploymentTabSection>
+    </>
   ));
+
+  return renderWithLoader({ instance })(() => authMethodsContent);
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/auth-methods.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/auth-methods.tsx
@@ -1,7 +1,7 @@
 import { renderWithLoader, renderWithPagination } from '@metorial/data-hooks';
 import { useCurrentInstance, useProviderAuthMethods } from '@metorial/state';
 import { Badge, Button, Flex, Text } from '@metorial/ui';
-import { Table } from '@metorial/ui-product';
+import { ID, Table } from '@metorial/ui-product';
 import {
   getProviderAuthMethodTypeColor,
   getProviderAuthMethodTypeLabel,
@@ -20,7 +20,7 @@ export let ProviderAuthMethodsPage = () => {
   let authMethodsContent = renderWithPagination(authMethods)(authMethods => (
     <>
       <Table
-        headers={['Name', 'Type', '']}
+        headers={['Name', 'Type', 'ID', '']}
         data={authMethods.data.items.map(method => {
           let description =
             method.description && method.description.length > 110
@@ -52,6 +52,7 @@ export let ProviderAuthMethodsPage = () => {
                   {getProviderAuthMethodTypeLabel(method.type)}
                 </Badge>
               </Flex>,
+              <ID id={method.id} />,
               <Flex justify="end" style={{ width: '100%' }}>
                 <Button
                   size="1"

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/deployments.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/deployments.tsx
@@ -1,35 +1,19 @@
 import { renderWithLoader } from '@metorial/data-hooks';
 import { useCurrentInstance, useProvider } from '@metorial/state';
-import { Input, Spacer } from '@metorial/ui';
-import { useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { useDebounced } from '../../../../hooks/useDebounced';
-import { ProviderDeploymentsTableSimple } from '../../scenes/providerDeployments/tableSimple';
+import { ProviderDeploymentsTable } from '../../scenes/providerDeployments/table';
 
 export let ProviderDeploymentsPage = () => {
   let instance = useCurrentInstance();
   let { providerId } = useParams();
   let provider = useProvider(instance.data?.id, providerId);
-  let [search, setSearch] = useState('');
-  let searchDebounced = useDebounced(search, 500);
 
   return renderWithLoader({ instance, provider })(({ instance, provider }) => (
     <>
-      <Input
-        label="Search"
-        hideLabel
-        placeholder="Search for deployments..."
-        value={search}
-        onChange={e => setSearch(e.target.value)}
-      />
-
-      <Spacer size={15} />
-
-      <ProviderDeploymentsTableSimple
+      <ProviderDeploymentsTable
         instanceId={instance.data.id}
         providerId={provider.data.id}
         providerName={provider.data.name}
-        search={searchDebounced}
       />
     </>
   ));

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/index.tsx
@@ -7,10 +7,11 @@ import {
   useProviderDeployments,
   useProviderListing
 } from '@metorial/state';
-import { Button, Spacer, Text } from '@metorial/ui';
+import { Attributes, Button, Spacer, Text } from '@metorial/ui';
 import { ID, SideBox } from '@metorial/ui-product';
 import dedent from 'dedent';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
 import {
   createJavascriptSdkInstallInstruction,
   createPythonSdkInstallInstruction
@@ -21,6 +22,12 @@ import { useProviderVersionContext } from './_layout';
 import { InstructionItem, Instructions } from './components/instructions';
 import { KeySelector } from './components/keySelector';
 import { Skills } from './components/skills';
+
+let Header = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 20px;
+`;
 
 export let ProviderOverviewPage = () => {
   let instance = useCurrentInstance();
@@ -203,23 +210,39 @@ export let ProviderOverviewPage = () => {
 
   return renderWithLoader({ provider })(({ provider }) => (
     <>
-      <SideBox
-        title="Test this provider"
-        description="Use the Metorial Explorer to test this provider."
-      >
-        <Link
-          to={Paths.instance.explorer(
-            instance.data?.organization,
-            instance.data?.project,
-            instance.data,
-            { provider_id: provider.data?.id }
-          )}
+      <Header>
+        <Attributes
+          itemWidth="200px"
+          attributes={[
+            {
+              label: 'Identifier',
+              content: <ID id={listing.data?.slug ?? provider.data.slug} />
+            },
+            {
+              label: 'Publisher',
+              content: provider.data.publisher.name
+            }
+          ]}
+        />
+
+        <SideBox
+          title="Test this provider"
+          description="Use the Metorial Explorer to test this provider."
         >
-          <Button as="span" size="2">
-            Open Explorer
-          </Button>
-        </Link>
-      </SideBox>
+          <Link
+            to={Paths.instance.explorer(
+              instance.data?.organization,
+              instance.data?.project,
+              instance.data,
+              { provider_id: provider.data?.id }
+            )}
+          >
+            <Button as="span" size="2">
+              Open Explorer
+            </Button>
+          </Link>
+        </SideBox>
+      </Header>
 
       <Spacer height={15} />
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/table.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/table.tsx
@@ -270,7 +270,7 @@ let providerDeploymentsTable = new DashboardTable<
     },
     {
       id: 'id',
-      isDefault: false,
+      isDefault: true,
       header: 'Deployment ID',
       render: deployment => <ID id={deployment.id} />
     }

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/details.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/details.tsx
@@ -42,7 +42,9 @@ export let ProviderInvocationDetails = ({
                 },
                 {
                   label: 'Type',
-                  value: formatTitleCase(invocation.type)
+                  value: formatTitleCase(
+                    invocation.type === 'unknown' ? 'Provider Call' : invocation.type
+                  )
                 },
                 {
                   label: 'Created',

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/authMethodDetails.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/authMethodDetails.tsx
@@ -1,5 +1,6 @@
 import { DashboardInstanceProvidersAuthMethodsListOutput } from '@metorial/dashboard-sdk';
-import { Badge, Dialog, Flex, Text, showModal, theme } from '@metorial/ui';
+import { Attributes, Badge, Dialog, Flex, Text, showModal, theme } from '@metorial/ui';
+import { ID } from '@metorial/ui-product';
 import { styled } from 'styled-components';
 import {
   getJsonSchemaObject,
@@ -39,9 +40,6 @@ let SchemaCard = styled.div`
   border-radius: 12px;
   background: #fff;
   overflow: hidden;
-  box-shadow:
-    0 1px 2px rgba(16, 24, 40, 0.04),
-    0 1px 3px rgba(16, 24, 40, 0.08);
 `;
 
 let SchemaCardHeader = styled.div`
@@ -237,9 +235,16 @@ export let showProviderAuthMethodDetailsModal = (method: ProviderAuthMethod) => 
   showModal(({ dialogProps }) => (
     <Dialog.Wrapper {...dialogProps} width={840}>
       <Dialog.Title>{method.name}</Dialog.Title>
-      <Dialog.Description>{method.description ?? 'No description.'}</Dialog.Description>
+      {method.description && <Dialog.Description>{method.description}</Dialog.Description>}
 
-      <Flex direction="column" gap={12} style={{ paddingTop: 8, paddingBottom: 20 }}>
+      <Flex direction="column" gap={12} style={{ paddingTop: 4 }}>
+        <Attributes
+          attributes={[
+            { label: 'Auth Method ID', content: <ID id={method.id} /> },
+            { label: 'Specification ID', content: <ID id={method.providerSpecificationId} /> }
+          ]}
+        />
+
         <SectionCard>
           <Flex gap={8} style={{ alignItems: 'center', flexWrap: 'wrap' }}>
             <Badge color={getProviderAuthMethodTypeColor(method.type)} size="1">

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/hooks/useConnectionTimeline.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/hooks/useConnectionTimeline.tsx
@@ -83,6 +83,8 @@ export let useConnectionTimeline = ({
   refetchConnectionRef.current = connectionQuery.refetch;
   let refetchProviderInvocationsRef = useRef(providerInvocations.refetch);
   refetchProviderInvocationsRef.current = providerInvocations.refetch;
+  let providerInvocationsLoadingRef = useRef(providerInvocations.isLoading);
+  providerInvocationsLoadingRef.current = providerInvocations.isLoading;
 
   useEffect(() => {
     if (!instanceId) return;
@@ -91,7 +93,9 @@ export let useConnectionTimeline = ({
       refetchMessagesRef.current?.();
       refetchEventsRef.current?.();
       refetchProviderRunsRef.current?.();
-      refetchProviderInvocationsRef.current?.();
+      if (!providerInvocationsLoadingRef.current) {
+        refetchProviderInvocationsRef.current?.();
+      }
     }, 5_000);
     return () => clearInterval(id);
   }, [instanceId, session.id, connection.id]);

--- a/src/frontend/state/src/deployment/loaders/providerSetupSessions.ts
+++ b/src/frontend/state/src/deployment/loaders/providerSetupSessions.ts
@@ -50,8 +50,10 @@ export let useCreateProviderSetupSession = (
             providerDeploymentId:
               body.providerDeploymentId ?? providerDeploymentId ?? undefined,
             configuration: {
+              ...body.configuration,
               ui: {
-                layout: 'light'
+                layout: 'light',
+                ...body.configuration?.ui
               }
             }
           })

--- a/src/systems/origin/apps/code-workspace/setup.sh
+++ b/src/systems/origin/apps/code-workspace/setup.sh
@@ -2,11 +2,16 @@
 
 set -e
 
-ROOT_DIR=$(pwd)
+ROOT_DIR=$(cd "$(dirname "$0")" && pwd)
+cd "$ROOT_DIR"
 
 FORCE_SETUP=${FORCE_SETUP:-false}
 
-IS_SETUP=$(find ./public/vscode -maxdepth 0 -type d | wc -l)
+IS_SETUP=0
+
+if [ -d ./public/vscode ]; then
+  IS_SETUP=1
+fi
 
 if [ "$IS_SETUP" -gt 0 ] && [ "$FORCE_SETUP" = false ]; then
   echo "VS Code workspace is already set up. Use FORCE_SETUP=true to force re-setup."
@@ -20,6 +25,7 @@ mkdir -p ./public/vscode
 
 OSS_NODE_MODULES_PATH=$(realpath ../../../../node_modules || echo "")
 ENTERPRISE_NODE_MODULES_PATH=$(realpath ../../../../../node_modules || echo "")
+ENTERPRISE_NODE_MODULES_PATH_2=$(realpath ../../../../../../node_modules || echo "")
 
 NODE_MODULES_PATH=$OSS_NODE_MODULES_PATH
 
@@ -27,9 +33,20 @@ if [ -d "$ENTERPRISE_NODE_MODULES_PATH" ]; then
   NODE_MODULES_PATH=$ENTERPRISE_NODE_MODULES_PATH
 fi
 
+if [ -d "$ENTERPRISE_NODE_MODULES_PATH_2" ]; then
+  NODE_MODULES_PATH=$ENTERPRISE_NODE_MODULES_PATH_2
+fi
+
 echo "Copying VS Code web files from $NODE_MODULES_PATH/vscode-web/dist to ./public/vscode-web"
 
 cp -r $NODE_MODULES_PATH/vscode-web/dist/** ./public/vscode
+
+# The copied VS Code web bundle includes a package.json with the upstream
+# name "Code - OSS". Because this app lives under the OSS npm workspace globs,
+# npm tries to treat ./public/vscode as a workspace package and fails on that
+# invalid package name during installs. The bundle is served as static assets,
+# so we remove npm metadata after copying.
+rm -f ./public/vscode/package.json ./public/vscode/package-lock.json
 
 mkdir -p ./public/vscode/vscode-textmate/release
 cp $NODE_MODULES_PATH/vscode-textmate/release/main.js ./public/vscode/vscode-textmate/release/
@@ -38,21 +55,41 @@ mkdir -p ./public/vscode/vscode-oniguruma/release
 cp $NODE_MODULES_PATH/vscode-oniguruma/release/main.js ./public/vscode/vscode-oniguruma/release/
 cp $NODE_MODULES_PATH/vscode-oniguruma/release/onig.wasm ./public/vscode/vscode-oniguruma/release/
 
+MEMFS_SOURCE_DIR="$ROOT_DIR/extensions/memfs"
+MEMFS_BUILD_DIR=$(mktemp -d)
 
-cd extensions/memfs
+cleanup() {
+  rm -rf "$MEMFS_BUILD_DIR"
+}
+
+trap cleanup EXIT
+
+echo "Preparing isolated MemFS build in $MEMFS_BUILD_DIR"
+
+cp "$MEMFS_SOURCE_DIR/package.json" "$MEMFS_BUILD_DIR/package.json"
+cp "$MEMFS_SOURCE_DIR/package-lock.json" "$MEMFS_BUILD_DIR/package-lock.json"
+cp "$MEMFS_SOURCE_DIR/tsconfig.json" "$MEMFS_BUILD_DIR/tsconfig.json"
+cp "$MEMFS_SOURCE_DIR/esbuild.js" "$MEMFS_BUILD_DIR/esbuild.js"
+cp "$MEMFS_SOURCE_DIR/eslint.config.mjs" "$MEMFS_BUILD_DIR/eslint.config.mjs"
+cp -R "$MEMFS_SOURCE_DIR/src" "$MEMFS_BUILD_DIR/src"
+
+cd "$MEMFS_BUILD_DIR"
 
 echo "Installing MemFS extension dependencies..."
 npm i
 
 echo "Building MemFS extension..."
-npm run package
+bun run package
 
-cd ../../
+cd "$ROOT_DIR"
 
 echo "Copying MemFS extension files to ./public/extensions/memfs"
 
-cp -r extensions/memfs/dist/** ./public/extensions/memfs
-cp extensions/memfs/package.json ./public/extensions/memfs/package.json
-cp extensions/memfs/package.nls.json ./public/extensions/memfs/package.nls.json
+cp -r "$MEMFS_BUILD_DIR/dist"/** ./public/extensions/memfs
+cp "$MEMFS_SOURCE_DIR/package.json" ./public/extensions/memfs/package.json
 
-cd $ROOT_DIR
+if [ -f "$MEMFS_SOURCE_DIR/package.nls.json" ]; then
+  cp "$MEMFS_SOURCE_DIR/package.nls.json" ./public/extensions/memfs/package.nls.json
+fi
+
+cd "$ROOT_DIR"

--- a/src/systems/shuttle/service/src/lib/function/call.ts
+++ b/src/systems/shuttle/service/src/lib/function/call.ts
@@ -68,8 +68,13 @@ export let callFunction = async <T>(
 export let getFunctionCallLogs = async (d: {
   server: FunctionServer;
   functionCallId: string;
+  waitForLogs?: boolean;
+  attempts?: number;
+  delayMs?: number;
 }) => {
-  for (let i = 0; i < 10; i++) {
+  let attempts = d.waitForLogs ? (d.attempts ?? 10) : 1;
+
+  for (let i = 0; i < attempts; i++) {
     try {
       let out = await functionBay.functionInvocation.get({
         tenantId: d.server.functionBayTenantId,
@@ -77,10 +82,14 @@ export let getFunctionCallLogs = async (d: {
         functionInvocationId: d.functionCallId
       });
 
-      if (out.logs.length > 0) return out.logs;
-    } catch (err) {}
+      if (!d.waitForLogs || out.logs.length > 0) return out.logs;
+    } catch (err) {
+      if (!d.waitForLogs) return [];
+    }
 
-    await delay(1000); // Wait for logs to be available
+    if (i < attempts - 1) {
+      await delay(d.delayMs ?? 1000); // Wait for logs to be available
+    }
   }
 
   return [];

--- a/src/systems/subspace/apps/public/frontend/src/pages/setupSession/components/setupLayout.tsx
+++ b/src/systems/subspace/apps/public/frontend/src/pages/setupSession/components/setupLayout.tsx
@@ -2,6 +2,7 @@ import { Spacer, Title } from '@metorial/ui';
 import { AnimatePresence, motion } from 'framer-motion';
 import React from 'react';
 import { keyframes, styled } from 'styled-components';
+import { SecuredByFooter } from './stepLayout';
 import type { Brand } from '../types';
 
 let AnimatedInner = styled(motion.div)`
@@ -83,6 +84,7 @@ export let SetupLayout = ({
   brand,
   providerName,
   providerImageUrl,
+  isWhitelabel,
   animation = 'scale',
   duration = 0.4
 }: {
@@ -97,12 +99,13 @@ export let SetupLayout = ({
   brand?: Brand;
   providerName?: string | null;
   providerImageUrl?: string | null;
+  isWhitelabel?: boolean;
 
   animation?: 'scale' | 'fade';
   duration?: number;
 }) => {
   return (
-    <InnerLayout>
+    <InnerLayout isWhitelabel={isWhitelabel}>
       <AnimatePresence>
         {main && (
           <AnimatedInner
@@ -255,13 +258,30 @@ let Content = styled.div`
   margin: auto 0; /* vertical centering when content is small */
 `;
 
-let InnerLayout = ({ children }: { children: React.ReactNode }) => {
+let Footer = styled.div`
+  display: flex;
+  justify-content: center;
+  padding-top: 24px;
+`;
+
+let InnerLayout = ({
+  children,
+  isWhitelabel
+}: {
+  children: React.ReactNode;
+  isWhitelabel?: boolean;
+}) => {
   return (
     <Wrapper>
       <Box>
         <Inner>
           <Side style={{ background: 'rgba(255, 255, 255, 1)' }} className="padded">
             <Content>{children}</Content>
+            {!isWhitelabel && (
+              <Footer>
+                <SecuredByFooter isMetorialElement logoSize={16} />
+              </Footer>
+            )}
           </Side>
         </Inner>
       </Box>

--- a/src/systems/subspace/apps/public/frontend/src/pages/setupSession/layouts/metorialElementsLayout.tsx
+++ b/src/systems/subspace/apps/public/frontend/src/pages/setupSession/layouts/metorialElementsLayout.tsx
@@ -36,8 +36,8 @@ let Card = styled.div`
   /* border: 1px solid ${theme.colors.gray300}; */
   overflow: hidden;
   display: flex;
-  flex-direction: column;
   align-items: center;
+  flex-direction: column;
 
   @media (max-width: 640px) {
     min-height: 100dvh;
@@ -52,6 +52,14 @@ let Card = styled.div`
     width: 500px;
     min-height: 700px;
   }
+`;
+
+let CardInner = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  min-height: 100%;
 `;
 
 let Header = styled.div`
@@ -195,10 +203,6 @@ let Footer = styled.div`
   font-size: 12px;
   color: ${theme.colors.gray600};
   padding: 16px 24px 24px;
-
-  @media (max-width: 640px) {
-    display: none;
-  }
 `;
 
 let FooterLink = styled.a`
@@ -215,6 +219,8 @@ let FooterLogo = styled.img`
   height: 14px;
   border-radius: 3px;
 `;
+
+let ContentWrapper = styled.div``;
 
 interface MetorialElementsLayoutProps {
   brand: Brand;
@@ -256,93 +262,93 @@ export let MetorialElementsLayout = ({
               : undefined
           }
         >
-          {!hideHeader && (
-            <Header
-              style={
-                variant === 'light'
-                  ? {
-                      borderBottom: 'none'
-                    }
-                  : undefined
-              }
-            >
-              <IconsRow>
-                <BrandIcon src={brand.imageUrl} alt={brand.name} />
+          <CardInner style={variant === 'light' ? { justifyContent: 'center' } : undefined}>
+            {!hideHeader && (
+              <Header style={variant === 'light' ? { borderBottom: 'none' } : undefined}>
+                <IconsRow>
+                  <BrandIcon src={brand.imageUrl} alt={brand.name} />
 
-                <AnimatePresence>
-                  {providerImageUrl && (
-                    <motion.div
-                      initial={{ opacity: 0, width: 0 }}
-                      animate={{ opacity: 1, width: 'auto' }}
-                      style={{ overflow: 'hidden' }}
-                    >
-                      <IconsRow>
-                        <Chevrons>
-                          <ChevronIcon delay={0} />
-                          <ChevronIcon delay={0.3} />
-                          <ChevronIcon delay={0.6} />
-                        </Chevrons>
-                        <ProviderIcon
-                          style={{
-                            background: `url(${providerImageUrl}) center/contain no-repeat`
-                          }}
-                        />
-                      </IconsRow>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </IconsRow>
-
-              <HeaderText>
-                <Title size="5" weight="strong" style={{ textAlign: 'center' }}>
-                  {providerName ? `Connect to ${providerName}` : 'Choose a provider'}
-                </Title>
-              </HeaderText>
-            </Header>
-          )}
-
-          {stepLabels.length > 1 && (
-            <StepIndicator align="center">
-              {stepLabels.map((label, index) => {
-                let isActive = index === currentStep;
-                let isCompleted = index < currentStep;
-                let isLast = index === stepLabels.length - 1;
-
-                return (
-                  <Flex key={label} align="center" style={{ flex: isLast ? 0 : 1 }}>
-                    <Flex align="center" gap={8}>
-                      <StepNumber $isCompleted={isCompleted} $isActive={isActive}>
-                        {isCompleted ? <RiCheckLine size={12} /> : index + 1}
-                      </StepNumber>
-                      <StepLabel
-                        size="1"
-                        weight="medium"
-                        $isCompleted={isCompleted}
-                        $isActive={isActive}
+                  <AnimatePresence>
+                    {providerImageUrl && (
+                      <motion.div
+                        initial={{ opacity: 0, width: 0 }}
+                        animate={{ opacity: 1, width: 'auto' }}
+                        style={{ overflow: 'hidden' }}
                       >
-                        {label}
-                      </StepLabel>
-                    </Flex>
-                    {!isLast && <StepConnector $isCompleted={isCompleted} />}
-                  </Flex>
-                );
-              })}
-            </StepIndicator>
-          )}
+                        <IconsRow>
+                          <Chevrons>
+                            <ChevronIcon delay={0} />
+                            <ChevronIcon delay={0.3} />
+                            <ChevronIcon delay={0.6} />
+                          </Chevrons>
+                          <ProviderIcon
+                            style={{
+                              background: `url(${providerImageUrl}) center/contain no-repeat`
+                            }}
+                          />
+                        </IconsRow>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </IconsRow>
 
-          <AnimateHeight>
-            <Content $hideHeader={hideHeader}>{children}</Content>
-          </AnimateHeight>
+                <HeaderText>
+                  <Title size="5" weight="strong" style={{ textAlign: 'center' }}>
+                    {providerName ? `Connect to ${providerName}` : 'Choose a provider'}
+                  </Title>
+                </HeaderText>
+              </Header>
+            )}
 
-          {!isWhitelabel && (
-            <Footer>
-              <span>Secured by</span>
-              <FooterLink href="https://metorial.com" target="_blank" rel="noopener noreferrer">
-                <FooterLogo src={METORIAL_LOGO_URL} alt="Metorial" />
-                Metorial
-              </FooterLink>
-            </Footer>
-          )}
+            <ContentWrapper style={variant === 'box' ? { flexGrow: 1 } : undefined}>
+              {stepLabels.length > 1 && (
+                <StepIndicator align="center">
+                  {stepLabels.map((label, index) => {
+                    let isActive = index === currentStep;
+                    let isCompleted = index < currentStep;
+                    let isLast = index === stepLabels.length - 1;
+
+                    return (
+                      <Flex key={label} align="center" style={{ flex: isLast ? 0 : 1 }}>
+                        <Flex align="center" gap={8}>
+                          <StepNumber $isCompleted={isCompleted} $isActive={isActive}>
+                            {isCompleted ? <RiCheckLine size={12} /> : index + 1}
+                          </StepNumber>
+                          <StepLabel
+                            size="1"
+                            weight="medium"
+                            $isCompleted={isCompleted}
+                            $isActive={isActive}
+                          >
+                            {label}
+                          </StepLabel>
+                        </Flex>
+                        {!isLast && <StepConnector $isCompleted={isCompleted} />}
+                      </Flex>
+                    );
+                  })}
+                </StepIndicator>
+              )}
+
+              <AnimateHeight>
+                <Content $hideHeader={hideHeader}>{children}</Content>
+              </AnimateHeight>
+            </ContentWrapper>
+
+            {!isWhitelabel && (
+              <Footer>
+                <span>Secured by</span>
+                <FooterLink
+                  href="https://metorial.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <FooterLogo src={METORIAL_LOGO_URL} alt="Metorial" />
+                  Metorial
+                </FooterLink>
+              </Footer>
+            )}
+          </CardInner>
         </Card>
       </Inner>
     </Wrapper>

--- a/src/systems/subspace/apps/public/frontend/src/pages/setupSession/setupSessionFlow.tsx
+++ b/src/systems/subspace/apps/public/frontend/src/pages/setupSession/setupSessionFlow.tsx
@@ -527,6 +527,7 @@ export let SetupSessionFlow = ({
           brand={brand}
           providerName={flowProvider?.name}
           providerImageUrl={flowProvider?.imageUrl}
+          isWhitelabel={isWhitelabel}
         >
           <DashboardEmbeddableLayout
             currentStep={currentStepIndex}

--- a/src/systems/subspace/apps/public/src/api/internal/presenters/brand.ts
+++ b/src/systems/subspace/apps/public/src/api/internal/presenters/brand.ts
@@ -1,0 +1,15 @@
+import type { Brand } from '@metorial-subspace/db';
+import { getImageUrl } from './utils';
+
+export let setupSessionBrandPresenter = (brand: Brand) => ({
+  object: 'brand',
+
+  id: brand.id,
+  name: brand.name,
+  imageUrl: getImageUrl({
+    id: brand.id,
+    image: brand.image
+  }),
+
+  createdAt: brand.createdAt
+});

--- a/src/systems/subspace/apps/public/src/api/internal/presenters/index.ts
+++ b/src/systems/subspace/apps/public/src/api/internal/presenters/index.ts
@@ -1,0 +1,5 @@
+export * from './brand';
+export * from './oauthSetup';
+export * from './setupSession';
+export * from './tool';
+export * from './utils';

--- a/src/systems/subspace/apps/public/src/api/internal/presenters/oauthSetup.ts
+++ b/src/systems/subspace/apps/public/src/api/internal/presenters/oauthSetup.ts
@@ -1,0 +1,94 @@
+import type {
+  Provider,
+  ProviderAuthConfig,
+  ProviderAuthCredentials,
+  ProviderAuthMethod,
+  ProviderDeployment,
+  ProviderOAuthSetup,
+  ProviderSpecification
+} from '@metorial-subspace/db';
+import {
+  setupSessionAuthConfigPresenter,
+  setupSessionAuthCredentialsPresenter,
+  setupSessionAuthMethodPresenter,
+  setupSessionDeploymentPreviewPresenter
+} from './setupSession';
+
+export let setupSessionOAuthSetupPresenter = (
+  providerOAuthSetup: ProviderOAuthSetup & {
+    provider: Provider;
+    deployment: ProviderDeployment | null;
+    authCredentials: ProviderAuthCredentials | null;
+    authMethod: ProviderAuthMethod & {
+      specification: Omit<ProviderSpecification, 'value'>;
+    };
+    authConfig:
+      | (ProviderAuthConfig & {
+          deployment: ProviderDeployment | null;
+        })
+      | null;
+  }
+) => {
+  let status =
+    (providerOAuthSetup.status === 'opened' || providerOAuthSetup.status === 'unused') &&
+    providerOAuthSetup.expiresAt <= new Date()
+      ? ('expired' as const)
+      : providerOAuthSetup.status;
+
+  return {
+    object: 'provider.oauth_setup',
+
+    id: providerOAuthSetup.id,
+    status,
+
+    isEphemeral: providerOAuthSetup.isEphemeral,
+
+    providerId: providerOAuthSetup.provider.id,
+
+    name: providerOAuthSetup.name,
+    description: providerOAuthSetup.description,
+    metadata: providerOAuthSetup.metadata,
+    toolFilter: providerOAuthSetup.toolFilter,
+
+    redirectUrl: providerOAuthSetup.redirectUrl,
+    errorCode: providerOAuthSetup.errorCode,
+    errorMessage: providerOAuthSetup.errorMessage,
+
+    url:
+      status !== 'expired' && status !== 'completed'
+        ? `/oauth-setup/${providerOAuthSetup.id}?client_secret=${providerOAuthSetup.clientSecret}`
+        : null,
+
+    authConfig: providerOAuthSetup.authConfig
+      ? setupSessionAuthConfigPresenter({
+          ...providerOAuthSetup.authConfig,
+          provider: providerOAuthSetup.provider,
+          authCredentials: providerOAuthSetup.authCredentials,
+          authMethod: providerOAuthSetup.authMethod
+        })
+      : null,
+
+    credentials: providerOAuthSetup.authCredentials
+      ? setupSessionAuthCredentialsPresenter({
+          ...providerOAuthSetup.authCredentials,
+          provider: providerOAuthSetup.provider
+        })
+      : null,
+
+    authMethod: setupSessionAuthMethodPresenter({
+      ...providerOAuthSetup.authMethod,
+      provider: providerOAuthSetup.provider
+    }),
+
+    deployment: providerOAuthSetup.deployment
+      ? setupSessionDeploymentPreviewPresenter({
+          ...providerOAuthSetup.deployment,
+          provider: providerOAuthSetup.provider
+        })
+      : null,
+
+    createdAt: providerOAuthSetup.createdAt,
+    updatedAt: providerOAuthSetup.updatedAt,
+    expiresAt: providerOAuthSetup.expiresAt
+  };
+};

--- a/src/systems/subspace/apps/public/src/api/internal/presenters/setupSession.ts
+++ b/src/systems/subspace/apps/public/src/api/internal/presenters/setupSession.ts
@@ -1,0 +1,440 @@
+import { shadowId } from '@lowerdeck/shadow-id';
+import type {
+  Identity,
+  IdentityCredential,
+  Provider,
+  ProviderAuthConfig,
+  ProviderAuthCredentials,
+  ProviderAuthMethod,
+  ProviderConfig,
+  ProviderConfigVault,
+  ProviderDeployment,
+  ProviderListing,
+  ProviderSetupSession,
+  ProviderSpecification
+} from '@metorial-subspace/db';
+import { getImageUrl } from './utils';
+
+type SetupSessionAuthMethod = ProviderAuthMethod & {
+  specification: Omit<ProviderSpecification, 'value'>;
+};
+
+type SetupSessionAuthConfig = ProviderAuthConfig & {
+  deployment: ProviderDeployment | null;
+  authCredentials: ProviderAuthCredentials | null;
+  authMethod: SetupSessionAuthMethod;
+};
+
+type SetupSessionConfig = ProviderConfig & {
+  deployment: ProviderDeployment | null;
+  fromVault:
+    | (ProviderConfigVault & {
+        deployment: ProviderDeployment | null;
+      })
+    | null;
+  specification: Omit<ProviderSpecification, 'value'>;
+};
+
+export let setupSessionSchemaPresenter = (
+  object: 'provider.setup_session.auth_config_schema' | 'provider.setup_session.config_schema',
+  schema: { type: 'none' } | { type: 'required'; schema: unknown }
+) => ({
+  object,
+  type: schema.type,
+  schema: schema.type === 'required' ? schema.schema : null
+});
+
+export let setupSessionProviderListingItemPresenter = (provider: {
+  id: string;
+  listingId: string;
+  name: string;
+  description: string | null;
+  slug: string;
+  image: {
+    type: 'file';
+    fileUrl?: string | null;
+    url?: string | null;
+  } | {
+    type: 'url';
+    url: string;
+  } | null;
+  groups: Array<{
+    id: string;
+    name: string;
+  }>;
+}) => ({
+  object: 'provider.listing#setup_session',
+
+  id: provider.listingId,
+  providerId: provider.id,
+
+  name: provider.name,
+  description: provider.description,
+  slug: provider.slug,
+  imageUrl: getImageUrl({
+    id: provider.listingId,
+    image: provider.image
+  }),
+
+  groups: provider.groups.map(group => ({
+    object: 'provider.listing.group',
+    id: group.id,
+    name: group.name
+  }))
+});
+
+export let setupSessionSelectedProviderPresenter = (
+  provider: Provider & {
+    listing: ProviderListing | null;
+  }
+) => ({
+  object: 'provider',
+
+  id: provider.id,
+  access: provider.access,
+  status: provider.status,
+  isDeprecated: provider.isDeprecated,
+
+  identifier: provider.identifier,
+  globalIdentifier: provider.globalIdentifier,
+  tag: provider.tag,
+
+  name: provider.listing?.name ?? provider.name,
+  description: provider.listing?.description ?? provider.description,
+  slug: provider.listing?.prettySlug ?? provider.listing?.slug ?? provider.prettySlug ?? provider.slug,
+  metadata: provider.metadata,
+  imageUrl: getImageUrl({
+    id: provider.listing?.id ?? provider.id,
+    image: provider.listing?.image ?? null
+  }),
+
+  listing: provider.listing
+    ? {
+        object: 'provider.listing',
+
+        id: provider.listing.id,
+        status: provider.listing.status,
+        isDeprecated: provider.listing.isDeprecated,
+
+        isPublic: provider.listing.isPublic,
+        isCustomized: provider.listing.isCustomized,
+
+        isMetorial: provider.listing.isMetorial,
+        isVerified: provider.listing.isVerified,
+        isOfficial: provider.listing.isOfficial,
+
+        name: provider.listing.name,
+        description: provider.listing.description,
+        slug: provider.listing.prettySlug ?? provider.listing.slug,
+        aliases: provider.listing.aliases,
+        skills: provider.listing.skills,
+        rank: provider.listing.rank,
+        imageUrl: getImageUrl({
+          id: provider.listing.id,
+          image: provider.listing.image
+        }),
+
+        deploymentsCount: provider.listing.deploymentsCount,
+        providerSessionsCount: provider.listing.providerSessionsCount,
+        providerMessagesCount: provider.listing.providerMessagesCount,
+
+        createdAt: provider.listing.createdAt,
+        updatedAt: provider.listing.updatedAt
+      }
+    : null,
+
+  createdAt: provider.createdAt,
+  updatedAt: provider.updatedAt
+});
+
+export let setupSessionAuthMethodPresenter = (
+  providerAuthMethod: SetupSessionAuthMethod & {
+    provider: Provider;
+  }
+) => ({
+  object: 'provider.capabilities.auth_method',
+
+  id: providerAuthMethod.id,
+  specId: providerAuthMethod.specId,
+  specUniqueIdentifier: providerAuthMethod.specUniqueIdentifier,
+  callableId: providerAuthMethod.callableId,
+  key: providerAuthMethod.key,
+  type: providerAuthMethod.type,
+  isDefault: providerAuthMethod.isDefault,
+
+  name: providerAuthMethod.name,
+  description: providerAuthMethod.description,
+
+  capabilities: providerAuthMethod.value.capabilities,
+  inputJsonSchema: providerAuthMethod.value.inputJsonSchema,
+  outputJsonSchema: providerAuthMethod.value.outputJsonSchema,
+
+  scopes:
+    providerAuthMethod.type === 'oauth'
+      ? (providerAuthMethod.value.scopes ?? []).map(scope => ({
+          object: 'provider.capabilities.auth_method.scope',
+          ...scope,
+          scope: scope.id,
+          id: shadowId('pamsco_', [providerAuthMethod.id], [scope.id])
+        }))
+      : null,
+
+  specificationId: providerAuthMethod.specification.id,
+  providerId: providerAuthMethod.provider.id,
+
+  createdAt: providerAuthMethod.createdAt,
+  updatedAt: providerAuthMethod.updatedAt
+});
+
+export let setupSessionAuthCredentialsPresenter = (
+  providerAuthCredentials: ProviderAuthCredentials & {
+    provider: Provider;
+  }
+) => ({
+  object: 'provider.auth_credentials',
+
+  id: providerAuthCredentials.id,
+  type: providerAuthCredentials.type,
+  status: providerAuthCredentials.status,
+  origin: providerAuthCredentials.origin,
+
+  isEphemeral: providerAuthCredentials.isEphemeral,
+  isDefault: providerAuthCredentials.isDefault,
+  isAutoRegistration: providerAuthCredentials.isAutoRegistration,
+  isManaged: providerAuthCredentials.origin !== 'tenant_created',
+  needsScopeSync: providerAuthCredentials.needsScopeSync,
+
+  providerId: providerAuthCredentials.provider.id,
+
+  name: providerAuthCredentials.name,
+  description: providerAuthCredentials.description,
+  metadata: providerAuthCredentials.metadata,
+  scopes: providerAuthCredentials.scopes ?? null,
+
+  createdAt: providerAuthCredentials.createdAt,
+  updatedAt: providerAuthCredentials.updatedAt
+});
+
+export let setupSessionDeploymentPreviewPresenter = (
+  providerDeployment: ProviderDeployment & {
+    provider: Provider;
+  }
+) => ({
+  object: 'provider.deployment#preview',
+
+  id: providerDeployment.id,
+  status: providerDeployment.status,
+
+  isEphemeral: providerDeployment.isEphemeral,
+  isDefault: providerDeployment.isDefault,
+
+  name: providerDeployment.name,
+  description: providerDeployment.description,
+  metadata: providerDeployment.metadata,
+  toolFilter: providerDeployment.toolFilter,
+  networkingRulesetIds: providerDeployment.networkingRulesetIds,
+
+  providerId: providerDeployment.provider.id,
+
+  createdAt: providerDeployment.createdAt,
+  updatedAt: providerDeployment.updatedAt
+});
+
+export let setupSessionConfigVaultPreviewPresenter = (
+  providerConfigVault: ProviderConfigVault & {
+    provider: Provider;
+    deployment: ProviderDeployment | null;
+  }
+) => ({
+  object: 'provider.config_vault#preview',
+
+  id: providerConfigVault.id,
+  status: providerConfigVault.status,
+
+  name: providerConfigVault.name,
+  description: providerConfigVault.description,
+  metadata: providerConfigVault.metadata,
+
+  providerId: providerConfigVault.provider.id,
+
+  deployment: providerConfigVault.deployment
+    ? setupSessionDeploymentPreviewPresenter({
+        ...providerConfigVault.deployment,
+        provider: providerConfigVault.provider
+      })
+    : null,
+
+  createdAt: providerConfigVault.createdAt,
+  updatedAt: providerConfigVault.updatedAt
+});
+
+export let setupSessionConfigPresenter = (
+  providerConfig: SetupSessionConfig & {
+    provider: Provider;
+  }
+) => ({
+  object: 'provider.config',
+
+  id: providerConfig.id,
+  status: providerConfig.status,
+
+  isEphemeral: providerConfig.isEphemeral,
+  isDefault: providerConfig.isDefault,
+  isForVault: providerConfig.isForVault,
+
+  name: providerConfig.name,
+  description: providerConfig.description,
+  metadata: providerConfig.metadata,
+  toolFilter: providerConfig.toolFilter,
+
+  providerId: providerConfig.provider.id,
+  specificationId: providerConfig.specification.id,
+
+  deployment: providerConfig.deployment
+    ? setupSessionDeploymentPreviewPresenter({
+        ...providerConfig.deployment,
+        provider: providerConfig.provider
+      })
+    : null,
+
+  fromVault: providerConfig.fromVault
+    ? setupSessionConfigVaultPreviewPresenter({
+        ...providerConfig.fromVault,
+        provider: providerConfig.provider
+      })
+    : null,
+
+  createdAt: providerConfig.createdAt,
+  updatedAt: providerConfig.updatedAt
+});
+
+export let setupSessionAuthConfigPresenter = (
+  providerAuthConfig: SetupSessionAuthConfig & {
+    provider: Provider;
+  }
+) => ({
+  object: 'provider.auth_config',
+
+  id: providerAuthConfig.id,
+  type: providerAuthConfig.type,
+  source: providerAuthConfig.source,
+  status: providerAuthConfig.status,
+
+  isEphemeral: providerAuthConfig.isEphemeral,
+  isDefault: providerAuthConfig.isDefault,
+
+  providerId: providerAuthConfig.provider.id,
+
+  name: providerAuthConfig.name,
+  description: providerAuthConfig.description,
+  metadata: providerAuthConfig.metadata,
+  scopes: providerAuthConfig.scopes,
+  toolFilter: providerAuthConfig.toolFilter,
+
+  deployment: providerAuthConfig.deployment
+    ? setupSessionDeploymentPreviewPresenter({
+        ...providerAuthConfig.deployment,
+        provider: providerAuthConfig.provider
+      })
+    : null,
+
+  credentials: providerAuthConfig.authCredentials
+    ? setupSessionAuthCredentialsPresenter({
+        ...providerAuthConfig.authCredentials,
+        provider: providerAuthConfig.provider
+      })
+    : null,
+
+  authMethod: setupSessionAuthMethodPresenter({
+    ...providerAuthConfig.authMethod,
+    provider: providerAuthConfig.provider
+  }),
+
+  createdAt: providerAuthConfig.createdAt,
+  updatedAt: providerAuthConfig.updatedAt
+});
+
+export let setupSessionPresenter = (
+  providerSetupSession: ProviderSetupSession & {
+    identity: Identity | null;
+    identityCredential: IdentityCredential | null;
+    authConfig: SetupSessionAuthConfig | null;
+    config: SetupSessionConfig | null;
+    deployment: ProviderDeployment | null;
+    provider: Provider | null;
+    authMethod: SetupSessionAuthMethod | null;
+    authCredentials: ProviderAuthCredentials | null;
+  }
+) => {
+  let status =
+    providerSetupSession.status === 'pending' && providerSetupSession.expiresAt <= new Date()
+      ? ('expired' as const)
+      : providerSetupSession.status;
+
+  return {
+    object: 'provider.setup_session',
+
+    id: providerSetupSession.id,
+    type: providerSetupSession.typeSelected,
+    typeSelected: providerSetupSession.typeSelected,
+    typeConcrete: providerSetupSession.typeConcrete,
+
+    status,
+
+    name: providerSetupSession.name,
+    description: providerSetupSession.description,
+    metadata: providerSetupSession.metadata,
+
+    providerId: providerSetupSession.provider?.id ?? null,
+    identityId: providerSetupSession.identity?.id ?? null,
+    identityCredentialId: providerSetupSession.identityCredential?.id ?? null,
+    configuration: providerSetupSession.configuration ?? null,
+
+    authMethod:
+      providerSetupSession.provider && providerSetupSession.authMethod
+        ? setupSessionAuthMethodPresenter({
+            ...providerSetupSession.authMethod,
+            provider: providerSetupSession.provider
+          })
+        : null,
+
+    deployment:
+      providerSetupSession.deployment && providerSetupSession.provider
+        ? setupSessionDeploymentPreviewPresenter({
+            ...providerSetupSession.deployment,
+            provider: providerSetupSession.provider
+          })
+        : null,
+
+    credentials:
+      providerSetupSession.authCredentials && providerSetupSession.provider
+        ? setupSessionAuthCredentialsPresenter({
+            ...providerSetupSession.authCredentials,
+            provider: providerSetupSession.provider
+          })
+        : null,
+
+    authConfig:
+      providerSetupSession.authConfig && providerSetupSession.provider
+        ? setupSessionAuthConfigPresenter({
+            ...providerSetupSession.authConfig,
+            provider: providerSetupSession.provider
+          })
+        : null,
+
+    config:
+      providerSetupSession.config && providerSetupSession.provider
+        ? setupSessionConfigPresenter({
+            ...providerSetupSession.config,
+            provider: providerSetupSession.provider
+          })
+        : null,
+
+    uiMode: providerSetupSession.uiMode,
+    redirectUrl: providerSetupSession.redirectUrl,
+
+    createdAt: providerSetupSession.createdAt,
+    updatedAt: providerSetupSession.updatedAt,
+    expiresAt: providerSetupSession.expiresAt
+  };
+};

--- a/src/systems/subspace/apps/public/src/api/internal/presenters/tool.ts
+++ b/src/systems/subspace/apps/public/src/api/internal/presenters/tool.ts
@@ -1,0 +1,14 @@
+export let setupSessionToolPresenter = (tool: {
+  id: string;
+  key: string;
+  name: string;
+  description: string | null;
+}) => ({
+  object: 'provider.capabilities.tool',
+
+  id: tool.id,
+  key: tool.key,
+
+  name: tool.name,
+  description: tool.description
+});

--- a/src/systems/subspace/apps/public/src/api/internal/presenters/utils.ts
+++ b/src/systems/subspace/apps/public/src/api/internal/presenters/utils.ts
@@ -1,0 +1,27 @@
+type ImageValue =
+  | {
+      type: 'file';
+      fileUrl?: string | null;
+      url?: string | null;
+    }
+  | {
+      type: 'url';
+      url: string;
+    }
+  | null
+  | undefined;
+
+export let getImageUrl = (entity: {
+  id: string;
+  image: ImageValue;
+}) => {
+  if (entity.image?.type === 'file') {
+    return entity.image.fileUrl ?? entity.image.url ?? '';
+  }
+
+  if (entity.image?.type === 'url') {
+    return entity.image.url;
+  }
+
+  return new URL(`https://avatar-cdn.metorial.com/aimg_${entity.id.split('_').pop()}`).toString();
+};

--- a/src/systems/subspace/apps/public/src/api/internal/setupSession.ts
+++ b/src/systems/subspace/apps/public/src/api/internal/setupSession.ts
@@ -1,13 +1,16 @@
 import { v } from '@lowerdeck/validation';
 import { providerSetupSessionUiService } from '@metorial-subspace/module-auth';
 import { brandService } from '@metorial-subspace/module-tenant';
-import {
-  brandPresenter,
-  getImageUrl,
-  providerOAuthSetupPresenter,
-  providerSetupSessionPresenter
-} from '@metorial-subspace/presenters';
 import { app } from './_app';
+import {
+  setupSessionBrandPresenter,
+  setupSessionOAuthSetupPresenter,
+  setupSessionPresenter,
+  setupSessionProviderListingItemPresenter,
+  setupSessionSchemaPresenter,
+  setupSessionSelectedProviderPresenter,
+  setupSessionToolPresenter
+} from './presenters';
 
 let sessionApp = app.use(async ctx => {
   let sessionId = ctx.body.sessionId;
@@ -44,23 +47,9 @@ export let getFullSession = async (
     session.brand ?? (await brandService.getBrandForTenant({ tenantId: session.tenant.id }));
 
   return {
-    provider: session.provider
-      ? {
-          id: session.provider.id,
-          name: session.provider.name,
-          description: session.provider.description,
-          slug: session.provider.slug,
-          imageUrl: session.provider.listing
-            ? getImageUrl(session.provider.listing)
-            : getImageUrl({
-                id: session.provider.id,
-                name: session.provider.name,
-                image: null
-              })
-        }
-      : null,
-    session: providerSetupSessionPresenter(session),
-    brand: brandPresenter(brand),
+    provider: session.provider ? setupSessionSelectedProviderPresenter(session.provider) : null,
+    session: setupSessionPresenter(session),
+    brand: setupSessionBrandPresenter(brand),
     isWhitelabel: session.tenant.isWhitelabel
   };
 };
@@ -98,7 +87,9 @@ export let setupSessionController = app.controller({
         providerSetupSession: ctx.session
       });
 
-      return { schema };
+      return {
+        schema: setupSessionSchemaPresenter('provider.setup_session.auth_config_schema', schema)
+      };
     }),
 
   getConfigSchema: sessionApp
@@ -114,7 +105,9 @@ export let setupSessionController = app.controller({
         providerSetupSession: ctx.session
       });
 
-      return { schema };
+      return {
+        schema: setupSessionSchemaPresenter('provider.setup_session.config_schema', schema)
+      };
     }),
 
   setConfig: sessionApp
@@ -183,22 +176,7 @@ export let setupSessionController = app.controller({
       });
 
       return {
-        items: providers.items.map(provider => ({
-          ...provider,
-          id: provider.listingId,
-          providerId: provider.id,
-          imageUrl: provider.image
-            ? getImageUrl({
-                id: provider.listingId,
-                name: provider.name,
-                image: provider.image as any
-              })
-            : getImageUrl({
-                id: provider.listingId,
-                name: provider.name,
-                image: null
-              })
-        })),
+        items: providers.items.map(provider => setupSessionProviderListingItemPresenter(provider)),
         pagination: {
           hasMoreBefore: providers.pagination.hasPreviousPage,
           hasMoreAfter: providers.pagination.hasNextPage
@@ -240,9 +218,11 @@ export let setupSessionController = app.controller({
     )
     .do(async ctx => {
       return {
-        items: await providerSetupSessionUiService.listTools({
-          providerSetupSession: ctx.session
-        })
+        items: (
+          await providerSetupSessionUiService.listTools({
+            providerSetupSession: ctx.session
+          })
+        ).map(tool => setupSessionToolPresenter(tool))
       };
     }),
 
@@ -260,6 +240,6 @@ export let setupSessionController = app.controller({
       });
       if (!oauthSetup) return null;
 
-      return providerOAuthSetupPresenter(oauthSetup);
+      return setupSessionOAuthSetupPresenter(oauthSetup);
     })
 });

--- a/src/systems/subspace/db/prisma/schema/listing/listing.prisma
+++ b/src/systems/subspace/db/prisma/schema/listing/listing.prisma
@@ -5,10 +5,11 @@ enum ProviderListingStatus {
 }
 
 model ProviderListing {
-  oid    BigInt                @id
-  id     String                @unique
-  status ProviderListingStatus
-  isDeprecated Boolean @default(false)
+  oid BigInt @id
+  id  String @unique
+
+  status       ProviderListingStatus
+  isDeprecated Boolean               @default(false)
 
   isPublic     Boolean @default(true)
   isCustomized Boolean @default(false)
@@ -18,10 +19,9 @@ model ProviderListing {
   isOfficial Boolean @default(false)
 
   name       String
-  slug       String  @unique
-  prettySlug String? @unique
-
-  aliases String[]
+  slug       String   @unique
+  prettySlug String?  @unique
+  aliases    String[]
 
   /// [EntityImage]
   image Json?

--- a/src/systems/subspace/db/prisma/schema/provider/provider.prisma
+++ b/src/systems/subspace/db/prisma/schema/provider/provider.prisma
@@ -32,9 +32,9 @@ model Provider {
   oid BigInt @id
   id  String @unique
 
-  access ProviderAccess
-  status ProviderStatus
-  isDeprecated Boolean @default(false)
+  access       ProviderAccess
+  status       ProviderStatus
+  isDeprecated Boolean        @default(false)
 
   hasEnvironments Boolean @default(false)
 
@@ -43,6 +43,7 @@ model Provider {
   globalIdentifier String? @unique
   name             String
   description      String?
+  prettySlug       String? @unique
 
   metadata Json?
 

--- a/src/systems/subspace/modules/auth/src/services/providerAuthConfig.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthConfig.ts
@@ -313,7 +313,8 @@ class providerAuthConfigServiceImpl {
           environment: d.environment,
           provider: d.provider,
           providerDeployment: d.providerDeployment,
-          authMethodId: d.input.authMethodId
+          authMethodId: d.input.authMethodId,
+          credentials: d.credentials
         });
 
       let credentials = d.credentials;

--- a/src/systems/subspace/modules/auth/src/services/providerAuthConfigInternal.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthConfigInternal.ts
@@ -6,6 +6,7 @@ import {
   db,
   type Environment,
   getId,
+  type Prisma,
   type Provider,
   type ProviderAuthConfig,
   type ProviderAuthConfigSource,
@@ -33,6 +34,12 @@ import type { ProviderAuthConfigCreateRes } from '@metorial-subspace/provider-ut
 import { providerAuthConfigCreatedQueue } from '../queues/lifecycle/providerAuthConfig';
 import { providerAuthConfigInclude } from './providerAuthConfig';
 
+type ProviderAuthMethodWithSpecification = Prisma.ProviderAuthMethodGetPayload<{
+  include: {
+    specification: true;
+  };
+}>;
+
 class providerAuthConfigInternalServiceImpl {
   async getVersionAndAuthMethod(d: {
     tenant: Tenant;
@@ -45,13 +52,18 @@ class providerAuthConfigInternalServiceImpl {
         | null;
     };
     authMethodId?: string;
-  }) {
+    credentials?: ProviderAuthCredentials;
+  }): Promise<{
+    version: ProviderVersion;
+    authMethod: ProviderAuthMethodWithSpecification;
+  }> {
     let version = await providerDeploymentInternalService.getCurrentVersionOptional({
       provider: d.provider,
       environment: d.environment,
       deployment: d.providerDeployment
     });
-    if (!version?.specificationOid) {
+    let specificationOid = version?.specificationOid;
+    if (specificationOid == null) {
       throw new ServiceError(
         badRequestError({
           message: 'Provider has not been discovered'
@@ -59,32 +71,91 @@ class providerAuthConfigInternalServiceImpl {
       );
     }
 
-    if (!d.authMethodId) {
-      let authMethod = await db.providerAuthMethod.findFirst({
-        where: {
-          providerOid: d.provider.oid,
-          specificationOid: version.specificationOid,
-          isDefault: true
-        },
-        include: {
-          specification: true
-        }
+    let managedCredentials = d.credentials
+      ? await this.getManagedProviderAuthCredentialsContext({
+          tenant: d.tenant,
+          solution: d.solution,
+          providerAuthCredentials: d.credentials
+        })
+      : null;
+    if (managedCredentials) {
+      let authMethod = await this.getManagedAuthMethodForVersion({
+        provider: d.provider,
+        specificationOid,
+        managedCredentials
       });
-      if (!authMethod) {
-        throw new ServiceError(
-          badRequestError({
-            message: 'Provider does not support authentication'
-          })
-        );
+
+      if (d.authMethodId) {
+        let requestedAuthMethod = await this.findAuthMethodForVersion({
+          provider: d.provider,
+          specificationOid,
+          authMethodId: d.authMethodId
+        });
+        if (!requestedAuthMethod || requestedAuthMethod.oid !== authMethod.oid) {
+          throw new ServiceError(
+            badRequestError({
+              message:
+                'Managed credentials can only be used with their configured auth method',
+              code: 'managed_credentials_auth_method_mismatch'
+            })
+          );
+        }
       }
 
-      return { version, authMethod };
+      return {
+        version: version as ProviderVersion,
+        authMethod: authMethod as ProviderAuthMethodWithSpecification
+      };
     }
 
-    let authMethod = await db.providerAuthMethod.findFirst({
+    let authMethod = d.authMethodId
+      ? await this.findAuthMethodForVersion({
+          provider: d.provider,
+          specificationOid,
+          authMethodId: d.authMethodId
+        })
+      : d.credentials?.type === 'oauth'
+        ? await this.findPreferredAuthMethodForVersion({
+            provider: d.provider,
+            specificationOid,
+            type: 'oauth'
+          })
+        : await this.findPreferredAuthMethodForVersion({
+            provider: d.provider,
+            specificationOid,
+            isDefault: true
+          });
+
+    if (!authMethod) {
+      throw new ServiceError(
+        badRequestError(
+          d.authMethodId
+            ? {
+                message: 'Invalid auth method for provider',
+                code: 'invalid_auth_method'
+              }
+            : {
+                message: 'Provider does not support authentication'
+              }
+        )
+      );
+    }
+
+    return {
+      version: version as ProviderVersion,
+      authMethod: authMethod as ProviderAuthMethodWithSpecification
+    };
+  }
+
+  private async findAuthMethodForVersion(d: {
+    provider: Provider;
+    specificationOid: bigint;
+    authMethodId: string;
+  }) {
+    return await db.providerAuthMethod.findFirst({
       where: {
         providerOid: d.provider.oid,
-        specificationOid: version.specificationOid,
+        specificationOid: d.specificationOid,
         OR: [
           { id: d.authMethodId },
           { specId: d.authMethodId },
@@ -98,18 +169,122 @@ class providerAuthConfigInternalServiceImpl {
       },
       include: {
         specification: true
-      }
+      },
+      orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }]
     });
-    if (!authMethod) {
-      throw new ServiceError(
-        badRequestError({
-          message: 'Invalid auth method for provider',
-          code: 'invalid_auth_method'
-        })
-      );
+  }
+
+  private async findPreferredAuthMethodForVersion(d: {
+    provider: Provider;
+    specificationOid: bigint;
+    isDefault?: boolean;
+    type?: keyof typeof ProviderAuthMethodType;
+  }) {
+    return await db.providerAuthMethod.findFirst({
+      where: {
+        providerOid: d.provider.oid,
+        specificationOid: d.specificationOid,
+        isDefault: d.isDefault,
+        type: d.type as any
+      },
+      include: {
+        specification: true
+      },
+      orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }]
+    });
+  }
+
+  private async getManagedAuthMethodForVersion(d: {
+    provider: Provider;
+    specificationOid: bigint;
+    managedCredentials: {
+      initialProviderAuthMethodOid: bigint;
+      providerAuthMethodGlobalOid: bigint | null;
+    };
+  }) {
+    let authMethod: ProviderAuthMethodWithSpecification | null = null;
+    let providerAuthMethodGlobalOid = d.managedCredentials.providerAuthMethodGlobalOid;
+
+    if (providerAuthMethodGlobalOid !== null) {
+      let result = await db.providerAuthMethod.findFirst({
+        where: {
+          providerOid: d.provider.oid,
+          specificationOid: d.specificationOid,
+          globalOid: providerAuthMethodGlobalOid
+        },
+        include: {
+          specification: true
+        }
+      });
+      authMethod = result as ProviderAuthMethodWithSpecification | null;
+    } else {
+      let result = await db.providerAuthMethod.findFirst({
+        where: {
+          oid: d.managedCredentials.initialProviderAuthMethodOid,
+          providerOid: d.provider.oid,
+          specificationOid: d.specificationOid
+        },
+        include: {
+          specification: true
+        }
+      });
+      authMethod = result as ProviderAuthMethodWithSpecification | null;
     }
 
-    return { version, authMethod };
+    if (authMethod) {
+      return authMethod;
+    }
+
+    throw new ServiceError(
+      badRequestError({
+        message: 'Managed credentials are not available for the resolved provider version',
+        code: 'managed_credentials_auth_method_unavailable'
+      })
+    );
+  }
+
+  private async getManagedProviderAuthCredentialsContext(d: {
+    tenant: Tenant;
+    solution: Solution;
+    providerAuthCredentials: ProviderAuthCredentials;
+  }) {
+    if (
+      d.providerAuthCredentials.origin === 'managed_public' &&
+      d.providerAuthCredentials.managedCredentialsOid
+    ) {
+      return await db.managedProviderAuthCredentials.findFirst({
+        where: {
+          oid: d.providerAuthCredentials.managedCredentialsOid,
+          solutionOid: d.solution.oid
+        },
+        select: {
+          initialProviderAuthMethodOid: true,
+          providerAuthMethodGlobalOid: true
+        }
+      });
+    }
+
+    if (d.providerAuthCredentials.origin !== 'managed_backing') {
+      return null;
+    }
+
+    let backing = await db.managedProviderAuthCredentialsBacking.findFirst({
+      where: {
+        providerAuthCredentialsOid: d.providerAuthCredentials.oid,
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid
+      },
+      select: {
+        managedCredentials: {
+          select: {
+            initialProviderAuthMethodOid: true,
+            providerAuthMethodGlobalOid: true
+          }
+        }
+      }
+    });
+
+    return backing?.managedCredentials ?? null;
   }
 
   async createProviderAuthConfigInternal(d: {

--- a/src/systems/subspace/modules/auth/src/services/providerOAuthSetup.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerOAuthSetup.ts
@@ -10,7 +10,6 @@ import {
   ID,
   type Provider,
   type ProviderAuthCredentials,
-  ProviderAuthMethodType,
   type ProviderDeployment,
   type ProviderDeploymentVersion,
   type ProviderOAuthSetup,
@@ -26,10 +25,7 @@ import {
   normalizeStatusForGet,
   normalizeStatusForList
 } from '@metorial-subspace/list-utils';
-import {
-  checkProviderMatch,
-  providerDeploymentInternalService
-} from '@metorial-subspace/module-provider-internal';
+import { checkProviderMatch } from '@metorial-subspace/module-provider-internal';
 import { checkTenant } from '@metorial-subspace/module-tenant';
 import { getBackend } from '@metorial-subspace/provider';
 import { addMinutes } from 'date-fns';
@@ -38,6 +34,7 @@ import {
   providerOAuthSetupCreatedQueue,
   providerOAuthSetupUpdatedQueue
 } from '../queues/lifecycle/providerOAuthSetup';
+import { providerAuthConfigInternalService } from './providerAuthConfigInternal';
 import { providerAuthCredentialsService } from './providerAuthCredentials';
 
 let include = {
@@ -139,7 +136,7 @@ class providerOAuthSetupServiceImpl {
       throw new ServiceError(
         badRequestError({
           message: 'No provider auth credentials provided for oauth method',
-          code: 'missing_oauth_credentials'
+          code: 'missing_auth_credentials'
         })
       );
     }
@@ -160,61 +157,24 @@ class providerOAuthSetupServiceImpl {
         throw new Error('Provider has no default variant');
       }
 
-      let version = await providerDeploymentInternalService.getCurrentVersionOptional({
-        provider: d.provider,
-        environment: d.environment,
-        deployment: d.providerDeployment
-      });
-      if (!version?.specificationOid) {
+      let { version, authMethod } =
+        await providerAuthConfigInternalService.getVersionAndAuthMethod({
+          tenant: d.tenant,
+          solution: d.solution,
+          environment: d.environment,
+          provider: d.provider,
+          providerDeployment: d.providerDeployment,
+          authMethodId: d.input.authMethodId,
+          credentials
+        });
+
+      if (authMethod.type !== 'oauth') {
         throw new ServiceError(
           badRequestError({
-            message: 'Provider has not been discovered'
-          })
-        );
-      }
-
-      let authMethod = d.input.authMethodId
-        ? await db.providerAuthMethod.findFirst({
-            where: {
-              providerOid: d.provider.oid,
-              specificationOid: version.specificationOid,
-              OR: [
-                { id: d.input.authMethodId },
-                { specId: d.input.authMethodId },
-                { specUniqueIdentifier: d.input.authMethodId },
-                { key: d.input.authMethodId },
-                { callableId: d.input.authMethodId },
-
-                ...(ProviderAuthMethodType[
-                  d.input.authMethodId as keyof typeof ProviderAuthMethodType
-                ]
-                  ? [{ type: d.input.authMethodId as any }]
-                  : [])
-              ]
-            }
-          })
-        : await db.providerAuthMethod.findFirst({
-            where: {
-              providerOid: d.provider.oid,
-              specificationOid: version.specificationOid,
-              type: 'oauth'
-            },
-            orderBy: { createdAt: 'asc' }
-          });
-      if (!authMethod) {
-        if (d.input.authMethodId) {
-          throw new ServiceError(
-            badRequestError({
-              message: 'Invalid auth method for provider',
-              code: 'invalid_auth_method'
-            })
-          );
-        }
-
-        throw new ServiceError(
-          badRequestError({
-            message: 'Provider has no OAuth auth method',
-            code: 'missing_oauth_method'
+            message: d.input.authMethodId
+              ? 'Invalid auth method for provider'
+              : 'Provider has no OAuth auth method',
+            code: d.input.authMethodId ? 'invalid_auth_method' : 'missing_oauth_method'
           })
         );
       }

--- a/src/systems/subspace/modules/auth/src/services/providerSetupSessionInternal.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerSetupSessionInternal.ts
@@ -101,6 +101,7 @@ class providerSetupSessionInternalServiceImpl {
         let inner: ProviderSetupSessionUncheckedUpdateInput = {};
         let credentials = d.credentials;
         let configInput = d.input.configInput;
+        let originalConcreteType = concreteType;
 
         if (concreteType === 'auth_only' || concreteType === 'auth_and_config') {
           let { authMethod } = await providerAuthConfigInternalService.getVersionAndAuthMethod(
@@ -110,11 +111,10 @@ class providerSetupSessionInternalServiceImpl {
               environment: d.environment,
               provider: d.provider,
               providerDeployment: d.providerDeployment,
-              authMethodId: d.input.authMethodId ?? (credentials ? 'oauth' : undefined)
+              authMethodId: d.input.authMethodId,
+              credentials
             }
           );
-
-          inner.authMethodOid = authMethod.oid;
 
           if (credentials && authMethod.type !== 'oauth') credentials = undefined;
           if (
@@ -135,43 +135,50 @@ class providerSetupSessionInternalServiceImpl {
             });
 
             if (!defaultCredentials) {
-              throw new ServiceError(
-                badRequestError({
-                  message: 'No default provider auth credentials found for oauth method',
-                  code: 'missing_oauth_credentials'
-                })
-              );
+              if (d.input.type === 'auto' && concreteType === 'auth_and_config') {
+                concreteType = 'config_only';
+              } else {
+                throw new ServiceError(
+                  badRequestError({
+                    message: 'No default provider auth credentials found for oauth method',
+                    code: 'missing_auth_credentials'
+                  })
+                );
+              }
+            } else {
+              credentials = defaultCredentials;
             }
-
-            credentials = defaultCredentials;
           }
 
-          inner.authCredentialsOid = credentials?.oid;
+          if (concreteType !== 'config_only') {
+            inner.authMethodOid = authMethod.oid;
+            inner.authCredentialsOid = credentials?.oid;
 
-          if (d.input.authConfigInput) {
-            let authConfigInner = await this.createProviderAuthConfig({
-              tenant: d.tenant,
-              solution: d.solution,
-              environment: d.environment,
-              provider: d.provider,
-              providerDeployment: d.providerDeployment,
-              credentials,
-              authMethod,
-              expiresAt: d.expiresAt,
-              input: {
-                name: d.input.name,
-                description: d.input.description,
-                metadata: d.input.metadata,
-                toolFilters: d.input.toolFilters,
-                config: d.input.authConfigInput
-              },
-              import: {
-                ip: d.import.ip,
-                ua: d.import.ua
-              }
-            });
+            if (d.input.authConfigInput) {
+              let authConfigInner = await this.createProviderAuthConfig({
+                tenant: d.tenant,
+                solution: d.solution,
+                environment: d.environment,
+                provider: d.provider,
+                providerDeployment: d.providerDeployment,
+                credentials,
+                authMethod,
+                expiresAt: d.expiresAt,
+                input: {
+                  name: d.input.name,
+                  description: d.input.description,
+                  metadata: d.input.metadata,
+                  toolFilters: d.input.toolFilters,
+                  config: d.input.authConfigInput
+                },
+                import: {
+                  ip: d.import.ip,
+                  ua: d.import.ua
+                }
+              });
 
-            inner = { ...inner, ...authConfigInner };
+              inner = { ...inner, ...authConfigInner };
+            }
           }
         }
 
@@ -257,7 +264,7 @@ class providerSetupSessionInternalServiceImpl {
         throw new ServiceError(
           badRequestError({
             message: 'No provider auth credentials provided for oauth method',
-            code: 'missing_oauth_credentials'
+            code: 'missing_auth_credentials'
           })
         );
       }
@@ -598,7 +605,9 @@ class providerSetupSessionInternalServiceImpl {
     });
 
     let configSchema = normalizeJsonSchema(schema.value.specification.configJsonSchema);
-    if (!configSchema) return { type: 'none' as const };
+    if (!configSchema) {
+      return { type: 'none' as const };
+    }
 
     let hasProperties =
       typeof configSchema === 'object' &&

--- a/src/systems/subspace/modules/auth/src/services/providerSetupSessionUi.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerSetupSessionUi.ts
@@ -73,13 +73,31 @@ class providerSetupSessionUiServiceImpl {
       };
     }
 
-    return await providerConfigService.getProviderConfigSchema({
+    let schema = await providerConfigService.getProviderConfigSchema({
       tenant: fullSession.tenant,
       solution: fullSession.solution,
       environment: fullSession.environment,
       provider: fullSession.provider,
       providerDeployment: fullSession.deployment ?? undefined
     });
+
+    let configSchema = normalizeJsonSchema(schema.value.specification.configJsonSchema);
+    let hasProperties =
+      configSchema &&
+      typeof configSchema === 'object' &&
+      'properties' in configSchema &&
+      Object.keys(configSchema.properties || {}).length > 0;
+
+    if (!configSchema || !hasProperties) {
+      return {
+        type: 'none' as const
+      };
+    }
+
+    return {
+      type: 'required' as const,
+      schema: configSchema
+    };
   }
 
   async getConfigSchemaWithoutSession(d: {
@@ -103,13 +121,13 @@ class providerSetupSessionUiServiceImpl {
     });
 
     let configSchema = normalizeJsonSchema(schema.value.specification.configJsonSchema);
-    if (!configSchema) return { type: 'none' as const };
-
     let hasProperties =
       configSchema &&
       typeof configSchema === 'object' &&
       'properties' in configSchema &&
       Object.keys(configSchema.properties || {}).length > 0;
+
+    if (!configSchema) return { type: 'none' as const };
 
     if (!hasProperties) return { type: 'none' as const };
 

--- a/src/systems/subspace/modules/provider-internal/src/services/provider.ts
+++ b/src/systems/subspace/modules/provider-internal/src/services/provider.ts
@@ -114,7 +114,9 @@ class providerInternalServiceImpl {
             prettySlug,
             provider: {
               slug: { not: d.info.slug },
-              globalIdentifier: { not: d.info.globalIdentifier }
+              globalIdentifier: d.info.globalIdentifier
+                ? { not: d.info.globalIdentifier }
+                : undefined
             }
           }
         })

--- a/src/systems/subspace/modules/provider-internal/src/services/provider.ts
+++ b/src/systems/subspace/modules/provider-internal/src/services/provider.ts
@@ -110,10 +110,15 @@ class providerInternalServiceImpl {
     let prettySlug = d.info.prettySlug;
     let existingWithPrettySlug = prettySlug
       ? await db.providerListing.findFirst({
-          where: { prettySlug }
+          where: {
+            prettySlug,
+            provider: {
+              slug: { not: d.info.slug },
+              globalIdentifier: { not: d.info.globalIdentifier }
+            }
+          }
         })
       : null;
-
     if (existingWithPrettySlug) prettySlug = `${prettySlug}-${generateCode(5)}`;
 
     return withTransaction(
@@ -167,6 +172,7 @@ class providerInternalServiceImpl {
           name: d.info.name,
           description: d.info.description,
           slug: d.info.slug,
+          prettySlug,
 
           entryOid: entry.oid,
           publisherOid: d.publisher.oid,
@@ -209,8 +215,8 @@ class providerInternalServiceImpl {
 
           isDefault: true,
 
-          name: d.info.name,
-          description: d.info.description,
+          name: provider.name,
+          description: provider.description,
 
           backendOid: d.source.backend.oid,
           providerOid: provider.oid,
@@ -265,11 +271,11 @@ class providerInternalServiceImpl {
           let inner = {
             ...allData,
 
-            name: d.info.name,
-            description: d.info.description,
-            slug: d.info.slug,
+            name: provider.name,
+            description: provider.description,
+            slug: provider.slug,
 
-            prettySlug,
+            prettySlug: provider.prettySlug,
             aliases: [...new Set(d.info.aliases)],
 
             image: d.info.image ?? { type: 'default' as const },

--- a/src/systems/subspace/packages/presenters/src/provider.ts
+++ b/src/systems/subspace/packages/presenters/src/provider.ts
@@ -87,7 +87,7 @@ export let providerPresenter = (
 
     name: provider.name,
     description: provider.description,
-    slug: provider.slug,
+    slug: provider.prettySlug ?? provider.slug,
     globalIdentifier: provider.globalIdentifier,
     metadata: provider.metadata,
 
@@ -108,7 +108,7 @@ export let providerPreviewPresenter = (provider: Provider) => ({
 
   name: provider.name,
   description: provider.description,
-  slug: provider.slug,
+  slug: provider.prettySlug ?? provider.slug,
   metadata: provider.metadata,
 
   createdAt: provider.createdAt,

--- a/src/systems/subspace/packages/presenters/src/providerListing.ts
+++ b/src/systems/subspace/packages/presenters/src/providerListing.ts
@@ -60,7 +60,7 @@ export let providerListingPresenter = (
 
   name: providerListing.name,
   description: providerListing.description,
-  slug: providerListing.prettySlug || providerListing.slug,
+  slug: providerListing.prettySlug ?? providerListing.slug,
   image: providerListing.image,
 
   aliases: providerListing.aliases,

--- a/src/systems/subspace/provider-backends/provider-shuttle/src/impl/providerInvocation.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/impl/providerInvocation.ts
@@ -66,11 +66,17 @@ export class ProviderInvocation extends IProviderInvocation {
   override async listProviderInvocations(
     data: ProviderInvocationListParam
   ): Promise<ProviderInvocationListRes> {
+    console.log('Listing provider invocations with data', data);
+
     let invocationMap = new Map<string, UnifiedProviderInvocation>();
     let queue = new PQueue({ concurrency: 5 });
     let serverConnectionLogsCache = new Map<
       string,
-      Awaited<ReturnType<typeof shuttle.serverConnection.getLogsSync>>
+      Promise<Awaited<ReturnType<typeof shuttle.serverConnection.getLogsSync>>>
+    >();
+    let functionInvocationLogsCache = new Map<
+      string,
+      Promise<Awaited<ReturnType<typeof shuttle.functionServerInvocation.getLogs>>>
     >();
 
     let messageProviderRuns = data.inputs.sessionMessageIds?.length
@@ -129,6 +135,11 @@ export class ProviderInvocation extends IProviderInvocation {
           serverConnectionIds: localConnections.map(connection => connection.id)
         })
       : [];
+    let serverConnectionIdsWithFunctionInvocations = new Set(
+      remoteInvocations
+        .map(invocation => invocation.serverConnectionId)
+        .filter((id): id is string => Boolean(id))
+    );
 
     let providerRunIdByConnectionId = new Map(
       localConnections.map(connection => [connection.id, connection.providerRun.id])
@@ -136,55 +147,82 @@ export class ProviderInvocation extends IProviderInvocation {
 
     let getServerConnectionLogs = async (serverConnectionId: string) => {
       let cached = serverConnectionLogsCache.get(serverConnectionId);
-      if (cached) return cached;
+      if (cached) return await cached;
 
-      let logs = await shuttle.serverConnection.getLogsSync({
-        serverConnectionId
-      });
-      serverConnectionLogsCache.set(serverConnectionId, logs);
+      console.log(`Fetching logs for server connection ${serverConnectionId}`);
+
+      let logsPromise = shuttle.serverConnection.getLogsSync({ serverConnectionId });
+      serverConnectionLogsCache.set(serverConnectionId, logsPromise);
+
+      let logs = await logsPromise;
+
+      console.log(`Fetched ${logs.length} logs for server connection ${serverConnectionId}`);
+
       return logs;
     };
 
-    await queue.addAll(
-      localConnections.map(connection => async () => {
-        let logs = await getServerConnectionLogs(connection.id);
-        let providerRunId = connection.providerRun.id;
+    let getFunctionInvocationLogs = async (functionInvocationId: string) => {
+      let cached = functionInvocationLogsCache.get(functionInvocationId);
+      if (cached) return await cached;
 
-        mergeInvocation(invocationMap, {
-          id: getShuttleServerConnectionProviderInvocationId(connection.id),
-          source: 'shuttle',
-          type: 'tool_call',
-          status: 'unknown',
-          providerRunIds: [providerRunId],
-          sessionMessageIds: sessionMessageIdsByProviderRunId.get(providerRunId) ?? [],
-          authConfigEventIds: [],
-          providerOAuthSetupIds: [],
-          toolCallId: null,
-          action: null,
-          requests: [],
-          responses: [],
-          requestTraces: [],
-          logs: logs.map(log => ({
-            timestamp: log.timestamp,
-            message: log.message,
-            outputType: log.outputType
-          })),
-          attachments: [],
-          error: null,
-          provider: null,
-          metadata: {
-            serverConnectionId: connection.id
-          },
-          createdAt: connection.providerRun.createdAt
-        });
-      })
+      let logsPromise = shuttle.functionServerInvocation.getLogs({ functionInvocationId });
+      functionInvocationLogsCache.set(functionInvocationId, logsPromise);
+
+      return await logsPromise;
+    };
+
+    console.log(
+      `Processing ${localConnections.length} local connections and ${remoteInvocations.length} remote invocations`
     );
 
     await queue.addAll(
+      localConnections
+        .filter(connection => !serverConnectionIdsWithFunctionInvocations.has(connection.id))
+        .map(connection => async () => {
+          let logs = await getServerConnectionLogs(connection.id);
+          let providerRunId = connection.providerRun.id;
+
+          mergeInvocation(invocationMap, {
+            id: getShuttleServerConnectionProviderInvocationId(connection.id),
+            source: 'shuttle',
+            type: 'tool_call',
+            status: 'unknown',
+            providerRunIds: [providerRunId],
+            sessionMessageIds: sessionMessageIdsByProviderRunId.get(providerRunId) ?? [],
+            authConfigEventIds: [],
+            providerOAuthSetupIds: [],
+            toolCallId: null,
+            action: null,
+            requests: [],
+            responses: [],
+            requestTraces: [],
+            logs: logs.map(log => ({
+              timestamp: log.timestamp,
+              message: log.message,
+              outputType: log.outputType
+            })),
+            attachments: [],
+            error: null,
+            provider: null,
+            metadata: {
+              serverConnectionId: connection.id
+            },
+            createdAt: connection.providerRun.createdAt
+          });
+        })
+    );
+
+    console.log(`Finished processing local connections, now processing remote invocations`);
+
+    await queue.addAll(
       remoteInvocations.map(invocation => async () => {
-        let logs = await shuttle.functionServerInvocation.getLogs({
-          functionInvocationId: invocation.id
-        });
+        console.log(
+          `Processing function invocation ${invocation.id} for server connection ${invocation.serverConnectionId}`
+        );
+        let logs = await getFunctionInvocationLogs(invocation.id);
+        console.log(
+          `Fetched ${logs.logs.length} logs for function invocation ${invocation.id}`
+        );
 
         let providerRunId = invocation.serverConnectionId
           ? (providerRunIdByConnectionId.get(invocation.serverConnectionId) ?? null)
@@ -228,6 +266,8 @@ export class ProviderInvocation extends IProviderInvocation {
       })
     );
 
+    console.log(`Finished processing remote invocations, now processing auth config events`);
+
     await queue.addAll(
       authConfigEvents.map(event => async () => {
         let type: UnifiedProviderInvocation['type'] = event.type.includes('oauth_setup')
@@ -244,9 +284,7 @@ export class ProviderInvocation extends IProviderInvocation {
           let invocation = await shuttle.functionServerInvocation.get({
             functionInvocationId: parsedId.sourceId
           });
-          let logs = await shuttle.functionServerInvocation.getLogs({
-            functionInvocationId: parsedId.sourceId
-          });
+          let logs = await getFunctionInvocationLogs(parsedId.sourceId);
 
           mergeInvocation(invocationMap, {
             id: getShuttleFunctionProviderInvocationId(invocation.id),
@@ -290,6 +328,7 @@ export class ProviderInvocation extends IProviderInvocation {
 
         let serverConnectionId = getServerConnectionIdFromPayload(event.payload);
         if (!serverConnectionId) return;
+        if (serverConnectionIdsWithFunctionInvocations.has(serverConnectionId)) return;
 
         let logs = await getServerConnectionLogs(serverConnectionId);
         let providerRunId = providerRunIdByConnectionId.get(serverConnectionId) ?? null;
@@ -333,6 +372,10 @@ export class ProviderInvocation extends IProviderInvocation {
           createdAt: event.createdAt
         });
       })
+    );
+
+    console.log(
+      `Finished processing provider invocations, total unique invocations: ${invocationMap.size}`
     );
 
     return {
@@ -482,8 +525,7 @@ export class ProviderInvocation extends IProviderInvocation {
     )
       ? 'failed'
       : relatedEvents.some(
-            event =>
-              event.type.endsWith('_completed') || event.type.endsWith('_succeeded')
+            event => event.type.endsWith('_completed') || event.type.endsWith('_succeeded')
           )
         ? 'succeeded'
         : 'unknown';

--- a/src/systems/subspace/provider-backends/provider-shuttle/src/impl/providerInvocation.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/impl/providerInvocation.ts
@@ -66,8 +66,6 @@ export class ProviderInvocation extends IProviderInvocation {
   override async listProviderInvocations(
     data: ProviderInvocationListParam
   ): Promise<ProviderInvocationListRes> {
-    console.log('Listing provider invocations with data', data);
-
     let invocationMap = new Map<string, UnifiedProviderInvocation>();
     let queue = new PQueue({ concurrency: 5 });
     let serverConnectionLogsCache = new Map<
@@ -149,14 +147,10 @@ export class ProviderInvocation extends IProviderInvocation {
       let cached = serverConnectionLogsCache.get(serverConnectionId);
       if (cached) return await cached;
 
-      console.log(`Fetching logs for server connection ${serverConnectionId}`);
-
       let logsPromise = shuttle.serverConnection.getLogsSync({ serverConnectionId });
       serverConnectionLogsCache.set(serverConnectionId, logsPromise);
 
       let logs = await logsPromise;
-
-      console.log(`Fetched ${logs.length} logs for server connection ${serverConnectionId}`);
 
       return logs;
     };
@@ -170,10 +164,6 @@ export class ProviderInvocation extends IProviderInvocation {
 
       return await logsPromise;
     };
-
-    console.log(
-      `Processing ${localConnections.length} local connections and ${remoteInvocations.length} remote invocations`
-    );
 
     await queue.addAll(
       localConnections
@@ -212,17 +202,9 @@ export class ProviderInvocation extends IProviderInvocation {
         })
     );
 
-    console.log(`Finished processing local connections, now processing remote invocations`);
-
     await queue.addAll(
       remoteInvocations.map(invocation => async () => {
-        console.log(
-          `Processing function invocation ${invocation.id} for server connection ${invocation.serverConnectionId}`
-        );
         let logs = await getFunctionInvocationLogs(invocation.id);
-        console.log(
-          `Fetched ${logs.logs.length} logs for function invocation ${invocation.id}`
-        );
 
         let providerRunId = invocation.serverConnectionId
           ? (providerRunIdByConnectionId.get(invocation.serverConnectionId) ?? null)
@@ -265,8 +247,6 @@ export class ProviderInvocation extends IProviderInvocation {
         });
       })
     );
-
-    console.log(`Finished processing remote invocations, now processing auth config events`);
 
     await queue.addAll(
       authConfigEvents.map(event => async () => {
@@ -372,10 +352,6 @@ export class ProviderInvocation extends IProviderInvocation {
           createdAt: event.createdAt
         });
       })
-    );
-
-    console.log(
-      `Finished processing provider invocations, total unique invocations: ${invocationMap.size}`
     );
 
     return {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes auth-method selection logic for setup sessions/OAuth flows and introduces new API presenter shapes that the public setup-session frontend depends on.
> 
> **Overview**
> Simplifies dashboard provider auth-method and deployment pages by replacing the custom table state/search implementation with `renderWithPagination` + `@metorial/ui-product` `Table`, and adds an explicit `ID` column plus improved empty states.
> 
> Improves the auth-method details modal to show `Auth Method ID`/`Specification ID` attributes and suppresses the placeholder description when none exists.
> 
> Fixes setup-session UI whitelabel behavior by conditionally hiding the “Secured by” footer, and adjusts layout structure for more consistent vertical sizing/centering.
> 
> Refactors public setup-session API responses behind new internal presenters (`setupSession*Presenter`), normalizing schema endpoints to `{ type: 'none' | 'required', schema }` and standardizing provider/tool/oauth payloads.
> 
> Hardens backend auth setup flows by centralizing auth-method resolution in `providerAuthConfigInternalService.getVersionAndAuthMethod` (including managed-credentials constraints and default ordering), reusing it for OAuth setup creation, and updating setup-session creation to fall back from `auth_and_config` to `config_only` when OAuth credentials are missing in auto mode (and standardizing error code to `missing_auth_credentials`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9f8b6529c49caf55a823600667172c906f6b256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->