### PR TITLE
Intersect auth scopes

### DIFF
--- a/src/systems/subspace/modules/provider-internal/src/lib/toolScopes.ts
+++ b/src/systems/subspace/modules/provider-internal/src/lib/toolScopes.ts
@@ -10,10 +10,9 @@ export type ScopeSource = {
 let intersectArrays = (
   arr1: string[] | null | undefined,
   arr2: string[] | null | undefined
-): string[] => {
-  if (!arr1 || !arr2) return [];
-  if (!arr1.length) return arr2;
-  if (!arr2.length) return arr1;
+): string[] | null => {
+  if (!arr1?.length) return arr2 ?? null;
+  if (!arr2?.length) return arr1;
 
   let set2 = new Set(arr2);
   return arr1.filter(item => set2.has(item));

--- a/src/systems/subspace/modules/provider-internal/src/lib/toolScopes.ts
+++ b/src/systems/subspace/modules/provider-internal/src/lib/toolScopes.ts
@@ -7,21 +7,25 @@ export type ScopeSource = {
   authCredentials?: { scopes?: PrismaJson.ProviderAuthScopes | null } | null;
 };
 
-/**
- * Resolve the list of granted scopes from an auth config / credentials pair.
- * Credentials take precedence over the auth config because they represent the
- * tenant-specific grant and may be narrower than the auth config's scopes.
- *
- * Returns `null` when no scope information is available. Callers should treat
- * `null` as "do not filter" to avoid accidentally blocking tools when no
- * authentication context is attached.
- */
-export let resolveGrantedScopes = (source: ScopeSource): string[] | null => {
-  let credentialScopes = source.authCredentials?.scopes;
-  if (credentialScopes?.length) return credentialScopes;
+let intersectArrays = (
+  arr1: string[] | null | undefined,
+  arr2: string[] | null | undefined
+): string[] => {
+  if (!arr1 || !arr2) return [];
+  if (!arr1.length) return arr2;
+  if (!arr2.length) return arr1;
 
+  let set2 = new Set(arr2);
+  return arr1.filter(item => set2.has(item));
+};
+
+export let resolveGrantedScopes = (source: ScopeSource): string[] | null => {
   let configScopes = source.authConfig?.scopes;
-  if (configScopes?.length) return configScopes;
+  let credentialScopes = source.authCredentials?.scopes;
+
+  if (configScopes?.length || credentialScopes?.length) {
+    return intersectArrays(configScopes, credentialScopes);
+  }
 
   return null;
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes scope resolution used for tool filtering/authorization, which can alter effective permissions and potentially block previously-allowed tool calls if scope sets differ.
> 
> **Overview**
> Updates `resolveGrantedScopes` to compute granted scopes as the **intersection** of `authConfig.scopes` and `authCredentials.scopes` (via a new `intersectArrays` helper) instead of returning one source with precedence.
> 
> This makes scope-based tool filtering/authorization more restrictive when both sources are present, while preserving the existing `null` behavior when no scope info exists (no filtering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dcaeb33373e617723a3084cfdddcc22e8931c48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->