### PR TITLE
Add tool call attachments to subspace

### DIFF
--- a/src/backend/apis/core/src/controllers/dashboard/user.ts
+++ b/src/backend/apis/core/src/controllers/dashboard/user.ts
@@ -1,5 +1,5 @@
-import { v } from '@lowerdeck/validation';
 import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { v } from '@lowerdeck/validation';
 import { userService } from '@metorial/module-user';
 import { Controller, Path } from '@metorial/rest';
 import { checkAccess } from '../../middleware/checkAccess';

--- a/src/systems/slates/apps/registry/src/queues/syncNpm.ts
+++ b/src/systems/slates/apps/registry/src/queues/syncNpm.ts
@@ -112,6 +112,7 @@ export let syncNpmPackagesQueueProcessor = syncNpmPackagesQueue.process(async da
 
 let syncNpmPackageQueue = createQueue<{
   packageName: string;
+  notFoundAttempt?: number;
 }>({
   name: 'sreg/slate/npm/pkg',
   redisUrl: env.service.REDIS_URL,
@@ -119,10 +120,31 @@ let syncNpmPackageQueue = createQueue<{
 });
 
 export let syncNpmPackageQueueProcessor = syncNpmPackageQueue.process(async data => {
-  let metadata = await fetchJson<{
+  let metadata: {
     name: string;
     versions?: Record<string, { version: string; dist?: { tarball?: string } }>;
-  }>(`${getNpmRegistryUrl()}/${encodeURIComponent(data.packageName)}`);
+  };
+
+  try {
+    metadata = await fetchJson<any>(
+      `${getNpmRegistryUrl()}/${encodeURIComponent(data.packageName)}`
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('404')) {
+      let notFoundAttempt = (data.notFoundAttempt ?? 0) + 1;
+
+      if (notFoundAttempt > 50) {
+        throw new Error(`Package ${data.packageName} not found after 50 attempts`);
+      }
+
+      await syncNpmPackageQueue.add(
+        { packageName: data.packageName, notFoundAttempt },
+        { id: btoa(data.packageName), delay: 1000 * randomIntBetween(60, 60 * 2) }
+      );
+    }
+
+    throw error;
+  }
   if (metadata.name !== data.packageName) return;
 
   let existingVersions = new Set(

--- a/src/systems/subspace/apps/public/src/api/public/index.ts
+++ b/src/systems/subspace/apps/public/src/api/public/index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { oauthCallbackApp } from './oauthCallback';
 import { oauthSetupApp } from './oauthSetup';
 import { setupSessionApp } from './setupSession';
+import { toolCallArtifactApp } from './toolCallArtifact';
 
 let assetsDir = path.join(process.cwd(), 'frontend', 'dist', 'assets');
 let assetCacheControl = 'public, max-age=31536000, immutable';
@@ -27,6 +28,7 @@ let serveAsset = async (key: string) => {
 export let app = createHono()
   .options('*', c => c.text(''))
   .get('/ping', c => c.text('OK'))
+  .route('/tool-call-artifacts', toolCallArtifactApp)
   .get('/subspace-public/assets/:key*', async c => {
     let key = c.req.param('key*');
     return await serveAsset(key);

--- a/src/systems/subspace/apps/public/src/api/public/toolCallArtifact.ts
+++ b/src/systems/subspace/apps/public/src/api/public/toolCallArtifact.ts
@@ -1,0 +1,17 @@
+import { createHono } from '@lowerdeck/hono';
+import { db } from '@metorial-subspace/db';
+
+export let toolCallArtifactApp = createHono().get('/:urlKey', async c => {
+  let urlKey = c.req.param('urlKey');
+
+  let attachment = await db.toolCallAttachment.findFirst({
+    where: { urlKey }
+  });
+  if (!attachment) return c.text('Tool call artifact not found', 404);
+
+  if (attachment.expiresAt && attachment.expiresAt < new Date()) {
+    return c.text('Tool call artifact has expired', 410);
+  }
+
+  return c.redirect(attachment.url);
+});

--- a/src/systems/subspace/db/prisma/schema/session/message.prisma
+++ b/src/systems/subspace/db/prisma/schema/session/message.prisma
@@ -146,5 +146,26 @@ model ToolCall {
 
   createdAt DateTime @default(now())
 
+  attachments ToolCallAttachment[]
+
   @@index([createdAt])
+}
+
+model ToolCallAttachment {
+  oid BigInt @id
+  id  String @unique
+
+  urlKey String @unique
+  url    String
+
+  mimeType  String?
+  expiresAt DateTime?
+
+  toolCallOid BigInt
+  toolCall    ToolCall @relation(fields: [toolCallOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@index([createdAt])
+  @@index([toolCallOid])
 }

--- a/src/systems/subspace/db/src/id.ts
+++ b/src/systems/subspace/db/src/id.ts
@@ -108,6 +108,7 @@ export let ID = createIdGenerator({
   callbackReceiverRegistration: idType.sorted('cbrr'),
 
   toolCall: idType.sorted('tcl'),
+  toolCallAttachment: idType.sorted('tca'),
 
   identityActor: idType.sorted('iac'),
   identity: idType.sorted('idn'),

--- a/src/systems/subspace/db/src/utils/index.ts
+++ b/src/systems/subspace/db/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './getOAuthCallbackUrl';
 export * from './inputOutputMcp';
+export * from './toolCallAttachment';

--- a/src/systems/subspace/db/src/utils/toolCallAttachment.ts
+++ b/src/systems/subspace/db/src/utils/toolCallAttachment.ts
@@ -1,0 +1,68 @@
+let isObject = (value: unknown): value is Record<string, any> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export let getToolCallAttachmentPath = (urlKey: string) => `/tool-call-artifacts/${urlKey}`;
+
+export let getToolCallAttachmentPublicUrl = (urlKey: string) => {
+  let path = getToolCallAttachmentPath(urlKey);
+  let baseUrl = process.env.PUBLIC_SERVICE_URL;
+
+  if (!baseUrl) return path;
+
+  try {
+    return new URL(path, baseUrl).toString();
+  } catch {
+    return path;
+  }
+};
+
+export let presentToolCallAttachment = (attachment: {
+  urlKey: string;
+  mimeType?: string | null;
+  expiresAt?: Date | null;
+}) => ({
+  type: 'url' as const,
+  url: getToolCallAttachmentPublicUrl(attachment.urlKey),
+  mimeType: attachment.mimeType ?? undefined,
+  urlExpiresAt: attachment.expiresAt ?? undefined
+});
+
+export let getRawToolCallAttachmentsFromOutput = (output: PrismaJson.SessionMessageOutput) => {
+  if (output.type !== 'tool.result' || !isObject(output.data)) return [];
+
+  let attachments = output.data.$attachments;
+  if (!Array.isArray(attachments)) return [];
+
+  return attachments.flatMap(attachment => {
+    if (!isObject(attachment)) return [];
+    if (attachment.type !== 'url' || typeof attachment.url !== 'string') return [];
+
+    let expiresAt =
+      typeof attachment.urlExpiresAt === 'string' || attachment.urlExpiresAt instanceof Date
+        ? new Date(attachment.urlExpiresAt)
+        : null;
+
+    return [
+      {
+        url: attachment.url,
+        mimeType: typeof attachment.mimeType === 'string' ? attachment.mimeType : null,
+        expiresAt: expiresAt && !Number.isNaN(expiresAt.getTime()) ? expiresAt : null
+      }
+    ];
+  });
+};
+
+export let replaceToolCallAttachmentsInOutput = (
+  output: PrismaJson.SessionMessageOutput,
+  attachments: Array<ReturnType<typeof presentToolCallAttachment>>
+) => {
+  if (output.type !== 'tool.result' || !isObject(output.data)) return output;
+
+  return {
+    ...output,
+    data: {
+      ...output.data,
+      $attachments: attachments
+    }
+  } satisfies PrismaJson.SessionMessageOutput;
+};

--- a/src/systems/subspace/modules/connection/src/controller/receiver.ts
+++ b/src/systems/subspace/modules/connection/src/controller/receiver.ts
@@ -226,7 +226,7 @@ export let startReceiver = () => {
 
       let result = {
         message,
-        output: res.output ?? NO_OUTPUT_ERROR,
+        output: message.output ?? res.output ?? NO_OUTPUT_ERROR,
         status: res.status,
         completedAt: res.completedAt
       } satisfies ConduitResult;

--- a/src/systems/subspace/modules/connection/src/mcp/sender.ts
+++ b/src/systems/subspace/modules/connection/src/mcp/sender.ts
@@ -58,6 +58,43 @@ type ID = string | number;
 
 export type HandleResponseOpts = { waitForResponse: boolean };
 
+let toolCallAttachmentSchema = {
+  type: 'object',
+  properties: {
+    type: {
+      type: 'string',
+      enum: ['url']
+    },
+    url: {
+      type: 'string'
+    },
+    mimeType: {
+      type: 'string'
+    },
+    urlExpiresAt: {
+      type: 'string'
+    }
+  },
+  required: ['type', 'url'],
+  additionalProperties: false
+};
+
+let augmentToolOutputSchemaForAttachments = (schema: Record<string, any> | undefined) => {
+  if (!schema || schema.type !== 'object') return schema;
+  if (schema.properties?.$attachments) return schema;
+
+  return {
+    ...schema,
+    properties: {
+      ...(schema.properties ?? {}),
+      $attachments: {
+        type: 'array',
+        items: toolCallAttachmentSchema
+      }
+    }
+  };
+};
+
 export class McpSender {
   constructor(
     private readonly mcpTransport: SessionConnectionMcpConnectionTransport,
@@ -378,7 +415,7 @@ export class McpSender {
               inputSchema: presented.inputJsonSchema as any,
               outputSchema:
                 presented.outputJsonSchema?.type === 'object'
-                  ? (presented.outputJsonSchema as any)
+                  ? (augmentToolOutputSchemaForAttachments(presented.outputJsonSchema) as any)
                   : undefined,
 
               icons: mcp?.icons,

--- a/src/systems/subspace/modules/connection/src/shared/completeMessage.ts
+++ b/src/systems/subspace/modules/connection/src/shared/completeMessage.ts
@@ -1,11 +1,15 @@
 import {
   db,
+  getRawToolCallAttachmentsFromOutput,
   getId,
+  presentToolCallAttachment,
+  replaceToolCallAttachmentsInOutput,
   type ProviderRun,
   type SessionError,
   type SessionMessageFailureReason,
   type SessionParticipant
 } from '@metorial-subspace/db';
+import { generateCustomId } from '@lowerdeck/id';
 import { finalizeMessageQueue } from '../queues/message/finalizeMessage';
 import { createError, messageFailureReasonToErrorType } from './createError';
 
@@ -41,47 +45,100 @@ export let completeMessage = async (
     };
   }
 
+  let currentMessage =
+    data.status === 'failed' || data.output?.type === 'tool.result'
+      ? await db.sessionMessage.findFirstOrThrow({
+          where: 'messageId' in filter ? { id: filter.messageId } : { oid: filter.messageOid },
+          include: { connection: true, session: true, toolCall: true }
+        })
+      : undefined;
+
   let error: SessionError | undefined;
   if (data.status === 'failed') {
-    let message = await db.sessionMessage.findFirstOrThrow({
-      where: 'messageId' in filter ? { id: filter.messageId } : { oid: filter.messageOid },
-      include: { connection: true, session: true }
-    });
-
     error = await createError({
       type: messageFailureReasonToErrorType(data.failureReason ?? 'provider_error'),
-      session: message.session,
-      connection: message.connection,
+      session: currentMessage!.session,
+      connection: currentMessage!.connection,
       output: data.output!,
       providerRun: data.providerRun
     });
   }
 
-  let message = await db.sessionMessage.update({
-    where: {
-      ...('messageId' in filter ? { id: filter.messageId } : { oid: filter.messageOid }),
-      status: 'waiting_for_response'
-    },
-    data: {
-      output: data.output,
-      status: data.status,
-      completedAt: data.completedAt ?? new Date(),
-      failureReason: data.failureReason,
+  let toolCallAttachments =
+    currentMessage?.toolCall && data.output?.type === 'tool.result'
+      ? getRawToolCallAttachmentsFromOutput(data.output)
+      : [];
 
-      errorOid: error?.oid,
-      providerRunOid: data.providerRun?.oid,
-      slateToolCallOid: data.slateToolCall?.oid,
-      responderParticipantOid: data.responderParticipant.oid
-    },
-    include: { toolCall: true }
-  });
+  let toolCallAttachmentRecords = currentMessage?.toolCall
+    ? toolCallAttachments.map(attachment => ({
+        ...getId('toolCallAttachment'),
+        urlKey: generateCustomId('tca_link_', 35),
+        url: attachment.url,
+        mimeType: attachment.mimeType,
+        expiresAt: attachment.expiresAt,
+        toolCallOid: currentMessage.toolCall!.oid
+      }))
+    : [];
 
-  if (message.toolCall) {
-    await db.toolCall.updateMany({
-      where: { oid: message.toolCall.oid },
-      data: { providerRunOid: message.providerRunOid }
-    });
+  if (toolCallAttachmentRecords.length && data.output?.type === 'tool.result') {
+    data.output = replaceToolCallAttachmentsInOutput(
+      data.output,
+      toolCallAttachmentRecords.map(presentToolCallAttachment)
+    );
   }
+
+  let message = await db.$transaction(async tx => {
+    let message = await tx.sessionMessage.update({
+      where: {
+        ...('messageId' in filter ? { id: filter.messageId } : { oid: filter.messageOid }),
+        status: 'waiting_for_response'
+      },
+      data: {
+        output: data.output,
+        status: data.status,
+        completedAt: data.completedAt ?? new Date(),
+        failureReason: data.failureReason,
+
+        errorOid: error?.oid,
+        providerRunOid: data.providerRun?.oid,
+        slateToolCallOid: data.slateToolCall?.oid,
+        responderParticipantOid: data.responderParticipant.oid
+      },
+      include: {
+        toolCall: {
+          include: {
+            attachments: true
+          }
+        }
+      }
+    });
+
+    if (message.toolCall) {
+      await tx.toolCall.updateMany({
+        where: { oid: message.toolCall.oid },
+        data: { providerRunOid: message.providerRunOid }
+      });
+
+      if (toolCallAttachmentRecords.length) {
+        await tx.toolCallAttachment.createMany({
+          data: toolCallAttachmentRecords
+        });
+
+        message = await tx.sessionMessage.findFirstOrThrow({
+          where: { oid: message.oid },
+          include: {
+            toolCall: {
+              include: {
+                attachments: true
+              }
+            }
+          }
+        });
+      }
+    }
+
+    return message;
+  });
 
   (async () => {
     await db.sessionEvent.updateMany({

--- a/src/systems/subspace/modules/session/src/services/sessionMessage.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionMessage.ts
@@ -51,6 +51,7 @@ class sessionMessageServiceImpl {
         messageOid: { in: messages.map(m => m.oid).filter(Boolean) }
       },
       include: {
+        attachments: true,
         tool: {
           include: {
             provider: true,

--- a/src/systems/subspace/modules/session/src/services/toolCall.ts
+++ b/src/systems/subspace/modules/session/src/services/toolCall.ts
@@ -4,6 +4,7 @@ import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import {
   db,
+  type ToolCallAttachment,
   type ToolCall,
   type Environment,
   type Session,
@@ -29,6 +30,7 @@ import { env } from '../env';
 import { sessionMessageInclude, sessionMessageService } from './sessionMessage';
 
 let include = {
+  attachments: true,
   tool: {
     include: {
       provider: true,
@@ -43,7 +45,9 @@ let connectionInitLock = createLock({
 });
 
 class toolCallServiceImpl {
-  async enrichToolCalls<T extends ToolCall>(toolCalls: T[]) {
+  async enrichToolCalls<T extends ToolCall & { attachments?: ToolCallAttachment[] }>(
+    toolCalls: T[]
+  ) {
     let messageOids = toolCalls.map(tc => tc.messageOid).filter(Boolean);
     let messages = await sessionMessageService.enrichMessages(
       await db.sessionMessage.findMany({

--- a/src/systems/subspace/packages/presenters/src/sessionMessage.ts
+++ b/src/systems/subspace/packages/presenters/src/sessionMessage.ts
@@ -10,6 +10,7 @@ import {
   type SessionMessage,
   type SessionParticipant,
   type SessionProvider,
+  type ToolCallAttachment,
   type ToolCall
 } from '@metorial-subspace/db';
 import { sessionErrorPresenter, type SessionErrorPresenterProps } from './sessionError';
@@ -25,6 +26,7 @@ export type SessionMessagePresenterProps = SessionMessage & {
   providerRun: ProviderRun | null;
   toolCall:
     | (ToolCall & {
+        attachments: ToolCallAttachment[];
         tool: ProviderTool & {
           provider: Provider;
           specification: Omit<ProviderSpecification, 'value'>;

--- a/src/systems/subspace/packages/presenters/src/toolCall.ts
+++ b/src/systems/subspace/packages/presenters/src/toolCall.ts
@@ -5,13 +5,16 @@ import {
   type Provider,
   type ProviderSpecification,
   type ProviderTool,
+  type ToolCallAttachment,
   type ToolCall
 } from '@metorial-subspace/db';
 import { providerToolPresenter } from './providerTool';
 import { sessionErrorPresenter } from './sessionError';
 import type { SessionMessagePresenterProps } from './sessionMessage';
+import { presentToolCallAttachment } from '@metorial-subspace/db';
 
 export type ToolCallPresenterProps = ToolCall & {
+  attachments: ToolCallAttachment[];
   tool: ProviderTool & {
     provider: Provider;
     specification: Omit<ProviderSpecification, 'value'>;
@@ -54,6 +57,7 @@ export let toolCallPresenter = async (toolCall: ToolCallPresenterProps) => {
     output: toolCall.message.output
       ? await messageOutputToToolCall(toolCall.message.output, toolCall.message)
       : null,
+    attachments: toolCall.attachments.map(presentToolCallAttachment),
 
     error: toolCall.message.error ? await sessionErrorPresenter(toolCall.message.error) : null,
 

--- a/src/systems/subspace/provider-backends/provider-slates/src/impl/run.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/impl/run.ts
@@ -175,13 +175,21 @@ export class ProviderRunConnection extends IProviderRunConnection {
       };
     }
 
+    let attachments = Array.isArray(res.attachments) ? res.attachments : [];
+    let output = attachments.length
+      ? {
+          ...res.output,
+          $attachments: attachments
+        }
+      : res.output;
+
     return {
       slateToolCall,
       output: {
         type: 'success',
         data: {
           type: 'tool.result',
-          data: res.output
+          data: output
         }
       }
     };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new persisted attachment model and public redirect route, plus modifies tool result handling and presenters; mistakes could expose unintended URLs or break tool-call result shapes. Also tweaks npm sync retry behavior which could affect queue load if misconfigured.
> 
> **Overview**
> Adds first-class *tool call attachments* to Subspace: tool results can now include a `$attachments` array, which is extracted on message completion, persisted as `ToolCallAttachment` records, and presented back as public URLs.
> 
> Introduces a public `GET /tool-call-artifacts/:urlKey` route that validates existence/expiry then redirects to the stored attachment URL, and updates session/tool-call enrichment + presenters to include `attachments` in API responses.
> 
> Extends MCP tool `outputSchema` advertisement to include `$attachments`, adjusts provider-slates to pass through attachments, and fixes receiver result output selection to prefer the stored `message.output`. Separately, the slates registry npm sync queue now retries 404 package metadata fetches with backoff (up to 50 attempts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3d4215e304a95c243057bfdaca8e686d0ab06c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->