### PR TITLE
Fix unexpected magic mcp session deletion

### DIFF
--- a/src/backend/modules/magic/src/lib/ensureSession.ts
+++ b/src/backend/modules/magic/src/lib/ensureSession.ts
@@ -281,13 +281,13 @@ let deleteSubspaceSessionSafe = async (d: {
   instance: Instance;
   subspaceSessionId: string;
 }) => {
-  try {
-    await subspaceSessionService.delete({
-      instance: d.instance,
-      sessionId: d.subspaceSessionId,
-      _allowMagicMcpDelete: true
-    });
-  } catch {}
+  // try {
+  //   await subspaceSessionService.delete({
+  //     instance: d.instance,
+  //     sessionId: d.subspaceSessionId,
+  //     _allowMagicMcpDelete: true
+  //   });
+  // } catch {}
 };
 
 let getSubspaceProviders = async (d: { instance: Instance; sessionTemplateId: string }) => {
@@ -298,7 +298,7 @@ let getSubspaceProviders = async (d: { instance: Instance; sessionTemplateId: st
   });
 
   return templateProviders.map(templateProvider => ({
-    sessionTemplateId: templateProvider.sessionTemplateId,
+    // sessionTemplateId: templateProvider.sessionTemplateId,
     providerDeployment: templateProvider.deployment?.id
       ? {
           type: 'reference' as const,
@@ -329,7 +329,7 @@ export let ensureMagicMcpSubspaceSession = async (magicMcpTarget: MagicMcpResolv
   let mapping = await getExistingMapping(target);
   let now = new Date();
 
-  if (isReusableMapping(mapping, target, now)) return mapping!;
+  if (false && isReusableMapping(mapping, target, now)) return mapping!;
 
   let providers = await getSubspaceProviders({
     instance: target.instance,

--- a/src/backend/modules/magic/src/lib/ensureSession.ts
+++ b/src/backend/modules/magic/src/lib/ensureSession.ts
@@ -329,7 +329,7 @@ export let ensureMagicMcpSubspaceSession = async (magicMcpTarget: MagicMcpResolv
   let mapping = await getExistingMapping(target);
   let now = new Date();
 
-  if (false && isReusableMapping(mapping, target, now)) return mapping!;
+  if (isReusableMapping(mapping, target, now)) return mapping!;
 
   let providers = await getSubspaceProviders({
     instance: target.instance,

--- a/src/systems/slates/apps/registry/src/queues/syncNpm.ts
+++ b/src/systems/slates/apps/registry/src/queues/syncNpm.ts
@@ -112,6 +112,7 @@ export let syncNpmPackagesQueueProcessor = syncNpmPackagesQueue.process(async da
 
 let syncNpmPackageQueue = createQueue<{
   packageName: string;
+  notFoundAttempt?: number;
 }>({
   name: 'sreg/slate/npm/pkg',
   redisUrl: env.service.REDIS_URL,
@@ -119,10 +120,33 @@ let syncNpmPackageQueue = createQueue<{
 });
 
 export let syncNpmPackageQueueProcessor = syncNpmPackageQueue.process(async data => {
-  let metadata = await fetchJson<{
+  let metadata: {
     name: string;
     versions?: Record<string, { version: string; dist?: { tarball?: string } }>;
-  }>(`${getNpmRegistryUrl()}/${encodeURIComponent(data.packageName)}`);
+  };
+
+  try {
+    metadata = await fetchJson<any>(
+      `${getNpmRegistryUrl()}/${encodeURIComponent(data.packageName)}`
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('404')) {
+      let notFoundAttempt = (data.notFoundAttempt ?? 0) + 1;
+
+      if (notFoundAttempt > 50) {
+        throw new Error(`Package ${data.packageName} not found after 50 attempts`);
+      }
+
+      await syncNpmPackageQueue.add(
+        { packageName: data.packageName, notFoundAttempt },
+        { id: btoa(data.packageName), delay: 1000 * randomIntBetween(60, 60 * 2) }
+      );
+
+      return;
+    }
+
+    throw error;
+  }
   if (metadata.name !== data.packageName) return;
 
   let existingVersions = new Set(

--- a/src/systems/subspace/modules/connection/src/mcp/sender.ts
+++ b/src/systems/subspace/modules/connection/src/mcp/sender.ts
@@ -230,16 +230,16 @@ export class McpSender {
     }
 
     if (id === undefined || id === null || method.startsWith('notifications/')) {
-      console.warn(
-        'Received MCP message without id or with notification method, ignoring:',
-        msg
-      );
-
       if (method === 'notifications/initialized') {
         let initNotification = mcpValidate(id, InitializedNotificationSchema, msg);
         if (!initNotification.success) return { mcp: initNotification.error, store: false };
         return this.handleInitializedMessage(initNotification.data);
       }
+
+      console.warn(
+        'Received MCP message without id or with notification method, ignoring:',
+        msg
+      );
 
       // TODO: handle notification for mcp-compatible backends
       // -> send to all backends that support it


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Disabling Subspace session deletion can lead to orphaned sessions/resource growth and changes session lifecycle behavior. The npm sync retry loop could increase queue load if many packages transiently 404.
> 
> **Overview**
> Prevents **unexpected Magic MCP Subspace session deletion** by effectively no-op’ing `deleteSubspaceSessionSafe`, so session cleanup is no longer attempted during mapping race/reconciliation.
> 
> Hardens Slate Registry npm syncing by adding `notFoundAttempt` tracking and delayed requeueing when a package fetch returns 404 (up to 50 attempts) instead of failing immediately.
> 
> Adjusts MCP message handling to process `notifications/initialized` before logging the "ignored" warning, reducing log noise for that expected notification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c2b883c18c7689a20dae4b6ea47adad751b2d48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->