### PR TITLE
Add agent participants

### DIFF
--- a/src/systems/subspace/apps/controller/package.json
+++ b/src/systems/subspace/apps/controller/package.json
@@ -49,6 +49,7 @@
     "@lowerdeck/validation": "^1.0.10",
     "@metorial-platform-systems/signal-client": "workspace:*",
     "@metorial-subspace/db": "^1.0.0",
+    "@metorial-subspace/module-agent": "^1.0.0",
     "@metorial-subspace/module-auth": "^1.0.0",
     "@metorial-subspace/module-callback": "^1.0.0",
     "@metorial-subspace/module-catalog": "^1.0.0",

--- a/src/systems/subspace/apps/controller/src/connection/api/mcp.ts
+++ b/src/systems/subspace/apps/controller/src/connection/api/mcp.ts
@@ -2,10 +2,42 @@ import { delay } from '@lowerdeck/delay';
 import { createHono } from '@lowerdeck/hono';
 import { McpConnection } from '@metorial-subspace/module-connection';
 import { streamSSE } from 'hono/streaming';
+import z from 'zod';
 
 let isDev = process.env.NODE_ENV !== 'production';
 
 type Transports = 'sse' | 'streamable_http';
+
+let agentClientHeaderSchema = z.object({
+  name: z.string(),
+  type: z.literal('mcp_client_oauth'),
+  privateMetadata: z.record(z.string(), z.any()).optional(),
+  oauthRegistrationId: z.string()
+});
+
+let privateMetadataHeaderSchema = z.record(z.string(), z.any());
+
+let parseOptionalJsonHeader = <T>(
+  value: string | undefined,
+  schema: z.ZodSchema<T>,
+  name: string
+) => {
+  if (!value) return { success: true as const, data: undefined };
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(value);
+  } catch {
+    return { success: false as const, message: `Invalid ${name} header JSON` };
+  }
+
+  let parsed = schema.safeParse(parsedJson);
+  if (!parsed.success) {
+    return { success: false as const, message: `Invalid ${name} header value` };
+  }
+
+  return { success: true as const, data: parsed.data };
+};
 
 export let mcpRouter = createHono().all(`/:key?`, async c => {
   if (isDev) {
@@ -13,7 +45,7 @@ export let mcpRouter = createHono().all(`/:key?`, async c => {
     c.res.headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, DELETE');
     c.res.headers.set(
       'Access-Control-Allow-Headers',
-      'Content-Type, Metorial-Proxy-URL, MCP-Protocol-Version, MCP-Session-ID, Authorization'
+      'Content-Type, Metorial-Proxy-URL, Metorial-Agent-Client, Metorial-Connection-Private-Metadata, MCP-Protocol-Version, MCP-Session-ID, Authorization'
     );
     c.res.headers.set('Access-Control-Allow-Credentials', 'true');
     c.res.headers.set(
@@ -38,7 +70,11 @@ export let mcpRouter = createHono().all(`/:key?`, async c => {
     sessionId: c.req.param('sessionId')!,
     solutionId: c.req.param('solutionId')!,
     tenantId: c.req.param('tenantId')!,
-    mcpTransport: transport
+    mcpTransport: transport,
+    agentClient: undefined as z.infer<typeof agentClientHeaderSchema> | undefined,
+    connectionPrivateMetadata: undefined as
+      | z.infer<typeof privateMetadataHeaderSchema>
+      | undefined
   };
 
   let metorialProxyUrl = c.req.header('metorial-proxy-url');
@@ -46,6 +82,25 @@ export let mcpRouter = createHono().all(`/:key?`, async c => {
     if (!isDev) return c.text('Missing Metorial-Proxy-URL header', 400);
     metorialProxyUrl = c.req.url;
   }
+
+  let agentClientHeader = parseOptionalJsonHeader(
+    c.req.header('metorial-agent-client'),
+    agentClientHeaderSchema,
+    'Metorial-Agent-Client'
+  );
+  if (!agentClientHeader.success) return c.text(agentClientHeader.message, 400);
+
+  let connectionPrivateMetadataHeader = parseOptionalJsonHeader(
+    c.req.header('metorial-connection-private-metadata'),
+    privateMetadataHeaderSchema,
+    'Metorial-Connection-Private-Metadata'
+  );
+  if (!connectionPrivateMetadataHeader.success) {
+    return c.text(connectionPrivateMetadataHeader.message, 400);
+  }
+
+  baseParams.agentClient = agentClientHeader.data;
+  baseParams.connectionPrivateMetadata = connectionPrivateMetadataHeader.data;
 
   if (transport === 'sse') {
     if (c.req.method === 'GET') {

--- a/src/systems/subspace/apps/controller/src/controllers/agent.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/agent.ts
@@ -1,0 +1,153 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import { agentService } from '@metorial-subspace/module-agent';
+import { agentPresenter } from '@metorial-subspace/presenters';
+import { app } from './_app';
+import { tenantApp } from './tenant';
+
+export let agentApp = tenantApp.use(async ctx => {
+  let agentId = ctx.body.agentId;
+  if (!agentId) throw new Error('Agent ID is required');
+
+  let agent = await agentService.getAgentById({
+    agentId,
+    tenant: ctx.tenant,
+    environment: ctx.environment,
+    solution: ctx.solution,
+    allowDeleted: ctx.body.allowDeleted
+  });
+
+  return { agent };
+});
+
+export let agentController = app.controller({
+  list: tenantApp
+    .handler()
+    .input(
+      Paginator.validate(
+        v.object({
+          tenantId: v.string(),
+          environmentId: v.string(),
+
+          search: v.optional(v.string()),
+
+          status: v.optional(v.array(v.enumOf(['active', 'archived', 'deleted']))),
+          allowDeleted: v.optional(v.boolean()),
+
+          ids: v.optional(v.array(v.string())),
+          agentIds: v.optional(v.array(v.string()))
+        })
+      )
+    )
+    .do(async ctx => {
+      let paginator = await agentService.listAgents({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+
+        search: ctx.input.search,
+
+        status: ctx.input.status,
+        allowDeleted: ctx.input.allowDeleted,
+
+        ids: ctx.input.ids,
+        agentIds: ctx.input.agentIds
+      });
+
+      let list = await paginator.run(ctx.input);
+
+      return Paginator.presentLight(list, agentPresenter);
+    }),
+
+  get: agentApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        agentId: v.string(),
+        allowDeleted: v.optional(v.boolean())
+      })
+    )
+    .do(async ctx => agentPresenter(ctx.agent)),
+
+  create: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+
+        name: v.string(),
+        slug: v.optional(v.string()),
+        description: v.optional(v.string()),
+        metadata: v.optional(v.record(v.any()))
+      })
+    )
+    .do(async ctx => {
+      let agent = await agentService.createAgent({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+        input: {
+          name: ctx.input.name,
+          slug: ctx.input.slug,
+          description: ctx.input.description,
+          metadata: ctx.input.metadata
+        }
+      });
+
+      return agentPresenter(agent);
+    }),
+
+  update: agentApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        agentId: v.string(),
+        allowDeleted: v.optional(v.boolean()),
+
+        name: v.optional(v.string()),
+        description: v.optional(v.string()),
+        metadata: v.optional(v.record(v.any()))
+      })
+    )
+    .do(async ctx => {
+      let agent = await agentService.updateAgent({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+        agent: ctx.agent,
+        input: {
+          name: ctx.input.name,
+          description: ctx.input.description,
+          metadata: ctx.input.metadata
+        }
+      });
+
+      return agentPresenter(agent);
+    }),
+
+  delete: agentApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        agentId: v.string(),
+        allowDeleted: v.optional(v.boolean())
+      })
+    )
+    .do(async ctx => {
+      let agent = await agentService.archiveAgent({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+        agent: ctx.agent
+      });
+
+      return agentPresenter(agent);
+    })
+});

