### PR TITLE
Add tool call rationale

### DIFF
--- a/src/systems/subspace/apps/controller/src/connection/tests/mcp.e2e.test.ts
+++ b/src/systems/subspace/apps/controller/src/connection/tests/mcp.e2e.test.ts
@@ -1,12 +1,12 @@
-import { describe, expect, it } from 'vitest';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { createHono } from '@lowerdeck/hono';
-import { mcpRouter } from '../api/mcp';
-import { testDb } from '../../test/setup';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { describe, expect, it } from 'vitest';
 import { createMcpE2eContext } from '../../test/fixtures';
 import { createHonoFetchAdapter } from '../../test/helpers/honoFetchAdapter';
 import { createMcpTestClient } from '../../test/helpers/mcpClientFactory';
 import { setupMcpE2ELifecycle } from '../../test/helpers/mcpE2ELifecycle';
+import { testDb } from '../../test/setup';
+import { mcpRouter } from '../api/mcp';
 
 let transportCases = [
   {
@@ -235,16 +235,19 @@ describe('mcp.e2e', () => {
           properties: {
             callRationale: expect.objectContaining({
               type: 'string',
-              description: expect.stringContaining('1-2 sentence description why the call is needed')
+              description: expect.stringContaining(
+                '1-2 sentence description why the call is needed'
+              )
             }),
             callDescription: expect.objectContaining({
               type: 'string',
-              description: expect.stringContaining('Describe what the calling agent or client wants to do')
+              description: expect.stringContaining(
+                'Describe what the calling agent or client wants to do'
+              )
             })
           }
         });
         expect(operationSchema.description).toContain('MUST be provided');
-        expect(operationSchema.description).toContain('backwards compatibility');
 
         let result = await mcp.client.callTool({
           name: addTool!.name,
@@ -284,7 +287,9 @@ describe('mcp.e2e', () => {
             }
           }
         });
-        expect((toolCall.message.input as any)?.data?.params?.arguments?.$operation).toBeUndefined();
+        expect(
+          (toolCall.message.input as any)?.data?.params?.arguments?.$operation
+        ).toBeUndefined();
       } finally {
         await mcp.cleanup();
       }

--- a/src/systems/subspace/apps/controller/src/connection/tests/mcp.e2e.test.ts
+++ b/src/systems/subspace/apps/controller/src/connection/tests/mcp.e2e.test.ts
@@ -206,4 +206,88 @@ describe('mcp.e2e', () => {
       }
     }
   );
+
+  it(
+    'injects $operation into tool schemas and stores extracted tool call metadata',
+    { timeout: 120_000 },
+    async () => {
+      let ctx = await createMcpE2eContext(testDb, {
+        remoteServerBaseUrl: lifecycle.getRemoteServerBaseUrl(),
+        transportCase: defaultTransportCase
+      });
+
+      let mcp = createMcpTestClient({
+        baseUrl: ctx.proxyUrl,
+        transportType: defaultTransportCase.clientTransport,
+        fetch: localFetch
+      });
+
+      try {
+        await mcp.connect();
+
+        let tools = await mcp.client.listTools();
+        let addTool = tools.tools.find(tool => /(^|[_.-])add([_.-]|$)/.test(tool.name));
+        expect(addTool).toBeTruthy();
+
+        let operationSchema = (addTool!.inputSchema as any)?.properties?.$operation;
+        expect(operationSchema).toMatchObject({
+          type: 'object',
+          properties: {
+            callRationale: expect.objectContaining({
+              type: 'string',
+              description: expect.stringContaining('1-2 sentence description why the call is needed')
+            }),
+            callDescription: expect.objectContaining({
+              type: 'string',
+              description: expect.stringContaining('Describe what the calling agent or client wants to do')
+            })
+          }
+        });
+        expect(operationSchema.description).toContain('MUST be provided');
+        expect(operationSchema.description).toContain('backwards compatibility');
+
+        let result = await mcp.client.callTool({
+          name: addTool!.name,
+          arguments: {
+            a: 1,
+            b: 2,
+            $operation: {
+              callRationale: 'We need the calculator tool to compute the user-requested sum.',
+              callDescription: 'Add the two provided numbers and return the result.'
+            }
+          }
+        });
+        let text = (
+          result as { content?: Array<{ type?: string; text?: string }> }
+        ).content?.find(p => p.type === 'text')?.text;
+
+        expect(text).toContain('Result: 3');
+
+        let toolCall = await testDb.toolCall.findFirstOrThrow({
+          where: {
+            sessionOid: ctx.session.oid,
+            rationale: 'We need the calculator tool to compute the user-requested sum.',
+            operation: 'Add the two provided numbers and return the result.'
+          },
+          orderBy: { createdAt: 'desc' },
+          include: { message: true }
+        });
+
+        expect(toolCall.message.input).toMatchObject({
+          type: 'mcp',
+          data: {
+            params: {
+              arguments: {
+                a: 1,
+                b: 2
+              }
+            }
+          }
+        });
+        expect((toolCall.message.input as any)?.data?.params?.arguments?.$operation).toBeUndefined();
+      } finally {
+        await mcp.cleanup();
+      }
+    }
+  );
 });

