### PR TITLE
Add signal callback delegation

### DIFF
--- a/src/backend/modules/subspace/src/services/providerInvocation.ts
+++ b/src/backend/modules/subspace/src/services/providerInvocation.ts
@@ -2,7 +2,7 @@ import { createSubspaceService } from '../lib/subspaceService';
 import { subspace } from '../subspace';
 
 export let subspaceProviderInvocationService = createSubspaceService(
-  subspace.providerDeployment,
+  subspace.providerInvocation,
   ['get', 'list'],
   inner => ({})
 );

--- a/src/systems/signal/service/src/services/eventDeliveryAttempt.ts
+++ b/src/systems/signal/service/src/services/eventDeliveryAttempt.ts
@@ -9,7 +9,8 @@ let include = {
     include: {
       event: {
         include: {
-          sender: true
+          sender: true,
+          callback: true
         }
       },
       destination: true

--- a/src/systems/signal/service/src/services/eventDeliveryIntent.ts
+++ b/src/systems/signal/service/src/services/eventDeliveryIntent.ts
@@ -7,7 +7,8 @@ import { db } from '../db';
 let include = {
   event: {
     include: {
-      sender: true
+      sender: true,
+      callback: true
     }
   },
   destination: {

--- a/src/systems/signal/service/src/services/eventDestination.ts
+++ b/src/systems/signal/service/src/services/eventDestination.ts
@@ -245,67 +245,6 @@ class eventDestinationServiceImpl {
     });
   }
 
-  async upsertExternalEventDestination(d: {
-    input: {
-      externalId: string;
-      isCallbackDestination?: boolean;
-      name: string;
-      description?: string | null;
-      eventTypes?: string[] | null;
-
-      retry?: {
-        type: EventRetryType;
-        delaySeconds: number;
-        maxAttempts: number;
-      };
-
-      variant: {
-        type: 'http_endpoint';
-        url: string;
-        method: WebhookMethod;
-      };
-    };
-    tenant: Tenant;
-    sender: Sender;
-  }) {
-    let existing = await db.eventDestination.findFirst({
-      where: {
-        externalId: d.input.externalId,
-        tenantOid: d.tenant.oid,
-        senderOid: d.sender.oid
-      },
-      include
-    });
-
-    if (!existing) {
-      return await this.createEventDestination({
-        tenant: d.tenant,
-        sender: d.sender,
-        input: {
-          externalId: d.input.externalId,
-          isCallbackDestination: d.input.isCallbackDestination ?? true,
-          name: d.input.name,
-          description: d.input.description ?? undefined,
-          eventTypes: d.input.eventTypes ?? undefined,
-          retry: d.input.retry,
-          variant: d.input.variant
-        }
-      });
-    }
-
-    return await this.updateEventDestination({
-      eventDestination: existing,
-      input: {
-        isCallbackDestination: d.input.isCallbackDestination ?? true,
-        name: d.input.name,
-        description: d.input.description ?? undefined,
-        eventTypes: d.input.eventTypes ?? undefined,
-        retry: d.input.retry,
-        variant: d.input.variant
-      }
-    });
-  }
-
   async deleteEventDestination(d: { eventDestination: EventDestination }) {
     if (d.eventDestination.status == 'inactive') {
       throw new ServiceError(

--- a/src/systems/slates/apps/hub/src/apis/public/tests/slateTriggerWebhook.e2e.test.ts
+++ b/src/systems/slates/apps/hub/src/apis/public/tests/slateTriggerWebhook.e2e.test.ts
@@ -248,6 +248,16 @@ vi.mock('../../../signal', async () => {
           identifier: signalTenant.identifier
         }
       };
+    },
+    getTenantForSignal: async (tenant: Tenant) => {
+      let signalTenant = tenant.signalTenantId
+        ? { id: tenant.signalTenantId, identifier: tenant.identifier, name: tenant.name }
+        : await ensureTenant(tenant);
+
+      return {
+        id: signalTenant.id,
+        identifier: signalTenant.identifier
+      };
     }
   };
 });

--- a/src/systems/slates/apps/hub/src/services/slateTriggerReceiver.ts
+++ b/src/systems/slates/apps/hub/src/services/slateTriggerReceiver.ts
@@ -153,6 +153,9 @@ class slateTriggerReceiverServiceImpl {
       name?: string;
       description?: string;
       eventTypes?: string[];
+      deliveryMode?: SlateTriggerReceiverDeliveryMode;
+      callbackId?: string | null;
+      callbackInstanceId?: string | null;
       triggers: {
         triggerId: string;
         state?: Record<string, any> | null;
@@ -201,6 +204,10 @@ class slateTriggerReceiverServiceImpl {
           slateOid: slate.oid,
           slateInstanceOid: slateInstance.oid,
           authConfigOid: authConfig?.oid ?? null,
+          deliveryMode:
+            d.input.deliveryMode ?? SlateTriggerReceiverDeliveryMode.legacy_signal_event,
+          callbackId: d.input.callbackId ?? null,
+          callbackInstanceId: d.input.callbackInstanceId ?? null,
           name: d.input.name,
           description: d.input.description,
           eventTypes: normalizeEventTypes(d.input.eventTypes)
@@ -257,6 +264,9 @@ class slateTriggerReceiverServiceImpl {
       name?: string | null;
       description?: string | null;
       eventTypes?: string[];
+      deliveryMode?: SlateTriggerReceiverDeliveryMode;
+      callbackId?: string | null;
+      callbackInstanceId?: string | null;
       triggers?: {
         triggerId: string;
         state?: Record<string, any> | null;
@@ -295,6 +305,9 @@ class slateTriggerReceiverServiceImpl {
       data: {
         authConfigOid:
           d.input.authConfig !== undefined ? (authConfig?.oid ?? null) : undefined,
+        deliveryMode: d.input.deliveryMode,
+        callbackId: d.input.callbackId,
+        callbackInstanceId: d.input.callbackInstanceId,
         name: d.input.name === null ? null : d.input.name,
         description: d.input.description === null ? null : d.input.description,
         eventTypes: d.input.eventTypes ? normalizeEventTypes(d.input.eventTypes) : undefined
@@ -453,6 +466,9 @@ class slateTriggerReceiverServiceImpl {
           receiverId: existing.id,
           input: {
             authConfig: d.authConfig ?? null,
+            deliveryMode: SlateTriggerReceiverDeliveryMode.callback_v2,
+            callbackId: d.input.callbackId,
+            callbackInstanceId: d.input.callbackInstanceId,
             name: d.input.name,
             description: d.input.description,
             eventTypes: d.input.eventTypes,
@@ -464,21 +480,15 @@ class slateTriggerReceiverServiceImpl {
           slateInstance: d.slateInstance,
           authConfig: d.authConfig ?? null,
           input: {
+            deliveryMode: SlateTriggerReceiverDeliveryMode.callback_v2,
+            callbackId: d.input.callbackId,
+            callbackInstanceId: d.input.callbackInstanceId,
             name: d.input.name ?? undefined,
             description: d.input.description ?? undefined,
             eventTypes: d.input.eventTypes,
             triggers: d.input.triggers
           }
         });
-
-    await db.slateTriggerReceiver.update({
-      where: { oid: receiver.oid },
-      data: {
-        deliveryMode: SlateTriggerReceiverDeliveryMode.callback_v2,
-        callbackId: d.input.callbackId,
-        callbackInstanceId: d.input.callbackInstanceId
-      }
-    });
 
     return await this.getTriggerReceiverById({
       tenant: d.tenant,

--- a/src/systems/slates/apps/hub/src/services/slateTriggerReceiverCore.ts
+++ b/src/systems/slates/apps/hub/src/services/slateTriggerReceiverCore.ts
@@ -25,7 +25,7 @@ import {
 
 let getCallbackEventOutput = (output: Record<string, any>) => {
   let { url, method, headers, receivedAt, ...semanticOutput } = output;
-  return Object.keys(semanticOutput).length ? semanticOutput : output;
+  return semanticOutput;
 };
 
 export class SlateTriggerReceiverCore {

--- a/src/systems/subspace/apps/controller/src/controllers/callbackDestination.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/callbackDestination.ts
@@ -26,6 +26,7 @@ export let callbackDestinationController = app.controller({
       Paginator.validate(
         v.object({
           tenantId: v.string(),
+          callbackIds: v.optional(v.array(v.string())),
           createdAt: createdAtValidator,
           updatedAt: updatedAtValidator
         })
@@ -35,11 +36,23 @@ export let callbackDestinationController = app.controller({
       let paginator = await callbackDestinationService.listCallbackDestinations({
         tenant: ctx.tenant,
         solution: ctx.solution,
+        callbackIds: ctx.input.callbackIds,
         createdAt: ctx.input.createdAt,
         updatedAt: ctx.input.updatedAt
       });
       let list = await paginator.run(ctx.input);
-      return Paginator.presentLight(list, callbackDestinationPresenter);
+      let enriched = await callbackDestinationService.enrichCallbackDestinations({
+        tenant: ctx.tenant,
+        callbackDestinations: list.items
+      });
+      return Paginator.presentLight(
+        {
+          ...list,
+          items: enriched
+        },
+        callbackDestination =>
+          callbackDestinationPresenter(callbackDestination, { includeSignatureToken: false })
+      );
     }),
 
   get: callbackDestinationApp
@@ -50,7 +63,14 @@ export let callbackDestinationController = app.controller({
         callbackDestinationId: v.string()
       })
     )
-    .do(async ctx => callbackDestinationPresenter(ctx.callbackDestination)),
+    .do(async ctx =>
+      callbackDestinationPresenter(
+        await callbackDestinationService.enrichCallbackDestination({
+          tenant: ctx.tenant,
+          callbackDestination: ctx.callbackDestination
+        })
+      )
+    ),
 
   create: tenantWithoutEnvironmentApp
     .handler()
@@ -74,7 +94,12 @@ export let callbackDestinationController = app.controller({
           url: ctx.input.url!
         }
       });
-      return callbackDestinationPresenter(callbackDestination);
+      return callbackDestinationPresenter(
+        await callbackDestinationService.enrichCallbackDestination({
+          tenant: ctx.tenant,
+          callbackDestination
+        })
+      );
     }),
 
   update: callbackDestinationApp
@@ -101,7 +126,12 @@ export let callbackDestinationController = app.controller({
           url: ctx.input.url
         }
       });
-      return callbackDestinationPresenter(callbackDestination);
+      return callbackDestinationPresenter(
+        await callbackDestinationService.enrichCallbackDestination({
+          tenant: ctx.tenant,
+          callbackDestination
+        })
+      );
     }),
 
   archive: callbackDestinationApp
@@ -118,6 +148,11 @@ export let callbackDestinationController = app.controller({
         solution: ctx.solution,
         callbackDestination: ctx.callbackDestination
       });
-      return callbackDestinationPresenter(callbackDestination);
+      return callbackDestinationPresenter(
+        await callbackDestinationService.enrichCallbackDestination({
+          tenant: ctx.tenant,
+          callbackDestination
+        })
+      );
     })
 });

--- a/src/systems/subspace/apps/controller/src/controllers/providerInvocation.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerInvocation.ts
@@ -1,4 +1,5 @@
 import { v } from '@lowerdeck/validation';
+import { callbackEventService } from '@metorial-subspace/module-callback';
 import { providerInvocationService } from '@metorial-subspace/module-session';
 import { providerInvocationPresenter } from '@metorial-subspace/presenters';
 import { app } from './_app';
@@ -33,10 +34,18 @@ export let providerInvocationController = app.controller({
         environmentId: v.string(),
         providerRunIds: v.optional(v.array(v.string())),
         sessionMessageIds: v.optional(v.array(v.string())),
+        callbackEventIds: v.optional(v.array(v.string())),
         authConfigEventIds: v.optional(v.array(v.string()))
       })
     )
     .do(async ctx => {
+      let callbackEventSourceIds = ctx.input.callbackEventIds?.length
+        ? await callbackEventService.listCallbackEventSourceIds({
+            tenant: ctx.tenant,
+            callbackEventIds: ctx.input.callbackEventIds
+          })
+        : undefined;
+
       let res = await providerInvocationService.listProviderInvocations({
         tenant: ctx.tenant,
         environment: ctx.environment,
@@ -44,6 +53,7 @@ export let providerInvocationController = app.controller({
         inputs: {
           providerRunIds: ctx.input.providerRunIds,
           sessionMessageIds: ctx.input.sessionMessageIds,
+          callbackEventSourceIds,
           authConfigEventIds: ctx.input.authConfigEventIds
         }
       });

--- a/src/systems/subspace/db/prisma/schema/callback/callback.prisma
+++ b/src/systems/subspace/db/prisma/schema/callback/callback.prisma
@@ -23,7 +23,9 @@ model CallbackDestination {
   url    String
   method String
 
-  slateTriggerDestinationId String
+  slateTriggerDestinationId String?
+  signalEventDestinationId  String?
+  lastSignalSyncedAt        DateTime?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
@@ -61,6 +63,7 @@ model Callback {
 
   status CallbackStatus
   mode   CallbackMode
+  isCallbacksV2 Boolean @default(false)
 
   name                        String
   description                 String?
@@ -136,6 +139,10 @@ model CallbackInstance {
 
   status             CallbackInstanceStatus
   registrationStatus CallbackInstanceRegistrationStatus
+  slateTriggerReceiverId String?
+  lastSyncErrorCode      String?
+  lastSyncErrorMessage   String?
+  lastSyncedAt           DateTime?
 
   activeRegistrationOid BigInt?                       @unique
   activeRegistration    CallbackReceiverRegistration? @relation("ActiveCallbackInstanceRegistration", fields: [activeRegistrationOid], references: [oid], onDelete: SetNull)

--- a/src/systems/subspace/docker-compose.dev.yml
+++ b/src/systems/subspace/docker-compose.dev.yml
@@ -257,7 +257,6 @@ services:
       INVOCATIONS_BUCKET_NAME: subspace-invocations
       INITIAL_REGISTRIES: 'http://slates-registry:52040'
       SIGNAL_API_URL: http://signal:52050/metorial-signal
-      SIGNAL_SENDER_IDENTIFIER: dev-subspace
       SLATES_HUB_INSTANCE_IDENTIFIER: dev-subspace
       SERVICE_PUBLIC_URL: http://localhost:52045
     depends_on:

--- a/src/systems/subspace/modules/callback/package.json
+++ b/src/systems/subspace/modules/callback/package.json
@@ -19,6 +19,7 @@
     "@metorial-subspace/db": "^1.0.0",
     "@metorial-subspace/module-provider-internal": "^1.0.0",
     "@metorial-subspace/provider-slates": "^1.0.0",
+    "@metorial-platform-systems/signal-client": "workspace:*",
     "@lowerdeck/validation": "^1.0.10"
   },
   "devDependencies": {

--- a/src/systems/subspace/modules/callback/src/env.ts
+++ b/src/systems/subspace/modules/callback/src/env.ts
@@ -3,6 +3,7 @@ import { v } from '@lowerdeck/validation';
 
 export let env = createValidatedEnv({
   service: {
-    REDIS_URL: v.string()
+    REDIS_URL: v.string(),
+    SIGNAL_API_URL: v.string()
   }
 });

--- a/src/systems/subspace/modules/callback/src/lib/callbackInstanceEnrichment.ts
+++ b/src/systems/subspace/modules/callback/src/lib/callbackInstanceEnrichment.ts
@@ -55,7 +55,8 @@ export let enrichCallbackInstanceTriggers = async (
 ): Promise<Map<string, EnrichedCallbackInstanceTrigger[]>> => {
   let receiverIdToInstanceIds = new Map<string, string[]>();
   for (let instance of instances) {
-    let receiverId = instance.activeRegistration?.slateTriggerReceiverId;
+    let receiverId =
+      instance.slateTriggerReceiverId ?? instance.activeRegistration?.slateTriggerReceiverId;
     if (!receiverId) continue;
     let ids = receiverIdToInstanceIds.get(receiverId);
     if (!ids) {
@@ -103,7 +104,8 @@ export let enrichSingleCallbackInstanceTriggers = async <
   callback: Callback,
   instance: I
 ): Promise<(EnrichedCallbackInstanceTrigger & I)[]> => {
-  let receiverId = instance.activeRegistration?.slateTriggerReceiverId;
+  let receiverId =
+    instance.slateTriggerReceiverId ?? instance.activeRegistration?.slateTriggerReceiverId;
   if (!receiverId) return [];
 
   let slatesTenant = await getTenantForSlates(tenant);

--- a/src/systems/subspace/modules/callback/src/reconciler/index.ts
+++ b/src/systems/subspace/modules/callback/src/reconciler/index.ts
@@ -3,8 +3,8 @@ import {
   callbackReconcileInstanceQueueProcessor,
   callbackReconcileInstancesPageQueueProcessor,
   callbackReconcileQueueProcessor,
-  callbackReconcileRegistrationAuditQueueProcessor,
-  callbackReconcileRegistrationsPageQueueProcessor
+  callbackV2MigrationCallbackQueueProcessor,
+  callbackV2MigrationScanQueueProcessor
 } from './queues/processors';
 
 export * from './lib/state';
@@ -16,6 +16,6 @@ export let reconcilerQueueProcessor = combineQueueProcessors([
   callbackReconcileQueueProcessor,
   callbackReconcileInstanceQueueProcessor,
   callbackReconcileInstancesPageQueueProcessor,
-  callbackReconcileRegistrationsPageQueueProcessor,
-  callbackReconcileRegistrationAuditQueueProcessor
+  callbackV2MigrationScanQueueProcessor,
+  callbackV2MigrationCallbackQueueProcessor
 ]);

--- a/src/systems/subspace/modules/callback/src/reconciler/lib/state.ts
+++ b/src/systems/subspace/modules/callback/src/reconciler/lib/state.ts
@@ -104,9 +104,3 @@ export let isCallbackSupported = (
   callback.providerDeployment.provider.type.attributes.backend === 'slates' &&
   callback.providerDeployment.provider.type.attributes.triggers.status === 'enabled';
 
-export let getActiveDestinationIds = (
-  callback: NonNullable<Awaited<ReturnType<typeof loadCallback>>>
-) =>
-  callback.callbackDestinationLinks
-    .filter(link => link.callbackDestination.status === 'active')
-    .map(link => link.callbackDestination.slateTriggerDestinationId);

--- a/src/systems/subspace/modules/callback/src/reconciler/lib/sync.ts
+++ b/src/systems/subspace/modules/callback/src/reconciler/lib/sync.ts
@@ -1,3 +1,4 @@
+import { isServiceError } from '@lowerdeck/error';
 import { db } from '@metorial-subspace/db';
 import { slates } from '@metorial-subspace/provider-slates/src/client';
 import { getTenantForSignal, signal } from '../../signal';
@@ -66,6 +67,48 @@ export let markRegistrationFailure = async (d: {
   });
 };
 
+let markCallbackV2IfReady = async (
+  callback: NonNullable<Awaited<ReturnType<typeof loadCallback>>>
+) => {
+  if (callback.isCallbacksV2) return;
+
+  if (!isCallbackSupported(callback) || callback.callbackProviderTriggers.length === 0) {
+    await db.callback.update({
+      where: { oid: callback.oid },
+      data: { isCallbacksV2: true }
+    });
+    return;
+  }
+
+  let attachedInstances = await db.callbackInstance.findMany({
+    where: {
+      callbackOid: callback.oid,
+      status: 'attached'
+    },
+    select: {
+      slateTriggerReceiverId: true,
+      activeRegistration: {
+        select: {
+          slateTriggerReceiverId: true
+        }
+      }
+    }
+  });
+
+  if (
+    attachedInstances.length === 0 ||
+    attachedInstances.some(
+      instance =>
+        !!(instance.slateTriggerReceiverId ?? instance.activeRegistration?.slateTriggerReceiverId)
+    )
+  ) {
+    await db.callback.update({
+      where: { oid: callback.oid },
+      data: { isCallbacksV2: true }
+    });
+  }
+};
+
 export let syncSignalCallback = async (d: { callbackId: string }) => {
   let callback = await loadCallback(d.callbackId);
   if (!callback) return;
@@ -97,10 +140,20 @@ export let syncSignalCallback = async (d: { callbackId: string }) => {
             }
           }))
         })
-      : await signal.callback.archive({
-          tenantId: signalTenant.id,
-          callbackId: callback.id
-        });
+      : await (async () => {
+          try {
+            return await signal.callback.archive({
+              tenantId: signalTenant.id,
+              callbackId: callback.id
+            });
+          } catch (error) {
+            if (isServiceError(error) && error.data.code === 'not_found') {
+              return null;
+            }
+
+            throw error;
+          }
+        })();
 
   if (signalCallback) {
     for (let link of signalCallback.destinations) {
@@ -118,10 +171,7 @@ export let syncSignalCallback = async (d: { callbackId: string }) => {
     }
   }
 
-  await db.callback.update({
-    where: { oid: callback.oid },
-    data: { isCallbacksV2: true }
-  });
+  await markCallbackV2IfReady(callback);
 };
 
 export let syncCallbackInstance = async (d: { callbackInstanceId: string }) => {
@@ -169,6 +219,8 @@ export let syncCallbackInstance = async (d: { callbackInstanceId: string }) => {
         }
       });
     }
+
+    await markCallbackV2IfReady(callback);
     return;
   }
 
@@ -203,6 +255,7 @@ export let syncCallbackInstance = async (d: { callbackInstanceId: string }) => {
       callbackInstanceOid: callbackInstance.oid,
       slateTriggerReceiverId: receiver.id
     });
+    await markCallbackV2IfReady(callback);
   } catch (error) {
     let message = error instanceof Error ? error.message : 'callback_reconcile_failed';
     await markRegistrationFailure({

--- a/src/systems/subspace/modules/callback/src/reconciler/lib/sync.ts
+++ b/src/systems/subspace/modules/callback/src/reconciler/lib/sync.ts
@@ -1,139 +1,126 @@
-import { db, getId, withTransaction } from '@metorial-subspace/db';
+import { db } from '@metorial-subspace/db';
 import { slates } from '@metorial-subspace/provider-slates/src/client';
+import { getTenantForSignal, signal } from '../../signal';
 import {
-  getActiveDestinationIds,
   getTenantForSlatesCached,
   isCallbackSupported,
+  loadCallback,
   loadCallbackInstance
 } from './state';
 
 export let detachRegistration = async (d: {
   callbackInstanceOid: bigint;
-  registrationOid: bigint;
-  slateTriggerReceiverId: string;
+  slateTriggerReceiverId?: string | null;
   slatesTenantId: string;
 }) => {
   try {
     if (d.slateTriggerReceiverId) {
-      await slates.slateTriggerReceiver.delete({
+      await slates.callbackRegistration.delete({
         tenantId: d.slatesTenantId,
         slateTriggerReceiverId: d.slateTriggerReceiverId
       });
     }
   } catch {}
 
-  await withTransaction(async db => {
-    await db.callbackReceiverRegistration.update({
-      where: { oid: d.registrationOid },
-      data: {
-        status: 'detached',
-        lastSyncedAt: new Date()
-      }
-    });
-
-    await db.callbackInstance.update({
-      where: { oid: d.callbackInstanceOid },
-      data: {
-        registrationStatus: 'registered',
-        activeRegistrationOid: null
-      }
-    });
-  });
-};
-
-export let detachOrphanRegistration = async (d: {
-  registrationOid: bigint;
-  slateTriggerReceiverId: string;
-  slatesTenantId: string;
-}) => {
-  try {
-    if (d.slateTriggerReceiverId) {
-      await slates.slateTriggerReceiver.delete({
-        tenantId: d.slatesTenantId,
-        slateTriggerReceiverId: d.slateTriggerReceiverId
-      });
-    }
-  } catch {}
-
-  await db.callbackReceiverRegistration.updateMany({
-    where: { oid: d.registrationOid },
+  await db.callbackInstance.update({
+    where: { oid: d.callbackInstanceOid },
     data: {
-      status: 'detached',
-      lastSyncedAt: new Date()
+      registrationStatus: 'registered',
+      slateTriggerReceiverId: null,
+      activeRegistrationOid: null,
+      lastSyncedAt: new Date(),
+      lastSyncErrorCode: null,
+      lastSyncErrorMessage: null
     }
   });
 };
 
 export let upsertActiveRegistration = async (d: {
   callbackInstanceOid: bigint;
-  callbackOid: bigint;
-  providerDeploymentConfigPairOid: bigint;
-  activeRegistrationOid?: bigint;
   slateTriggerReceiverId: string;
 }) =>
-  withTransaction(async db => {
-    let registrationOid = d.activeRegistrationOid;
-
-    if (registrationOid) {
-      await db.callbackReceiverRegistration.update({
-        where: { oid: registrationOid },
-        data: {
-          slateTriggerReceiverId: d.slateTriggerReceiverId,
-          status: 'active',
-          lastErrorCode: null,
-          lastErrorMessage: null,
-          lastSyncedAt: new Date()
-        }
-      });
-    } else {
-      let registration = await db.callbackReceiverRegistration.create({
-        data: {
-          ...getId('callbackReceiverRegistration'),
-          callbackOid: d.callbackOid,
-          providerDeploymentConfigPairOid: d.providerDeploymentConfigPairOid,
-          callbackInstanceOid: d.callbackInstanceOid,
-          slateTriggerReceiverId: d.slateTriggerReceiverId,
-          status: 'active',
-          lastErrorCode: null,
-          lastErrorMessage: null,
-          lastSyncedAt: new Date()
-        },
-        select: { oid: true }
-      });
-      registrationOid = registration.oid;
+  db.callbackInstance.update({
+    where: { oid: d.callbackInstanceOid },
+    data: {
+      registrationStatus: 'registered',
+      slateTriggerReceiverId: d.slateTriggerReceiverId,
+      activeRegistrationOid: null,
+      lastSyncedAt: new Date(),
+      lastSyncErrorCode: null,
+      lastSyncErrorMessage: null
     }
-
-    await db.callbackInstance.update({
-      where: { oid: d.callbackInstanceOid },
-      data: {
-        registrationStatus: 'registered',
-        activeRegistrationOid: registrationOid
-      }
-    });
   });
 
 export let markRegistrationFailure = async (d: {
   callbackInstanceOid: bigint;
-  activeRegistrationOid?: bigint;
   message: string;
 }) => {
-  if (d.activeRegistrationOid) {
-    await db.callbackReceiverRegistration.update({
-      where: { oid: d.activeRegistrationOid },
-      data: {
-        lastErrorCode: 'registration_failed',
-        lastErrorMessage: d.message,
-        lastSyncedAt: new Date()
-      }
-    });
-    return;
-  }
-
   await db.callbackInstance.update({
     where: { oid: d.callbackInstanceOid },
     data: {
-      registrationStatus: 'pending'
+      registrationStatus: 'pending',
+      lastSyncErrorCode: 'registration_failed',
+      lastSyncErrorMessage: d.message,
+      lastSyncedAt: new Date()
     }
+  });
+};
+
+export let syncSignalCallback = async (d: { callbackId: string }) => {
+  let callback = await loadCallback(d.callbackId);
+  if (!callback) return;
+
+  let signalTenant = await getTenantForSignal(callback.tenant);
+  let activeDestinations = callback.callbackDestinationLinks
+    .map(link => link.callbackDestination)
+    .filter(destination => destination.status === 'active');
+  let eventTypes = [
+    ...new Set(callback.callbackProviderTriggers.flatMap(trigger => trigger.eventTypes))
+  ];
+
+  let signalCallback =
+    callback.status === 'active' && isCallbackSupported(callback)
+      ? await signal.callback.upsert({
+          tenantId: signalTenant.id,
+          callbackId: callback.id,
+          name: callback.name,
+          description: callback.description,
+          eventTypes,
+          destinations: activeDestinations.map(destination => ({
+            externalId: destination.id,
+            name: destination.name,
+            description: destination.description,
+            variant: {
+              type: 'http_endpoint',
+              url: destination.url,
+              method: destination.method as 'POST' | 'PUT' | 'PATCH'
+            }
+          }))
+        })
+      : await signal.callback.archive({
+          tenantId: signalTenant.id,
+          callbackId: callback.id
+        });
+
+  if (signalCallback) {
+    for (let link of signalCallback.destinations) {
+      if (!link.destination.externalId) continue;
+      await db.callbackDestination.updateMany({
+        where: {
+          tenantOid: callback.tenantOid,
+          id: link.destination.externalId
+        },
+        data: {
+          signalEventDestinationId: link.destination.id,
+          lastSignalSyncedAt: new Date()
+        }
+      });
+    }
+  }
+
+  await db.callback.update({
+    where: { oid: callback.oid },
+    data: { isCallbacksV2: true }
   });
 };
 
@@ -142,7 +129,6 @@ export let syncCallbackInstance = async (d: { callbackInstanceId: string }) => {
   if (!callbackInstance) return;
 
   let callback = callbackInstance.callback;
-  let destinationIds = getActiveDestinationIds(callback);
   let providerTriggerInputs = callback.callbackProviderTriggers.map(trigger => ({
     triggerId: trigger.providerTrigger.specId,
     ...(callback.pollIntervalSecondsOverride !== null &&
@@ -153,21 +139,21 @@ export let syncCallbackInstance = async (d: { callbackInstanceId: string }) => {
   let eventTypes = [
     ...new Set(callback.callbackProviderTriggers.flatMap(trigger => trigger.eventTypes))
   ];
-  let activeRegistration = callbackInstance.activeRegistration;
+  let slateTriggerReceiverId =
+    callbackInstance.slateTriggerReceiverId ??
+    callbackInstance.activeRegistration?.slateTriggerReceiverId;
 
   if (
     callbackInstance.status !== 'attached' ||
     !isCallbackSupported(callback) ||
-    !destinationIds.length ||
     !providerTriggerInputs.length
   ) {
-    if (activeRegistration) {
+    if (slateTriggerReceiverId) {
       let slatesTenant = await getTenantForSlatesCached(callback.tenant);
 
       await detachRegistration({
         callbackInstanceOid: callbackInstance.oid,
-        registrationOid: activeRegistration.oid,
-        slateTriggerReceiverId: activeRegistration.slateTriggerReceiverId,
+        slateTriggerReceiverId,
         slatesTenantId: slatesTenant.id
       });
     } else {
@@ -175,7 +161,11 @@ export let syncCallbackInstance = async (d: { callbackInstanceId: string }) => {
         where: { oid: callbackInstance.oid },
         data: {
           registrationStatus: 'registered',
-          activeRegistrationOid: null
+          slateTriggerReceiverId: null,
+          activeRegistrationOid: null,
+          lastSyncedAt: new Date(),
+          lastSyncErrorCode: null,
+          lastSyncErrorMessage: null
         }
       });
     }
@@ -183,6 +173,8 @@ export let syncCallbackInstance = async (d: { callbackInstanceId: string }) => {
   }
 
   try {
+    await syncSignalCallback({ callbackId: callback.id });
+
     let slatesTenant = await getTenantForSlatesCached(callback.tenant);
     let slateInstanceId =
       callbackInstance.providerDeploymentConfigPair.providerConfigVersion.slateInstance?.id;
@@ -195,37 +187,26 @@ export let syncCallbackInstance = async (d: { callbackInstanceId: string }) => {
       callbackInstance.providerDeploymentConfigPair.providerAuthConfigVersion?.slateAuthConfig
         ?.id ?? null;
 
-    let receiver = activeRegistration
-      ? await slates.slateTriggerReceiver.update({
-          tenantId: slatesTenant.id,
-          slateTriggerReceiverId: activeRegistration.slateTriggerReceiverId,
-          authConfigId,
-          destinations: destinationIds,
-          triggers: providerTriggerInputs,
-          eventTypes
-        })
-      : await slates.slateTriggerReceiver.create({
-          tenantId: slatesTenant.id,
-          slateInstanceId,
-          authConfigId: authConfigId ?? undefined,
-          destinations: destinationIds,
-          triggers: providerTriggerInputs,
-          eventTypes,
-          name: `Callback ${callback.id}`
-        });
+    let receiver = await slates.callbackRegistration.upsert({
+      tenantId: slatesTenant.id,
+      callbackId: callback.id,
+      callbackInstanceId: callbackInstance.id,
+      slateTriggerReceiverId,
+      slateInstanceId,
+      authConfigId,
+      triggers: providerTriggerInputs,
+      eventTypes,
+      name: `Callback ${callback.id}`
+    });
 
     await upsertActiveRegistration({
       callbackInstanceOid: callbackInstance.oid,
-      callbackOid: callback.oid,
-      providerDeploymentConfigPairOid: callbackInstance.providerDeploymentConfigPairOid,
-      activeRegistrationOid: activeRegistration?.oid,
       slateTriggerReceiverId: receiver.id
     });
   } catch (error) {
     let message = error instanceof Error ? error.message : 'callback_reconcile_failed';
     await markRegistrationFailure({
       callbackInstanceOid: callbackInstance.oid,
-      activeRegistrationOid: activeRegistration?.oid,
       message
     });
   }

--- a/src/systems/subspace/modules/callback/src/reconciler/queues/definitions.ts
+++ b/src/systems/subspace/modules/callback/src/reconciler/queues/definitions.ts
@@ -26,26 +26,25 @@ export let callbackReconcileInstancesPageQueue = createQueue<{
   }
 });
 
-export let callbackReconcileRegistrationsPageQueue = createQueue<{
-  callbackId: string;
+export let callbackV2MigrationScanQueue = createQueue<{
   cursor?: string;
 }>({
-  name: 'sub/callback/reconcile/registrations/page',
+  name: 'sub/callback/v2-migration/scan',
   redisUrl: env.service.REDIS_URL,
   workerOpts: {
     concurrency: 1
   }
 });
 
-export let callbackReconcileRegistrationAuditQueue = createQueue<{
-  registrationId: string;
+export let callbackV2MigrationCallbackQueue = createQueue<{
+  callbackId: string;
 }>({
-  name: 'sub/callback/reconcile/registration/audit',
+  name: 'sub/callback/v2-migration/callback',
   redisUrl: env.service.REDIS_URL,
   workerOpts: {
-    concurrency: 10,
+    concurrency: 5,
     limiter: {
-      max: 20,
+      max: 10,
       duration: 1000
     }
   }

--- a/src/systems/subspace/modules/callback/src/reconciler/queues/processors.ts
+++ b/src/systems/subspace/modules/callback/src/reconciler/queues/processors.ts
@@ -120,3 +120,5 @@ export let callbackV2MigrationCallbackQueueProcessor =
     await syncSignalCallback({ callbackId: data.callbackId });
     await callbackReconcileInstancesPageQueue.add({ callbackId: data.callbackId });
   });
+
+await callbackV2MigrationScanQueue.add({}, { id: 'callbacks-v2-migration' });

--- a/src/systems/subspace/modules/callback/src/reconciler/queues/processors.ts
+++ b/src/systems/subspace/modules/callback/src/reconciler/queues/processors.ts
@@ -1,24 +1,15 @@
 import { db } from '@metorial-subspace/db';
 import { callbackRegistrationReconcileQueue } from '@metorial-subspace/module-provider-internal/src/queues/lifecycle/deploymentConfigPair';
-import {
-  callbackInclude,
-  getActiveDestinationIds,
-  getTenantForSlatesCached,
-  isCallbackSupported,
-  REGISTRATION_PAGE_SIZE,
-  TRIGGER_PAGE_SIZE
-} from '../lib/state';
-import {
-  detachOrphanRegistration,
-  detachRegistration,
-  syncCallbackInstance
-} from '../lib/sync';
+import { TRIGGER_PAGE_SIZE } from '../lib/state';
+import { syncCallbackInstance, syncSignalCallback } from '../lib/sync';
 import {
   callbackReconcileInstanceQueue,
   callbackReconcileInstancesPageQueue,
-  callbackReconcileRegistrationAuditQueue,
-  callbackReconcileRegistrationsPageQueue
+  callbackV2MigrationCallbackQueue,
+  callbackV2MigrationScanQueue
 } from './definitions';
+
+let CALLBACK_MIGRATION_PAGE_SIZE = 100;
 
 export let callbackReconcileQueueProcessor = callbackRegistrationReconcileQueue.process(
   async data => {
@@ -30,8 +21,8 @@ export let callbackReconcileQueueProcessor = callbackRegistrationReconcileQueue.
     }
 
     if (data.callbackId) {
+      await syncSignalCallback({ callbackId: data.callbackId });
       await callbackReconcileInstancesPageQueue.add({ callbackId: data.callbackId });
-      await callbackReconcileRegistrationsPageQueue.add({ callbackId: data.callbackId });
       return;
     }
 
@@ -95,78 +86,37 @@ export let callbackReconcileInstancesPageQueueProcessor =
     }
   });
 
-export let callbackReconcileRegistrationsPageQueueProcessor =
-  callbackReconcileRegistrationsPageQueue.process(async data => {
-    let rows = await db.callbackReceiverRegistration.findMany({
+export let callbackV2MigrationScanQueueProcessor = callbackV2MigrationScanQueue.process(
+  async data => {
+    let callbacks = await db.callback.findMany({
       where: {
-        callback: {
-          id: data.callbackId
-        },
-        status: 'active',
+        isCallbacksV2: false,
+        status: { not: 'deleted' },
         id: data.cursor ? { gt: data.cursor } : undefined
       },
       orderBy: { id: 'asc' },
-      take: REGISTRATION_PAGE_SIZE,
+      take: CALLBACK_MIGRATION_PAGE_SIZE,
       select: { id: true }
     });
-    if (!rows.length) return;
+    if (!callbacks.length) return;
 
-    await callbackReconcileRegistrationAuditQueue.addManyWithOps(
-      rows.map(row => ({
-        data: { registrationId: row.id },
-        opts: { id: row.id }
+    await callbackV2MigrationCallbackQueue.addManyWithOps(
+      callbacks.map(callback => ({
+        data: { callbackId: callback.id },
+        opts: { id: callback.id }
       }))
     );
 
-    if (rows.length === REGISTRATION_PAGE_SIZE) {
-      await callbackReconcileRegistrationsPageQueue.add({
-        callbackId: data.callbackId,
-        cursor: rows[rows.length - 1]!.id
+    if (callbacks.length === CALLBACK_MIGRATION_PAGE_SIZE) {
+      await callbackV2MigrationScanQueue.add({
+        cursor: callbacks[callbacks.length - 1]!.id
       });
     }
-  });
+  }
+);
 
-export let callbackReconcileRegistrationAuditQueueProcessor =
-  callbackReconcileRegistrationAuditQueue.process(async data => {
-    let registration = await db.callbackReceiverRegistration.findFirst({
-      where: { id: data.registrationId },
-      include: {
-        callback: {
-          include: callbackInclude
-        },
-        callbackInstance: {
-          select: {
-            oid: true,
-            activeRegistrationOid: true
-          }
-        }
-      }
-    });
-    if (!registration) return;
-
-    let slatesTenant = await getTenantForSlatesCached(registration.callback.tenant);
-
-    if (registration.callbackInstance.activeRegistrationOid !== registration.oid) {
-      await detachOrphanRegistration({
-        registrationOid: registration.oid,
-        slateTriggerReceiverId: registration.slateTriggerReceiverId,
-        slatesTenantId: slatesTenant.id
-      });
-      return;
-    }
-
-    let callback = registration.callback;
-    let destinationIds = getActiveDestinationIds(callback);
-    if (
-      !isCallbackSupported(callback) ||
-      !destinationIds.length ||
-      callback.callbackProviderTriggers.length === 0
-    ) {
-      await detachRegistration({
-        callbackInstanceOid: registration.callbackInstance.oid,
-        registrationOid: registration.oid,
-        slateTriggerReceiverId: registration.slateTriggerReceiverId,
-        slatesTenantId: slatesTenant.id
-      });
-    }
+export let callbackV2MigrationCallbackQueueProcessor =
+  callbackV2MigrationCallbackQueue.process(async data => {
+    await syncSignalCallback({ callbackId: data.callbackId });
+    await callbackReconcileInstancesPageQueue.add({ callbackId: data.callbackId });
   });

--- a/src/systems/subspace/modules/callback/src/services/callbackDelivery.ts
+++ b/src/systems/subspace/modules/callback/src/services/callbackDelivery.ts
@@ -1,7 +1,16 @@
 import { notFoundError, ServiceError } from '@lowerdeck/error';
 import { Service } from '@lowerdeck/service';
 import { db, type Environment, type Solution, type Tenant } from '@metorial-subspace/db';
-import { getTenantForSlates, slates } from '@metorial-subspace/provider-slates/src/client';
+import { getTenantForSignal, signal } from '../signal';
+
+let emptyList = {
+  object: 'list',
+  items: [],
+  pagination: {
+    has_more_after: false,
+    has_more_before: false
+  }
+};
 
 class callbackDeliveryServiceImpl {
   private async resolveContext(d: {
@@ -28,50 +37,16 @@ class callbackDeliveryServiceImpl {
     });
     if (!callback) throw new ServiceError(notFoundError('callback', d.callbackId));
 
-    let registrations = await db.callbackReceiverRegistration.findMany({
-      where: {
-        callbackOid: callback.oid,
-        status: 'active'
-      }
-    });
-
-    let slatesTenant = await getTenantForSlates(d.tenant);
-
     return {
       callback,
-      registrations,
-      slatesTenant,
-      linkedSlatesDestinationIds: callback.callbackDestinationLinks
-        .map(link => link.callbackDestination.slateTriggerDestinationId)
+      linkedDestinationIds: callback.callbackDestinationLinks
+        .map(link => link.callbackDestination.signalEventDestinationId ?? link.callbackDestination.id)
         .filter(Boolean),
-      activeSlatesDestinationIds: callback.callbackDestinationLinks
+      activeDestinationIds: callback.callbackDestinationLinks
         .filter(link => link.callbackDestination.status === 'active')
-        .map(link => link.callbackDestination.slateTriggerDestinationId)
+        .map(link => link.callbackDestination.signalEventDestinationId ?? link.callbackDestination.id)
         .filter(Boolean)
     };
-  }
-
-  private async matchesRegistrationForDeliveryEvent(d: {
-    slatesTenantId: string;
-    registrations: { slateTriggerReceiverId: string }[];
-    deliveryEventId: string;
-  }) {
-    let triggerReceiverIds = d.registrations
-      .map(reg => reg.slateTriggerReceiverId)
-      .filter(Boolean);
-
-    if (triggerReceiverIds.length === 0) return false;
-
-    let events = await slates.slateTriggerEvent.list({
-      tenantId: d.slatesTenantId,
-      triggerReceiverIds,
-      limit: 100,
-      order: 'desc'
-    });
-
-    return events.items.some(
-      event => event.id === d.deliveryEventId || event.signalEventId === d.deliveryEventId
-    );
   }
 
   async listCallbackDeliveries(d: {
@@ -90,10 +65,8 @@ class callbackDeliveryServiceImpl {
     };
   }) {
     let context = await this.resolveContext(d);
+    if (!context.callback.isCallbacksV2) return emptyList;
 
-    let receiverIds = context.registrations
-      .map(reg => reg.slateTriggerReceiverId)
-      .filter(Boolean);
     let destinationIds = d.input.destinationIds?.length
       ? (
           await db.callbackDestination.findMany({
@@ -102,16 +75,17 @@ class callbackDeliveryServiceImpl {
               solutionOid: d.solution.oid,
               id: { in: d.input.destinationIds }
             },
-            select: { slateTriggerDestinationId: true }
+            select: { id: true, signalEventDestinationId: true }
           })
         )
-          .map(item => item.slateTriggerDestinationId)
-          .filter(id => context.activeSlatesDestinationIds.includes(id))
+          .map(item => item.signalEventDestinationId ?? item.id)
+          .filter(id => context.activeDestinationIds.includes(id))
       : undefined;
 
-    return await slates.slateTriggerDelivery.list({
-      tenantId: context.slatesTenant.id,
-      triggerReceiverIds: receiverIds.length ? receiverIds : ['__none__'],
+    let signalTenant = await getTenantForSignal(d.tenant);
+    return await signal.callback.listDeliveries({
+      tenantId: signalTenant.id,
+      callbackId: context.callback.id,
       destinationIds,
       status: d.input.status,
       limit: d.input.limit,
@@ -130,25 +104,16 @@ class callbackDeliveryServiceImpl {
     eventDeliveryIntentId: string;
   }) {
     let context = await this.resolveContext(d);
-    let delivery = await slates.slateTriggerDelivery.get({
-      tenantId: context.slatesTenant.id,
-      eventDeliveryIntentId: d.eventDeliveryIntentId
-    });
-
-    let matchesRegistration = await this.matchesRegistrationForDeliveryEvent({
-      slatesTenantId: context.slatesTenant.id,
-      registrations: context.registrations,
-      deliveryEventId: delivery.event.id
-    });
-
-    if (
-      !matchesRegistration &&
-      !context.linkedSlatesDestinationIds.includes(delivery.destination.id)
-    ) {
+    if (!context.callback.isCallbacksV2) {
       throw new ServiceError(notFoundError('callback.delivery', d.eventDeliveryIntentId));
     }
 
-    return delivery;
+    let signalTenant = await getTenantForSignal(d.tenant);
+    return await signal.callback.getDelivery({
+      tenantId: signalTenant.id,
+      callbackId: context.callback.id,
+      eventDeliveryIntentId: d.eventDeliveryIntentId
+    });
   }
 
   async listCallbackDeliveryAttempts(d: {
@@ -167,10 +132,8 @@ class callbackDeliveryServiceImpl {
     };
   }) {
     let context = await this.resolveContext(d);
+    if (!context.callback.isCallbacksV2) return emptyList;
 
-    let receiverIds = context.registrations
-      .map(reg => reg.slateTriggerReceiverId)
-      .filter(Boolean);
     let destinationIds = d.input.destinationIds?.length
       ? (
           await db.callbackDestination.findMany({
@@ -179,14 +142,15 @@ class callbackDeliveryServiceImpl {
               solutionOid: d.solution.oid,
               id: { in: d.input.destinationIds }
             },
-            select: { slateTriggerDestinationId: true }
+            select: { id: true, signalEventDestinationId: true }
           })
-        ).map(item => item.slateTriggerDestinationId)
+        ).map(item => item.signalEventDestinationId ?? item.id)
       : undefined;
 
-    return await slates.slateTriggerDelivery.listAttempts({
-      tenantId: context.slatesTenant.id,
-      triggerReceiverIds: receiverIds.length ? receiverIds : ['__none__'],
+    let signalTenant = await getTenantForSignal(d.tenant);
+    return await signal.callback.listDeliveryAttempts({
+      tenantId: signalTenant.id,
+      callbackId: context.callback.id,
       destinationIds,
       status: d.input.status,
       limit: d.input.limit,
@@ -205,27 +169,18 @@ class callbackDeliveryServiceImpl {
     eventDeliveryAttemptId: string;
   }) {
     let context = await this.resolveContext(d);
-    let attempt = await slates.slateTriggerDelivery.getAttempt({
-      tenantId: context.slatesTenant.id,
-      eventDeliveryAttemptId: d.eventDeliveryAttemptId
-    });
-
-    let matchesRegistration = await this.matchesRegistrationForDeliveryEvent({
-      slatesTenantId: context.slatesTenant.id,
-      registrations: context.registrations,
-      deliveryEventId: attempt.intent.event.id
-    });
-
-    if (
-      !matchesRegistration &&
-      !context.linkedSlatesDestinationIds.includes(attempt.intent.destination.id)
-    ) {
+    if (!context.callback.isCallbacksV2) {
       throw new ServiceError(
         notFoundError('callback.delivery_attempt', d.eventDeliveryAttemptId)
       );
     }
 
-    return attempt;
+    let signalTenant = await getTenantForSignal(d.tenant);
+    return await signal.callback.getDeliveryAttempt({
+      tenantId: signalTenant.id,
+      callbackId: context.callback.id,
+      eventDeliveryAttemptId: d.eventDeliveryAttemptId
+    });
   }
 }
 

--- a/src/systems/subspace/modules/callback/src/services/callbackDestination.ts
+++ b/src/systems/subspace/modules/callback/src/services/callbackDestination.ts
@@ -10,10 +10,65 @@ import {
   type Tenant
 } from '@metorial-subspace/db';
 import { type DateFilter, normalizeDateFilter } from '@metorial-subspace/list-utils';
-import { getTenantForSlates, slates } from '@metorial-subspace/provider-slates/src/client';
 import { callbackRegistrationService } from './callbackRegistration';
+import { getTenantForSignal, signal } from '../signal';
+import { syncSignalCallback } from '../reconciler/lib/sync';
+
+type SignalDestination = Awaited<ReturnType<typeof signal.eventDestination.get>>;
+type EnrichedCallbackDestination = CallbackDestination & {
+  signalDestination?: SignalDestination | null;
+};
 
 class callbackDestinationServiceImpl {
+  private async syncLinkedCallbacksToSignal(d: {
+    tenant: Tenant;
+    callbackDestination: CallbackDestination;
+  }) {
+    let callbacks = await db.callbackDestinationLink.findMany({
+      where: { callbackDestinationOid: d.callbackDestination.oid },
+      select: { callback: { select: { id: true } } }
+    });
+
+    await Promise.all(
+      callbacks.map(async link => {
+        await syncSignalCallback({ callbackId: link.callback.id });
+      })
+    );
+  }
+
+  async enrichCallbackDestination(d: {
+    tenant: Tenant;
+    callbackDestination: CallbackDestination;
+  }): Promise<EnrichedCallbackDestination> {
+    if (!d.callbackDestination.signalEventDestinationId) return d.callbackDestination;
+
+    try {
+      let signalTenant = await getTenantForSignal(d.tenant);
+      let signalDestination = await signal.eventDestination.get({
+        tenantId: signalTenant.id,
+        eventDestinationId: d.callbackDestination.signalEventDestinationId
+      });
+
+      return {
+        ...d.callbackDestination,
+        signalDestination
+      };
+    } catch {
+      return d.callbackDestination;
+    }
+  }
+
+  async enrichCallbackDestinations(d: {
+    tenant: Tenant;
+    callbackDestinations: CallbackDestination[];
+  }) {
+    return await Promise.all(
+      d.callbackDestinations.map(callbackDestination =>
+        this.enrichCallbackDestination({ tenant: d.tenant, callbackDestination })
+      )
+    );
+  }
+
   private normalizeAndValidateEndpoint(d: { url: string; method?: 'POST' | 'PUT' | 'PATCH' }) {
     let parsed: URL;
     try {
@@ -45,6 +100,7 @@ class callbackDestinationServiceImpl {
   async listCallbackDestinations(d: {
     tenant: Tenant;
     solution: Solution;
+    callbackIds?: string[];
     createdAt?: DateFilter;
     updatedAt?: DateFilter;
   }) {
@@ -57,6 +113,19 @@ class callbackDestinationServiceImpl {
             solutionOid: d.solution.oid,
             status: { notIn: [CallbackDestinationStatus.deleted] },
             AND: [
+              d.callbackIds?.length
+                ? {
+                    callbackDestinationLinks: {
+                      some: {
+                        callback: {
+                          id: { in: d.callbackIds },
+                          tenantOid: d.tenant.oid,
+                          solutionOid: d.solution.oid
+                        }
+                      }
+                    }
+                  }
+                : undefined!,
               d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
               d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
             ].filter(Boolean)
@@ -101,15 +170,6 @@ class callbackDestinationServiceImpl {
       method: 'POST'
     });
 
-    let slatesTenant = await getTenantForSlates(d.tenant);
-    let slateDestination = await slates.slateTriggerDestination.create({
-      tenantId: slatesTenant.id,
-      name: d.input.name,
-      description: d.input.description,
-      url: endpoint.url,
-      method: endpoint.method
-    });
-
     return await db.callbackDestination.create({
       data: {
         ...getId('callbackDestination'),
@@ -120,8 +180,7 @@ class callbackDestinationServiceImpl {
         description: d.input.description,
         metadata: d.input.metadata,
         url: endpoint.url,
-        method: endpoint.method,
-        slateTriggerDestinationId: slateDestination.id
+        method: endpoint.method
       }
     });
   }
@@ -146,16 +205,6 @@ class callbackDestinationServiceImpl {
         })
       : null;
 
-    let slatesTenant = await getTenantForSlates(d.tenant);
-    await slates.slateTriggerDestination.update({
-      tenantId: slatesTenant.id,
-      slateTriggerDestinationId: destination.slateTriggerDestinationId,
-      name: d.input.name,
-      description: d.input.description,
-      url: endpoint?.url,
-      method: endpoint?.method
-    });
-
     let updated = await db.callbackDestination.update({
       where: { oid: destination.oid },
       data: {
@@ -167,18 +216,24 @@ class callbackDestinationServiceImpl {
       }
     });
 
+    await this.syncLinkedCallbacksToSignal({
+      tenant: d.tenant,
+      callbackDestination: updated
+    });
+
     let callbacks = await db.callbackDestinationLink.findMany({
       where: { callbackDestinationOid: updated.oid },
       select: { callback: { select: { id: true } } }
     });
-
     await Promise.all(
       callbacks.map(link =>
         callbackRegistrationService.enqueueReconcile({ callbackId: link.callback.id })
       )
     );
 
-    return updated;
+    return await db.callbackDestination.findFirstOrThrow({
+      where: { oid: updated.oid }
+    });
   }
 
   async archiveCallbackDestination(d: {
@@ -195,6 +250,11 @@ class callbackDestinationServiceImpl {
       }
     });
 
+    await this.syncLinkedCallbacksToSignal({
+      tenant: d.tenant,
+      callbackDestination: archived
+    });
+
     let callbacks = await db.callbackDestinationLink.findMany({
       where: { callbackDestinationOid: destination.oid },
       select: { callback: { select: { id: true } } }
@@ -206,7 +266,9 @@ class callbackDestinationServiceImpl {
       )
     );
 
-    return archived;
+    return await db.callbackDestination.findFirstOrThrow({
+      where: { oid: archived.oid }
+    });
   }
 }
 

--- a/src/systems/subspace/modules/callback/src/services/callbackEvent.ts
+++ b/src/systems/subspace/modules/callback/src/services/callbackEvent.ts
@@ -90,8 +90,6 @@ class callbackEventServiceImpl {
       order: d.input.order
     });
 
-    console.log(res.items.map(e => JSON.stringify([e.id, e.createdAt])));
-
     return {
       object: res.object,
       items: res.items.map(toCallbackEvent),

--- a/src/systems/subspace/modules/callback/src/services/callbackEvent.ts
+++ b/src/systems/subspace/modules/callback/src/services/callbackEvent.ts
@@ -1,14 +1,41 @@
 import { notFoundError, ServiceError } from '@lowerdeck/error';
 import { Service } from '@lowerdeck/service';
 import {
-  CallbackReceiverRegistrationStatus,
   CallbackStatus,
   db,
   type Environment,
   type Solution,
   type Tenant
 } from '@metorial-subspace/db';
-import { getTenantForSlates, slates } from '@metorial-subspace/provider-slates/src/client';
+import { getTenantForSignal, signal } from '../signal';
+
+let emptyList = {
+  object: 'list',
+  items: [],
+  pagination: {
+    hasNextPage: false,
+    hasPreviousPage: false
+  }
+};
+
+let toCallbackEvent = (event: Awaited<ReturnType<typeof signal.callback.getEvent>>) => {
+  return {
+    id: event.id,
+    externalId: event.externalId ?? null,
+    type: event.type,
+    sourceId: event.sourceId ?? event.id,
+    triggerKey: event.triggerKey,
+    input: event.input,
+    output: event.output,
+    status: event.status,
+    error: event.error,
+    deliveryStatus: event.deliveryStatus as 'sent' | 'failed' | 'pending' | 'skipped',
+    callbackId: event.callbackId,
+    callbackInstanceId: event.callbackInstanceId ?? null,
+    providerDeploymentConfigPairId: null,
+    createdAt: event.createdAt
+  };
+};
 
 class callbackEventServiceImpl {
   private async resolveContext(d: {
@@ -30,20 +57,7 @@ class callbackEventServiceImpl {
       throw new ServiceError(notFoundError('callback', d.callbackId));
     }
 
-    let registrations = await db.callbackReceiverRegistration.findMany({
-      where: {
-        callbackOid: callback.oid,
-        status: CallbackReceiverRegistrationStatus.active
-      },
-      include: {
-        providerDeploymentConfigPair: true,
-        callbackInstance: true
-      }
-    });
-
-    let slatesTenant = await getTenantForSlates(d.tenant);
-
-    return { callback, registrations, slatesTenant };
+    return { callback };
   }
 
   async listCallbackEvents(d: {
@@ -61,13 +75,13 @@ class callbackEventServiceImpl {
     };
   }) {
     let context = await this.resolveContext(d);
-    let receiverIds = context.registrations
-      .map(reg => reg.slateTriggerReceiverId)
-      .filter(Boolean);
 
-    let res = await slates.slateTriggerEvent.list({
-      tenantId: context.slatesTenant.id,
-      triggerReceiverIds: receiverIds.length ? receiverIds : undefined,
+    if (!context.callback.isCallbacksV2) return emptyList;
+
+    let signalTenant = await getTenantForSignal(d.tenant);
+    let res = await signal.callback.listEvents({
+      tenantId: signalTenant.id,
+      callbackId: context.callback.id,
       eventTypes: d.input.eventTypes,
       limit: d.input.limit,
       after: d.input.after,
@@ -76,22 +90,15 @@ class callbackEventServiceImpl {
       order: d.input.order
     });
 
-    let registrationByReceiverId = new Map(
-      context.registrations.map(reg => [reg.slateTriggerReceiverId, reg] as const)
-    );
+    console.log(res.items.map(e => JSON.stringify([e.id, e.createdAt])));
 
     return {
-      ...res,
-      items: res.items.map(item => {
-        let registration = registrationByReceiverId.get(item.triggerReceiverId);
-        return {
-          ...item,
-          callbackId: context.callback.id,
-          providerDeploymentConfigPairId:
-            registration?.providerDeploymentConfigPair.id ?? null,
-          callbackInstanceId: registration?.callbackInstance.id ?? null
-        };
-      })
+      object: res.object,
+      items: res.items.map(toCallbackEvent),
+      pagination: {
+        hasNextPage: res.pagination.has_more_after,
+        hasPreviousPage: res.pagination.has_more_before
+      }
     };
   }
 
@@ -103,25 +110,30 @@ class callbackEventServiceImpl {
     slateTriggerEventId: string;
   }) {
     let context = await this.resolveContext(d);
-
-    let event = await slates.slateTriggerEvent.get({
-      tenantId: context.slatesTenant.id,
-      slateTriggerEventId: d.slateTriggerEventId
-    });
-
-    let registration = context.registrations.find(
-      reg => reg.slateTriggerReceiverId === event.triggerReceiverId
-    );
-    if (!registration) {
+    if (!context.callback.isCallbacksV2) {
       throw new ServiceError(notFoundError('callback.event', d.slateTriggerEventId));
     }
 
-    return {
-      ...event,
+    let signalTenant = await getTenantForSignal(d.tenant);
+    let event = await signal.callback.getEvent({
+      tenantId: signalTenant.id,
       callbackId: context.callback.id,
-      providerDeploymentConfigPairId: registration.providerDeploymentConfigPair.id,
-      callbackInstanceId: registration.callbackInstance.id
-    };
+      callbackEventId: d.slateTriggerEventId
+    });
+
+    return toCallbackEvent(event);
+  }
+
+  async listCallbackEventSourceIds(d: { tenant: Tenant; callbackEventIds: string[] }) {
+    if (d.callbackEventIds.length === 0) return [];
+
+    let signalTenant = await getTenantForSignal(d.tenant);
+    let events = await signal.callback.listEventsByIds({
+      tenantId: signalTenant.id,
+      callbackEventIds: d.callbackEventIds
+    });
+
+    return events.map(event => event.externalId).filter((id): id is string => Boolean(id));
   }
 }
 

--- a/src/systems/subspace/modules/callback/src/services/callbackInstance.ts
+++ b/src/systems/subspace/modules/callback/src/services/callbackInstance.ts
@@ -2,13 +2,11 @@ import { internalServerError, notFoundError, ServiceError } from '@lowerdeck/err
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import {
-  CallbackReceiverRegistrationStatus,
   db,
   getId,
   withTransaction,
   type Callback,
   type CallbackInstance,
-  type CallbackReceiverRegistration,
   type Environment,
   type ProviderAuthConfig,
   type ProviderConfig,
@@ -216,16 +214,14 @@ class callbackInstanceServiceImpl {
 
   async detach(d: {
     tenant: Tenant;
-    callbackInstance: CallbackInstance & {
-      activeRegistration: CallbackReceiverRegistration | null;
-    };
+    callbackInstance: CallbackInstance;
   }) {
-    if (d.callbackInstance.activeRegistration) {
+    if (d.callbackInstance.slateTriggerReceiverId) {
       let slatesTenant = await getTenantForSlates(d.tenant);
       try {
-        await slates.slateTriggerReceiver.delete({
+        await slates.callbackRegistration.delete({
           tenantId: slatesTenant.id,
-          slateTriggerReceiverId: d.callbackInstance.activeRegistration.slateTriggerReceiverId
+          slateTriggerReceiverId: d.callbackInstance.slateTriggerReceiverId
         });
       } catch (err: any) {
         throw new ServiceError(
@@ -237,22 +233,14 @@ class callbackInstanceServiceImpl {
     }
 
     return await withTransaction(async db => {
-      if (d.callbackInstance.activeRegistration) {
-        await db.callbackReceiverRegistration.update({
-          where: { oid: d.callbackInstance.activeRegistration.oid },
-          data: {
-            status: CallbackReceiverRegistrationStatus.detached,
-            lastSyncedAt: new Date()
-          }
-        });
-      }
-
       return await db.callbackInstance.update({
         where: { oid: d.callbackInstance.oid },
         data: {
           status: 'detached',
           registrationStatus: 'pending',
-          activeRegistrationOid: null
+          activeRegistrationOid: null,
+          slateTriggerReceiverId: null,
+          lastSyncedAt: new Date()
         },
         include: callbackInstanceInclude
       });

--- a/src/systems/subspace/modules/callback/src/services/callbackRegistration.ts
+++ b/src/systems/subspace/modules/callback/src/services/callbackRegistration.ts
@@ -1,9 +1,14 @@
 import { Service } from '@lowerdeck/service';
 import { callbackRegistrationReconcileQueue } from '@metorial-subspace/module-provider-internal/src/queues/lifecycle/deploymentConfigPair';
+import { callbackV2MigrationScanQueue } from '../reconciler';
 
 class callbackRegistrationServiceImpl {
   async enqueueReconcile(d: { callbackId: string } | { callbackInstanceId: string }) {
     await callbackRegistrationReconcileQueue.add(d);
+  }
+
+  async enqueueCallbacksV2Migration() {
+    await callbackV2MigrationScanQueue.add({}, { id: 'callbacks-v2-migration' });
   }
 }
 

--- a/src/systems/subspace/modules/callback/src/signal.ts
+++ b/src/systems/subspace/modules/callback/src/signal.ts
@@ -1,0 +1,20 @@
+import { createLocallyCachedFunction } from '@lowerdeck/cache';
+import { createSignalClient } from '@metorial-platform-systems/signal-client';
+import type { Tenant } from '@metorial-subspace/db';
+import { env } from './env';
+
+export let signal = createSignalClient({
+  endpoint: env.service.SIGNAL_API_URL
+});
+
+let getSignalTenantCached = createLocallyCachedFunction({
+  getHash: (tenant: Tenant) => tenant.identifier,
+  ttlSeconds: 60,
+  provider: async (tenant: Tenant) =>
+    await signal.tenant.upsert({
+      identifier: tenant.identifier,
+      name: tenant.name
+    })
+});
+
+export let getTenantForSignal = async (tenant: Tenant) => await getSignalTenantCached(tenant);

--- a/src/systems/subspace/modules/session/src/services/providerInvocation.ts
+++ b/src/systems/subspace/modules/session/src/services/providerInvocation.ts
@@ -38,6 +38,7 @@ class providerInvocationServiceImpl {
     inputs: {
       providerRunIds?: string[];
       sessionMessageIds?: string[];
+      callbackEventSourceIds?: string[];
       authConfigEventIds?: string[];
     };
   }) {
@@ -46,6 +47,7 @@ class providerInvocationServiceImpl {
       {
         providerRunIds: string[];
         sessionMessageIds: string[];
+        callbackEventSourceIds: string[];
         authConfigEventIds: string[];
       }
     >();
@@ -56,6 +58,7 @@ class providerInvocationServiceImpl {
         bucket = {
           providerRunIds: [],
           sessionMessageIds: [],
+          callbackEventSourceIds: [],
           authConfigEventIds: []
         };
         buckets.set(backendOid, bucket);
@@ -111,6 +114,20 @@ class providerInvocationServiceImpl {
       }
     }
 
+    if (d.inputs.callbackEventSourceIds?.length) {
+      let backend = await db.backend.findFirst({
+        where: {
+          type: 'slates'
+        }
+      });
+
+      if (backend) {
+        ensureBucket(backend.oid).callbackEventSourceIds.push(
+          ...d.inputs.callbackEventSourceIds
+        );
+      }
+    }
+
     if (d.inputs.authConfigEventIds?.length) {
       let authConfigEvents = await db.providerAuthConfigEvent.findMany({
         where: {
@@ -144,6 +161,7 @@ class providerInvocationServiceImpl {
         inputs: {
           providerRunIds: bucket.providerRunIds,
           sessionMessageIds: bucket.sessionMessageIds,
+          callbackEventSourceIds: bucket.callbackEventSourceIds,
           authConfigEventIds: bucket.authConfigEventIds
         }
       });

--- a/src/systems/subspace/packages/presenters/src/callbackDelivery.ts
+++ b/src/systems/subspace/packages/presenters/src/callbackDelivery.ts
@@ -1,15 +1,16 @@
-import type { createSlatesHubInternalClient } from '@metorial-platform-systems/slates-client';
+import type { createSignalClient } from '@metorial-platform-systems/signal-client';
 
-type SlatesClient = ReturnType<typeof createSlatesHubInternalClient>;
+type SignalClient = ReturnType<typeof createSignalClient>;
 
-type CallbackDelivery = Awaited<ReturnType<SlatesClient['slateTriggerDelivery']['get']>>;
-type CallbackDeliveryList = Awaited<ReturnType<SlatesClient['slateTriggerDelivery']['list']>>;
+type CallbackDelivery = Awaited<ReturnType<SignalClient['callback']['getDelivery']>>;
+type CallbackDeliveryList = Awaited<ReturnType<SignalClient['callback']['listDeliveries']>>;
 type CallbackDeliveryAttempt = Awaited<
-  ReturnType<SlatesClient['slateTriggerDelivery']['getAttempt']>
+  ReturnType<SignalClient['callback']['getDeliveryAttempt']>
 >;
 type CallbackDeliveryAttemptList = Awaited<
-  ReturnType<SlatesClient['slateTriggerDelivery']['listAttempts']>
+  ReturnType<SignalClient['callback']['listDeliveryAttempts']>
 >;
+type CallbackDeliveryEmbeddedAttempt = NonNullable<CallbackDelivery['attempts']>[number];
 
 let presentDestination = (destination: CallbackDelivery['destination']) => ({
   object: 'callback.delivery.destination',
@@ -50,6 +51,21 @@ let presentEvent = (event: CallbackDelivery['event']) => ({
   updatedAt: event.updatedAt
 });
 
+let presentAttempt = (attempt: CallbackDeliveryEmbeddedAttempt) => ({
+  object: 'callback.delivery_attempt',
+
+  id: attempt.id,
+  status: attempt.status,
+  attemptNumber: attempt.attemptNumber,
+  durationMs: attempt.durationMs,
+  error: attempt.error,
+  response: attempt.response,
+
+  createdAt: attempt.createdAt,
+  startedAt: attempt.startedAt,
+  completedAt: attempt.completedAt
+});
+
 export let callbackDeliveryPresenter = (delivery: CallbackDelivery) => ({
   object: 'callback.delivery',
 
@@ -60,6 +76,7 @@ export let callbackDeliveryPresenter = (delivery: CallbackDelivery) => ({
 
   event: presentEvent(delivery.event),
   destination: presentDestination(delivery.destination),
+  attempts: delivery.attempts ? delivery.attempts.map(presentAttempt) : null,
 
   createdAt: delivery.createdAt,
   updatedAt: delivery.updatedAt,

--- a/src/systems/subspace/packages/presenters/src/callbackDestination.ts
+++ b/src/systems/subspace/packages/presenters/src/callbackDestination.ts
@@ -1,10 +1,27 @@
 import type { CallbackDestination } from '@metorial-subspace/db';
 
-export let callbackDestinationPresenter = (callbackDestination: CallbackDestination) => ({
+type EnrichedCallbackDestination = CallbackDestination & {
+  signalDestination?: {
+    id: string;
+    webhook: {
+      id: string;
+      url: string;
+      method: string;
+      signingSecret: string;
+      createdAt: Date;
+    } | null;
+  } | null;
+};
+
+export let callbackDestinationPresenter = (
+  callbackDestination: EnrichedCallbackDestination,
+  opts?: { includeSignatureToken?: boolean }
+) => ({
   object: 'callback.destination',
 
   id: callbackDestination.id,
   status: callbackDestination.status,
+  signalDestinationId: callbackDestination.signalEventDestinationId,
 
   name: callbackDestination.name,
   description: callbackDestination.description,
@@ -12,6 +29,18 @@ export let callbackDestinationPresenter = (callbackDestination: CallbackDestinat
 
   url: callbackDestination.url,
   method: callbackDestination.method,
+  webhook: callbackDestination.signalDestination?.webhook
+    ? {
+        id: callbackDestination.signalDestination.webhook.id,
+        url: callbackDestination.signalDestination.webhook.url,
+        method: callbackDestination.signalDestination.webhook.method,
+        signatureToken:
+          opts?.includeSignatureToken === false
+            ? undefined
+            : callbackDestination.signalDestination.webhook.signingSecret,
+        createdAt: callbackDestination.signalDestination.webhook.createdAt
+      }
+    : null,
 
   createdAt: callbackDestination.createdAt,
   updatedAt: callbackDestination.updatedAt

--- a/src/systems/subspace/packages/presenters/src/callbackEvent.ts
+++ b/src/systems/subspace/packages/presenters/src/callbackEvent.ts
@@ -1,25 +1,36 @@
-import type { createSlatesHubInternalClient } from '@metorial-platform-systems/slates-client';
-
-type SlatesClient = ReturnType<typeof createSlatesHubInternalClient>;
-
-type SlatesEvent = Awaited<ReturnType<SlatesClient['slateTriggerEvent']['get']>>;
-
-type CallbackEvent = SlatesEvent & {
+type CallbackEvent = {
+  id: string;
+  externalId: string | null;
+  type: string;
+  sourceId: string;
+  triggerKey: string | null;
+  input: any;
+  output: any;
+  status: 'pending' | 'processing' | 'retrying' | 'succeeded' | 'failed' | 'skipped';
+  error: {
+    code: string | null;
+    message: string | null;
+  } | null;
+  deliveryStatus: 'pending' | 'sent' | 'failed' | 'skipped';
   callbackId: string;
   providerDeploymentConfigPairId: string | null;
   callbackInstanceId: string | null;
+  createdAt: Date;
 };
 
 export let callbackEventPresenter = (event: CallbackEvent) => ({
   object: 'callback.event',
 
   id: event.id,
+  externalId: event.externalId,
   type: event.type,
   sourceId: event.sourceId,
   triggerKey: event.triggerKey,
 
   input: event.input,
   output: event.output,
+  status: event.status,
+  error: event.error,
   deliveryStatus: event.deliveryStatus,
 
   callbackId: event.callbackId,
@@ -28,10 +39,12 @@ export let callbackEventPresenter = (event: CallbackEvent) => ({
   createdAt: event.createdAt
 });
 
-type CallbackEventListResult = Awaited<
-  ReturnType<SlatesClient['slateTriggerEvent']['list']>
-> & {
+type CallbackEventListResult = {
   items: CallbackEvent[];
+  pagination: {
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+  };
 };
 
 export let callbackEventListPresenter = (result: CallbackEventListResult) => ({

--- a/src/systems/subspace/packages/presenters/src/callbackInstance.ts
+++ b/src/systems/subspace/packages/presenters/src/callbackInstance.ts
@@ -68,6 +68,7 @@ export let callbackInstancePresenter = (
           })
         | null;
     };
+    slateTriggerReceiverId?: string | null;
     activeRegistration?: CallbackReceiverRegistration | null;
   },
   receiverTriggers?: EnrichedCallbackInstanceTrigger[]

--- a/src/systems/subspace/provider-backends/provider-slates/src/impl/providerInvocation.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/impl/providerInvocation.ts
@@ -63,6 +63,19 @@ let toLogs = (logs: Array<{ timestamp: number | Date; message: string }> = []) =
 let getSlateProviderInvocationId = (slateInvocationId: string) =>
   createProviderInvocationId('slate.invocation', slateInvocationId);
 
+let getCallbackInvocationActionName = (type: string) => {
+  switch (type) {
+    case 'webhook_handle':
+      return 'Receive Webhook Event';
+    case 'poll':
+      return 'Poll For Callback Events';
+    case 'map_event':
+      return 'Process Callback Result';
+    default:
+      return 'Callback Invocation';
+  }
+};
+
 export class ProviderInvocation extends IProviderInvocation {
   override async listProviderInvocations(
     data: ProviderInvocationListParam
@@ -120,6 +133,52 @@ export class ProviderInvocation extends IProviderInvocation {
           metadata: {
             slateSessionId: remote.sessionId,
             slateVersionId: remote.slateVersionId
+          },
+          createdAt: remote.createdAt
+        });
+      })
+    );
+
+    let callbackInvocations = data.inputs.callbackEventSourceIds?.length
+      ? (
+          await slates.slateTriggerInvocation.list({
+            tenantId: tenant.id,
+            slateTriggerEventInputIds: data.inputs.callbackEventSourceIds,
+            limit: data.inputs.callbackEventSourceIds.length * 3
+          })
+        ).items
+      : [];
+
+    await queue.addAll(
+      callbackInvocations.map(triggerInvocation => async () => {
+        let remote = triggerInvocation.invocation;
+
+        mergeInvocation(invocationMap, {
+          id: getSlateProviderInvocationId(remote.id),
+          source: 'slates',
+          type: 'tool_call',
+          status: getInvocationStatus(remote.status),
+          providerRunIds: [],
+          sessionMessageIds: [],
+          authConfigEventIds: [],
+          providerOAuthSetupIds: [],
+          toolCallId: null,
+          action: {
+            id: triggerInvocation.id,
+            key: triggerInvocation.type,
+            name: getCallbackInvocationActionName(triggerInvocation.type)
+          },
+          requests: remote.requests ?? [],
+          responses: remote.responses ?? [],
+          requestTraces: remote.requestTraces ?? [],
+          logs: toLogs(remote.logs ?? []),
+          attachments: remote.attachments ?? [],
+          error: toInvocationError(remote.error),
+          provider: remote.provider ?? null,
+          metadata: {
+            slateTriggerInvocationId: triggerInvocation.id,
+            slateTriggerInvocationType: triggerInvocation.type,
+            slateTriggerEventId: triggerInvocation.triggerEventId
           },
           createdAt: remote.createdAt
         });

--- a/src/systems/subspace/provider-backends/provider-utils/src/interfaces/providerInvocation.ts
+++ b/src/systems/subspace/provider-backends/provider-utils/src/interfaces/providerInvocation.ts
@@ -47,6 +47,7 @@ export interface ProviderInvocationListParam {
   inputs: {
     providerRunIds?: string[];
     sessionMessageIds?: string[];
+    callbackEventSourceIds?: string[];
     authConfigEventIds?: string[];
   };
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Large cross-system refactor that changes callback persistence and delivery/event retrieval semantics and introduces a background migration/sync path with new DB fields; mis-sync or gating bugs could break callback delivery visibility or registration.
> 
> **Overview**
> Moves **callback delivery/event APIs** in Subspace to delegate to Signal when `Callback.isCallbacksV2` is enabled, returning empty/not-found behavior otherwise, and updates presenters to match Signal’s delivery/attempt/event shapes (including embedded attempts and webhook signing secret exposure controls).
> 
> Adds **Signal callback synchronization**: `syncSignalCallback` upserts/archives callbacks + destinations in Signal, persists `signalEventDestinationId/lastSignalSyncedAt`, and introduces queues to scan/migrate callbacks to v2; callback instance registration now uses Slates `callbackRegistration` upsert/delete and stores `slateTriggerReceiverId` + last sync error fields directly on `CallbackInstance`.
> 
> Extends controller/service surface area: callback destinations can be filtered by `callbackIds` and are enriched with Signal destination/webhook details; provider invocation listing now supports `callbackEventIds` by mapping them to source IDs via the new `callbackEventService.listCallbackEventSourceIds`, and the Slates provider backend can list related invocations for those callback events. Also adjusts Subspace provider invocation service to point at `subspace.providerInvocation` and removes unused Signal sender env config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12c4a6db73bda3b4c14173fbee0265f07e0c2a29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->