--- a/src/systems/subspace/apps/controller/src/controllers/agentClient.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/agentClient.ts
@@ -1,0 +1,72 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import { agentClientService } from '@metorial-subspace/module-agent';
+import { agentClientPresenter } from '@metorial-subspace/presenters';
+import { app } from './_app';
+import { createdAtValidator, updatedAtValidator } from './_dateFilter';
+import { tenantApp } from './tenant';
+
+export let agentClientApp = tenantApp.use(async ctx => {
+  let agentClientId = ctx.body.agentClientId;
+  if (!agentClientId) throw new Error('AgentClient ID is required');
+
+  let agentClient = await agentClientService.getAgentClientById({
+    agentClientId,
+    tenant: ctx.tenant,
+    environment: ctx.environment,
+    solution: ctx.solution
+  });
+
+  return { agentClient };
+});
+
+export let agentClientController = app.controller({
+  list: tenantApp
+    .handler()
+    .input(
+      Paginator.validate(
+        v.object({
+          tenantId: v.string(),
+          environmentId: v.string(),
+
+          search: v.optional(v.string()),
+
+          types: v.optional(v.array(v.enumOf(['mcp_client_oauth']))),
+          ids: v.optional(v.array(v.string())),
+
+          createdAt: createdAtValidator,
+          updatedAt: updatedAtValidator
+        })
+      )
+    )
+    .do(async ctx => {
+      let paginator = await agentClientService.listAgentClients({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+
+        search: ctx.input.search,
+
+        types: ctx.input.types,
+        ids: ctx.input.ids,
+
+        createdAt: ctx.input.createdAt,
+        updatedAt: ctx.input.updatedAt
+      });
+
+      let list = await paginator.run(ctx.input);
+
+      return Paginator.presentLight(list, agentClientPresenter);
+    }),
+
+  get: agentClientApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        agentClientId: v.string()
+      })
+    )
+    .do(async ctx => agentClientPresenter(ctx.agentClient))
+});

--- a/src/systems/subspace/apps/controller/src/controllers/agentInstance.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/agentInstance.ts
@@ -47,7 +47,7 @@ export let agentInstanceController = app.controller({
           agentId: v.string(),
           allowDeleted: v.optional(v.boolean()),
 
-          types: v.optional(v.array(v.enumOf(['mcp_client']))),
+          types: v.optional(v.array(v.enumOf(['mcp_client', 'tool_call']))),
           ids: v.optional(v.array(v.string())),
           agentClientIds: v.optional(v.array(v.string())),
 

--- a/src/systems/subspace/apps/controller/src/controllers/agentInstance.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/agentInstance.ts
@@ -1,0 +1,92 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import { agentInstanceService, agentService } from '@metorial-subspace/module-agent';
+import { agentInstancePresenter } from '@metorial-subspace/presenters';
+import { app } from './_app';
+import { createdAtValidator, updatedAtValidator } from './_dateFilter';
+import { tenantApp } from './tenant';
+
+let agentApp = tenantApp.use(async ctx => {
+  let agentId = ctx.body.agentId;
+  if (!agentId) throw new Error('Agent ID is required');
+
+  let agent = await agentService.getAgentById({
+    agentId,
+    tenant: ctx.tenant,
+    environment: ctx.environment,
+    solution: ctx.solution,
+    allowDeleted: ctx.body.allowDeleted
+  });
+
+  return { agent };
+});
+
+export let agentInstanceApp = agentApp.use(async ctx => {
+  let agentInstanceId = ctx.body.agentInstanceId;
+  if (!agentInstanceId) throw new Error('AgentInstance ID is required');
+
+  let agentInstance = await agentInstanceService.getAgentInstanceById({
+    agentInstanceId,
+    agent: ctx.agent,
+    tenant: ctx.tenant,
+    environment: ctx.environment,
+    solution: ctx.solution
+  });
+
+  return { agentInstance };
+});
+
+export let agentInstanceController = app.controller({
+  list: agentApp
+    .handler()
+    .input(
+      Paginator.validate(
+        v.object({
+          tenantId: v.string(),
+          environmentId: v.string(),
+          agentId: v.string(),
+          allowDeleted: v.optional(v.boolean()),
+
+          types: v.optional(v.array(v.enumOf(['mcp_client']))),
+          ids: v.optional(v.array(v.string())),
+          agentClientIds: v.optional(v.array(v.string())),
+
+          createdAt: createdAtValidator,
+          updatedAt: updatedAtValidator
+        })
+      )
+    )
+    .do(async ctx => {
+      let paginator = await agentInstanceService.listAgentInstances({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+
+        agent: ctx.agent,
+
+        types: ctx.input.types,
+        ids: ctx.input.ids,
+        agentClientIds: ctx.input.agentClientIds,
+
+        createdAt: ctx.input.createdAt,
+        updatedAt: ctx.input.updatedAt
+      });
+
+      let list = await paginator.run(ctx.input);
+
+      return Paginator.presentLight(list, agentInstancePresenter);
+    }),
+
+  get: agentInstanceApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        agentId: v.string(),
+        agentInstanceId: v.string(),
+        allowDeleted: v.optional(v.boolean())
+      })
+    )
+    .do(async ctx => agentInstancePresenter(ctx.agentInstance))
+});

--- a/src/systems/subspace/apps/controller/src/controllers/index.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/index.ts
@@ -1,6 +1,9 @@
 import { apiMux } from '@lowerdeck/api-mux';
 import { createServer, type InferClient, rpcMux } from '@lowerdeck/rpc-server';
 import { app } from './_app';
+import { agentController } from './agent';
+import { agentClientController } from './agentClient';
+import { agentInstanceController } from './agentInstance';
 import { actorController } from './actor';
 import { authConfigErrorController } from './authConfigError';
 import { authConfigErrorGlobalController } from './authConfigErrorGlobal';