--- a/src/systems/subspace/apps/controller/src/controllers/toolCall.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/toolCall.ts
@@ -96,6 +96,8 @@ export let toolCallController = app.controller({
 
         agentId: v.optional(v.string()),
         metadata: v.optional(v.record(v.any())),
+        rationale: v.optional(v.string()),
+        operation: v.optional(v.string()),
         input: v.record(v.any()),
         toolId: v.string()
       })
@@ -118,6 +120,8 @@ export let toolCallController = app.controller({
         input: {
           agentId: ctx.input.agentId,
           metadata: ctx.input.metadata,
+          rationale: ctx.input.rationale,
+          operation: ctx.input.operation,
           input: ctx.input.input,
           toolId: ctx.input.toolId
         }

--- a/src/systems/subspace/db/prisma/schema/session/message.prisma
+++ b/src/systems/subspace/db/prisma/schema/session/message.prisma
@@ -120,6 +120,9 @@ model ToolCall {
   toolKey  String
   metadata Json?
 
+  rationale String?
+  operation String?
+
   messageOid BigInt         @unique
   message    SessionMessage @relation(fields: [messageOid], references: [oid])
 

--- a/src/systems/subspace/modules/agent/src/services/agentClient.ts
+++ b/src/systems/subspace/modules/agent/src/services/agentClient.ts
@@ -97,10 +97,12 @@ class agentClientServiceImpl {
     };
   }) {
     return await withTransaction(async db => {
+      let newId = getId('agentClient');
+
       let agentClient = await db.agentClient.upsert({
         where: { foreignId: d.input.foreignId },
         create: {
-          ...getId('agentClient'),
+          ...newId,
 
           name: d.input.name.trim(),
           type: d.input.type,
@@ -139,9 +141,12 @@ class agentClientServiceImpl {
         }
       });
 
-      await addAfterTransactionHook(async () =>
-        indexAgentClientQueue.add({ agentClientId: agentClient.id })
-      );
+      let isNew = agentClient.id === newId.id;
+      if (isNew) {
+        await addAfterTransactionHook(async () =>
+          indexAgentClientQueue.add({ agentClientId: agentClient.id })
+        );
+      }
 
       return { agentClient, agentClientRegistration };
     });

--- a/src/systems/subspace/modules/connection/src/mcp/sender.ts
+++ b/src/systems/subspace/modules/connection/src/mcp/sender.ts
@@ -49,6 +49,7 @@ import { uniqBy } from 'lodash';
 import { PING_MESSAGE_ID_PREFIX } from '../const';
 import { mcpOutputSchemaNormalizer } from '../lib/mcpOutputSchemaNormalizer';
 import { providerToolPresenter } from '../presenter';
+import { injectToolCallOperationIntoInputSchema } from '../shared/toolCallOperation';
 import { upsertParticipant } from '../shared/upsertParticipant';
 import type { McpControlMessageHandler } from './control';
 import type { McpManager } from './manager';
@@ -376,7 +377,9 @@ export class McpSender {
               name: presented.key,
               title: presented.title ?? presented.name,
 
-              inputSchema: presented.inputJsonSchema as any,
+              inputSchema: injectToolCallOperationIntoInputSchema(
+                presented.inputJsonSchema
+              ) as any,
               outputSchema:
                 presented.outputJsonSchema?.type === 'object'
                   ? (mcpOutputSchemaNormalizer(presented.outputJsonSchema, {

--- a/src/systems/subspace/modules/connection/src/sender/manager.ts
+++ b/src/systems/subspace/modules/connection/src/sender/manager.ts
@@ -53,6 +53,7 @@ import { topics } from '../lib/topic';
 import { completeMessage } from '../shared/completeMessage';
 import { createError } from '../shared/createError';
 import { createMessage, type CreateMessageProps } from '../shared/createMessage';
+import { extractToolCallOperation } from '../shared/toolCallOperation';
 import { createWarning } from '../shared/createWarning';
 import { upsertParticipant } from '../shared/upsertParticipant';
 
@@ -82,6 +83,8 @@ export interface CallToolProps {
   input: PrismaJson.SessionMessageInput;
   waitForResponse: boolean;
   transport: SessionConnectionTransport;
+  rationale?: string;
+  operation?: string;
   clientMcpId?: PrismaJson.SessionMessageClientMcpId;
   parentMessage?: SessionMessage;
 }
@@ -723,6 +726,11 @@ export class SenderManager {
     }
 
     let { provider, tool, instance } = await this.getToolById({ toolId: d.toolId });
+    let extractedToolCall = extractToolCallOperation({
+      input: d.input,
+      rationale: d.rationale,
+      operation: d.operation
+    });
 
     let { allowed } = checkToolAccess(tool, provider, 'call');
 
@@ -734,7 +742,9 @@ export class SenderManager {
       status: 'waiting_for_response',
       type: d.transport === 'mcp' ? 'mcp_message' : 'tool_call',
       source: 'client',
-      input: d.input,
+      input: extractedToolCall.input,
+      rationale: extractedToolCall.rationale,
+      operation: extractedToolCall.operation,
       senderParticipant: participant,
       clientMcpId: d.clientMcpId,
       transport: d.transport,
@@ -755,7 +765,7 @@ export class SenderManager {
           toolId: tool.id,
           toolKey: tool.key,
 
-          input: d.input
+          input: extractedToolCall.input
         } satisfies ConduitInput);
 
         if (!res.success) {

--- a/src/systems/subspace/modules/connection/src/shared/createMessage.ts
+++ b/src/systems/subspace/modules/connection/src/shared/createMessage.ts
@@ -35,6 +35,8 @@ export interface CreateMessageProps {
   provider?: SessionProvider;
 
   tool?: ProviderTool;
+  rationale?: string;
+  operation?: string;
   methodOrToolKey?: string;
 
   isProductive: boolean;
@@ -121,6 +123,8 @@ export let createMessage = async (data: CreateMessagePropsFull) => {
               ...getId('toolCall'),
               toolOid: data.tool.oid,
               toolKey: data.tool.key,
+              rationale: data.rationale,
+              operation: data.operation,
               sessionOid: data.session.oid,
               tenantOid: data.session.tenantOid,
               solutionOid: data.session.solutionOid,

--- a/src/systems/subspace/modules/connection/src/shared/toolCallOperation.ts
+++ b/src/systems/subspace/modules/connection/src/shared/toolCallOperation.ts
@@ -1,0 +1,124 @@
+type JsonObject = Record<string, any>;
+
+let TOOL_CALL_OPERATION_FIELD_SCHEMA = {
+  type: 'object',
+  description:
+    'MUST be provided for all tool calls! Include callRationale and callDescription so the system can record why the tool call is needed and what the caller is trying to do.',
+  additionalProperties: false,
+  properties: {
+    callRationale: {
+      type: 'string',
+      description:
+        'MUST be provided for all tool calls! Provide a 1-2 sentence description why the call is needed.'
+    },
+    callDescription: {
+      type: 'string',
+      description:
+        'MUST be provided for all tool calls! Describe what you want to achieve with this tool call, e.g., "find the latest news about business in the US"'
+    }
+  }
+};
+
+let isJsonObject = (value: unknown): value is JsonObject =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+export let injectToolCallOperationIntoInputSchema = (inputSchema: unknown) => {
+  let schema = isJsonObject(inputSchema) ? inputSchema : {};
+  let properties = isJsonObject(schema.properties) ? schema.properties : {};
+
+  return {
+    ...schema,
+    type: schema.type ?? 'object',
+    properties: {
+      ...properties,
+      $operation: TOOL_CALL_OPERATION_FIELD_SCHEMA
+    }
+  };
+};
+
+let getToolCallOperationData = (value: unknown) => {
+  if (!isJsonObject(value)) {
+    return {
+      rationale: undefined,
+      operation: undefined
+    };
+  }
+
+  return {
+    rationale: typeof value.callRationale === 'string' ? value.callRationale : undefined,
+    operation: typeof value.callDescription === 'string' ? value.callDescription : undefined
+  };
+};
+
+export let extractToolCallOperation = (d: {
+  input: PrismaJson.SessionMessageInput;
+  rationale?: string;
+  operation?: string;
+}): {
+  input: PrismaJson.SessionMessageInput;
+  rationale?: string;
+  operation?: string;
+} => {
+  let rationale = d.rationale;
+  let operation = d.operation;
+
+  if (d.input.type === 'tool.call' && isJsonObject(d.input.data)) {
+    let { $operation, ...inputData } = d.input.data;
+    let operationData = getToolCallOperationData($operation);
+
+    return {
+      input: {
+        ...d.input,
+        data: inputData
+      } satisfies PrismaJson.SessionMessageInput,
+      rationale: rationale ?? operationData.rationale,
+      operation: operation ?? operationData.operation
+    };
+  }
+
+  if (d.input.type === 'mcp' && isJsonObject(d.input.data)) {
+    let messageData = d.input.data as JsonObject;
+    if (messageData.method !== 'tools/call') {
+      return {
+        input: d.input,
+        rationale,
+        operation
+      };
+    }
+
+    let params = isJsonObject(messageData.params) ? messageData.params : null;
+    let argumentsData = params && isJsonObject(params.arguments) ? params.arguments : null;
+
+    if (!params || !argumentsData) {
+      return {
+        input: d.input,
+        rationale,
+        operation
+      };
+    }
+
+    let { $operation, ...argumentsInput } = argumentsData;
+    let operationData = getToolCallOperationData($operation);
+
+    return {
+      input: {
+        ...d.input,
+        data: {
+          ...messageData,
+          params: {
+            ...params,
+            arguments: argumentsInput
+          }
+        }
+      } as unknown as PrismaJson.SessionMessageInput,
+      rationale: rationale ?? operationData.rationale,
+      operation: operation ?? operationData.operation
+    };
+  }
+
+  return {
+    input: d.input,
+    rationale,
+    operation
+  };
+};

--- a/src/systems/subspace/modules/session/src/services/toolCall.ts
+++ b/src/systems/subspace/modules/session/src/services/toolCall.ts
@@ -185,6 +185,8 @@ class toolCallServiceImpl {
       toolId: string;
       input: Record<string, any>;
       agentId?: string;
+      rationale?: string;
+      operation?: string;
     };
   }) {
     checkDeletedRelation(d.session);
@@ -273,6 +275,8 @@ class toolCallServiceImpl {
         type: 'tool.call',
         data: d.input.input
       },
+      rationale: d.input.rationale,
+      operation: d.input.operation,
       waitForResponse: true,
       transport: 'tool_call'
     });

--- a/src/systems/subspace/packages/presenters/src/toolCall.ts
+++ b/src/systems/subspace/packages/presenters/src/toolCall.ts
@@ -36,6 +36,8 @@ export let toolCallPresenter = async (toolCall: ToolCallPresenterProps) => {
 
     id: toolCall.id,
     toolKey: toolCall.toolKey,
+    rationale: toolCall.rationale,
+    operation: toolCall.operation,
 
     type: 'tool_call',
     status: toolCall.message.status,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches MCP tool schema/argument handling and persists new fields to the `ToolCall` model, so mismatches could break tool-call compatibility or data writes; changes are localized and covered by a new E2E test.
> 
> **Overview**
> Adds first-class *tool call intent metadata* by introducing optional `rationale` and `operation` fields on `ToolCall`, threading them through the controller/service layers and including them in the tool-call API presenter output.
> 
> For MCP clients, `tools/list` now injects a required `$operation` object into each tool’s input schema, and `tools/call` requests have `$operation` extracted and stripped from stored/sent arguments while persisting the extracted rationale/operation; new E2E coverage asserts both schema injection and DB persistence.
> 
> Separately, `agentClientService.upsertAgentClient` now enqueues search indexing only when the record is newly created (not on every upsert).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b68d7eead6208b8dd756082892d0f60923be954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->