### PR TITLE
Harden auth urls

### DIFF
--- a/src/systems/shuttle/service/src/lib/oauth/normalizeAuthorizationUrl.test.ts
+++ b/src/systems/shuttle/service/src/lib/oauth/normalizeAuthorizationUrl.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeAuthorizationUrl } from './normalizeAuthorizationUrl';
+
+describe('normalizeAuthorizationUrl', () => {
+  it('keeps https authorization URLs and clears userinfo', () => {
+    expect(normalizeAuthorizationUrl('https://user:pass@example.com/oauth')).toBe(
+      'https://example.com/oauth'
+    );
+  });
+
+  it('adds https for URLs without a protocol', () => {
+    expect(normalizeAuthorizationUrl('example.com/oauth?state=abc')).toBe(
+      'https://example.com/oauth?state=abc'
+    );
+  });
+
+  it('replaces invalid protocols with https', () => {
+    expect(normalizeAuthorizationUrl('http://user:pass@example.com/oauth')).toBe(
+      'https://example.com/oauth'
+    );
+    expect(normalizeAuthorizationUrl('ftp://user:pass@example.com/oauth')).toBe(
+      'https://example.com/oauth'
+    );
+  });
+});

--- a/src/systems/shuttle/service/src/lib/oauth/normalizeAuthorizationUrl.ts
+++ b/src/systems/shuttle/service/src/lib/oauth/normalizeAuthorizationUrl.ts
@@ -1,0 +1,16 @@
+export let normalizeAuthorizationUrl = (rawUrl: string) => {
+  let authorizationUrl = rawUrl.trim();
+
+  if (!authorizationUrl.startsWith('https://')) {
+    authorizationUrl = authorizationUrl.replace(/^[a-z][a-z0-9+.-]*:\/*/i, '');
+    authorizationUrl = authorizationUrl.replace(/^\/+/, '');
+    authorizationUrl = `https://${authorizationUrl}`;
+  }
+
+  let url = new URL(authorizationUrl);
+  url.protocol = 'https:';
+  url.username = '';
+  url.password = '';
+
+  return url.toString();
+};

--- a/src/systems/shuttle/service/src/lib/oauth/oauthUtils.ts
+++ b/src/systems/shuttle/service/src/lib/oauth/oauthUtils.ts
@@ -20,6 +20,7 @@ import {
   type TokenResponse,
   type UserProfile
 } from './types';
+import { normalizeAuthorizationUrl } from './normalizeAuthorizationUrl';
 
 axios.defaults.headers.common['Accept-Encoding'] = 'gzip';
 
@@ -63,7 +64,7 @@ export class OAuthUtils {
     state?: string;
     codeChallenge?: string;
   }): string {
-    let url = new URL(authEndpoint);
+    let url = new URL(normalizeAuthorizationUrl(authEndpoint));
 
     url.searchParams.set('response_type', 'code');
     url.searchParams.set('client_id', clientId);

--- a/src/systems/shuttle/service/src/services/oauth/delegated/authorization.ts
+++ b/src/systems/shuttle/service/src/services/oauth/delegated/authorization.ts
@@ -11,6 +11,7 @@ import { db } from '../../../db';
 import { getId } from '../../../id';
 import { callFunction } from '../../../lib/function/call';
 import { oauthErrorDescriptions } from '../../../lib/oauth/oauthErrors';
+import { normalizeAuthorizationUrl } from '../../../lib/oauth/normalizeAuthorizationUrl';
 import { functionServerInvocationService } from '../../functionServerInvocation';
 import { secretService } from '../../secret';
 import { serverEventService } from '../serverEvent';
@@ -131,7 +132,7 @@ class delegatedOauthAuthorizationServiceImpl {
     return {
       type: 'redirect' as const,
       setup,
-      redirectUrl: res.result.authorizationUrl,
+      redirectUrl: normalizeAuthorizationUrl(res.result.authorizationUrl),
       functionInvocationId: functionInvocation?.functionBayInvocationId ?? res.functionCallId
     };
   }

--- a/src/systems/slates/apps/hub/src/lib/normalizeAuthorizationUrl.test.ts
+++ b/src/systems/slates/apps/hub/src/lib/normalizeAuthorizationUrl.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeAuthorizationUrl } from './normalizeAuthorizationUrl';
+
+describe('normalizeAuthorizationUrl', () => {
+  it('keeps https authorization URLs and clears userinfo', () => {
+    expect(normalizeAuthorizationUrl('https://user:pass@example.com/oauth')).toBe(
+      'https://example.com/oauth'
+    );
+  });
+
+  it('adds https for URLs without a protocol', () => {
+    expect(normalizeAuthorizationUrl('example.com/oauth?state=abc')).toBe(
+      'https://example.com/oauth?state=abc'
+    );
+  });
+
+  it('replaces invalid protocols with https', () => {
+    expect(normalizeAuthorizationUrl('http://user:pass@example.com/oauth')).toBe(
+      'https://example.com/oauth'
+    );
+    expect(normalizeAuthorizationUrl('ftp://user:pass@example.com/oauth')).toBe(
+      'https://example.com/oauth'
+    );
+  });
+});

--- a/src/systems/slates/apps/hub/src/lib/normalizeAuthorizationUrl.ts
+++ b/src/systems/slates/apps/hub/src/lib/normalizeAuthorizationUrl.ts
@@ -1,0 +1,16 @@
+export let normalizeAuthorizationUrl = (rawUrl: string) => {
+  let authorizationUrl = rawUrl.trim();
+
+  if (!authorizationUrl.startsWith('https://')) {
+    authorizationUrl = authorizationUrl.replace(/^[a-z][a-z0-9+.-]*:\/*/i, '');
+    authorizationUrl = authorizationUrl.replace(/^\/+/, '');
+    authorizationUrl = `https://${authorizationUrl}`;
+  }
+
+  let url = new URL(authorizationUrl);
+  url.protocol = 'https:';
+  url.username = '';
+  url.password = '';
+
+  return url.toString();
+};

