### PR TITLE
Various dashboard fixes and improvements

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/pages/explorer/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/explorer/index.tsx
@@ -203,12 +203,14 @@ export let ExplorerPage = () => {
         providerConfigId?: string;
         providerConfigVaultId?: string;
         providerAuthConfigId?: string;
+        name?: string;
       }
     ) => {
       if (!instance.data) return;
       setIsCreatingSession(true);
 
       let [res, err] = await createSession.mutate({
+        name: options?.name,
         providers: [
           {
             providerDeploymentId: deploymentId,
@@ -425,7 +427,9 @@ export let ExplorerPage = () => {
       !requiresProviderConfig &&
       !requiresAuthConfig
     ) {
-      createSessionForDeployment(providerDeploymentId);
+      createSessionForDeployment(providerDeploymentId, {
+        name: `Explorer Session - ${new Date().toLocaleString()}`
+      });
     }
   }, [
     providerDeploymentId,
@@ -483,6 +487,7 @@ export let ExplorerPage = () => {
               provider.data?.name ??
               'Provider'
             }
+            defaultAuthConfigName="Explorer Auth"
             providerDeploymentId={providerDeploymentId}
             selectedConfiguration={selectedConfiguration}
             onSelectedConfigurationChange={setSelectedConfiguration}
@@ -510,6 +515,8 @@ export let ExplorerPage = () => {
                       if (!canOpenExplorer) return;
 
                       createSessionForDeployment(providerDeploymentId, {
+                        name: `Explorer Session - ${new Date().toLocaleString()}`,
+
                         providerConfigId:
                           selectedConfiguration.kind === 'config'
                             ? selectedConfiguration.id

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createButton.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createButton.tsx
@@ -29,6 +29,7 @@ export let ProviderAuthConfigCreateButton = (
       providerDeploymentId: p.providerDeploymentId,
       providerId: p.providerId,
       initialAuthMethodId: authMethodId,
+      defaultAuthConfigName: p.defaultAuthConfigName,
       autoStartManagedCredentialSetup: p.autoStartManagedCredentialSetup,
       onCreate: p.onCreate,
       onBack: p.onBack

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createModal.tsx
@@ -12,6 +12,7 @@ export type ProviderAuthConfigCreateModalProps = {
   providerDeploymentId?: string;
   providerId?: string;
   initialAuthMethodId: string;
+  defaultAuthConfigName?: string;
   autoStartManagedCredentialSetup?: boolean;
   onCreate?: (authConfig: { id: string; name?: string | null }) => void;
   onBack?: () => void;
@@ -160,6 +161,7 @@ export let ProviderAuthConfigCreateFlowContent = (
             providerId={providerId}
             providerName={providerName}
             providerImageUrl={authCreation.provider.data?.publisher.imageUrl}
+            defaultAuthConfigName={p.defaultAuthConfigName}
             selectedMethod={method}
             autoStartManagedCredentialSetup={p.autoStartManagedCredentialSetup}
             previewMode={previewMode}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createSetupFlowModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createSetupFlowModal.tsx
@@ -5,10 +5,10 @@ import { ProviderSetupSessionEmbed } from '../providerDeployments/setupSessionEm
 import { AuthMethod } from './modalHelpers';
 import { PreviewMode, SetupFlowLayout, SetupFlowPreviewSidebar } from './previewSidebar';
 
-let onboardingAuthDetails = {
-  name: 'Onboarding Auth',
+let getDefaultAuthDetails = (defaultAuthConfigName: string) => ({
+  name: defaultAuthConfigName,
   description: ''
-};
+});
 
 export let ProviderAuthConfigSetupFlowCreateContent = (p: {
   instanceId: string;
@@ -16,6 +16,7 @@ export let ProviderAuthConfigSetupFlowCreateContent = (p: {
   providerId: string;
   providerName: string;
   providerImageUrl?: string | null;
+  defaultAuthConfigName?: string;
   selectedMethod: AuthMethod;
   autoStartManagedCredentialSetup?: boolean;
   previewMode: PreviewMode;
@@ -26,7 +27,8 @@ export let ProviderAuthConfigSetupFlowCreateContent = (p: {
   onWindowOpenStateChange?: (isOpen: boolean) => void;
   embedded?: boolean;
 }) => {
-  let [authPreviewDetails, setAuthPreviewDetails] = useState(onboardingAuthDetails);
+  let defaultAuthDetails = getDefaultAuthDetails(p.defaultAuthConfigName ?? 'Provider Auth');
+  let [authPreviewDetails, setAuthPreviewDetails] = useState(defaultAuthDetails);
 
   return (
     <>
@@ -49,7 +51,7 @@ export let ProviderAuthConfigSetupFlowCreateContent = (p: {
             flattenOAuthCredentialsFlow
             showExternalPreviewSidebar
             collectAuthConfigDetails
-            initialAuthConfigDetails={onboardingAuthDetails}
+            initialAuthConfigDetails={defaultAuthDetails}
             autoStartManagedCredentialSetup={p.autoStartManagedCredentialSetup}
             onAuthConfigDetailsChange={setAuthPreviewDetails}
             cancelLabel={p.onCancel ? 'Close' : 'Cancel'}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/methodPickerModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/methodPickerModal.tsx
@@ -53,6 +53,7 @@ let ProviderAuthConfigMethodPickerModalContent = (
           providerDeploymentId: p.providerDeploymentId,
           providerId: p.providerId,
           initialAuthMethodId: values.authMethodId,
+          defaultAuthConfigName: p.defaultAuthConfigName,
           autoStartManagedCredentialSetup: p.autoStartManagedCredentialSetup,
           onCreate: p.onCreate,
           onBack: p.onBack
@@ -94,6 +95,7 @@ let ProviderAuthConfigMethodPickerModalContent = (
         providerDeploymentId: p.providerDeploymentId,
         providerId: p.providerId,
         initialAuthMethodId: singleMethodId,
+        defaultAuthConfigName: p.defaultAuthConfigName,
         autoStartManagedCredentialSetup: p.autoStartManagedCredentialSetup,
         onCreate: onCreateRef.current,
         onBack: onBackRef.current

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/helpers.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/helpers.tsx
@@ -1,8 +1,7 @@
 import { CodeBlock } from '@metorial/code';
 import type { ReactNode } from 'react';
 
-export let getStatusBadgeColor = (status: string) =>
-  status === 'error' ? 'red' : 'green';
+export let getStatusBadgeColor = (status: string) => (status === 'error' ? 'red' : 'green');
 
 export let getMethodBadgeColor = (method: string | null | undefined) => {
   let normalized = method?.toUpperCase();
@@ -30,18 +29,123 @@ export let formatDuration = (durationMs: number | null | undefined) => {
 export let stringifyJson = (value: unknown) => {
   try {
     if (typeof value === 'string') {
-      let trimmed = value.trim();
-      if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
-        try {
-          return JSON.stringify(JSON.parse(trimmed), null, 2);
-        } catch {}
-      }
-      return value;
+      return formatJsonTextForDisplay(value).code;
     }
     return JSON.stringify(value, null, 2);
   } catch {
     return String(value);
   }
+};
+
+let tryParseJson = (value: string) => {
+  try {
+    return { ok: true as const, value: JSON.parse(value) };
+  } catch {
+    return { ok: false as const };
+  }
+};
+
+let looksLikeJsonText = (value: string) => {
+  let trimmed = value.trim();
+  return trimmed.startsWith('{') || trimmed.startsWith('[');
+};
+
+let prettyPrintJsonLikeText = (value: string) => {
+  let output = '';
+  let indent = 0;
+  let inString = false;
+  let isEscaped = false;
+
+  let newline = () => {
+    output = output.replace(/[ \t]+$/g, '');
+    if (!output.endsWith('\n')) output += '\n';
+    output += '  '.repeat(Math.max(indent, 0));
+  };
+
+  for (let character of value) {
+    if (inString) {
+      output += character;
+
+      if (isEscaped) {
+        isEscaped = false;
+      } else if (character === '\\') {
+        isEscaped = true;
+      } else if (character === '"') {
+        inString = false;
+      }
+
+      continue;
+    }
+
+    if (character === '"') {
+      inString = true;
+      output += character;
+      continue;
+    }
+
+    if (/\s/.test(character)) continue;
+
+    if (character === '{' || character === '[') {
+      output += character;
+      indent += 1;
+      newline();
+      continue;
+    }
+
+    if (character === '}' || character === ']') {
+      indent = Math.max(indent - 1, 0);
+      output = output.replace(/[ \t]+$/g, '');
+      if (!output.endsWith('\n')) output += '\n';
+      output += '  '.repeat(indent);
+      output += character;
+      continue;
+    }
+
+    if (character === ',') {
+      output += character;
+      newline();
+      continue;
+    }
+
+    if (character === ':') {
+      output += ': ';
+      continue;
+    }
+
+    output += character;
+  }
+
+  return output.trimEnd();
+};
+
+export let formatJsonTextForDisplay = (value: string) => {
+  let parsed = tryParseJson(value);
+  if (parsed.ok) {
+    return {
+      code: JSON.stringify(parsed.value, null, 2),
+      isValid: true,
+      isBestEffort: false,
+      isTruncated: false
+    };
+  }
+
+  if (!looksLikeJsonText(value)) {
+    return {
+      code: value,
+      isValid: false,
+      isBestEffort: false,
+      isTruncated: false
+    };
+  }
+
+  let trimmed = value.trim();
+
+  return {
+    code: prettyPrintJsonLikeText(value),
+    isValid: false,
+    isBestEffort: true,
+    isTruncated: /\[truncated\]\s*$/i.test(trimmed)
+  };
 };
 
 export let isEmptyValue = (value: unknown) => {
@@ -53,12 +157,7 @@ export let isEmptyValue = (value: unknown) => {
 };
 
 export let renderJsonCodeBlock = (value: unknown) => (
-  <CodeBlock
-    lineNumbers={false}
-    code={stringifyJson(value)}
-    language="json"
-    padding="12px"
-  />
+  <CodeBlock lineNumbers={false} code={stringifyJson(value)} language="json" padding="12px" />
 );
 
 export let headersToItems = (

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/requestTraces.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/requestTraces.tsx
@@ -4,6 +4,7 @@ import { RiArrowDownLine, RiArrowUpLine, RiTimeLine } from '@remixicon/react';
 import type { ReactNode } from 'react';
 import {
   formatDuration,
+  formatJsonTextForDisplay,
   getMethodBadgeColor,
   getResponseBadgeColor,
   headersToItems,
@@ -69,10 +70,7 @@ let renderStructuredBody = (body: any): ReactNode => {
   }
 
   if (contentType?.includes('json') && typeof raw === 'string') {
-    let pretty = raw;
-    try {
-      pretty = JSON.stringify(JSON.parse(raw), null, 2);
-    } catch {}
+    let formattedJson = formatJsonTextForDisplay(raw);
 
     return (
       <>
@@ -80,7 +78,12 @@ let renderStructuredBody = (body: any): ReactNode => {
           <SectionSubHeading>Body</SectionSubHeading>
           {tag}
         </BodySubHeader>
-        <CodeBlock lineNumbers={false} code={pretty} language="json" padding="12px" />
+        <CodeBlock
+          lineNumbers={false}
+          code={formattedJson.code}
+          language="json"
+          padding="12px"
+        />
       </>
     );
   }

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
@@ -610,6 +610,7 @@ type ProviderSetupSectionsProps = {
   instanceId: string;
   providerId: string;
   providerName: string;
+  defaultAuthConfigName?: string;
   providerDeploymentId?: string | null;
   selectedConfiguration: ConfigurationSelection;
   onSelectedConfigurationChange: (value: ConfigurationSelection) => void;
@@ -912,6 +913,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
                 instanceId={p.instanceId}
                 providerDeploymentId={p.providerDeploymentId ?? undefined}
                 providerId={p.providerId}
+                defaultAuthConfigName={p.defaultAuthConfigName}
                 autoStartManagedCredentialSetup={autoStartManagedCredentialSetup}
                 onCreate={async authConfig => {
                   pendingCreatedAuthConfigIdRef.current = authConfig.id;

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/usage/usage.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/usage/usage.tsx
@@ -31,6 +31,7 @@ let ChartFadeLayer = styled.div<{ $visible: boolean }>`
   inset: 0;
   opacity: ${({ $visible }) => ($visible ? 1 : 0)};
   transition: opacity 240ms ease;
+  pointer-events: none;
 `;
 
 let ChartContent = styled.div<{ $visible: boolean }>`

--- a/src/packages/frontend/chart/src/chart.tsx
+++ b/src/packages/frontend/chart/src/chart.tsx
@@ -3,6 +3,16 @@ import { ApexOptions } from 'apexcharts';
 import { memo, useMemo } from 'react';
 import ReactApexChart from 'react-apexcharts';
 
+let chartColors = [
+  theme.colors.blue800,
+  theme.colors.purple800,
+  theme.colors.orange800,
+  theme.colors.cyan800,
+  theme.colors.indigo800,
+  theme.colors.violet800,
+  theme.colors.iris800
+];
+
 export let Chart = memo(
   ({
     height = 300,
@@ -48,14 +58,7 @@ export let Chart = memo(
     let options = useMemo(
       () =>
         ({
-          colors: [
-            theme.colors.red600,
-            theme.colors.green800,
-            theme.colors.blue800,
-            theme.colors.yellow800,
-            theme.colors.purple800,
-            theme.colors.orange800
-          ],
+          colors: chartColors,
           chart: {
             type: type == 'line' ? 'area' : type == 'pie' ? 'pie' : 'bar',
             height: 350,
@@ -99,10 +102,11 @@ export let Chart = memo(
               : {
                   type: 'gradient',
                   gradient: {
-                    shadeIntensity: 1,
+                    gradientToColors: chartColors,
+                    shadeIntensity: 0,
                     inverseColors: false,
                     opacityFrom: 0.5,
-                    opacityTo: 0,
+                    opacityTo: 0.05,
                     stops: [0, 90, 100]
                   }
                 },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily UI/UX tweaks (naming, default form values, display formatting, styling) with minimal behavioral impact beyond how sessions/auth configs are labeled and how JSON bodies are rendered.
> 
> **Overview**
> Explorer-created sessions are now given a human-readable `name` (timestamped) when auto-created or opened from the setup flow.
> 
> Auth config creation flows now accept a `defaultAuthConfigName` and use it to prefill the setup-flow auth config details (wired through `ProviderSetupSections`/create modals), with Explorer defaulting this to `Explorer Auth`.
> 
> Provider invocation request trace JSON rendering is hardened: adds `formatJsonTextForDisplay` to pretty-print valid JSON and best-effort format JSON-like/truncated text instead of showing raw/one-line payloads. Separately tweaks dashboard usage chart loading overlay (`pointer-events: none`) and updates shared chart color/gradient palette in `@metorial/chart`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66e3eddb6c18790760b8c86a2f7b3e51d96e5697. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->