### PR TITLE
Improve callback apis

### DIFF
--- a/src/backend/apis/core/src/controllers/provider/callbackDestination.ts
+++ b/src/backend/apis/core/src/controllers/provider/callbackDestination.ts
@@ -4,6 +4,7 @@ import { v } from '@lowerdeck/validation';
 import { subspaceCallbackDestinationService } from '@metorial/module-subspace';
 import { Controller } from '@metorial/rest';
 import { dateFilterValidator } from '../../lib/dateFilter';
+import { normalizeArrayParam } from '../../lib/normalizeArrayParam';
 import { checkAccess } from '../../middleware/checkAccess';
 import { instanceGroup, instancePath } from '../../middleware/instanceGroup';
 import { callbackDestinationPresenter } from '../../presenters';
@@ -44,6 +45,13 @@ export let callbackDestinationController = Controller.create(
         Paginator.validate(
           v.object(
             {
+              callback_id: v.optional(
+                v.union([v.string(), v.array(v.string())]),
+                {
+                  description:
+                    'Only include destinations linked to the callback ID(s).'
+                }
+              ),
               created_at: dateFilterValidator('callback destination creation time'),
               updated_at: dateFilterValidator('callback destination last update time')
             },
@@ -54,6 +62,7 @@ export let callbackDestinationController = Controller.create(
       .do(async ctx => {
         let paginator = await subspaceCallbackDestinationService.list({
           instance: ctx.instance,
+          callbackIds: normalizeArrayParam(ctx.query.callback_id),
           createdAt: ctx.query.created_at,
           updatedAt: ctx.query.updated_at
         });

--- a/src/backend/apis/core/src/controllers/provider/providerInvocation.ts
+++ b/src/backend/apis/core/src/controllers/provider/providerInvocation.ts
@@ -63,6 +63,9 @@ export let providerInvocationController = Controller.create(
           session_message_id: v.optional(v.union([v.string(), v.array(v.string())]), {
             description: 'Filter by session message ID(s)'
           }),
+          callback_event_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+            description: 'Filter by callback event ID(s)'
+          }),
           auth_config_event_id: v.optional(v.union([v.string(), v.array(v.string())]), {
             description: 'Filter by auth config event ID(s)'
           })
@@ -73,6 +76,7 @@ export let providerInvocationController = Controller.create(
           instance: ctx.instance,
           providerRunIds: normalizeArrayParam(ctx.query.provider_run_id),
           sessionMessageIds: normalizeArrayParam(ctx.query.session_message_id),
+          callbackEventIds: normalizeArrayParam(ctx.query.callback_event_id),
           authConfigEventIds: normalizeArrayParam(ctx.query.auth_config_event_id)
         });
 

--- a/src/backend/apis/core/src/presenters/implementation/provider/callbackEvent.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/callbackEvent.ts
@@ -3,24 +3,28 @@ import { Presenter } from '@metorial/presenter';
 import { callbackEventType } from '../../types';
 
 export let v1CallbackEventPresenter = Presenter.create(callbackEventType)
-  .presenter(async ({ callbackEvent }) => ({
-    object: 'callback.event' as const,
+  .presenter(async ({ callbackEvent }) => {
+    return {
+      object: 'callback.event' as const,
 
-    id: callbackEvent.id,
-    type: callbackEvent.type,
-    source_id: callbackEvent.sourceId,
-    trigger_key: callbackEvent.triggerKey,
+      id: callbackEvent.id,
+      type: callbackEvent.type,
+      source_id: callbackEvent.sourceId,
+      trigger_key: callbackEvent.triggerKey,
 
-    input: callbackEvent.input,
-    output: callbackEvent.output,
+      input: callbackEvent.input,
+      output: callbackEvent.output,
 
-    delivery_status: callbackEvent.deliveryStatus,
+      status: callbackEvent.status,
+      error: callbackEvent.error,
+      delivery_status: callbackEvent.deliveryStatus,
 
-    callback_id: callbackEvent.callbackId,
-    callback_instance_id: callbackEvent.callbackInstanceId,
+      callback_id: callbackEvent.callbackId,
+      callback_instance_id: callbackEvent.callbackInstanceId,
 
-    created_at: callbackEvent.createdAt
-  }))
+      created_at: callbackEvent.createdAt
+    };
+  })
   .schema(
     v.object({
       object: v.literal('callback.event', {
@@ -46,14 +50,41 @@ export let v1CallbackEventPresenter = Presenter.create(callbackEventType)
         description: 'Trigger key that produced this event',
         examples: ['messages.created']
       }),
-      input: v.record(v.any(), {
-        name: 'input',
-        description: 'Original trigger input payload captured for the event'
-      }),
-      output: v.record(v.any(), {
-        name: 'output',
-        description: 'Trigger output payload resolved for the event'
-      }),
+      input: v.nullable(
+        v.record(v.any(), {
+          name: 'input',
+          description: 'Original trigger input payload captured for the event'
+        })
+      ),
+      output: v.nullable(
+        v.record(v.any(), {
+          name: 'output',
+          description: 'Trigger output payload resolved for the event'
+        })
+      ),
+      status: v.enumOf(
+        ['pending', 'processing', 'retrying', 'succeeded', 'failed', 'skipped'] as const,
+        {
+          name: 'status',
+          description: 'Lifecycle status for this callback event'
+        }
+      ),
+      error: v.nullable(
+        v.object({
+          code: v.nullable(
+            v.string({
+              name: 'code',
+              description: 'Machine-readable callback event error code'
+            })
+          ),
+          message: v.nullable(
+            v.string({
+              name: 'message',
+              description: 'Human-readable callback event error message'
+            })
+          )
+        })
+      ),
       delivery_status: v.enumOf(['pending', 'sent', 'failed', 'skipped'] as const, {
         name: 'delivery_status',
         description: 'Aggregate delivery status for this callback event'

--- a/src/backend/apis/core/src/presenters/implementation/provider/callbackNotification.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/callbackNotification.ts
@@ -181,6 +181,97 @@ let callbackNotificationEventSchema = v.object({
   })
 });
 
+let callbackNotificationAttemptSchema = v.object({
+  object: v.literal('callback.notification.attempt', {
+    description: "String representing the object's type"
+  }),
+  id: v.string({
+    name: 'id',
+    description: 'Unique delivery attempt identifier',
+    examples: ['sda_4dEfGhJkLmNpQrSt']
+  }),
+  status: v.enumOf(['succeeded', 'failed'] as const, {
+    name: 'status',
+    description: 'Delivery attempt status'
+  }),
+  attempt_number: v.number({
+    name: 'attempt_number',
+    description: '1-based sequence number for the delivery attempt'
+  }),
+  duration_ms: v.number({
+    name: 'duration_ms',
+    description: 'How long the delivery attempt took in milliseconds'
+  }),
+  error: v.nullable(
+    v.object(
+      {
+        code: v.string({
+          name: 'code',
+          description: 'Machine-readable attempt error code'
+        }),
+        message: v.string({
+          name: 'message',
+          description: 'Human-readable attempt error message'
+        })
+      },
+      {
+        name: 'error',
+        description: 'Attempt-specific error payload, if present'
+      }
+    )
+  ),
+  response: v.nullable(
+    v.object(
+      {
+        status_code: v.number({
+          name: 'status_code',
+          description: 'HTTP response status code returned for the attempt'
+        }),
+        body: v.nullable(
+          v.string({
+            name: 'body',
+            description: 'Captured response body for the attempt, if stored'
+          })
+        ),
+        headers: v.nullable(
+          v.array(
+            v.object({
+              key: v.string({
+                name: 'key',
+                description: 'Response header key'
+              }),
+              value: v.string({
+                name: 'value',
+                description: 'Response header value'
+              })
+            }),
+            {
+              name: 'headers',
+              description: 'Captured response headers for the attempt, if stored'
+            }
+          )
+        )
+      },
+      {
+        name: 'response',
+        description: 'Captured delivery response metadata for the attempt'
+      }
+    )
+  ),
+  created_at: v.date({
+    name: 'created_at',
+    description: 'Timestamp when the attempt record was created'
+  }),
+  started_at: v.date({
+    name: 'started_at',
+    description: 'Timestamp when the delivery attempt started'
+  }),
+  completed_at: v.date({
+    name: 'completed_at',
+    description: 'Timestamp when the delivery attempt completed'
+  })
+});
+
 export let v1CallbackNotificationPresenter = Presenter.create(callbackNotificationType)
   .presenter(async ({ callbackNotification }) => ({
     object: 'callback.notification' as const,
@@ -220,6 +311,26 @@ export let v1CallbackNotificationPresenter = Presenter.create(callbackNotificati
       created_at: callbackNotification.destination.createdAt,
       updated_at: callbackNotification.destination.updatedAt
     },
+    attempts: callbackNotification.attempts
+      ? callbackNotification.attempts.map(attempt => ({
+          object: 'callback.notification.attempt' as const,
+          id: attempt.id,
+          status: attempt.status,
+          attempt_number: attempt.attemptNumber,
+          duration_ms: attempt.durationMs,
+          error: attempt.error,
+          response: attempt.response
+            ? {
+                status_code: attempt.response.statusCode,
+                body: attempt.response.body,
+                headers: attempt.response.headers
+              }
+            : null,
+          created_at: attempt.createdAt,
+          started_at: attempt.startedAt,
+          completed_at: attempt.completedAt
+        }))
+      : null,
     created_at: callbackNotification.createdAt,
     updated_at: callbackNotification.updatedAt,
     last_attempt_at: callbackNotification.lastAttemptAt,
@@ -267,6 +378,13 @@ export let v1CallbackNotificationPresenter = Presenter.create(callbackNotificati
       }),
       event: callbackNotificationEventSchema,
       destination: callbackNotificationDestinationSchema,
+      attempts: v.nullable(
+        v.array(callbackNotificationAttemptSchema, {
+          name: 'attempts',
+          description:
+            'Recorded delivery attempts for this notification. Present on detailed responses when available.'
+        })
+      ),
       created_at: v.date({
         name: 'created_at',
         description: 'Timestamp when the notification was created',

--- a/src/backend/apis/core/src/presenters/implementation/provider/magicMcpServer.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/magicMcpServer.ts
@@ -52,7 +52,8 @@ export let dashboardMagicMcpServerPresenter = Presenter.create(magicMcpServerTyp
 
     return {
       ...inner,
-      session_template_id: magicMcpServer.subspaceSessionTemplateId
+      session_template_id: magicMcpServer.subspaceSessionTemplateId,
+      provider_template_id: magicMcpServer.providerTemplateId
     };
   })
   .schema(
@@ -60,6 +61,7 @@ export let dashboardMagicMcpServerPresenter = Presenter.create(magicMcpServerTyp
       v1MagicMcpServerPresenter.schema,
       v.object({
         session_template_id: v.string(),
+        provider_template_id: v.nullable(v.string()),
         session_id: v.nullable(v.string())
       })
     ])

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/callbacks/destinations.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/callbacks/destinations.tsx
@@ -35,7 +35,13 @@ type CallbackNotificationListItem =
 export let CallbackDestinationsList = (p: { callbackId: string | undefined }) => {
   let instance = useCurrentInstance();
   let callback = useCallback(instance.data?.id, p.callbackId);
-  let destinations = useCallbackDestinations(instance.data?.id, { order: 'desc' });
+  let destinations = useCallbackDestinations(
+    instance.data?.id && p.callbackId ? instance.data.id : null,
+    {
+      callbackId: p.callbackId,
+      order: 'desc'
+    }
+  );
   let notifications = useCallbackNotifications(instance.data?.id, p.callbackId, {
     order: 'desc'
   });
@@ -59,7 +65,7 @@ export let CallbackDestinationsList = (p: { callbackId: string | undefined }) =>
       }
     }
 
-    let destinationItems = (callback.data?.destinations ?? []).map(destination => ({
+    let destinationItems = (destinations.data?.items ?? []).map(destination => ({
       destination,
       latestNotification: latestByDestination.get(destination.id)
     }));
@@ -67,7 +73,7 @@ export let CallbackDestinationsList = (p: { callbackId: string | undefined }) =>
     return {
       items: destinationItems
     };
-  }, [callback.data?.destinations, notifications.data?.items]);
+  }, [destinations.data?.items, notifications.data?.items]);
 
   let destinationSelectItems = (destinations.data?.items ?? []).map(destination => ({
     id: destination.id,
@@ -191,6 +197,8 @@ export let CallbackDestinationsList = (p: { callbackId: string | undefined }) =>
               updateCallback.mutate({
                 destinationIds: nextDestinationIds
               });
+
+              destinations.refetch();
             }
           })
         }

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/callbacks/events.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/callbacks/events.tsx
@@ -1,10 +1,52 @@
 import { CodeBlock } from '@metorial/code';
 import { renderWithLoader, renderWithPagination } from '@metorial/data-hooks';
-import { useCallbackEvent, useCallbackEvents, useCurrentInstance } from '@metorial/state';
-import { Attributes, Badge, Panel, RenderDate, Spacer, Text } from '@metorial/ui';
+import {
+  useCallbackEvent,
+  useCallbackEvents,
+  useCurrentInstance,
+  useProviderInvocations
+} from '@metorial/state';
+import {
+  Attributes,
+  Badge,
+  Button,
+  Datalist,
+  Error,
+  Panel,
+  RenderDate,
+  Spacer,
+  Text
+} from '@metorial/ui';
 import { Box, ID, Table } from '@metorial/ui-product';
+import { RiArrowUpLine, RiTimeLine } from '@remixicon/react';
 import { useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { ProviderInvocationEntry } from '../providerInvocations/entry';
+import {
+  formatJsonTextForDisplay,
+  getMethodBadgeColor,
+  headersToItems,
+  isEmptyValue,
+  normalizeContentType,
+  prismLanguageForContentType,
+  renderJsonCodeBlock
+} from '../providerInvocations/helpers';
+import { showProviderInvocationPanel } from '../providerInvocations/panel';
+import {
+  BodySubHeader,
+  ContentTypeTag,
+  Divider,
+  ExchangeLabel,
+  ExchangeSide,
+  HeadersCard,
+  MethodBadge,
+  RequestCard,
+  RequestMeta,
+  RequestMetaItem,
+  RequestTopRow,
+  SectionSubHeading,
+  Url
+} from '../providerInvocations/styled';
 import { RouterPanel } from '../routerPanel';
 
 let CALLBACK_EVENTS_POLL_MS = 3000;
@@ -17,17 +59,240 @@ let formatJson = (value: unknown) => {
   }
 };
 
-let getDeliveryStatusBadge = (status?: string) => {
-  let color: 'blue' | 'gray' | 'red' | 'orange' =
-    status === 'delivered'
+let getLifecycleStatusBadge = (status?: string) => {
+  let color: 'green' | 'blue' | 'gray' | 'red' | 'orange' =
+    status === 'succeeded'
       ? 'blue'
       : status === 'failed'
         ? 'red'
         : status === 'retrying'
           ? 'orange'
-          : 'gray';
+          : status === 'processing'
+            ? 'blue'
+            : 'gray';
 
   return <Badge color={color}>{status ?? 'unknown'}</Badge>;
+};
+
+type CallbackEventLifecycleFields = {
+  status?: 'pending' | 'processing' | 'retrying' | 'succeeded' | 'failed' | 'skipped';
+  error?: {
+    code: string | null;
+    message: string | null;
+  } | null;
+};
+
+let getLifecycleFields = (event: unknown) => event as CallbackEventLifecycleFields;
+
+type HttpCallbackEventInput = {
+  url?: unknown;
+  method?: unknown;
+  headers?: unknown;
+  payload?: unknown;
+  body?: unknown;
+  receivedAt?: unknown;
+};
+
+let isHttpEventInput = (input: unknown): input is HttpCallbackEventInput => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return false;
+
+  let record = input as Record<string, unknown>;
+  return typeof record.url === 'string' && typeof record.method === 'string';
+};
+
+let getHeaderValue = (headers: unknown, name: string) => {
+  let normalizedName = name.toLowerCase();
+
+  if (Array.isArray(headers)) {
+    for (let header of headers) {
+      if (Array.isArray(header) && header.length >= 2) {
+        if (String(header[0]).toLowerCase() === normalizedName) return header[1];
+      } else if (header && typeof header === 'object') {
+        let item = header as { key?: unknown; name?: unknown; value?: unknown };
+        let key = item.key ?? item.name;
+        if (key != null && String(key).toLowerCase() === normalizedName) return item.value;
+      }
+    }
+  }
+
+  if (headers && typeof headers === 'object') {
+    for (let [key, value] of Object.entries(headers as Record<string, unknown>)) {
+      if (key.toLowerCase() === normalizedName) return value;
+    }
+  }
+
+  return null;
+};
+
+let renderHttpBody = (body: unknown, contentType: string | null) => {
+  let tag = contentType ? <ContentTypeTag>{contentType}</ContentTypeTag> : null;
+
+  if (isEmptyValue(body)) {
+    return (
+      <>
+        <BodySubHeader>
+          <SectionSubHeading>Body</SectionSubHeading>
+          {tag}
+        </BodySubHeader>
+        <Text size="1" color="gray600">
+          No body captured.
+        </Text>
+      </>
+    );
+  }
+
+  if (contentType === 'application/x-www-form-urlencoded' && typeof body === 'string') {
+    let params: { label: string; value: string }[] = [];
+
+    try {
+      let searchParams = new URLSearchParams(body);
+      searchParams.forEach((value, key) => {
+        params.push({ label: key, value });
+      });
+    } catch {}
+
+    if (params.length > 0) {
+      return (
+        <>
+          <BodySubHeader>
+            <SectionSubHeading>Body</SectionSubHeading>
+            {tag}
+          </BodySubHeader>
+          <HeadersCard>
+            <Datalist items={params} />
+          </HeadersCard>
+        </>
+      );
+    }
+  }
+
+  if (contentType?.includes('json') && typeof body === 'string') {
+    let formattedJson = formatJsonTextForDisplay(body);
+
+    return (
+      <>
+        <BodySubHeader>
+          <SectionSubHeading>Body</SectionSubHeading>
+          {tag}
+        </BodySubHeader>
+        <CodeBlock
+          lineNumbers={false}
+          code={formattedJson.code}
+          language="json"
+          padding="12px"
+        />
+      </>
+    );
+  }
+
+  if (typeof body === 'string') {
+    return (
+      <>
+        <BodySubHeader>
+          <SectionSubHeading>Body</SectionSubHeading>
+          {tag}
+        </BodySubHeader>
+        <CodeBlock
+          lineNumbers={false}
+          code={body}
+          language={prismLanguageForContentType(contentType)}
+          padding="12px"
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <BodySubHeader>
+        <SectionSubHeading>Body</SectionSubHeading>
+        {tag}
+      </BodySubHeader>
+      {renderJsonCodeBlock(body)}
+    </>
+  );
+};
+
+let HttpEventInput = ({ input }: { input: HttpCallbackEventInput }) => {
+  let method = typeof input.method === 'string' ? input.method.toUpperCase() : 'REQUEST';
+  let url = typeof input.url === 'string' ? input.url : null;
+  let headerItems = headersToItems(input.headers);
+  let contentType = normalizeContentType(getHeaderValue(input.headers, 'content-type'));
+  let body = 'payload' in input ? input.payload : input.body;
+  let receivedAtDate =
+    typeof input.receivedAt === 'string' ? new Date(input.receivedAt) : null;
+  let receivedAt =
+    receivedAtDate && !Number.isNaN(receivedAtDate.getTime()) ? receivedAtDate : null;
+
+  return (
+    <RequestCard style={{ padding: 0, border: 'none' }}>
+      <RequestTopRow>
+        <MethodBadge color={getMethodBadgeColor(method)}>{method}</MethodBadge>
+        {url ? <Url>{url}</Url> : null}
+      </RequestTopRow>
+
+      {receivedAt ? (
+        <RequestMeta>
+          <RequestMetaItem>
+            <RiTimeLine size={12} />
+            <RenderDate date={receivedAt} />
+          </RequestMetaItem>
+        </RequestMeta>
+      ) : null}
+
+      <Divider />
+
+      <ExchangeSide>
+        <ExchangeLabel>
+          <RiArrowUpLine />
+          Request
+        </ExchangeLabel>
+
+        <ExchangeSide>
+          <SectionSubHeading>Headers</SectionSubHeading>
+          {headerItems ? (
+            <HeadersCard>
+              <Datalist items={headerItems} />
+            </HeadersCard>
+          ) : !isEmptyValue(input.headers) ? (
+            renderJsonCodeBlock(input.headers)
+          ) : (
+            <Text size="1" color="gray600">
+              No headers captured.
+            </Text>
+          )}
+        </ExchangeSide>
+
+        <ExchangeSide>{renderHttpBody(body, contentType)}</ExchangeSide>
+      </ExchangeSide>
+    </RequestCard>
+  );
+};
+
+let EventProviderInvocations = ({ eventId }: { eventId: string }) => {
+  let instance = useCurrentInstance();
+  let invocations = useProviderInvocations(instance.data?.id, { callbackEventId: eventId });
+
+  return (
+    <Box
+      title="Provider Invocations"
+      description="Provider-side logs and traces associated with this callback event."
+    >
+      {renderWithLoader({ invocations })(({ invocations }) =>
+        invocations.data.items.length ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 15 }}>
+            {invocations.data.items.map(invocation => (
+              <ProviderInvocationEntry key={invocation.id} invocation={invocation} />
+            ))}
+          </div>
+        ) : (
+          <Text size="2" color="gray600">
+            No provider invocations were captured for this callback event.
+          </Text>
+        )
+      )}
+    </Box>
+  );
 };
 
 export let CallbackEventsList = (p: { callbackId: string | undefined }) => {
@@ -40,7 +305,10 @@ export let CallbackEventsList = (p: { callbackId: string | undefined }) => {
     !!events.data &&
     (events.data.items.length === 0 ||
       events.data.items.some(
-        event => !['delivered', 'failed'].includes(event.deliveryStatus)
+        event =>
+          !['succeeded', 'failed', 'skipped'].includes(
+            getLifecycleFields(event).status ?? 'pending'
+          ) || event.deliveryStatus === 'pending'
       ));
 
   useEffect(() => {
@@ -67,14 +335,27 @@ export let CallbackEventsList = (p: { callbackId: string | undefined }) => {
       {renderWithPagination(events)(events => (
         <>
           <Table
-            headers={['Delivery', 'Type', 'Created']}
+            headers={['Status', 'Delivery', 'Type', 'Created', '']}
             data={events.data.items.map(event => ({
               data: [
-                getDeliveryStatusBadge(event.deliveryStatus),
+                getLifecycleStatusBadge(getLifecycleFields(event).status),
                 <Text size="2" weight="strong">
                   {event.type || event.triggerKey}
                 </Text>,
-                <RenderDate date={event.createdAt} />
+                <RenderDate date={event.createdAt} />,
+                <Button
+                  size="1"
+                  variant="outline"
+                  onClick={e => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    showProviderInvocationPanel({
+                      callbackEventId: event.id
+                    });
+                  }}
+                >
+                  View Logs
+                </Button>
               ],
               onClick: () =>
                 setSearchParams(params => {
@@ -116,59 +397,85 @@ let Event = ({ eventId, callbackId }: { eventId: string; callbackId: string }) =
   let input = useMemo(() => formatJson(event.data?.input), [event.data?.input]);
   let output = useMemo(() => formatJson(event.data?.output), [event.data?.output]);
 
-  return renderWithLoader({ event })(({ event }) => (
-    <>
-      <Attributes
-        itemWidth="320px"
-        attributes={[
-          {
-            label: 'Delivery Status',
-            content: getDeliveryStatusBadge(event.data.deliveryStatus)
-          },
-          {
-            label: 'Event Type',
-            content: event.data.type || 'N/A'
-          },
-          {
-            label: 'Trigger Key',
-            content: event.data.triggerKey
-          },
-          {
-            label: 'Source ID',
-            content: event.data.sourceId
-          },
-          {
-            label: 'Callback Instance ID',
-            content: event.data.callbackInstanceId ? (
-              <ID id={event.data.callbackInstanceId} />
-            ) : (
-              'N/A'
-            )
-          },
-          {
-            label: 'Created At',
-            content: <RenderDate date={event.data.createdAt} />
-          }
-        ]}
-      />
+  return (
+    <div>
+      {renderWithLoader({ event })(({ event }) => {
+        let httpInput = isHttpEventInput(event.data.input) ? event.data.input : null;
 
-      <Spacer height={15} />
+        return (
+          <>
+            <Attributes
+              itemWidth="300px"
+              attributes={[
+                {
+                  label: 'Lifecycle Status',
+                  content: getLifecycleStatusBadge(getLifecycleFields(event.data).status)
+                },
+                {
+                  label: 'Event Type',
+                  content: event.data.type || 'N/A'
+                },
+                {
+                  label: 'Trigger Key',
+                  content: event.data.triggerKey
+                },
+                {
+                  label: 'Error',
+                  content: event.data.error ? (
+                    <Error>
+                      {event.data.error.code}: {event.data.error.message}
+                    </Error>
+                  ) : (
+                    'N/A'
+                  )
+                },
+                {
+                  label: 'Callback Instance ID',
+                  content: event.data.callbackInstanceId ? (
+                    <ID id={event.data.callbackInstanceId} />
+                  ) : (
+                    'N/A'
+                  )
+                },
+                {
+                  label: 'Created At',
+                  content: <RenderDate date={event.data.createdAt} />
+                }
+              ]}
+            />
 
-      <Box
-        title="Input Payload"
-        description="The raw payload captured for this callback event."
-      >
-        <CodeBlock language="json" code={input} />
-      </Box>
+            <Spacer height={15} />
 
-      <Spacer height={15} />
+            <Box
+              title={httpInput ? 'HTTP Request' : 'Input Payload'}
+              description={
+                httpInput
+                  ? 'The request captured for this callback event.'
+                  : 'The raw payload captured for this callback event.'
+              }
+            >
+              {httpInput ? (
+                <HttpEventInput input={httpInput} />
+              ) : (
+                <CodeBlock variant="seamless" language="json" code={input} />
+              )}
+            </Box>
 
-      <Box
-        title="Output Payload"
-        description="The normalized output stored for downstream callback deliveries."
-      >
-        <CodeBlock language="json" code={output} />
-      </Box>
-    </>
-  ));
+            <Spacer height={15} />
+
+            <Box
+              title="Output Payload"
+              description="The normalized output stored for downstream callback deliveries."
+            >
+              <CodeBlock variant="seamless" language="json" code={output} />
+            </Box>
+
+            <Spacer height={15} />
+
+            <EventProviderInvocations eventId={event.data.id} />
+          </>
+        );
+      })}
+    </div>
+  );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/callbacks/logs.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/callbacks/logs.tsx
@@ -16,8 +16,37 @@ import {
   Text
 } from '@metorial/ui';
 import { Box, ID, Table } from '@metorial/ui-product';
+import { RiArrowDownLine, RiArrowUpLine, RiTimeLine } from '@remixicon/react';
+import type { ReactNode } from 'react';
 import { useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import {
+  formatDuration,
+  formatJsonTextForDisplay,
+  getMethodBadgeColor,
+  getResponseBadgeColor,
+  headersToItems,
+  isEmptyValue,
+  normalizeContentType,
+  prismLanguageForContentType,
+  renderJsonCodeBlock
+} from '../providerInvocations/helpers';
+import {
+  BodySubHeader,
+  ContentTypeTag,
+  Divider,
+  ExchangeLabel,
+  ExchangeSide,
+  HeadersCard,
+  MethodBadge,
+  RequestCard,
+  RequestList,
+  RequestMeta,
+  RequestMetaItem,
+  RequestTopRow,
+  SectionSubHeading,
+  Url
+} from '../providerInvocations/styled';
 import { RouterPanel } from '../routerPanel';
 
 let CALLBACK_NOTIFICATIONS_POLL_MS = 3000;
@@ -49,6 +78,300 @@ export let getNotificationStatusBadge = (status?: string) => {
           : 'gray';
 
   return <Badge color={color}>{status ?? 'unknown'}</Badge>;
+};
+
+export let getNotificationAttemptStatusBadge = (status?: string) => {
+  let color: 'green' | 'gray' | 'red' =
+    status === 'succeeded' ? 'green' : status === 'failed' ? 'red' : 'gray';
+
+  return <Badge color={color}>{status ?? 'unknown'}</Badge>;
+};
+
+let renderStructuredBody = (body: unknown, contentType?: string | null): ReactNode => {
+  let normalizedContentType = normalizeContentType(contentType);
+  let tag = normalizedContentType ? (
+    <ContentTypeTag>{normalizedContentType}</ContentTypeTag>
+  ) : null;
+
+  if (
+    normalizedContentType === 'application/x-www-form-urlencoded' &&
+    typeof body === 'string'
+  ) {
+    let params: { label: ReactNode; value: ReactNode }[] = [];
+    try {
+      let searchParams = new URLSearchParams(body);
+      searchParams.forEach((value, key) => {
+        params.push({ label: key, value });
+      });
+    } catch {}
+
+    if (params.length > 0) {
+      return (
+        <>
+          <BodySubHeader>
+            <SectionSubHeading>Body</SectionSubHeading>
+            {tag}
+          </BodySubHeader>
+          <HeadersCard>
+            <Datalist items={params} />
+          </HeadersCard>
+        </>
+      );
+    }
+  }
+
+  if (normalizedContentType?.includes('json') && typeof body === 'string') {
+    let formattedJson = formatJsonTextForDisplay(body);
+
+    return (
+      <>
+        <BodySubHeader>
+          <SectionSubHeading>Body</SectionSubHeading>
+          {tag}
+        </BodySubHeader>
+        <CodeBlock
+          lineNumbers={false}
+          code={formattedJson.code}
+          language="json"
+          padding="12px"
+        />
+      </>
+    );
+  }
+
+  if (typeof body === 'string') {
+    let formattedJson = formatJsonTextForDisplay(body);
+
+    if (formattedJson.isValid || formattedJson.isBestEffort) {
+      return (
+        <>
+          <BodySubHeader>
+            <SectionSubHeading>Body</SectionSubHeading>
+            {tag}
+          </BodySubHeader>
+          <CodeBlock
+            lineNumbers={false}
+            code={formattedJson.code}
+            language="json"
+            padding="12px"
+          />
+        </>
+      );
+    }
+
+    return (
+      <>
+        <BodySubHeader>
+          <SectionSubHeading>Body</SectionSubHeading>
+          {tag}
+        </BodySubHeader>
+        <CodeBlock
+          lineNumbers={false}
+          code={body}
+          language={prismLanguageForContentType(normalizedContentType)}
+          padding="12px"
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <BodySubHeader>
+        <SectionSubHeading>Body</SectionSubHeading>
+        {tag}
+      </BodySubHeader>
+      {renderJsonCodeBlock(body)}
+    </>
+  );
+};
+
+let getContentType = (headers: unknown) => {
+  if (Array.isArray(headers)) {
+    let header = headers.find(
+      item =>
+        item &&
+        typeof item === 'object' &&
+        'key' in item &&
+        String((item as { key?: unknown }).key).toLowerCase() === 'content-type'
+    ) as { value?: unknown } | undefined;
+
+    return normalizeContentType(header?.value);
+  }
+
+  if (headers && typeof headers === 'object') {
+    return normalizeContentType(
+      Object.entries(headers as Record<string, unknown>).find(
+        ([key]) => key.toLowerCase() === 'content-type'
+      )?.[1] ?? null
+    );
+  }
+
+  return null;
+};
+
+let ExchangePart = ({
+  label,
+  icon,
+  headers,
+  body
+}: {
+  label: string;
+  icon: ReactNode;
+  headers: unknown;
+  body: unknown;
+}) => {
+  let hasHeaders = !isEmptyValue(headers);
+  let hasBody = !isEmptyValue(body);
+  let headerItems = hasHeaders ? headersToItems(headers) : null;
+  let contentType = getContentType(headers);
+
+  if (!hasHeaders && !hasBody) {
+    return (
+      <ExchangeSide>
+        <ExchangeLabel>
+          {icon}
+          {label}
+        </ExchangeLabel>
+        <Text size="1" color="gray600">
+          No payload captured.
+        </Text>
+      </ExchangeSide>
+    );
+  }
+
+  return (
+    <ExchangeSide>
+      <ExchangeLabel>
+        {icon}
+        {label}
+      </ExchangeLabel>
+
+      {headerItems ? (
+        <ExchangeSide>
+          <SectionSubHeading>Headers</SectionSubHeading>
+          <HeadersCard>
+            <Datalist items={headerItems} />
+          </HeadersCard>
+        </ExchangeSide>
+      ) : hasHeaders ? (
+        <ExchangeSide>
+          <SectionSubHeading>Headers</SectionSubHeading>
+          {renderJsonCodeBlock(headers)}
+        </ExchangeSide>
+      ) : null}
+
+      {hasBody ? <ExchangeSide>{renderStructuredBody(body, contentType)}</ExchangeSide> : null}
+    </ExchangeSide>
+  );
+};
+
+let NotificationAttempts = ({
+  destination,
+  eventRequest,
+  attempts
+}: {
+  destination: {
+    webhook?: {
+      url?: string | null;
+      method?: string | null;
+    } | null;
+  };
+  eventRequest:
+    | {
+        body?: string | null;
+        headers?: { key: string; value: string }[] | null;
+      }
+    | null
+    | undefined;
+  attempts: {
+    id: string;
+    status: string;
+    attemptNumber: number;
+    durationMs: number;
+    error?: unknown;
+    response?: {
+      statusCode: number;
+      body?: string | null;
+      headers?: { key: string; value: string }[] | null;
+    } | null;
+    createdAt: Date;
+  }[];
+}) => {
+  if (!attempts.length) return null;
+
+  let method = destination.webhook?.method ?? 'POST';
+  let url = destination.webhook?.url ?? null;
+
+  return (
+    <Box
+      title="Delivery Attempts"
+      description="Each recorded attempt for this notification delivery, including the outbound request and captured response."
+    >
+      <RequestList>
+        {attempts.map(attempt => (
+          <RequestCard key={attempt.id} style={{ padding: 0, border: 'none' }}>
+            <RequestTopRow>
+              <MethodBadge color={getMethodBadgeColor(method)}>{method}</MethodBadge>
+              {url ? <Url>{url}</Url> : null}
+              {attempt.response ? (
+                <Badge color={getResponseBadgeColor(attempt.response.statusCode)}>
+                  {attempt.response.statusCode}
+                </Badge>
+              ) : null}
+              {getNotificationAttemptStatusBadge(attempt.status)}
+            </RequestTopRow>
+
+            <RequestMeta>
+              <RequestMetaItem>
+                <Text size="1" weight="strong">
+                  Attempt #{attempt.attemptNumber}
+                </Text>
+              </RequestMetaItem>
+              <RequestMetaItem>
+                <RiTimeLine size={12} />
+                {formatDuration(attempt.durationMs) ?? `${attempt.durationMs} ms`}
+              </RequestMetaItem>
+              <RequestMetaItem>
+                <RenderDate date={attempt.createdAt} />
+              </RequestMetaItem>
+            </RequestMeta>
+
+            <Divider />
+
+            <ExchangePart
+              label="Request"
+              icon={<RiArrowUpLine />}
+              headers={eventRequest?.headers}
+              body={eventRequest?.body}
+            />
+
+            <ExchangePart
+              label="Response"
+              icon={<RiArrowDownLine />}
+              headers={attempt.response?.headers}
+              body={attempt.response?.body}
+            />
+
+            {!!attempt.error && (
+              <>
+                <Divider />
+                <ExchangeSide>
+                  <ExchangeLabel>Error</ExchangeLabel>
+                  <CodeBlock
+                    lineNumbers={false}
+                    language="json"
+                    code={formatJson(attempt.error)}
+                    padding="12px"
+                  />
+                </ExchangeSide>
+              </>
+            )}
+          </RequestCard>
+        ))}
+      </RequestList>
+    </Box>
+  );
 };
 
 export let CallbackLogsList = (p: { callbackId: string | undefined }) => {
@@ -169,124 +492,133 @@ let Notification = ({
     [notification.data?.event.request]
   );
   let error = useMemo(() => formatJson(notification.data?.error), [notification.data?.error]);
+  let attempts = notification.data?.attempts ?? [];
 
-  return renderWithLoader({ notification })(({ notification }) => (
-    <>
-      <Attributes
-        itemWidth="300px"
-        attributes={[
-          {
-            label: 'Status',
-            content: getNotificationStatusBadge(notification.data.status)
-          },
-          {
-            label: 'Attempt Count',
-            content: notification.data.attemptCount
-          },
-          {
-            label: 'Notification ID',
-            content: <ID id={notification.data.id} />
-          },
-          {
-            label: 'Event',
-            content: notification.data.event.type
-          },
-          {
-            label: 'Destination',
-            content: notification.data.destination.name
-          },
-          {
-            label: 'Last Attempt At',
-            content: notification.data.lastAttemptAt ? (
-              <RenderDate date={notification.data.lastAttemptAt} />
-            ) : (
-              'N/A'
-            )
-          },
-          {
-            label: 'Next Attempt At',
-            content: notification.data.nextAttemptAt ? (
-              <RenderDate date={notification.data.nextAttemptAt} />
-            ) : (
-              'N/A'
-            )
-          }
-        ]}
-      />
-
-      <Spacer height={15} />
-
-      <Box
-        title="Destination"
-        description="The destination selected for this notification delivery."
-      >
-        <Datalist
-          items={[
-            { label: 'Name', value: notification.data.destination.name },
-            {
-              label: 'URL',
-              value: notification.data.destination.webhook?.url ?? 'N/A'
-            },
-            {
-              label: 'Method',
-              value: notification.data.destination.webhook?.method ?? 'N/A'
-            },
-            {
-              label: 'Destination ID',
-              value: <ID id={notification.data.destination.id} />
-            }
-          ]}
-        />
-      </Box>
-
-      <Spacer height={15} />
-
-      <Box
-        title="Event Request"
-        description="The event payload stored with the notification delivery."
-      >
-        <CodeBlock language="json" code={eventRequest} />
-
-        <Spacer height={15} />
-
-        <Text size="2" weight="strong">
-          Request Headers
-        </Text>
-
-        <Spacer height={10} />
-
-        <Datalist
-          items={
-            notification.data?.event.request?.headers?.map(header => ({
-              label: header.key,
-              value: header.value
-            })) ?? []
-          }
-        />
-      </Box>
-
-      {notification.data.error && (
+  return (
+    <div>
+      {renderWithLoader({ notification })(({ notification }) => (
         <>
+          <Attributes
+            itemWidth="300px"
+            attributes={[
+              {
+                label: 'Status',
+                content: getNotificationStatusBadge(notification.data.status)
+              },
+              {
+                label: 'Attempt Count',
+                content: notification.data.attemptCount
+              },
+              {
+                label: 'Notification ID',
+                content: <ID id={notification.data.id} />
+              },
+              {
+                label: 'Event',
+                content: notification.data.event.type
+              },
+              {
+                label: 'Destination',
+                content: notification.data.destination.name
+              },
+              {
+                label: 'Next Attempt At',
+                content: notification.data.nextAttemptAt ? (
+                  <RenderDate date={notification.data.nextAttemptAt} />
+                ) : (
+                  'N/A'
+                )
+              }
+            ]}
+          />
+
           <Spacer height={15} />
 
           <Box
-            title="Delivery Error"
-            description="The most recent delivery error for this notification."
+            title="Destination"
+            description="The destination selected for this notification delivery."
           >
-            <CodeBlock language="json" code={error} />
+            <Datalist
+              items={[
+                { label: 'Name', value: notification.data.destination.name },
+                {
+                  label: 'URL',
+                  value: notification.data.destination.webhook?.url ?? 'N/A'
+                },
+                {
+                  label: 'Method',
+                  value: notification.data.destination.webhook?.method ?? 'N/A'
+                },
+                {
+                  label: 'Destination ID',
+                  value: <ID id={notification.data.destination.id} />
+                }
+              ]}
+            />
           </Box>
-        </>
-      )}
 
-      {notification.data.status === 'retrying' && (
-        <>
           <Spacer height={15} />
-          <Callout color="orange">
-            This notification is scheduled to retry until delivery succeeds or the retry policy
-            is exhausted.
-          </Callout>
+
+          <Box
+            title="Event Request"
+            description="The event payload stored with the notification delivery."
+          >
+            <CodeBlock language="json" code={eventRequest} />
+
+            <Spacer height={15} />
+
+            <Text size="2" weight="strong">
+              Request Headers
+            </Text>
+
+            <Spacer height={10} />
+
+            <Datalist
+              items={
+                notification.data?.event.request?.headers?.map(header => ({
+                  label: header.key,
+                  value: header.value
+                })) ?? []
+              }
+            />
+          </Box>
+
+          {attempts.length > 0 && (
+            <>
+              <Spacer height={15} />
+
+              <NotificationAttempts
+                destination={notification.data.destination}
+                eventRequest={notification.data.event.request}
+                attempts={attempts}
+              />
+            </>
+          )}
+
+          {notification.data.error && (
+            <>
+              <Spacer height={15} />
+
+              <Box
+                title="Delivery Error"
+                description="The most recent delivery error for this notification."
+              >
+                <CodeBlock language="json" code={error} />
+              </Box>
+            </>
+          )}
+
+          {notification.data.status === 'retrying' && (
+            <>
+              <Spacer height={15} />
+              <Callout color="orange">
+                This notification is scheduled to retry until delivery succeeds or the retry
+                policy is exhausted.
+              </Callout>
+            </>
+          )}
         </>
-      )}
-    </>
-  ));
+      ))}
+    </div>
+  );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/callbacks/overview.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/callbacks/overview.tsx
@@ -317,32 +317,6 @@ export let CallbackOverview = (p: { callbackId: string | undefined }) => {
           <Spacer height={15} />
 
           <Box
-            title="Provider Triggers"
-            description="These provider triggers can create callback events for this callback."
-          >
-            {callback.data.providerTriggers.length > 0 ? (
-              <Table
-                headers={['Trigger', 'Key', 'Event Types']}
-                data={callback.data.providerTriggers.map(trigger => ({
-                  data: [
-                    <Text size="2" weight="strong">
-                      {trigger.providerTrigger.name}
-                    </Text>,
-                    trigger.providerTrigger.key,
-                    trigger.eventTypes.length ? trigger.eventTypes.join(', ') : 'All'
-                  ]
-                }))}
-              />
-            ) : (
-              <Callout color="gray">
-                No provider triggers have been attached to this callback yet.
-              </Callout>
-            )}
-          </Box>
-
-          <Spacer height={15} />
-
-          <Box
             title="Instances"
             description="Callback instances track registration state for provider configuration combinations."
             rightActions={
@@ -629,7 +603,7 @@ let CallbackInstanceDetails = (p: {
     ReturnType<typeof useCallbackInstances>['useDeleteMutator']
   >;
 }) => {
-  let firstTrigger = p.callbackInstance.triggers[0];
+  let firstTrigger = p.callbackInstance.triggers.find(trigger => trigger.webhookUrl);
 
   return (
     <>
@@ -701,7 +675,7 @@ let CallbackInstanceDetails = (p: {
 
       <Spacer height={15} />
 
-      {firstTrigger.webhookUrl && !firstTrigger.isWebhookRegistered && (
+      {firstTrigger?.webhookUrl && !firstTrigger.isWebhookRegistered && (
         <>
           <Box
             title="Trigger Endpoint"

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/magicMcp/serversGrid.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/magicMcp/serversGrid.tsx
@@ -137,14 +137,18 @@ let magicServersTable = new DashboardTable<MagicMcpServersTableProps, Server>(
       id: 'providerTemplateId',
       isDefault: false,
       header: 'Provider Template ID',
-      render: server =>
-        server.providerTemplateId ? (
-          <ID id={server.providerTemplateId} />
+      render: server => {
+        let providerTemplateId = (server as { providerTemplateId?: string | null })
+          .providerTemplateId;
+
+        return providerTemplateId ? (
+          <ID id={providerTemplateId} />
         ) : (
           <Text size="2" color="gray600">
             -
           </Text>
-        )
+        );
+      }
     },
     {
       id: 'updatedAt',

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/details.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/details.tsx
@@ -1,6 +1,6 @@
 import type { DashboardInstanceProviderInvocationsGetOutput } from '@metorial/dashboard-sdk';
 import { renderWithLoader } from '@metorial/data-hooks';
-import { useCurrentInstance, useProviderInvocation } from '@metorial/state';
+import { useCurrentInstance, useProviderInvocation, useProviderInvocations } from '@metorial/state';
 import { Badge, Callout, Datalist, RenderDate } from '@metorial/ui';
 import { RunLogs } from '../../components/runLogs';
 import {
@@ -125,4 +125,29 @@ export let ProviderInvocationById = ({
   return renderWithLoader({ invocation })(({ invocation }) => (
     <ProviderInvocationDetails invocation={invocation.data} hideHeader={hideHeader} />
   ));
+};
+
+export let ProviderInvocationByCallbackEventId = ({
+  callbackEventId,
+  hideHeader
+}: {
+  callbackEventId: string;
+  hideHeader?: boolean;
+}) => {
+  let instance = useCurrentInstance();
+  let invocations = useProviderInvocations(instance.data?.id, { callbackEventId });
+
+  return renderWithLoader({ invocations })(({ invocations }) => {
+    let invocation = invocations.data.items[0];
+
+    if (!invocation) {
+      return (
+        <Callout color="gray">
+          <span>No provider invocation logs were captured for this callback event.</span>
+        </Callout>
+      );
+    }
+
+    return <ProviderInvocationDetails invocation={invocation} hideHeader={hideHeader} />;
+  });
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/panel.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/panel.tsx
@@ -1,21 +1,29 @@
 import { Panel, showModal } from '@metorial/ui';
-import { ProviderInvocationById } from './details';
+import { ProviderInvocationByCallbackEventId, ProviderInvocationById } from './details';
 
-export let ProviderInvocationPanel = (p: { providerInvocationId: string }) => (
+type ProviderInvocationPanelProps =
+  | { providerInvocationId: string }
+  | { callbackEventId: string };
+
+export let ProviderInvocationPanel = (p: ProviderInvocationPanelProps) => (
   <>
     <Panel.Header>
       <Panel.Title>Provider Invocation</Panel.Title>
     </Panel.Header>
 
     <Panel.Content>
-      <ProviderInvocationById providerInvocationId={p.providerInvocationId} />
+      {'providerInvocationId' in p ? (
+        <ProviderInvocationById providerInvocationId={p.providerInvocationId} />
+      ) : (
+        <ProviderInvocationByCallbackEventId callbackEventId={p.callbackEventId} />
+      )}
     </Panel.Content>
   </>
 );
 
-export let showProviderInvocationPanel = (p: { providerInvocationId: string }) =>
+export let showProviderInvocationPanel = (p: ProviderInvocationPanelProps) =>
   showModal(({ dialogProps }) => (
     <Panel.Wrapper {...dialogProps} width={900}>
-      <ProviderInvocationPanel providerInvocationId={p.providerInvocationId} />
+      <ProviderInvocationPanel {...p} />
     </Panel.Wrapper>
   ));

--- a/src/packages/frontend/ui/src/error/index.tsx
+++ b/src/packages/frontend/ui/src/error/index.tsx
@@ -27,7 +27,13 @@ export let Error = ({
 
   if (typeof children == 'string' && children.startsWith('[') && children.includes(']')) {
     let endIndex = children.indexOf(']');
-    inner = children.substring(endIndex + 1);
+    let str = children.substring(endIndex + 1);
+
+    if (str.startsWith(':')) {
+      str = str.substring(1);
+    }
+
+    inner = str.trim();
   }
 
   return (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it extends API query parameters and response schemas for callbacks/notifications and updates dashboard views to consume the new fields, which could break clients relying on prior shapes or status semantics.
> 
> **Overview**
> Improves callback diagnostics across API and dashboard by **adding richer filtering and log visibility**.
> 
> Backend: callback destination listing now supports filtering by `callback_id`, provider invocation listing adds `callback_event_id` filtering, `callback.event` responses include lifecycle `status`/`error` and allow nullable `input`/`output`, callback notification responses can include detailed `attempts`, and Magic MCP server dashboard payloads now include `provider_template_id`.
> 
> Frontend dashboard: callback destinations list now queries destinations directly (scoped to a callback) and refetches after creation; callback events UI switches to lifecycle status, renders HTTP-shaped event inputs as request details, and links provider invocation logs via a panel; notification details now show per-attempt request/response metadata; minor robustness tweaks for callback instance trigger selection and provider template ID rendering; `Error` text formatting trims bracketed prefixes more cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d99da3215f4c5ef9b8c6a22a7eee776734c8788f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->