### PR TITLE
Add consumer connectors

### DIFF
--- a/src/backend/apis/connection/src/magic.ts
+++ b/src/backend/apis/connection/src/magic.ts
@@ -7,7 +7,7 @@ import {
 import { createExecutionContext, provideExecutionContext } from '@lowerdeck/execution-context';
 import { useRequestContext } from '@lowerdeck/hono';
 import { extractToken } from '@metorial/bearer';
-import { Instance } from '@metorial/db';
+import { db, Instance } from '@metorial/db';
 import { generateSnowflakeId } from '@metorial/id';
 import { AuthInfo } from '@metorial/module-access';
 import { consumerIntegrationService } from '@metorial/module-consumer';
@@ -20,7 +20,10 @@ import {
   resolveMagicMcpTargetByIdOrAlias,
   resolveMagicMcpTargetByIdOrAliasSafe
 } from '@metorial/module-magic';
-import { proxyMcpRequestToSubspace } from '@metorial/module-subspace';
+import {
+  proxyMcpRequestToSubspace,
+  type SubspaceProxyAgentClient
+} from '@metorial/module-subspace';
 import { Authenticator } from '@metorial/rest';
 import type { Context } from 'hono';
 import { authenticateAndResolveInstance } from './getSession';
@@ -34,6 +37,7 @@ export type MagicMcpSubspaceSessionInfo = {
   type: 'magic_mcp_subspace_session';
   magicMcpTarget: MagicMcpTargetForRouting;
   magicMcpSessionMapping: MagicMcpSubspaceMapping;
+  agentClient?: SubspaceProxyAgentClient | null;
 };
 
 export let getMagicMcpTokenSecretFromRequest = (request: Request, url: URL) => {
@@ -134,6 +138,45 @@ let ensureMagicMcpApiKeyAccess = async (d: {
       });
     }
   }
+};
+
+let resolveAgentClientForMagicMcpToken = async (d: {
+  magicMcpToken: MagicMcpTokenForRouting;
+}): Promise<SubspaceProxyAgentClient | null> => {
+  let consumerAuthAttempt = await db.consumerAuthAttempt.findFirst({
+    where: {
+      magicMcpTokenOid: d.magicMcpToken.oid
+    },
+    orderBy: {
+      updatedAt: 'desc'
+    },
+    select: {
+      consumerAuthClient: {
+        select: {
+          id: true,
+          name: true,
+          consumerClient: {
+            select: {
+              id: true,
+              name: true
+            }
+          }
+        }
+      }
+    }
+  });
+  if (!consumerAuthAttempt?.consumerAuthClient) {
+    return null;
+  }
+
+  let consumerAuthClient = consumerAuthAttempt.consumerAuthClient;
+
+  return {
+    name: consumerAuthClient.consumerClient?.name ?? consumerAuthClient.name,
+    type: 'mcp_client_oauth',
+    foreignId: consumerAuthClient.consumerClient?.id ?? consumerAuthClient.id,
+    oauthRegistrationId: consumerAuthClient.id
+  };
 };
 
 export let resolveMagicMcpSubspaceSession = async (d: {
@@ -243,10 +286,17 @@ export let resolveMagicMcpSubspaceSession = async (d: {
     });
   }
 
+  let agentClient = magicMcpToken
+    ? await resolveAgentClientForMagicMcpToken({
+        magicMcpToken
+      })
+    : null;
+
   return {
     type: 'magic_mcp_subspace_session',
     magicMcpTarget,
-    magicMcpSessionMapping
+    magicMcpSessionMapping,
+    agentClient
   };
 };
 
@@ -281,7 +331,10 @@ export let handleMagicMcpRequest = async (d: {
       return await proxyMcpRequestToSubspace(
         d.c,
         sessionInfo.magicMcpTarget.target.instance,
-        sessionInfo.magicMcpSessionMapping.subspaceSessionId
+        sessionInfo.magicMcpSessionMapping.subspaceSessionId,
+        {
+          agentClient: sessionInfo.agentClient
+        }
       );
     }
   );

--- a/src/backend/modules/subspace/src/proxy/index.ts
+++ b/src/backend/modules/subspace/src/proxy/index.ts
@@ -10,6 +10,14 @@ let baseConnectionUrl = env.subspace.SUBSPACE_CONNECTION_URL;
 
 let Sentry = getSentry();
 