--- a/src/systems/slates/apps/hub/src/services/slateOAuthHandler.ts
+++ b/src/systems/slates/apps/hub/src/services/slateOAuthHandler.ts
@@ -4,6 +4,7 @@ import { db } from '../db';
 import { env } from '../env';
 import { getId, ID, snowflake } from '../id';
 import { extractExpiresAt } from '../lib/extractExpiresAt';
+import { normalizeAuthorizationUrl } from '../lib/normalizeAuthorizationUrl';
 import { processAuthQueue } from '../queues/instance/processAuth';
 import { secretService } from './secret';
 import { slateErrorService } from './slateError';
@@ -118,7 +119,7 @@ class slateOAuthHandlerServiceImpl {
 
     return {
       setupCookieValue: setup.id,
-      authorizationUrl: urlRes.data.authorizationUrl
+      authorizationUrl: normalizeAuthorizationUrl(urlRes.data.authorizationUrl)
     };
   }
 

--- a/src/systems/slates/apps/hub/vitest.unit.config.ts
+++ b/src/systems/slates/apps/hub/vitest.unit.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    exclude: ['src/**/*.e2e.test.ts'],
+    pool: 'forks'
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches OAuth authorization redirect URL construction/handling in both `shuttle` and `slates`, which can affect login flows and redirect behavior if provider URLs are malformed or unexpected.
> 
> **Overview**
> Adds a shared `normalizeAuthorizationUrl` helper (and unit tests) that trims input, forces `https`, strips any existing scheme/userinfo, and returns a normalized URL string.
> 
> Updates OAuth flows to run provider-supplied authorization endpoints/URLs through this normalizer before building redirects (in `OAuthUtils.buildAuthorizationUrl`, delegated OAuth authorization redirects, and `slateOAuthHandler`), and adds a `vitest` unit config for the slates hub app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 349c9e338c7b7f31e97a70754b6ded173c35f2ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->