### PR TITLE
Add artifact url camo

### DIFF
--- a/src/systems/subspace/apps/public/src/api/public/toolCallArtifact.ts
+++ b/src/systems/subspace/apps/public/src/api/public/toolCallArtifact.ts
@@ -1,5 +1,7 @@
+import { base62 } from '@lowerdeck/base62';
 import { createHono } from '@lowerdeck/hono';
 import { db } from '@metorial-subspace/db';
+import { env } from '../../env';
 
 export let toolCallArtifactApp = createHono().get('/:urlKey', async c => {
   let urlKey = c.req.param('urlKey');
@@ -11,6 +13,18 @@ export let toolCallArtifactApp = createHono().get('/:urlKey', async c => {
 
   if (attachment.expiresAt && attachment.expiresAt < new Date()) {
     return c.text('Tool call artifact has expired', 410);
+  }
+
+  if (env.files.TOOL_CALL_ATTACHMENT_CAMO_URL) {
+    let camoUrl = new URL(env.files.TOOL_CALL_ATTACHMENT_CAMO_URL);
+    camoUrl.pathname = base62.encode(
+      JSON.stringify({
+        url: attachment.url,
+        ts: Date.now() / 1000,
+        ex: attachment.expiresAt ? attachment.expiresAt.getTime() / 1000 : undefined
+      })
+    );
+    return c.redirect(camoUrl.toString());
   }
 
   return c.redirect(attachment.url);

--- a/src/systems/subspace/apps/public/src/env.ts
+++ b/src/systems/subspace/apps/public/src/env.ts
@@ -1,3 +1,8 @@
 import { createValidatedEnv } from '@lowerdeck/env';
+import { v } from '@lowerdeck/validation';
 
-export let env = createValidatedEnv({});
+export let env = createValidatedEnv({
+  files: {
+    TOOL_CALL_ATTACHMENT_CAMO_URL: v.string()
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the public artifact redirect behavior to optionally route through a camo/proxy URL, and introduces a new validated env var that may affect deployments if not configured as expected.
> 
> **Overview**
> Public `GET /:urlKey` tool-call artifact requests now **optionally redirect through a configured camo/proxy** (`env.files.TOOL_CALL_ATTACHMENT_CAMO_URL`) by base62-encoding a JSON payload containing the source URL, a timestamp, and optional expiry.
> 
> Adds the new `TOOL_CALL_ATTACHMENT_CAMO_URL` entry to the public app’s validated environment config, falling back to the direct attachment URL redirect when unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 753e7b58e1218991ccdb79799eef881147ba1deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->