+export type SubspaceProxyAgentClient = {
+  name: string;
+  type: 'mcp_client_oauth';
+  privateMetadata?: Record<string, any>;
+  foreignId: string;
+  oauthRegistrationId: string;
+};
+
 let getSubspaceMcpUrl = async (instance: Instance, sessionId: string, inputUrl: URL) => {
   let { tenant, solution } = await getTenantForSubspace(instance);
 
@@ -19,13 +27,17 @@ let getSubspaceMcpUrl = async (instance: Instance, sessionId: string, inputUrl: 
 export let proxyMcpRequestToSubspace = async (
   c: Context,
   instance: Instance,
-  sessionId: string
+  sessionId: string,
+  d?: {
+    agentClient?: SubspaceProxyAgentClient | null;
+  }
 ): Promise<Response> => {
   let inputUrl = new URL(c.req.url);
   let subspaceUrl = await getSubspaceMcpUrl(instance, sessionId, inputUrl);
 
   let headers = new Headers(c.req.raw.headers);
   headers.set('User-Agent', c.req.header('User-Agent') || 'unknown');
+  headers.delete('Metorial-Agent-Client');
 
   let finalHostName = inputUrl.hostname;
   if (
@@ -47,6 +59,10 @@ export let proxyMcpRequestToSubspace = async (
       ? `https://${inputUrl.hostname}${inputUrl.pathname}${inputUrl.search}`
       : `http://${inputUrl.host}${inputUrl.pathname}${inputUrl.search}`
   );
+
+  if (d?.agentClient) {
+    headers.set('Metorial-Agent-Client', JSON.stringify(d.agentClient));
+  }
 
   await Fabric.fire('provider.session_message.created:before', { instance });
 

--- a/src/systems/subspace/apps/controller/src/connection/api/mcp.ts
+++ b/src/systems/subspace/apps/controller/src/connection/api/mcp.ts
@@ -12,7 +12,8 @@ let agentClientHeaderSchema = z.object({
   name: z.string(),
   type: z.literal('mcp_client_oauth'),
   privateMetadata: z.record(z.string(), z.any()).optional(),
-  oauthRegistrationId: z.string()
+  oauthRegistrationId: z.string(),
+  foreignId: z.string()
 });
 
 let privateMetadataHeaderSchema = z.record(z.string(), z.any());

--- a/src/systems/subspace/apps/controller/src/controllers/agentInstance.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/agentInstance.ts
@@ -1,25 +1,10 @@
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
-import { agentInstanceService, agentService } from '@metorial-subspace/module-agent';
+import { agentInstanceService } from '@metorial-subspace/module-agent';
 import { agentInstancePresenter } from '@metorial-subspace/presenters';
 import { app } from './_app';
 import { createdAtValidator, updatedAtValidator } from './_dateFilter';
-import { tenantApp } from './tenant';
-
-let agentApp = tenantApp.use(async ctx => {
-  let agentId = ctx.body.agentId;
-  if (!agentId) throw new Error('Agent ID is required');
-
-  let agent = await agentService.getAgentById({
-    agentId,
-    tenant: ctx.tenant,
-    environment: ctx.environment,
-    solution: ctx.solution,
-    allowDeleted: ctx.body.allowDeleted
-  });
-
-  return { agent };
-});
+import { agentApp } from './agent';
 
 export let agentInstanceApp = agentApp.use(async ctx => {
   let agentInstanceId = ctx.body.agentInstanceId;

--- a/src/systems/subspace/apps/controller/src/controllers/sessionParticipant.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/sessionParticipant.ts
@@ -61,11 +61,23 @@ export let sessionParticipantController = app.controller({
         environment: ctx.environment,
         solution: ctx.solution,
 
-        types: ctx.input.types?.map(t =>
-          t === 'mcp_client' || t === 'metorial_protocol_client' || t === 'tool_call'
-            ? 'agent'
-            : t
-        ),
+        types: ctx.input.types?.flatMap(t => {
+          if (
+            t === 'mcp_client' ||
+            t === 'metorial_protocol_client' ||
+            t === 'tool_call' ||
+            t === 'agent'
+          ) {
+            return [
+              'legacy_mcp_client',
+              'legacy_metorial_protocol_client',
+              'legacy_tool_call',
+              'agent'
+            ] as const;
+          }
+
+          return t;
+        }),
 
         ids: ctx.input.ids,
         sessionIds: ctx.input.sessionIds,

--- a/src/systems/subspace/db/prisma/schema/agents/agent.prisma
+++ b/src/systems/subspace/db/prisma/schema/agents/agent.prisma
@@ -69,12 +69,29 @@ model AgentClient {
   solutionOid Int
   solution    Solution @relation(fields: [solutionOid], references: [oid], onDelete: Cascade)
 
-  privateMetadata     Json?
-  oauthRegistrationId String? @unique
+  privateMetadata Json?
+  foreignId       String? @unique
 
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @default(now()) @updatedAt
   lastConnectedAt DateTime?
+
+  agentInstances           AgentInstance[]
+  agentClientRegistrations AgentClientRegistration[]
+}
+
+model AgentClientRegistration {
+  oid BigInt @id
+  id  String @unique
+
+  privateMetadata     Json?
+  oauthRegistrationId String? @unique
+
+  agentClientOid BigInt
+  agentClient    AgentClient @relation(fields: [agentClientOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
 
   agentInstances AgentInstance[]
 }
@@ -102,9 +119,13 @@ model AgentInstance {
   agentClientOid BigInt?
   agentClient    AgentClient? @relation(fields: [agentClientOid], references: [oid], onDelete: Cascade)
 
-  createdAt           DateTime             @default(now())
-  updatedAt           DateTime             @default(now()) @updatedAt
-  lastConnectedAt     DateTime?
+  agentClientRegistrationOid BigInt?
+  agentClientRegistration    AgentClientRegistration? @relation(fields: [agentClientRegistrationOid], references: [oid], onDelete: Cascade)
+
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @default(now()) @updatedAt
+  lastConnectedAt DateTime?
+
   sessionParticipants SessionParticipant[]
 
   @@unique([agentOid, hash])

--- a/src/systems/subspace/db/src/id.ts
+++ b/src/systems/subspace/db/src/id.ts
@@ -127,6 +127,7 @@ export let ID = createIdGenerator({
   identityDelegationCredentialOverride: idType.sorted('idco'),
   agent: idType.sorted('agt'),
   agentClient: idType.sorted('agc'),
+  agentClientRegistration: idType.sorted('agr'),
   agentInstance: idType.sorted('agi')
 });
 

--- a/src/systems/subspace/modules/agent/src/services/agentClient.ts
+++ b/src/systems/subspace/modules/agent/src/services/agentClient.ts
@@ -92,66 +92,58 @@ class agentClientServiceImpl {
       name: string;
       type: AgentClientType;
       privateMetadata?: Record<string, any>;
-      oauthRegistrationId?: string;
+      foreignId: string;
+      oauthRegistrationId: string;
     };
   }) {
     return await withTransaction(async db => {
-      let oauthRegistrationId = d.input.oauthRegistrationId?.trim() || undefined;
-      let newId = getId('agentClient');
+      let agentClient = await db.agentClient.upsert({
+        where: { foreignId: d.input.foreignId },
+        create: {
+          ...getId('agentClient'),
 
-      let agentClient = oauthRegistrationId
-        ? await db.agentClient.upsert({
-            where: { oauthRegistrationId },
-            create: {
-              ...newId,
+          name: d.input.name.trim(),
+          type: d.input.type,
 
-              name: d.input.name.trim(),
-              type: d.input.type,
+          privateMetadata: d.input.privateMetadata,
+          foreignId: d.input.foreignId,
+          lastConnectedAt: new Date(),
 
-              privateMetadata: d.input.privateMetadata,
-              oauthRegistrationId,
-              lastConnectedAt: new Date(),
+          tenantOid: d.tenant.oid,
+          solutionOid: d.solution.oid,
+          environmentOid: d.environment.oid
+        },
+        update: {
+          name: d.input.name.trim(),
+          type: d.input.type,
+          privateMetadata: d.input.privateMetadata,
+          lastConnectedAt: new Date(),
+          tenantOid: d.tenant.oid,
+          solutionOid: d.solution.oid,
+          environmentOid: d.environment.oid
+        }
+      });
 
-              tenantOid: d.tenant.oid,
-              solutionOid: d.solution.oid,
-              environmentOid: d.environment.oid
-            },
-            update: {
-              name: d.input.name.trim(),
-              type: d.input.type,
-              privateMetadata: d.input.privateMetadata,
-              lastConnectedAt: new Date(),
-              tenantOid: d.tenant.oid,
-              solutionOid: d.solution.oid,
-              environmentOid: d.environment.oid
-            }
-          })
-        : await db.agentClient.create({
-            data: {
-              ...getId('agentClient'),
+      let agentClientRegistration = await db.agentClientRegistration.upsert({
+        where: { oauthRegistrationId: d.input.oauthRegistrationId },
+        create: {
+          ...getId('agentClientRegistration'),
 
-              name: d.input.name.trim(),
-              type: d.input.type,
+          oauthRegistrationId: d.input.oauthRegistrationId,
+          privateMetadata: d.input.privateMetadata,
+          agentClientOid: agentClient.oid
+        },
+        update: {
+          privateMetadata: d.input.privateMetadata,
+          agentClientOid: agentClient.oid
+        }
+      });
 
-              privateMetadata: d.input.privateMetadata,
-              oauthRegistrationId,
-              lastConnectedAt: new Date(),
+      await addAfterTransactionHook(async () =>
+        indexAgentClientQueue.add({ agentClientId: agentClient.id })
+      );
 
-              tenantOid: d.tenant.oid,
-              solutionOid: d.solution.oid,
-              environmentOid: d.environment.oid
-            }
-          });
-
-      let isNew = agentClient.oid == newId.oid;
-
-      if (isNew) {
-        await addAfterTransactionHook(async () =>
-          indexAgentClientQueue.add({ agentClientId: agentClient.id })
-        );
-      }
-
-      return agentClient;
+      return { agentClient, agentClientRegistration };
     });
   }
 
@@ -163,7 +155,8 @@ class agentClientServiceImpl {
       name: string;
       type: AgentClientType;
       privateMetadata?: Record<string, any>;
-      oauthRegistrationId?: string;
+      foreignId: string;
+      oauthRegistrationId: string;
     };
   }) {
     return await this.upsertAgentClient(d);

--- a/src/systems/subspace/modules/agent/src/services/agentInstance.ts
+++ b/src/systems/subspace/modules/agent/src/services/agentInstance.ts
@@ -5,6 +5,7 @@ import { Service } from '@lowerdeck/service';
 import {
   type Agent,
   type AgentClient,
+  type AgentClientRegistration,
   type AgentInstanceType,
   db,
   type Environment,
@@ -22,7 +23,8 @@ import { checkTenant } from '@metorial-subspace/module-tenant';
 
 let include = {
   agent: true,
-  agentClient: true
+  agentClient: true,
+  agentClientRegistration: true
 };
 
 class agentInstanceServiceImpl {
@@ -97,6 +99,7 @@ class agentInstanceServiceImpl {
 
     agent: Agent;
     agentClient?: AgentClient | null;
+    agentClientRegistration?: AgentClientRegistration | null;
 
     input: {
       name: string;
@@ -108,6 +111,18 @@ class agentInstanceServiceImpl {
     checkTenant(d, d.agent);
     checkTenant(d, d.agentClient);
     checkDeletedRelation(d.agent);
+
+    if (
+      d.agentClient &&
+      d.agentClientRegistration &&
+      d.agentClientRegistration.agentClientOid !== d.agentClient.oid
+    ) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Agent client registration does not belong to the provided agent client'
+        })
+      );
+    }
 
     if (d.agent.type === 'tool_call' && d.input.type !== 'tool_call') {
       throw new ServiceError(
@@ -123,6 +138,7 @@ class agentInstanceServiceImpl {
         d.input.version,
         d.agent.id,
         d.agentClient?.id ?? null,
+        d.agentClientRegistration?.id ?? null,
         d.input.type
       ])
     );
@@ -146,7 +162,8 @@ class agentInstanceServiceImpl {
           lastConnectedAt: new Date(),
 
           agentOid: d.agent.oid,
-          agentClientOid: d.agentClient?.oid
+          agentClientOid: d.agentClient?.oid,
+          agentClientRegistrationOid: d.agentClientRegistration?.oid
         },
         update: {
           name: d.input.name.trim(),
@@ -154,7 +171,8 @@ class agentInstanceServiceImpl {
           description: d.input.description?.trim() || undefined,
           type: d.input.type,
           lastConnectedAt: new Date(),
-          agentClientOid: d.agentClient?.oid
+          agentClientOid: d.agentClient?.oid,
+          agentClientRegistrationOid: d.agentClientRegistration?.oid
         },
         include
       });

--- a/src/systems/subspace/modules/connection/src/sender/manager.ts
+++ b/src/systems/subspace/modules/connection/src/sender/manager.ts
@@ -96,6 +96,7 @@ export interface SenderMangerProps {
     name: string;
     type: 'mcp_client_oauth';
     privateMetadata?: Record<string, any>;
+    foreignId: string;
     oauthRegistrationId: string;
   };
   connectionPrivateMetadata?: Record<string, any>;
@@ -282,7 +283,7 @@ export class SenderManager {
   }
 
   private async ensureConnectionClientAgentContext(d: InitProps['client']) {
-    let agentClient = await this.ensureAgentClientUpserted();
+    let agentClientContext = await this.ensureAgentClientUpserted();
 
     let agent = await agentService.upsertAgent({
       tenant: this.tenant,
@@ -303,7 +304,8 @@ export class SenderManager {
         where: { oid: this.session.environmentOid }
       }),
       agent,
-      agentClient,
+      agentClient: agentClientContext?.agentClient,
+      agentClientRegistration: agentClientContext?.agentClientRegistration,
       input: {
         name: d.name,
         version: typeof d.version === 'string' ? d.version : undefined,
@@ -314,7 +316,8 @@ export class SenderManager {
 
     return {
       agent,
-      agentClient,
+      agentClient: agentClientContext?.agentClient ?? null,
+      agentClientRegistration: agentClientContext?.agentClientRegistration ?? null,
       agentInstance
     };
   }

--- a/src/systems/subspace/packages/presenters/src/agentClient.ts
+++ b/src/systems/subspace/packages/presenters/src/agentClient.ts
@@ -7,8 +7,8 @@ export let agentClientPresenter = (agentClient: AgentClient) => ({
   type: agentClient.type,
 
   name: agentClient.name,
+  foreignId: agentClient.foreignId,
   privateMetadata: agentClient.privateMetadata,
-  oauthRegistrationId: agentClient.oauthRegistrationId,
 
   createdAt: agentClient.createdAt,
   updatedAt: agentClient.updatedAt,

--- a/src/systems/subspace/packages/presenters/src/agentInstance.ts
+++ b/src/systems/subspace/packages/presenters/src/agentInstance.ts
@@ -1,10 +1,16 @@
-import type { Agent, AgentClient, AgentInstance } from '@metorial-subspace/db';
+import type {
+  Agent,
+  AgentClient,
+  AgentClientRegistration,
+  AgentInstance
+} from '@metorial-subspace/db';
 import { agentClientPresenter } from './agentClient';
 
 export let agentInstancePresenter = (
   agentInstance: AgentInstance & {
     agent: Agent;
     agentClient: AgentClient | null;
+    agentClientRegistration: AgentClientRegistration | null;
   }
 ) => ({
   object: 'agent.instance',
@@ -18,6 +24,7 @@ export let agentInstancePresenter = (
 
   agentId: agentInstance.agent.id,
   agentClientId: agentInstance.agentClient?.id ?? null,
+  agentClientRegistrationId: agentInstance.agentClientRegistration?.id ?? null,
   agentClient: agentInstance.agentClient ? agentClientPresenter(agentInstance.agentClient) : null,
 
   createdAt: agentInstance.createdAt,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Includes a Prisma schema change and shifts identity/upsert keys from `oauthRegistrationId` to `foreignId`, which can affect data integrity and downstream joins/migrations. It also changes proxy header handling and request metadata that could impact session attribution if malformed or missing.
> 
> **Overview**
> Adds optional `Metorial-Agent-Client` propagation end-to-end: `magic.ts` resolves an agent client from the latest `consumerAuthAttempt` for a magic MCP token, `proxyMcpRequestToSubspace` now strips any inbound header and conditionally injects a JSON payload, and the subspace controller validates the header now requiring `foreignId`.
> 
> Refactors subspace agent client storage by introducing `AgentClientRegistration` (unique `oauthRegistrationId`) and moving stable identity to `AgentClient.foreignId`; `agentClientService.upsertAgentClient` now upserts both records and returns them, `AgentInstance` gains an optional `agentClientRegistration` relation (included in hashes/validation), and presenters/connection sender logic are updated accordingly.
> 
> Also adjusts `sessionParticipant` filtering to expand legacy client type filters to new legacy-* variants and simplifies `agentInstance` controller wiring by reusing `agentApp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70c4c26ef50f08a873d1eb9553a9ea9ee2b8a38e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->