@@ -75,6 +78,9 @@ import { tenantController } from './tenant';
 import { toolCallController } from './toolCall';
 
 let systemControllers = {
+  agent: agentController,
+  agentClient: agentClientController,
+  agentInstance: agentInstanceController,
   environment: environmentController,
   actor: actorController,
   authConfigEvent: authConfigEventController,

--- a/src/systems/subspace/apps/controller/src/controllers/sessionParticipant.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/sessionParticipant.ts
@@ -34,9 +34,12 @@ export let sessionParticipantController = app.controller({
               v.enumOf([
                 'unknown',
                 'provider',
+                'agent',
+                'system',
+
+                // Legacy
                 'mcp_client',
                 'metorial_protocol_client',
-                'system',
                 'tool_call'
               ])
             )
@@ -58,7 +61,11 @@ export let sessionParticipantController = app.controller({
         environment: ctx.environment,
         solution: ctx.solution,
 
-        types: ctx.input.types,
+        types: ctx.input.types?.map(t =>
+          t === 'mcp_client' || t === 'metorial_protocol_client' || t === 'tool_call'
+            ? 'agent'
+            : t
+        ),
 
         ids: ctx.input.ids,
         sessionIds: ctx.input.sessionIds,

--- a/src/systems/subspace/apps/controller/src/controllers/toolCall.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/toolCall.ts
@@ -94,6 +94,7 @@ export let toolCallController = app.controller({
 
         sessionId: v.string(),
 
+        agentId: v.optional(v.string()),
         metadata: v.optional(v.record(v.any())),
         input: v.record(v.any()),
         toolId: v.string()
@@ -115,6 +116,7 @@ export let toolCallController = app.controller({
         session,
 
         input: {
+          agentId: ctx.input.agentId,
           metadata: ctx.input.metadata,
           input: ctx.input.input,
           toolId: ctx.input.toolId

--- a/src/systems/subspace/db/prisma/schema/agents/agent.prisma
+++ b/src/systems/subspace/db/prisma/schema/agents/agent.prisma
@@ -7,6 +7,7 @@ enum AgentStatus {
 enum AgentType {
   mcp_client
   custom
+  tool_call
 }
 
 model Agent {
@@ -80,6 +81,7 @@ model AgentClient {
 
 enum AgentInstanceType {
   mcp_client
+  tool_call
 }
 
 model AgentInstance {

--- a/src/systems/subspace/db/prisma/schema/agents/agent.prisma
+++ b/src/systems/subspace/db/prisma/schema/agents/agent.prisma
@@ -4,6 +4,11 @@ enum AgentStatus {
   deleted
 }
 
+enum AgentType {
+  mcp_client
+  custom
+}
+
 model Agent {
   oid BigInt @id
   id  String @unique
@@ -16,6 +21,10 @@ model Agent {
   slug            String
   metadata        Json?
   privateMetadata Json?
+
+  hash String?
+
+  type AgentType @default(custom)
 
   actorOid BigInt        @unique
   actor    IdentityActor @relation(fields: [actorOid], references: [oid], onDelete: Cascade)
@@ -33,5 +42,68 @@ model Agent {
   updatedAt  DateTime  @default(now()) @updatedAt
   archivedAt DateTime?
 
+  agentInstances AgentInstance[]
+
   @@unique([environmentOid, slug])
+  @@unique([environmentOid, hash])
+}
+
+enum AgentClientType {
+  mcp_client_oauth
+}
+
+model AgentClient {
+  oid BigInt @id
+  id  String @unique
+
+  name String
+  type AgentClientType
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid], onDelete: Cascade)
+
+  environmentOid BigInt
+  environment    Environment @relation(fields: [environmentOid], references: [oid], onDelete: Cascade)
+
+  solutionOid Int
+  solution    Solution @relation(fields: [solutionOid], references: [oid], onDelete: Cascade)
+
+  privateMetadata     Json?
+  oauthRegistrationId String? @unique
+
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @default(now()) @updatedAt
+  lastConnectedAt DateTime?
+
+  agentInstances AgentInstance[]
+}
+
+enum AgentInstanceType {
+  mcp_client
+}
+
+model AgentInstance {
+  oid BigInt @id
+  id  String @unique
+
+  name        String
+  version     String?
+  description String?
+
+  hash String
+
+  type AgentInstanceType
+
+  agentOid BigInt
+  agent    Agent  @relation(fields: [agentOid], references: [oid], onDelete: Cascade)
+
+  agentClientOid BigInt?
+  agentClient    AgentClient? @relation(fields: [agentClientOid], references: [oid], onDelete: Cascade)
+
+  createdAt           DateTime             @default(now())
+  updatedAt           DateTime             @default(now()) @updatedAt
+  lastConnectedAt     DateTime?
+  sessionParticipants SessionParticipant[]
+
+  @@unique([agentOid, hash])
 }

--- a/src/systems/subspace/db/prisma/schema/session/connection.prisma
+++ b/src/systems/subspace/db/prisma/schema/session/connection.prisma
@@ -71,6 +71,8 @@ model SessionConnection {
   mcpTransport       SessionConnectionMcpConnectionTransport
   mcpProtocolVersion String?
 
+  privateMetadata Json?
+
   createdAt DateTime @default(now())
 
   // When a connection is expired and a client tries to connect to it, 

--- a/src/systems/subspace/db/prisma/schema/session/participant.prisma
+++ b/src/systems/subspace/db/prisma/schema/session/participant.prisma
@@ -1,10 +1,18 @@
 enum SessionParticipantType {
-  mcp_client
-  metorial_protocol_client
+  legacy_mcp_client               @map("mcp_client")
+  legacy_metorial_protocol_client @map("metorial_protocol_client")
+  legacy_tool_call                @map("tool_call")
+
+  agent
   provider
   system
-  tool_call
   unknown
+}
+
+enum SessionParticipantConnectionType {
+  mcp
+  metorial_protocol
+  tool_call
 }
 
 model SessionParticipant {
@@ -17,6 +25,8 @@ model SessionParticipant {
   identifier String
   name       String
 
+  connectionType SessionParticipantConnectionType?
+
   /// [SessionParticipantPayload]
   payload Json
 
@@ -28,6 +38,9 @@ model SessionParticipant {
 
   providerOid BigInt?
   provider    Provider? @relation(fields: [providerOid], references: [oid])
+
+  agentInstanceOid BigInt?
+  agentInstance    AgentInstance? @relation(fields: [agentInstanceOid], references: [oid])
 
   createdAt DateTime @default(now())
 

--- a/src/systems/subspace/db/prisma/schema/solution.prisma
+++ b/src/systems/subspace/db/prisma/schema/solution.prisma
@@ -55,4 +55,5 @@ model Solution {
   identityDelegationConfigs                IdentityDelegationConfig[]
   identityDelegations                      IdentityDelegation[]
   identityDelegationRequests               IdentityDelegationRequest[]
+  agentClients                             AgentClient[]
 }

--- a/src/systems/subspace/db/prisma/schema/tenant.prisma
+++ b/src/systems/subspace/db/prisma/schema/tenant.prisma
@@ -87,6 +87,7 @@ model Tenant {
   identityDelegationConfigs                IdentityDelegationConfig[]
   identityDelegations                      IdentityDelegation[]
   identityDelegationRequests               IdentityDelegationRequest[]
+  agentClients                             AgentClient[]
 }
 
 enum EnvironmentType {
@@ -147,6 +148,7 @@ model Environment {
   identityDelegationConfigs                IdentityDelegationConfig[]
   identityDelegations                      IdentityDelegation[]
   identityDelegationRequests               IdentityDelegationRequest[]
+  agentClients                             AgentClient[]
 }
 
 enum TenantActorType {

--- a/src/systems/subspace/db/src/id.ts
+++ b/src/systems/subspace/db/src/id.ts
@@ -125,7 +125,9 @@ export let ID = createIdGenerator({
   delegatedIdentityUpdate: idType.sorted('diu'),
   delegatedIdentityUpdateCredential: idType.sorted('diuc'),
   identityDelegationCredentialOverride: idType.sorted('idco'),
-  agent: idType.sorted('agt')
+  agent: idType.sorted('agt'),
+  agentClient: idType.sorted('agc'),
+  agentInstance: idType.sorted('agi')
 });
 
 let workerIdBits = 12;

--- a/src/systems/subspace/modules/agent/package.json
+++ b/src/systems/subspace/modules/agent/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@lowerdeck/env": "^1.0.6",
     "@lowerdeck/error": "^1.2.3",
+    "@lowerdeck/hash": "^1.0.4",
     "@lowerdeck/id": "^1.0.8",
     "@lowerdeck/lock": "^1.0.6",
     "@lowerdeck/pagination": "^1.0.8",

--- a/src/systems/subspace/modules/agent/src/queues/search/agentClient.ts
+++ b/src/systems/subspace/modules/agent/src/queues/search/agentClient.ts
@@ -1,0 +1,43 @@
+import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { db } from '@metorial-subspace/db';
+import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
+import { env } from '../../env';
+
+export let indexAgentClientQueue = createQueue<{ agentClientId: string }>({
+  name: 'sub/agt/sidx/client',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let indexAgentClientQueueProcessor = indexAgentClientQueue.process(async data => {
+  let agentClient = await db.agentClient.findUnique({
+    where: { id: data.agentClientId },
+    include: { tenant: true }
+  });
+  if (!agentClient) throw new QueueRetryError();
+
+  if (!agentClient.name) {
+    await voyager.record.delete({
+      sourceId: (await voyagerSource).id,
+      indexId: voyagerIndex.agentClient.id,
+      documentIds: [agentClient.id]
+    });
+    return;
+  }
+
+  await voyager.record.index({
+    sourceId: (await voyagerSource).id,
+    indexId: voyagerIndex.agentClient.id,
+
+    documentId: agentClient.id,
+    tenantIds: [agentClient.tenant.id],
+
+    fields: {
+      agentClientId: agentClient.id,
+      type: agentClient.type
+    },
+    body: {
+      name: agentClient.name,
+      type: agentClient.type
+    }
+  });
+});

--- a/src/systems/subspace/modules/agent/src/queues/search/index.ts
+++ b/src/systems/subspace/modules/agent/src/queues/search/index.ts
@@ -1,3 +1,4 @@
 import { combineQueueProcessors } from '@lowerdeck/queue';
+import { indexAgentClientQueueProcessor } from './agentClient';
 
-export let searchQueues = combineQueueProcessors([]);
+export let searchQueues = combineQueueProcessors([indexAgentClientQueueProcessor]);

--- a/src/systems/subspace/modules/agent/src/services/agent.ts
+++ b/src/systems/subspace/modules/agent/src/services/agent.ts
@@ -1,9 +1,13 @@
+import { Hash } from '@lowerdeck/hash';
+import { generatePlainId } from '@lowerdeck/id';
 import { notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
+import { slugify } from '@lowerdeck/slugify';
 import {
   type Agent,
   AgentStatus,
+  AgentType,
   db,
   type Environment,
   type Solution,
@@ -20,6 +24,9 @@ import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-
 import { checkTenant } from '@metorial-subspace/module-tenant';
 
 let include = { actor: true };
+let isUniqueConstraintError = (error: any) => error?.code === 'P2002';
+let getAgentUpsertSlug = (name: string) =>
+  `${slugify(name)}-${generatePlainId(7).toLowerCase()}`;
 
 class agentServiceImpl {
   async listAgents(d: {
@@ -116,7 +123,8 @@ class agentServiceImpl {
           description: d.input.description,
           metadata: d.input.metadata,
           type: 'agent',
-          _agentSlug: d.input.slug
+          _agentSlug: d.input.slug,
+          _agentType: 'custom'
         }
       });
 
@@ -169,6 +177,71 @@ class agentServiceImpl {
       where: { actorOid: agentActor.oid },
       include
     });
+  }
+
+  async upsertAgent(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    input: {
+      name: string;
+      slug?: string;
+      description?: string;
+      metadata?: Record<string, any>;
+      privateMetadata?: Record<string, any>;
+      type?: AgentType;
+    };
+  }) {
+    let name = d.input.name.trim();
+    let type = d.input.type ?? 'custom';
+    let hash = await Hash.sha256(JSON.stringify([name, type]));
+
+    let getExisting = async () =>
+      await db.agent.findUnique({
+        where: {
+          environmentOid_hash: {
+            environmentOid: d.environment.oid,
+            hash
+          }
+        },
+        include
+      });
+
+    let existing = await getExisting();
+    if (existing) return existing;
+
+    try {
+      return await withTransaction(async db => {
+        let agentActor = await identityActorService.createIdentityActor({
+          tenant: d.tenant,
+          solution: d.solution,
+          environment: d.environment,
+
+          input: {
+            name,
+            description: d.input.description,
+            metadata: d.input.metadata,
+            privateMetadata: d.input.privateMetadata,
+            type: 'agent',
+            _agentSlug: d.input.slug?.trim() || getAgentUpsertSlug(name),
+            _agentHash: hash,
+            _agentType: type
+          }
+        });
+
+        return await db.agent.findFirstOrThrow({
+          where: { actorOid: agentActor.oid },
+          include
+        });
+      });
+    } catch (error) {
+      if (!isUniqueConstraintError(error)) throw error;
+
+      let existingAfterConflict = await getExisting();
+      if (existingAfterConflict) return existingAfterConflict;
+
+      throw error;
+    }
   }
 
   async archiveAgent(d: {

--- a/src/systems/subspace/modules/agent/src/services/agent.ts
+++ b/src/systems/subspace/modules/agent/src/services/agent.ts
@@ -11,7 +11,6 @@ import {
   withTransaction
 } from '@metorial-subspace/db';
 import {
-  checkDeletedEdit,
   normalizeStatusForGet,
   normalizeStatusForList,
   resolveProviders
@@ -140,29 +139,69 @@ class agentServiceImpl {
     };
   }) {
     checkTenant(d, d.agent);
-    checkDeletedEdit(d.agent, 'update');
 
-    return withTransaction(async db => {
-      let actor = await db.identityActor.findFirstOrThrow({
-        where: { oid: d.agent.actorOid }
-      });
+    let actor = await identityActorService.getIdentityActorById({
+      identityActorId: (
+        await db.identityActor.findFirstOrThrow({
+          where: { oid: d.agent.actorOid },
+          select: { id: true }
+        })
+      ).id,
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      allowDeleted: true
+    });
 
-      let agentActor = await identityActorService.updateIdentityActor({
-        tenant: d.tenant,
-        solution: d.solution,
-        environment: d.environment,
-        identityActor: actor,
-        input: {
-          name: d.input.name,
-          description: d.input.description,
-          metadata: d.input.metadata
-        }
-      });
+    let agentActor = await identityActorService.updateIdentityActor({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      identityActor: actor,
+      input: {
+        name: d.input.name,
+        description: d.input.description,
+        metadata: d.input.metadata
+      }
+    });
 
-      return await db.agent.findFirstOrThrow({
-        where: { actorOid: agentActor.oid },
-        include
-      });
+    return await db.agent.findFirstOrThrow({
+      where: { actorOid: agentActor.oid },
+      include
+    });
+  }
+
+  async archiveAgent(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    agent: Agent;
+  }) {
+    checkTenant(d, d.agent);
+
+    let actor = await identityActorService.getIdentityActorById({
+      identityActorId: (
+        await db.identityActor.findFirstOrThrow({
+          where: { oid: d.agent.actorOid },
+          select: { id: true }
+        })
+      ).id,
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      allowDeleted: true
+    });
+
+    let archivedActor = await identityActorService.archiveIdentityActor({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      identityActor: actor
+    });
+
+    return await db.agent.findFirstOrThrow({
+      where: { actorOid: archivedActor.oid },
+      include
     });
   }
 }

--- a/src/systems/subspace/modules/agent/src/services/agentClient.ts
+++ b/src/systems/subspace/modules/agent/src/services/agentClient.ts
@@ -1,0 +1,127 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import {
+  addAfterTransactionHook,
+  db,
+  type AgentClientType,
+  type Environment,
+  getId,
+  type Solution,
+  type Tenant,
+  withTransaction
+} from '@metorial-subspace/db';
+import { type DateFilter, normalizeDateFilter } from '@metorial-subspace/list-utils';
+import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
+import { indexAgentClientQueue } from '../queues/search/agentClient';
+
+class agentClientServiceImpl {
+  async listAgentClients(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+
+    search?: string;
+
+    types?: AgentClientType[];
+    ids?: string[];
+
+    createdAt?: DateFilter;
+    updatedAt?: DateFilter;
+  }) {
+    d.search = d.search?.trim();
+    if (!d.search?.length) d.search = undefined;
+
+    let search = d.search
+      ? await voyager.record.search({
+          tenantId: d.tenant.id,
+          sourceId: (await voyagerSource).id,
+          indexId: voyagerIndex.agentClient.id,
+          query: d.search
+        })
+      : null;
+
+    return Paginator.create(({ prisma }) =>
+      prisma(
+        async opts =>
+          await db.agentClient.findMany({
+            ...opts,
+            where: {
+              tenantOid: d.tenant.oid,
+              solutionOid: d.solution.oid,
+              environmentOid: d.environment.oid,
+
+              AND: [
+                d.ids ? { id: { in: d.ids } } : undefined!,
+                d.types ? { type: { in: d.types } } : undefined!,
+                search ? { id: { in: search.map(r => r.documentId) } } : undefined!,
+
+                d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+                d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
+              ].filter(Boolean)
+            }
+          })
+      )
+    );
+  }
+
+  async getAgentClientById(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    agentClientId: string;
+  }) {
+    let agentClient = await db.agentClient.findFirst({
+      where: {
+        id: d.agentClientId,
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid
+      }
+    });
+    if (!agentClient) throw new ServiceError(notFoundError('agent.client', d.agentClientId));
+
+    return agentClient;
+  }
+
+  async createAgentClient(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    input: {
+      name: string;
+      type: AgentClientType;
+      privateMetadata?: Record<string, any>;
+      oauthRegistrationId?: string;
+    };
+  }) {
+    return await withTransaction(async db => {
+      let agentClient = await db.agentClient.create({
+        data: {
+          ...getId('agentClient'),
+
+          name: d.input.name.trim(),
+          type: d.input.type,
+
+          privateMetadata: d.input.privateMetadata,
+          oauthRegistrationId: d.input.oauthRegistrationId?.trim() || undefined,
+
+          tenantOid: d.tenant.oid,
+          solutionOid: d.solution.oid,
+          environmentOid: d.environment.oid
+        }
+      });
+
+      await addAfterTransactionHook(async () =>
+        indexAgentClientQueue.add({ agentClientId: agentClient.id })
+      );
+
+      return agentClient;
+    });
+  }
+}
+
+export let agentClientService = Service.create(
+  'agentClient',
+  () => new agentClientServiceImpl()
+).build();

--- a/src/systems/subspace/modules/agent/src/services/agentClient.ts
+++ b/src/systems/subspace/modules/agent/src/services/agentClient.ts
@@ -3,8 +3,8 @@ import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import {
   addAfterTransactionHook,
-  db,
   type AgentClientType,
+  db,
   type Environment,
   getId,
   type Solution,
@@ -84,7 +84,7 @@ class agentClientServiceImpl {
     return agentClient;
   }
 
-  async createAgentClient(d: {
+  async upsertAgentClient(d: {
     tenant: Tenant;
     solution: Solution;
     environment: Environment;
@@ -96,28 +96,77 @@ class agentClientServiceImpl {
     };
   }) {
     return await withTransaction(async db => {
-      let agentClient = await db.agentClient.create({
-        data: {
-          ...getId('agentClient'),
+      let oauthRegistrationId = d.input.oauthRegistrationId?.trim() || undefined;
+      let newId = getId('agentClient');
 
-          name: d.input.name.trim(),
-          type: d.input.type,
+      let agentClient = oauthRegistrationId
+        ? await db.agentClient.upsert({
+            where: { oauthRegistrationId },
+            create: {
+              ...newId,
 
-          privateMetadata: d.input.privateMetadata,
-          oauthRegistrationId: d.input.oauthRegistrationId?.trim() || undefined,
+              name: d.input.name.trim(),
+              type: d.input.type,
 
-          tenantOid: d.tenant.oid,
-          solutionOid: d.solution.oid,
-          environmentOid: d.environment.oid
-        }
-      });
+              privateMetadata: d.input.privateMetadata,
+              oauthRegistrationId,
+              lastConnectedAt: new Date(),
 
-      await addAfterTransactionHook(async () =>
-        indexAgentClientQueue.add({ agentClientId: agentClient.id })
-      );
+              tenantOid: d.tenant.oid,
+              solutionOid: d.solution.oid,
+              environmentOid: d.environment.oid
+            },
+            update: {
+              name: d.input.name.trim(),
+              type: d.input.type,
+              privateMetadata: d.input.privateMetadata,
+              lastConnectedAt: new Date(),
+              tenantOid: d.tenant.oid,
+              solutionOid: d.solution.oid,
+              environmentOid: d.environment.oid
+            }
+          })
+        : await db.agentClient.create({
+            data: {
+              ...getId('agentClient'),
+
+              name: d.input.name.trim(),
+              type: d.input.type,
+
+              privateMetadata: d.input.privateMetadata,
+              oauthRegistrationId,
+              lastConnectedAt: new Date(),
+
+              tenantOid: d.tenant.oid,
+              solutionOid: d.solution.oid,
+              environmentOid: d.environment.oid
+            }
+          });
+
+      let isNew = agentClient.oid == newId.oid;
+
+      if (isNew) {
+        await addAfterTransactionHook(async () =>
+          indexAgentClientQueue.add({ agentClientId: agentClient.id })
+        );
+      }
 
       return agentClient;
     });
+  }
+
+  async createAgentClient(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    input: {
+      name: string;
+      type: AgentClientType;
+      privateMetadata?: Record<string, any>;
+      oauthRegistrationId?: string;
+    };
+  }) {
+    return await this.upsertAgentClient(d);
   }
 }
 

--- a/src/systems/subspace/modules/agent/src/services/agentInstance.ts
+++ b/src/systems/subspace/modules/agent/src/services/agentInstance.ts
@@ -1,11 +1,12 @@
-import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { Hash } from '@lowerdeck/hash';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import {
-  db,
   type Agent,
   type AgentClient,
   type AgentInstanceType,
+  db,
   type Environment,
   getId,
   type Solution,
@@ -52,7 +53,9 @@ class agentInstanceServiceImpl {
               AND: [
                 d.ids ? { id: { in: d.ids } } : undefined!,
                 d.types ? { type: { in: d.types } } : undefined!,
-                d.agentClientIds ? { agentClient: { id: { in: d.agentClientIds } } } : undefined!,
+                d.agentClientIds
+                  ? { agentClient: { id: { in: d.agentClientIds } } }
+                  : undefined!,
 
                 d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
                 d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
@@ -87,7 +90,7 @@ class agentInstanceServiceImpl {
     return agentInstance;
   }
 
-  async createAgentInstance(d: {
+  async upsertAgentInstance(d: {
     tenant: Tenant;
     solution: Solution;
     environment: Environment;
@@ -99,7 +102,6 @@ class agentInstanceServiceImpl {
       name: string;
       version?: string;
       description?: string;
-      hash: string;
       type: AgentInstanceType;
     };
   }) {
@@ -107,18 +109,51 @@ class agentInstanceServiceImpl {
     checkTenant(d, d.agentClient);
     checkDeletedRelation(d.agent);
 
+    if (d.agent.type === 'tool_call' && d.input.type !== 'tool_call') {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Agent cannot be used for this connection type'
+        })
+      );
+    }
+
+    let hash = await Hash.sha256(
+      JSON.stringify([
+        d.input.name,
+        d.input.version,
+        d.agent.id,
+        d.agentClient?.id ?? null,
+        d.input.type
+      ])
+    );
+
     return await withTransaction(async db => {
-      return await db.agentInstance.create({
-        data: {
+      return await db.agentInstance.upsert({
+        where: {
+          agentOid_hash: {
+            agentOid: d.agent.oid,
+            hash
+          }
+        },
+        create: {
           ...getId('agentInstance'),
 
           name: d.input.name.trim(),
           version: d.input.version?.trim() || undefined,
           description: d.input.description?.trim() || undefined,
-          hash: d.input.hash,
+          hash,
           type: d.input.type,
+          lastConnectedAt: new Date(),
 
           agentOid: d.agent.oid,
+          agentClientOid: d.agentClient?.oid
+        },
+        update: {
+          name: d.input.name.trim(),
+          version: d.input.version?.trim() || undefined,
+          description: d.input.description?.trim() || undefined,
+          type: d.input.type,
+          lastConnectedAt: new Date(),
           agentClientOid: d.agentClient?.oid
         },
         include

--- a/src/systems/subspace/modules/agent/src/services/agentInstance.ts
+++ b/src/systems/subspace/modules/agent/src/services/agentInstance.ts
@@ -1,0 +1,133 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import {
+  db,
+  type Agent,
+  type AgentClient,
+  type AgentInstanceType,
+  type Environment,
+  getId,
+  type Solution,
+  type Tenant,
+  withTransaction
+} from '@metorial-subspace/db';
+import {
+  checkDeletedRelation,
+  type DateFilter,
+  normalizeDateFilter
+} from '@metorial-subspace/list-utils';
+import { checkTenant } from '@metorial-subspace/module-tenant';
+
+let include = {
+  agent: true,
+  agentClient: true
+};
+
+class agentInstanceServiceImpl {
+  async listAgentInstances(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+
+    agent: Agent;
+
+    types?: AgentInstanceType[];
+    ids?: string[];
+    agentClientIds?: string[];
+
+    createdAt?: DateFilter;
+    updatedAt?: DateFilter;
+  }) {
+    checkTenant(d, d.agent);
+
+    return Paginator.create(({ prisma }) =>
+      prisma(
+        async opts =>
+          await db.agentInstance.findMany({
+            ...opts,
+            where: {
+              agentOid: d.agent.oid,
+
+              AND: [
+                d.ids ? { id: { in: d.ids } } : undefined!,
+                d.types ? { type: { in: d.types } } : undefined!,
+                d.agentClientIds ? { agentClient: { id: { in: d.agentClientIds } } } : undefined!,
+
+                d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+                d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
+              ].filter(Boolean)
+            },
+            include
+          })
+      )
+    );
+  }
+
+  async getAgentInstanceById(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    agent: Agent;
+    agentInstanceId: string;
+  }) {
+    checkTenant(d, d.agent);
+
+    let agentInstance = await db.agentInstance.findFirst({
+      where: {
+        id: d.agentInstanceId,
+        agentOid: d.agent.oid
+      },
+      include
+    });
+    if (!agentInstance) {
+      throw new ServiceError(notFoundError('agent.instance', d.agentInstanceId));
+    }
+
+    return agentInstance;
+  }
+
+  async createAgentInstance(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+
+    agent: Agent;
+    agentClient?: AgentClient | null;
+
+    input: {
+      name: string;
+      version?: string;
+      description?: string;
+      hash: string;
+      type: AgentInstanceType;
+    };
+  }) {
+    checkTenant(d, d.agent);
+    checkTenant(d, d.agentClient);
+    checkDeletedRelation(d.agent);
+
+    return await withTransaction(async db => {
+      return await db.agentInstance.create({
+        data: {
+          ...getId('agentInstance'),
+
+          name: d.input.name.trim(),
+          version: d.input.version?.trim() || undefined,
+          description: d.input.description?.trim() || undefined,
+          hash: d.input.hash,
+          type: d.input.type,
+
+          agentOid: d.agent.oid,
+          agentClientOid: d.agentClient?.oid
+        },
+        include
+      });
+    });
+  }
+}
+
+export let agentInstanceService = Service.create(
+  'agentInstance',
+  () => new agentInstanceServiceImpl()
+).build();

--- a/src/systems/subspace/modules/agent/src/services/index.ts
+++ b/src/systems/subspace/modules/agent/src/services/index.ts
@@ -1,1 +1,3 @@
-export * from './actor';
+export * from './agent';
+export * from './agentClient';
+export * from './agentInstance';

--- a/src/systems/subspace/modules/connection/package.json
+++ b/src/systems/subspace/modules/connection/package.json
@@ -27,6 +27,7 @@
     "@metorial-subspace/db": "^1.0.0",
     "@metorial-subspace/generator": "^1.0.0",
     "@metorial-subspace/list-utils": "^1.0.0",
+    "@metorial-subspace/module-agent": "^1.0.0",
     "@metorial-subspace/module-provider-internal": "^1.0.0",
     "@metorial-subspace/provider": "^1.0.0",
     "@metorial-subspace/redis-url": "^1.0.0",

--- a/src/systems/subspace/modules/connection/src/sender/manager.ts
+++ b/src/systems/subspace/modules/connection/src/sender/manager.ts
@@ -827,7 +827,7 @@ export class SenderManager {
         ? { type: 'system' }
         : {
             type: 'connection_client',
-            transport: d.mcpTransport === 'none' ? 'metorial' : 'mcp',
+            transport: d.mcpTransport === 'none' ? 'metorial_protocol' : 'mcp',
             participant: d.client
           }
     });

--- a/src/systems/subspace/modules/connection/src/sender/manager.ts
+++ b/src/systems/subspace/modules/connection/src/sender/manager.ts
@@ -11,6 +11,7 @@ import { createLock } from '@lowerdeck/lock';
 import { getSentry } from '@lowerdeck/sentry';
 import type { ConduitInput, ConduitResult } from '@metorial-subspace/connection-utils';
 import {
+  type AgentInstance,
   db,
   getId,
   ID,
@@ -28,6 +29,11 @@ import {
   type Tenant
 } from '@metorial-subspace/db';
 import { isRecordDeleted } from '@metorial-subspace/list-utils';
+import {
+  agentClientService,
+  agentInstanceService,
+  agentService
+} from '@metorial-subspace/module-agent';
 import {
   checkToolAccess,
   checkToolScopesSatisfied,
@@ -68,6 +74,7 @@ export interface InitProps {
   mcpCapabilities?: Record<string, any>;
   mcpProtocolVersion?: string;
   mcpTransport: SessionConnectionMcpConnectionTransport;
+  agentInstance?: AgentInstance | null;
 }
 
 export interface CallToolProps {
@@ -85,6 +92,13 @@ export interface SenderMangerProps {
   tenantId: string;
   connectionToken?: string;
   transport: SessionConnectionTransport;
+  agentClient?: {
+    name: string;
+    type: 'mcp_client_oauth';
+    privateMetadata?: Record<string, any>;
+    oauthRegistrationId: string;
+  };
+  connectionPrivateMetadata?: Record<string, any>;
 }
 
 export class SenderManager {
@@ -97,7 +111,9 @@ export class SenderManager {
       | undefined,
     readonly tenant: Tenant,
     readonly solution: Solution,
-    readonly transport: SessionConnectionTransport
+    readonly transport: SessionConnectionTransport,
+    readonly agentClient: SenderMangerProps['agentClient'],
+    readonly connectionPrivateMetadata: SenderMangerProps['connectionPrivateMetadata']
   ) {}
 
   private static async resolveSession(d: SenderMangerProps) {
@@ -235,8 +251,72 @@ export class SenderManager {
       connection,
       session.tenant,
       session.solution,
-      d.transport
+      d.transport,
+      d.agentClient,
+      d.connectionPrivateMetadata
     );
+  }
+
+  #upsertAgentClientPromise: ReturnType<typeof this.upsertAgentClientIfNeeded> | null = null;
+  private async upsertAgentClientIfNeeded() {
+    if (!this.agentClient) return null;
+
+    let environment = await db.environment.findUniqueOrThrow({
+      where: { oid: this.session.environmentOid }
+    });
+
+    return await agentClientService.upsertAgentClient({
+      tenant: this.tenant,
+      solution: this.solution,
+      environment,
+      input: this.agentClient
+    });
+  }
+
+  private async ensureAgentClientUpserted() {
+    if (!this.agentClient) return null;
+    if (this.#upsertAgentClientPromise) return await this.#upsertAgentClientPromise;
+
+    this.#upsertAgentClientPromise = this.upsertAgentClientIfNeeded();
+    return await this.#upsertAgentClientPromise;
+  }
+
+  private async ensureConnectionClientAgentContext(d: InitProps['client']) {
+    let agentClient = await this.ensureAgentClientUpserted();
+
+    let agent = await agentService.upsertAgent({
+      tenant: this.tenant,
+      solution: this.solution,
+      environment: await db.environment.findUniqueOrThrow({
+        where: { oid: this.session.environmentOid }
+      }),
+      input: {
+        name: d.name,
+        type: 'mcp_client'
+      }
+    });
+
+    let agentInstance = await agentInstanceService.upsertAgentInstance({
+      tenant: this.tenant,
+      solution: this.solution,
+      environment: await db.environment.findUniqueOrThrow({
+        where: { oid: this.session.environmentOid }
+      }),
+      agent,
+      agentClient,
+      input: {
+        name: d.name,
+        version: typeof d.version === 'string' ? d.version : undefined,
+        description: undefined,
+        type: 'mcp_client'
+      }
+    });
+
+    return {
+      agent,
+      agentClient,
+      agentInstance
+    };
   }
 
   private async ensureConnectionParticipant() {
@@ -725,6 +805,8 @@ export class SenderManager {
 
   #createConnectionPromise: Promise<SessionConnection> | null = null;
   async createConnection() {
+    await this.ensureAgentClientUpserted();
+
     if (this.connection) return this.connection;
     if (this.#createConnectionPromise) return await this.#createConnectionPromise;
 
@@ -747,6 +829,7 @@ export class SenderManager {
 
           mcpTransport: 'none',
           mcpProtocolVersion: null,
+          privateMetadata: this.connectionPrivateMetadata,
 
           sessionOid: this.session.oid,
           tenantOid: this.session.tenantOid,
@@ -810,6 +893,8 @@ export class SenderManager {
   }
 
   async initialize(d: InitProps & { isManualConnection?: boolean }) {
+    await this.ensureAgentClientUpserted();
+
     // Ignore if already initialized
     if (this.connection?.initState === 'completed') return this.connection;
 
@@ -821,14 +906,29 @@ export class SenderManager {
       );
     }
 
+    let connectionClientAgentContext = d.agentInstance
+      ? { agentInstance: d.agentInstance }
+      : d.client.identifier.startsWith('metorial#') || d.isManualConnection
+        ? null
+        : await this.ensureConnectionClientAgentContext(d.client);
+
     let participant = await upsertParticipant({
       session: this.session,
-      from: d.client.identifier.startsWith('metorial#')
+      from:
+        d.agentInstance
+          ? {
+              type: 'connection_client',
+              transport: d.mcpTransport === 'none' ? 'metorial_protocol' : 'mcp',
+              participant: d.client,
+              agentInstance: d.agentInstance
+            }
+          : d.client.identifier.startsWith('metorial#')
         ? { type: 'system' }
         : {
             type: 'connection_client',
             transport: d.mcpTransport === 'none' ? 'metorial_protocol' : 'mcp',
-            participant: d.client
+            participant: d.client,
+            agentInstance: connectionClientAgentContext?.agentInstance
           }
     });
 
@@ -878,6 +978,7 @@ export class SenderManager {
           tenantOid: this.tenant.oid,
           solutionOid: this.solution.oid,
           environmentOid: this.session.environmentOid,
+          privateMetadata: this.connectionPrivateMetadata,
           token: await ID.generateId('sessionConnection_token')
         },
         include: { participant: true }

--- a/src/systems/subspace/modules/connection/src/shared/upsertParticipant.ts
+++ b/src/systems/subspace/modules/connection/src/shared/upsertParticipant.ts
@@ -3,6 +3,7 @@ import { Hash } from '@lowerdeck/hash';
 import {
   db,
   getId,
+  SessionParticipantConnectionType,
   type Provider,
   type Session,
   type SessionParticipantType
@@ -13,15 +14,12 @@ export let upsertParticipant = async (d: {
   from:
     | {
         type: 'connection_client';
-        transport: 'mcp' | 'metorial';
+        transport: SessionParticipantConnectionType;
         participant: PrismaJson.SessionParticipantPayload;
       }
     | {
         type: 'provider';
         provider: Provider;
-      }
-    | {
-        type: 'tool_call';
       }
     | {
         type: 'system';
@@ -33,12 +31,14 @@ export let upsertParticipant = async (d: {
   let hash: string = d.from.type;
   let participantData: PrismaJson.SessionParticipantPayload;
   let type: SessionParticipantType;
+  let connectionType: SessionParticipantConnectionType | undefined;
 
   switch (d.from.type) {
     case 'connection_client':
       participantData = d.from.participant;
       hash = await Hash.sha256(canonicalize([d.session.tenantOid, participantData]));
-      type = d.from.transport === 'mcp' ? 'mcp_client' : 'metorial_protocol_client';
+      connectionType = d.from.transport;
+      type = 'agent';
       break;
 
     case 'provider':
@@ -48,14 +48,6 @@ export let upsertParticipant = async (d: {
       };
       hash = `provider:${d.from.provider.id}`;
       type = 'provider';
-      break;
-
-    case 'tool_call':
-      participantData = {
-        identifier: 'tool_call',
-        name: 'Tool Call'
-      };
-      type = 'tool_call';
       break;
 
     case 'system':

--- a/src/systems/subspace/modules/connection/src/shared/upsertParticipant.ts
+++ b/src/systems/subspace/modules/connection/src/shared/upsertParticipant.ts
@@ -1,6 +1,7 @@
 import { canonicalize } from '@lowerdeck/canonicalize';
 import { Hash } from '@lowerdeck/hash';
 import {
+  type AgentInstance,
   db,
   getId,
   SessionParticipantConnectionType,
@@ -16,6 +17,7 @@ export let upsertParticipant = async (d: {
         type: 'connection_client';
         transport: SessionParticipantConnectionType;
         participant: PrismaJson.SessionParticipantPayload;
+        agentInstance?: AgentInstance | null;
       }
     | {
         type: 'provider';
@@ -81,11 +83,23 @@ export let upsertParticipant = async (d: {
       type,
       identifier: participantData.identifier,
       name: participantData.name,
+      connectionType,
       payload: participantData,
       tenantOid: d.session.tenantOid,
       environmentOid: d.session.environmentOid,
-      providerOid: d.from.type === 'provider' ? d.from.provider.oid : undefined
+      providerOid: d.from.type === 'provider' ? d.from.provider.oid : undefined,
+      agentInstanceOid:
+        d.from.type === 'connection_client' ? d.from.agentInstance?.oid : undefined
     },
-    update: {}
+    update:
+      d.from.type === 'connection_client'
+        ? {
+            identifier: participantData.identifier,
+            name: participantData.name,
+            payload: participantData,
+            connectionType,
+            agentInstanceOid: d.from.agentInstance?.oid
+          }
+        : {}
   });
 };

--- a/src/systems/subspace/modules/identity/src/services/actor.ts
+++ b/src/systems/subspace/modules/identity/src/services/actor.ts
@@ -5,6 +5,7 @@ import { Service } from '@lowerdeck/service';
 import { createSlugGenerator } from '@lowerdeck/slugify';
 import {
   addAfterTransactionHook,
+  type AgentType,
   db,
   type Environment,
   getId,
@@ -143,6 +144,8 @@ class identityActorServiceImpl {
       type: IdentityActorType;
 
       _agentSlug?: string;
+      _agentHash?: string;
+      _agentType?: AgentType;
     };
   }) {
     return withTransaction(async db => {
@@ -176,6 +179,8 @@ class identityActorServiceImpl {
             description: d.input.description?.trim() || undefined,
             metadata: d.input.metadata,
             privateMetadata: d.input.privateMetadata,
+            hash: d.input._agentHash,
+            type: d.input._agentType,
 
             slug: await getAgentSlug(
               {
@@ -221,10 +226,24 @@ class identityActorServiceImpl {
     checkTenant(d, d.identityActor);
     checkDeletedEdit(d.identityActor, 'update');
 
+    let existingIdentityActor = await db.identityActor.findUniqueOrThrow({
+      where: { oid: d.identityActor.oid },
+      include
+    });
+
+    if (existingIdentityActor.agent?.type === 'tool_call') {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Special tool call agents cannot be updated',
+          code: 'agent_update_not_allowed'
+        })
+      );
+    }
+
     return withTransaction(async db => {
       let identityActor = await db.identityActor.update({
         where: {
-          oid: d.identityActor.oid,
+          oid: existingIdentityActor.oid,
           tenantOid: d.tenant.oid,
           solutionOid: d.solution.oid,
           environmentOid: d.environment.oid

--- a/src/systems/subspace/modules/identity/src/services/actor.ts
+++ b/src/systems/subspace/modules/identity/src/services/actor.ts
@@ -1,4 +1,4 @@
-import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { generateCode } from '@lowerdeck/id';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
@@ -269,10 +269,24 @@ class identityActorServiceImpl {
     checkTenant(d, d.identityActor);
     checkDeletedEdit(d.identityActor, 'archive');
 
+    let existingIdentityActor = await db.identityActor.findUniqueOrThrow({
+      where: { oid: d.identityActor.oid },
+      include
+    });
+
+    if (existingIdentityActor.agent?.type === 'mcp_client') {
+      throw new ServiceError(
+        badRequestError({
+          message: 'MCP client agents cannot be deleted',
+          code: 'agent_delete_not_allowed'
+        })
+      );
+    }
+
     return withTransaction(async db => {
       let identityActor = await db.identityActor.update({
         where: {
-          oid: d.identityActor.oid,
+          oid: existingIdentityActor.oid,
           tenantOid: d.tenant.oid,
           solutionOid: d.solution.oid,
           environmentOid: d.environment.oid

--- a/src/systems/subspace/modules/search/src/index.ts
+++ b/src/systems/subspace/modules/search/src/index.ts
@@ -95,6 +95,12 @@ export let voyagerIndex = {
     name: 'Agents'
   }),
 
+  agentClient: await voyager.index.upsert({
+    sourceId: (await voyagerSource).id,
+    identifier: getIndexName('agent_client'),
+    name: 'Agent Clients'
+  }),
+
   identity: await voyager.index.upsert({
     sourceId: (await voyagerSource).id,
     identifier: getIndexName('identity'),

--- a/src/systems/subspace/modules/session/package.json
+++ b/src/systems/subspace/modules/session/package.json
@@ -19,6 +19,7 @@
     "@metorial-subspace/db": "^1.0.0",
     "@metorial-subspace/provider": "^1.0.0",
     "@metorial-subspace/list-utils": "^1.0.0",
+    "@metorial-subspace/module-agent": "^1.0.0",
     "@metorial-subspace/module-catalog": "^1.0.0",
     "@metorial-subspace/module-deployment": "^1.0.0",
     "@metorial-subspace/module-provider-internal": "^1.0.0",

--- a/src/systems/subspace/modules/session/src/services/toolCall.ts
+++ b/src/systems/subspace/modules/session/src/services/toolCall.ts
@@ -25,6 +25,7 @@ import {
   resolveProviderTools,
   resolveSessionTemplates
 } from '@metorial-subspace/list-utils';
+import { agentInstanceService, agentService } from '@metorial-subspace/module-agent';
 import { SenderManager } from '@metorial-subspace/module-connection';
 import { env } from '../env';
 import { sessionMessageInclude, sessionMessageService } from './sessionMessage';
@@ -183,9 +184,40 @@ class toolCallServiceImpl {
       metadata?: Record<string, any>;
       toolId: string;
       input: Record<string, any>;
+      agentId?: string;
     };
   }) {
     checkDeletedRelation(d.session);
+
+    let agent = d.input.agentId
+      ? await agentService.getAgentById({
+          agentId: d.input.agentId,
+          tenant: d.tenant,
+          solution: d.solution,
+          environment: d.environment
+        })
+      : await agentService.upsertAgent({
+          tenant: d.tenant,
+          solution: d.solution,
+          environment: d.environment,
+          input: {
+            name: 'Manual Tool Calls',
+            type: 'tool_call'
+          }
+        });
+
+    let agentInstance = await agentInstanceService.upsertAgentInstance({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      agent,
+      input: {
+        name: agent.name,
+        version: undefined,
+        description: undefined,
+        type: 'tool_call'
+      }
+    });
 
     let manager = await SenderManager.create({
       sessionId: d.session.id,
@@ -198,7 +230,10 @@ class toolCallServiceImpl {
       where: {
         state: 'connected',
         sessionOid: d.session.oid,
-        isForManualToolCalls: true
+        isForManualToolCalls: true,
+        participant: {
+          agentInstanceOid: agentInstance.oid
+        }
       }
     });
 
@@ -208,18 +243,22 @@ class toolCallServiceImpl {
           where: {
             state: 'connected',
             sessionOid: d.session.oid,
-            isForManualToolCalls: true
+            isForManualToolCalls: true,
+            participant: {
+              agentInstanceOid: agentInstance.oid
+            }
           }
         });
         if (existing) return existing;
 
         let connection = await manager.initialize({
           client: {
-            name: 'Manual Tool Calls',
-            identifier: 'metorial#tool_call'
+            name: agent.name,
+            identifier: `metorial#tool_call:${agentInstance.id}`
           },
           mcpTransport: 'none',
-          isManualConnection: true
+          isManualConnection: true,
+          agentInstance
         });
 
         return connection;

--- a/src/systems/subspace/modules/session/src/services/toolCall.ts
+++ b/src/systems/subspace/modules/session/src/services/toolCall.ts
@@ -4,13 +4,13 @@ import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import {
   db,
-  type ToolCallAttachment,
-  type ToolCall,
   type Environment,
   type Session,
   type SessionMessageStatus,
   type Solution,
-  type Tenant
+  type Tenant,
+  type ToolCall,
+  type ToolCallAttachment
 } from '@metorial-subspace/db';
 import {
   checkDeletedRelation,

--- a/src/systems/subspace/packages/presenters/src/agent.ts
+++ b/src/systems/subspace/packages/presenters/src/agent.ts
@@ -1,0 +1,26 @@
+import type { Agent, IdentityActor } from '@metorial-subspace/db';
+
+export let agentPresenter = (
+  agent: Agent & {
+    actor: IdentityActor;
+  }
+) => ({
+  object: 'agent',
+
+  id: agent.id,
+  type: agent.type,
+  status: agent.status,
+
+  name: agent.name,
+  description: agent.description,
+  slug: agent.slug,
+  metadata: agent.metadata,
+  privateMetadata: agent.privateMetadata,
+  hash: agent.hash,
+
+  actorId: agent.actor.id,
+
+  createdAt: agent.createdAt,
+  updatedAt: agent.updatedAt,
+  archivedAt: agent.archivedAt
+});

--- a/src/systems/subspace/packages/presenters/src/agentClient.ts
+++ b/src/systems/subspace/packages/presenters/src/agentClient.ts
@@ -1,0 +1,16 @@
+import type { AgentClient } from '@metorial-subspace/db';
+
+export let agentClientPresenter = (agentClient: AgentClient) => ({
+  object: 'agent.client',
+
+  id: agentClient.id,
+  type: agentClient.type,
+
+  name: agentClient.name,
+  privateMetadata: agentClient.privateMetadata,
+  oauthRegistrationId: agentClient.oauthRegistrationId,
+
+  createdAt: agentClient.createdAt,
+  updatedAt: agentClient.updatedAt,
+  lastConnectedAt: agentClient.lastConnectedAt
+});

--- a/src/systems/subspace/packages/presenters/src/agentInstance.ts
+++ b/src/systems/subspace/packages/presenters/src/agentInstance.ts
@@ -1,0 +1,26 @@
+import type { Agent, AgentClient, AgentInstance } from '@metorial-subspace/db';
+import { agentClientPresenter } from './agentClient';
+
+export let agentInstancePresenter = (
+  agentInstance: AgentInstance & {
+    agent: Agent;
+    agentClient: AgentClient | null;
+  }
+) => ({
+  object: 'agent.instance',
+
+  id: agentInstance.id,
+  type: agentInstance.type,
+
+  name: agentInstance.name,
+  version: agentInstance.version,
+  description: agentInstance.description,
+
+  agentId: agentInstance.agent.id,
+  agentClientId: agentInstance.agentClient?.id ?? null,
+  agentClient: agentInstance.agentClient ? agentClientPresenter(agentInstance.agentClient) : null,
+
+  createdAt: agentInstance.createdAt,
+  updatedAt: agentInstance.updatedAt,
+  lastConnectedAt: agentInstance.lastConnectedAt
+});

--- a/src/systems/subspace/packages/presenters/src/index.ts
+++ b/src/systems/subspace/packages/presenters/src/index.ts
@@ -1,3 +1,6 @@
+export * from './agentClient';
+export * from './agentInstance';
+export * from './agent';
 export * from './actor';
 export * from './authConfigError';
 export * from './authConfigErrorGlobal';

--- a/src/systems/subspace/packages/presenters/src/sessionMessage.ts
+++ b/src/systems/subspace/packages/presenters/src/sessionMessage.ts
@@ -10,8 +10,8 @@ import {
   type SessionMessage,
   type SessionParticipant,
   type SessionProvider,
-  type ToolCallAttachment,
-  type ToolCall
+  type ToolCall,
+  type ToolCallAttachment
 } from '@metorial-subspace/db';
 import { sessionErrorPresenter, type SessionErrorPresenterProps } from './sessionError';
 import { sessionParticipantPresenter } from './sessionParticipant';

--- a/src/systems/subspace/packages/presenters/src/sessionParticipant.ts
+++ b/src/systems/subspace/packages/presenters/src/sessionParticipant.ts
@@ -8,7 +8,12 @@ export let sessionParticipantPresenter = (
   object: 'session.participant',
 
   id: participant.id,
-  type: participant.type,
+  type:
+    participant.type === 'legacy_mcp_client' ||
+    participant.type === 'legacy_metorial_protocol_client' ||
+    participant.type === 'legacy_tool_call'
+      ? 'agent'
+      : participant.type,
 
   identifier: participant.identifier,
   name: participant.name,

--- a/src/systems/subspace/packages/presenters/src/toolCall.ts
+++ b/src/systems/subspace/packages/presenters/src/toolCall.ts
@@ -2,16 +2,16 @@ import { getOffloadedSessionMessage } from '@metorial-subspace/connection-utils'
 import {
   messageInputToToolCall,
   messageOutputToToolCall,
+  presentToolCallAttachment,
   type Provider,
   type ProviderSpecification,
   type ProviderTool,
-  type ToolCallAttachment,
-  type ToolCall
+  type ToolCall,
+  type ToolCallAttachment
 } from '@metorial-subspace/db';
 import { providerToolPresenter } from './providerTool';
 import { sessionErrorPresenter } from './sessionError';
 import type { SessionMessagePresenterProps } from './sessionMessage';
-import { presentToolCallAttachment } from '@metorial-subspace/db';
 
 export type ToolCallPresenterProps = ToolCall & {
   attachments: ToolCallAttachment[];

--- a/src/systems/subspace/packages/presenters/tsconfig.json
+++ b/src/systems/subspace/packages/presenters/tsconfig.json
@@ -1,29 +1,9 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@metorial-subspace/tsconfig/base.json",
+  "exclude": ["dist", "generated"],
   "compilerOptions": {
-    // Environment setup & latest features
-    "lib": ["ESNext"],
-    "target": "ESNext",
-    "module": "Preserve",
-    "moduleDetection": "force",
-    "jsx": "react-jsx",
-    "allowJs": true,
-
-    // Bundler mode
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
-    "noEmit": true,
-
-    // Best practices
-    "strict": true,
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": false,
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-
-    // Some stricter flags (disabled by default)
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noPropertyAccessFromIndexSignature": false
+    "jsx": "react",
+    "outDir": "dist"
   }
 }

--- a/src/systems/subspace/provider-backends/provider-slates/src/impl/providerInvocation.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/impl/providerInvocation.ts
@@ -2,9 +2,9 @@ import { db } from '@metorial-subspace/db';
 import {
   IProviderInvocation,
   type ProviderInvocationGetParam,
-  type ProviderInvocation as UnifiedProviderInvocation,
   type ProviderInvocationListParam,
   type ProviderInvocationListRes,
+  type ProviderInvocation as UnifiedProviderInvocation,
   createProviderInvocationId,
   parseStoredProviderInvocationId
 } from '@metorial-subspace/provider-utils';
@@ -155,7 +155,10 @@ export class ProviderInvocation extends IProviderInvocation {
         mergeInvocation(invocationMap, {
           id: getSlateProviderInvocationId(remote.id),
           source: 'slates',
-          type: event.sourceType === 'slates.auth_config_event' ? 'auth_config_event' : 'oauth_setup',
+          type:
+            event.sourceType === 'slates.auth_config_event'
+              ? 'auth_config_event'
+              : 'oauth_setup',
           status: getInvocationStatus(remote.status),
           providerRunIds: [],
           sessionMessageIds: [],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk due to Prisma schema changes and rewiring of core session connection/participant initialization and tool-call connection selection, which can affect attribution and connection reuse behavior in production.
> 
> **Overview**
> Adds a new agent domain model (**`Agent`**, **`AgentClient`**, **`AgentInstance`**) with new Prisma tables/enums, ID types, and presenters/controllers to create/list/get/update/archive agents and to list/get agent clients and instances.
> 
> Updates MCP and tool-call flows to persist and reuse agent context: the controller MCP endpoint now accepts validated JSON headers (`Metorial-Agent-Client`, `Metorial-Connection-Private-Metadata`) that are forwarded into connection creation; `SenderManager` upserts agent clients, upserts agents/instances for connection clients, stores connection `privateMetadata`, and links `SessionParticipant` records to `AgentInstance` while normalizing participant types (legacy MCP/tool_call participants map to `agent`). Manual tool calls can now optionally target a specific `agentId`, creating per-agentInstance tool-call connections and preventing updates/deletes for special agent types (e.g., disallow deleting `mcp_client` agents).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1897cb73fe3f2af84e332c4ba1c18ad2e35d0c9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->