### PR TITLE
Add integration config ownership

### DIFF
--- a/src/systems/subspace/apps/controller/src/controllers/integrationInstance.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/integrationInstance.ts
@@ -11,8 +11,7 @@ import { normalizeToolFilters, toolFiltersValidator } from './sessionProvider';
 import { tenantApp } from './tenant';
 
 let integrationInstanceProviderInputValidator = v.object({
-  integrationProviderId: v.optional(v.string()),
-  providerId: v.optional(v.string()),
+  providerId: v.string(),
   providerConfigId: v.optional(v.nullable(v.string())),
   providerAuthConfigId: v.optional(v.nullable(v.string())),
   toolFilters: toolFiltersValidator,
@@ -129,7 +128,7 @@ export let integrationInstanceController = app.controller({
           metadata: ctx.input.metadata,
           privateMetadata: ctx.input.privateMetadata,
           providers: ctx.input.providers?.map(provider => ({
-            providerId: (provider.providerId ?? provider.integrationProviderId)!,
+            providerId: provider.providerId,
             providerConfigId: provider.providerConfigId,
             providerAuthConfigId: provider.providerAuthConfigId ?? undefined,
             isOverrideToolFilter: provider.isOverrideToolFilter,
@@ -171,7 +170,7 @@ export let integrationInstanceController = app.controller({
           metadata: ctx.input.metadata,
           privateMetadata: ctx.input.privateMetadata,
           providers: ctx.input.providers?.map(provider => ({
-            providerId: (provider.providerId ?? provider.integrationProviderId)!,
+            providerId: provider.providerId,
             providerConfigId: provider.providerConfigId,
             providerAuthConfigId: provider.providerAuthConfigId ?? undefined,
             isOverrideToolFilter: provider.isOverrideToolFilter,

--- a/src/systems/subspace/db/prisma/schema/auth/authConfig.prisma
+++ b/src/systems/subspace/db/prisma/schema/auth/authConfig.prisma
@@ -61,6 +61,12 @@ model ProviderAuthConfig {
   backendOid BigInt
   backend    Backend @relation(fields: [backendOid], references: [oid])
 
+  owningIntegrationInstanceOid BigInt?
+  owningIntegrationInstance    IntegrationInstance? @relation(fields: [owningIntegrationInstanceOid], references: [oid])
+
+  owningIntegrationInstanceProviderOid BigInt?
+  owningIntegrationInstanceProvider    IntegrationInstanceProvider? @relation(fields: [owningIntegrationInstanceProviderOid], references: [oid])
+
   deploymentOid BigInt?
   deployment    ProviderDeployment? @relation(fields: [deploymentOid], references: [oid])
 

--- a/src/systems/subspace/db/prisma/schema/deployment/config.prisma
+++ b/src/systems/subspace/db/prisma/schema/deployment/config.prisma
@@ -38,6 +38,12 @@ model ProviderConfig {
   specificationOid BigInt
   specification    ProviderSpecification @relation(fields: [specificationOid], references: [oid])
 
+  owningIntegrationInstanceOid BigInt?
+  owningIntegrationInstance    IntegrationInstance? @relation(fields: [owningIntegrationInstanceOid], references: [oid])
+
+  owningIntegrationInstanceProviderOid BigInt?
+  owningIntegrationInstanceProvider    IntegrationInstanceProvider? @relation(fields: [owningIntegrationInstanceProviderOid], references: [oid])
+
   deploymentOid BigInt?
   deployment    ProviderDeployment? @relation(fields: [deploymentOid], references: [oid])
 

--- a/src/systems/subspace/db/prisma/schema/intergration/instance.prisma
+++ b/src/systems/subspace/db/prisma/schema/intergration/instance.prisma
@@ -30,9 +30,12 @@ model IntegrationInstance {
   solutionOid Int
   solution    Solution @relation(fields: [solutionOid], references: [oid], onDelete: Cascade)
 
-  createdAt                    DateTime                      @default(now())
-  updatedAt                    DateTime                      @default(now()) @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
   integrationInstanceProviders IntegrationInstanceProvider[]
+  providerConfigs              ProviderConfig[]
+  providerAuthConfigs          ProviderAuthConfig[]
 
   @@index([tenantOid, solutionOid, environmentOid, status])
   @@index([integrationOid, status])
@@ -86,6 +89,8 @@ model IntegrationInstanceProvider {
   updatedAt DateTime @default(now()) @updatedAt
 
   integrationInstanceProviderVersions IntegrationInstanceProviderVersion[]
+  providerConfigs                     ProviderConfig[]
+  providerAuthConfigs                 ProviderAuthConfig[]
 
   @@unique([integrationInstanceOid, integrationProviderOid])
   @@index([tenantOid, solutionOid, environmentOid, status])

--- a/src/systems/subspace/modules/auth/src/services/providerAuthConfig.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthConfig.ts
@@ -544,9 +544,11 @@ class providerAuthConfigServiceImpl {
     solution: Solution;
     environment: Environment;
     providerAuthConfig: ProviderAuthConfig;
+    _canArchiveOwned?: boolean;
   }) {
     checkTenant(d, d.providerAuthConfig);
     checkDeletedEdit(d.providerAuthConfig, 'archive');
+    this.assertCanArchiveOwned(d);
 
     return withTransaction(async db => {
       let archivedAt = new Date();
@@ -573,6 +575,28 @@ class providerAuthConfigServiceImpl {
 
       return providerAuthConfig;
     });
+  }
+
+  private assertCanArchiveOwned(d: {
+    providerAuthConfig: ProviderAuthConfig;
+    _canArchiveOwned?: boolean;
+  }) {
+    if (d._canArchiveOwned) return;
+    if (
+      d.providerAuthConfig.owningIntegrationInstanceOid === null &&
+      d.providerAuthConfig.owningIntegrationInstanceProviderOid === null
+    ) {
+      return;
+    }
+
+    throw new ServiceError(
+      badRequestError({
+        message:
+          'Provider auth config is owned by an integration instance provider and cannot be archived directly.',
+        code: 'provider_auth_config_owned_archive_not_allowed',
+        data: { id: d.providerAuthConfig.id }
+      })
+    );
   }
 }
 

--- a/src/systems/subspace/modules/deployment/src/services/providerConfig.ts
+++ b/src/systems/subspace/modules/deployment/src/services/providerConfig.ts
@@ -594,10 +594,12 @@ class providerConfigServiceImpl {
     solution: Solution;
     environment: Environment;
     providerConfig: ProviderConfig;
+    _canArchiveOwned?: boolean;
   }) {
     await this.assertNotForVault(d);
     checkTenant(d, d.providerConfig);
     checkDeletedEdit(d.providerConfig, 'archive');
+    this.assertCanArchiveOwned(d);
 
     return withTransaction(async db => {
       let archivedAt = new Date();
@@ -653,6 +655,28 @@ class providerConfigServiceImpl {
         })
       );
     }
+  }
+
+  private assertCanArchiveOwned(d: {
+    providerConfig: ProviderConfig;
+    _canArchiveOwned?: boolean;
+  }) {
+    if (d._canArchiveOwned) return;
+    if (
+      d.providerConfig.owningIntegrationInstanceOid === null &&
+      d.providerConfig.owningIntegrationInstanceProviderOid === null
+    ) {
+      return;
+    }
+
+    throw new ServiceError(
+      badRequestError({
+        message:
+          'Provider config is owned by an integration instance provider and cannot be archived directly.',
+        code: 'provider_config_owned_archive_not_allowed',
+        data: { id: d.providerConfig.id }
+      })
+    );
   }
 }
 

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstanceProvider.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstanceProvider.ts
@@ -1,4 +1,7 @@
 import { createQueue } from '@lowerdeck/queue';
+import { db } from '@metorial-subspace/db';
+import { providerAuthConfigService } from '@metorial-subspace/module-auth';
+import { providerConfigService } from '@metorial-subspace/module-deployment';
 import { env } from '../../env';
 import { indexIntegrationInstanceQueue } from '../search/integrationInstance';
 
@@ -12,7 +15,41 @@ export let integrationInstanceProviderSetQueue = createQueue<{
 
 export let integrationInstanceProviderSetQueueProcessor =
   integrationInstanceProviderSetQueue.process(async data => {
+    let integrationInstanceProvider = await db.integrationInstanceProvider.findUnique({
+      where: { id: data.integrationInstanceProviderId },
+      include: { integrationInstance: true, tenant: true, solution: true, environment: true }
+    });
+    if (!integrationInstanceProvider) return;
+
     await indexIntegrationInstanceQueue.add({
       integrationInstanceId: data.integrationInstanceId
     });
+
+    if (integrationInstanceProvider.status === 'archived') {
+      let versions = await db.integrationInstanceProviderVersion.findMany({
+        where: { integrationInstanceProviderOid: integrationInstanceProvider.oid },
+        include: { config: true, authConfig: true }
+      });
+
+      for (let current of versions) {
+        if (current.config?.status === 'active') {
+          await providerConfigService.archiveProviderConfig({
+            tenant: integrationInstanceProvider.tenant,
+            solution: integrationInstanceProvider.solution,
+            environment: integrationInstanceProvider.environment,
+            providerConfig: current.config,
+            _canArchiveOwned: true
+          });
+        }
+        if (current.authConfig?.status === 'active') {
+          await providerAuthConfigService.archiveProviderAuthConfig({
+            tenant: integrationInstanceProvider.tenant,
+            solution: integrationInstanceProvider.solution,
+            environment: integrationInstanceProvider.environment,
+            providerAuthConfig: current.authConfig,
+            _canArchiveOwned: true
+          });
+        }
+      }
+    }
   });

--- a/src/systems/subspace/modules/integration/src/services/integrationInstanceProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstanceProvider.ts
@@ -9,6 +9,8 @@ import {
   type IntegrationInstance,
   type IntegrationInstanceProvider,
   type IntegrationInstanceProviderStatus,
+  type ProviderAuthConfig,
+  type ProviderConfig,
   type Solution,
   type Tenant,
   withTransaction
@@ -71,6 +73,38 @@ let requireCurrentIntegrationProviderVersion = async (integrationProviderOid: bi
 
 let isAllowAllToolFilter = (toolFilter: PrismaJson.ToolFilter | null | undefined) =>
   normalizeIntegrationProviderToolFilter(toolFilter).type === 'v1.allow_all';
+
+let configOwnershipError = (kind: 'config' | 'auth_config', id: string) =>
+  badRequestError({
+    message: `Provider ${kind === 'config' ? 'config' : 'auth config'} is already connected to another integration instance provider.`,
+    code:
+      kind === 'config'
+        ? 'provider_config_already_owned'
+        : 'provider_auth_config_already_owned',
+    data: { id }
+  });
+
+let assertCanUseOwnedResource = (d: {
+  kind: 'config' | 'auth_config';
+  resource: Pick<
+    ProviderConfig | ProviderAuthConfig,
+    'id' | 'owningIntegrationInstanceOid' | 'owningIntegrationInstanceProviderOid'
+  >;
+  integrationInstanceOid: bigint;
+  integrationInstanceProviderOid?: bigint;
+}) => {
+  let hasOwner =
+    d.resource.owningIntegrationInstanceOid !== null ||
+    d.resource.owningIntegrationInstanceProviderOid !== null;
+  if (!hasOwner) return;
+
+  if (
+    d.resource.owningIntegrationInstanceOid !== d.integrationInstanceOid ||
+    d.resource.owningIntegrationInstanceProviderOid !== d.integrationInstanceProviderOid
+  ) {
+    throw new ServiceError(configOwnershipError(d.kind, d.resource.id));
+  }
+};
 
 export type SetIntegrationInstanceProviderInput = {
   providerId: string;
@@ -429,6 +463,22 @@ class integrationInstanceProviderServiceImpl {
         let materialProvider = materialProviders[idx]!;
         let combination = combinations[idx]!;
         let existing = existingByIntegrationProviderOid.get(integrationProvider.oid);
+        let deploymentOid = materialProvider.currentVersion!.deploymentOid;
+
+        assertCanUseOwnedResource({
+          kind: 'config',
+          resource: combination.config,
+          integrationInstanceOid: d.integrationInstance.oid,
+          integrationInstanceProviderOid: existing?.oid
+        });
+        if (combination.authConfig) {
+          assertCanUseOwnedResource({
+            kind: 'auth_config',
+            resource: combination.authConfig,
+            integrationInstanceOid: d.integrationInstance.oid,
+            integrationInstanceProviderOid: existing?.oid
+          });
+        }
 
         let integrationInstanceProvider = existing
           ? await db.integrationInstanceProvider.update({
@@ -459,6 +509,58 @@ class integrationInstanceProviderServiceImpl {
                 environmentOid: d.environment.oid
               }
             });
+
+        let configUpdate = await db.providerConfig.updateMany({
+          where: {
+            oid: combination.config.oid,
+            OR: [
+              {
+                owningIntegrationInstanceOid: null,
+                owningIntegrationInstanceProviderOid: null
+              },
+              {
+                owningIntegrationInstanceOid: d.integrationInstance.oid,
+                owningIntegrationInstanceProviderOid: integrationInstanceProvider.oid
+              }
+            ]
+          },
+          data: {
+            owningIntegrationInstanceOid: d.integrationInstance.oid,
+            owningIntegrationInstanceProviderOid: integrationInstanceProvider.oid,
+            deploymentOid
+          }
+        });
+        if (configUpdate.count !== 1) {
+          throw new ServiceError(configOwnershipError('config', combination.config.id));
+        }
+
+        if (combination.authConfig) {
+          let authConfigUpdate = await db.providerAuthConfig.updateMany({
+            where: {
+              oid: combination.authConfig.oid,
+              OR: [
+                {
+                  owningIntegrationInstanceOid: null,
+                  owningIntegrationInstanceProviderOid: null
+                },
+                {
+                  owningIntegrationInstanceOid: d.integrationInstance.oid,
+                  owningIntegrationInstanceProviderOid: integrationInstanceProvider.oid
+                }
+              ]
+            },
+            data: {
+              owningIntegrationInstanceOid: d.integrationInstance.oid,
+              owningIntegrationInstanceProviderOid: integrationInstanceProvider.oid,
+              deploymentOid
+            }
+          });
+          if (authConfigUpdate.count !== 1) {
+            throw new ServiceError(
+              configOwnershipError('auth_config', combination.authConfig.id)
+            );
+          }
+        }
 
         await createIntegrationInstanceProviderVersion({
           integrationInstanceProviderOid: integrationInstanceProvider.oid,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Prisma schema and resource lifecycle rules for provider configs/auth configs, which can affect attachment/archival behavior and requires correct migration/backfill to avoid unexpected rejections.
> 
> **Overview**
> Adds explicit **ownership tracking** for `ProviderConfig`/`ProviderAuthConfig` by introducing `owningIntegrationInstance(Oid)` and `owningIntegrationInstanceProvider(Oid)` relations in Prisma, plus back-relations from `IntegrationInstance` and `IntegrationInstanceProvider`.
> 
> Enforces this ownership in services: `setIntegrationInstanceProviders` now atomically claims configs/auth-configs (and prevents reusing ones owned by another instance/provider), while `archiveProviderConfig`/`archiveProviderAuthConfig` reject direct archiving of owned resources unless an internal override is used.
> 
> Updates lifecycle behavior so archiving an `IntegrationInstanceProvider` automatically archives any active config/auth-config referenced by its versions, and tightens the controller API to require `providerId` (removing the `integrationProviderId` fallback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba7708c256e01cbdd6b6566f1531879017c99fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->