### PR TITLE
Allow optional output properties

### DIFF
--- a/src/systems/subspace/modules/connection/src/lib/mcpOutputSchemaNormalizer.ts
+++ b/src/systems/subspace/modules/connection/src/lib/mcpOutputSchemaNormalizer.ts
@@ -1,0 +1,61 @@
+let toolCallAttachmentSchema = {
+  type: 'object',
+  properties: {
+    type: {
+      type: 'string',
+      enum: ['url']
+    },
+    url: {
+      type: 'string'
+    },
+    mimeType: {
+      type: 'string'
+    },
+    urlExpiresAt: {
+      type: 'string'
+    }
+  },
+  required: ['type', 'url'],
+  additionalProperties: false
+};
+
+type JsonSchema = Record<string, any>;
+
+export let mcpOutputSchemaNormalizer = (
+  schema: JsonSchema | undefined,
+  opts: { isRoot?: boolean } = {}
+): JsonSchema | undefined => {
+  if (!schema || typeof schema !== 'object') return schema;
+
+  if (schema.type === 'array') {
+    return {
+      ...schema,
+      items: mcpOutputSchemaNormalizer(
+        schema.items && typeof schema.items === 'object' ? schema.items : {},
+        { isRoot: false }
+      )
+    };
+  }
+
+  if (schema.type !== 'object') return schema;
+
+  let properties: Record<string, any> = Object.fromEntries(
+    Object.entries(schema.properties ?? {}).map(([key, value]) => [
+      key,
+      mcpOutputSchemaNormalizer(value as JsonSchema, { isRoot: false })
+    ])
+  );
+
+  if (opts.isRoot && !properties.$attachments) {
+    properties.$attachments = {
+      type: 'array',
+      items: toolCallAttachmentSchema
+    };
+  }
+
+  return {
+    ...schema,
+    properties,
+    additionalProperties: true
+  };
+};

--- a/src/systems/subspace/modules/connection/src/mcp/sender.ts
+++ b/src/systems/subspace/modules/connection/src/mcp/sender.ts
@@ -47,6 +47,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { uniqBy } from 'lodash';
 import { PING_MESSAGE_ID_PREFIX } from '../const';
+import { mcpOutputSchemaNormalizer } from '../lib/mcpOutputSchemaNormalizer';
 import { providerToolPresenter } from '../presenter';
 import { upsertParticipant } from '../shared/upsertParticipant';
 import type { McpControlMessageHandler } from './control';
@@ -57,43 +58,6 @@ let Sentry = getSentry();
 type ID = string | number;
 
 export type HandleResponseOpts = { waitForResponse: boolean };
-
-let toolCallAttachmentSchema = {
-  type: 'object',
-  properties: {
-    type: {
-      type: 'string',
-      enum: ['url']
-    },
-    url: {
-      type: 'string'
-    },
-    mimeType: {
-      type: 'string'
-    },
-    urlExpiresAt: {
-      type: 'string'
-    }
-  },
-  required: ['type', 'url'],
-  additionalProperties: false
-};
-
-let augmentToolOutputSchemaForAttachments = (schema: Record<string, any> | undefined) => {
-  if (!schema || schema.type !== 'object') return schema;
-  if (schema.properties?.$attachments) return schema;
-
-  return {
-    ...schema,
-    properties: {
-      ...(schema.properties ?? {}),
-      $attachments: {
-        type: 'array',
-        items: toolCallAttachmentSchema
-      }
-    }
-  };
-};
 
 export class McpSender {
   constructor(
@@ -414,8 +378,10 @@ export class McpSender {
 
               inputSchema: presented.inputJsonSchema as any,
               outputSchema:
-                presented.outputJsonSchema?.type === 'object'
-                  ? (augmentToolOutputSchemaForAttachments(presented.outputJsonSchema) as any)
+                presented.outputJsonSchema
+                  ? (mcpOutputSchemaNormalizer(presented.outputJsonSchema, {
+                      isRoot: presented.outputJsonSchema?.type === 'object'
+                    }) as any)
                   : undefined,
 
               icons: mcp?.icons,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the advertised MCP JSON Schemas for tool outputs (loosening `additionalProperties`), which may affect downstream clients/validation expectations but is isolated to schema generation logic.
> 
> **Overview**
> Tool `outputSchema` handling for `tools/list` is reworked: instead of only augmenting top-level object outputs with `$attachments`, schemas are now passed through a new recursive `mcpOutputSchemaNormalizer`.
> 
> The normalizer walks object/array schemas, ensures the root object includes `$attachments`, and **forces `additionalProperties: true` on all object schemas**, effectively allowing tools to return extra/optional fields beyond those explicitly declared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 782bbc705d411e3d641d9209a4fcf2f445376019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->