### PR TITLE
Add integration tool call filters

### DIFF
--- a/src/systems/subspace/apps/controller/src/controllers/sessionProvider.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/sessionProvider.ts
@@ -61,6 +61,15 @@ export let toolFiltersValidator = v.nullable(
       toolFilterValidator,
       v.array(toolFilterValidator),
       v.object({
+        type: v.literal('v1.allow_all'),
+        ignoreParentFilters: v.optional(v.boolean())
+      }),
+      v.object({
+        type: v.literal('v1.filter'),
+        ignoreParentFilters: v.optional(v.boolean()),
+        filters: v.array(toolFilterValidator)
+      }),
+      v.object({
         ignoreParentFilters: v.optional(v.boolean()),
         filters: v.optional(
           v.nullable(v.union([toolFilterValidator, v.array(toolFilterValidator)]))

--- a/src/systems/subspace/db/prisma/schema/intergration/delegatedInstance.prisma
+++ b/src/systems/subspace/db/prisma/schema/intergration/delegatedInstance.prisma
@@ -122,6 +122,8 @@ model DelegatedIntegrationInstanceProvider {
   /// [ToolFilter]
   toolFilter Json?
 
+  isOverrideToolFilter Boolean @default(false)
+
   tenantOid BigInt
   tenant    Tenant @relation(fields: [tenantOid], references: [oid])
 

--- a/src/systems/subspace/db/prisma/schema/session/provider.prisma
+++ b/src/systems/subspace/db/prisma/schema/session/provider.prisma
@@ -17,7 +17,7 @@ model SessionProvider {
 
   tag String
 
-  /// [ToolFilter]
+  /// [ToolFilterChain]
   toolFilter Json
 
   sessionOid BigInt

--- a/src/systems/subspace/db/prisma/schema/session/template.prisma
+++ b/src/systems/subspace/db/prisma/schema/session/template.prisma
@@ -59,7 +59,7 @@ model SessionTemplateProvider {
 
   status SessionTemplateProviderStatus
 
-  /// [ToolFilter]
+  /// [ToolFilterChain]
   toolFilter Json
 
   sessionTemplateOid BigInt

--- a/src/systems/subspace/db/src/db.ts
+++ b/src/systems/subspace/db/src/db.ts
@@ -124,6 +124,8 @@ declare global {
           )[];
         };
 
+    type ToolFilterChain = ToolFilter | ToolFilter[];
+
     type ProviderSetupSessionProviderSearch = {
       groups?: { groupId: string }[];
       collections?: { collectionId: string }[];

--- a/src/systems/subspace/modules/integration/src/services/delegatedIntegrationInstanceProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/delegatedIntegrationInstanceProvider.ts
@@ -41,6 +41,17 @@ export type SetDelegatedIntegrationInstanceProviderInput = {
   toolFilters?: PrismaJson.ToolFilter | null;
 };
 
+let stripToolFilterOverrideFlag = (
+  toolFilter: PrismaJson.ToolFilter
+): PrismaJson.ToolFilter => {
+  if (toolFilter.type === 'v1.allow_all') return { type: 'v1.allow_all' };
+
+  return {
+    type: 'v1.filter',
+    filters: toolFilter.filters
+  };
+};
+
 class delegatedIntegrationInstanceProviderServiceImpl {
   async listDelegatedIntegrationInstanceProviders(d: {
     tenant: Tenant;
@@ -327,15 +338,22 @@ class delegatedIntegrationInstanceProviderServiceImpl {
         );
 
         let input = d.input[idx]!;
+        let existing = existingBySourceProviderOid.get(sourceProvider.oid);
+        let inputToolFilter =
+          input.toolFilters === undefined
+            ? undefined
+            : normalizeToolFilters(input.toolFilters);
+        let isOverrideToolFilter =
+          inputToolFilter?.ignoreParentFilters ?? existing?.isOverrideToolFilter ?? false;
         let toolFilter =
           input.toolFilters === undefined
-            ? ((existingBySourceProviderOid.get(sourceProvider.oid)?.toolFilter as
-                | PrismaJson.ToolFilter
-                | null
-                | undefined) ?? null)
-            : normalizeToolFilters(input.toolFilters);
+            ? existing?.toolFilter
+              ? stripToolFilterOverrideFlag(
+                  normalizeToolFilters(existing.toolFilter as PrismaJson.ToolFilter)
+                )
+              : null
+            : stripToolFilterOverrideFlag(inputToolFilter!);
 
-        let existing = existingBySourceProviderOid.get(sourceProvider.oid);
         let delegatedProvider = existing
           ? await db.delegatedIntegrationInstanceProvider.update({
               where: { oid: existing.oid },
@@ -351,7 +369,8 @@ class delegatedIntegrationInstanceProviderServiceImpl {
                 integrationOid: sourceProvider.integrationOid,
                 integrationInstanceOid: sourceProvider.integrationInstanceOid,
                 integrationProviderOid: sourceProvider.integrationProviderOid,
-                toolFilter: toolFilter ?? Prisma.JsonNull
+                toolFilter: toolFilter ?? Prisma.JsonNull,
+                isOverrideToolFilter
               }
             })
           : await db.delegatedIntegrationInstanceProvider.create({
@@ -369,6 +388,7 @@ class delegatedIntegrationInstanceProviderServiceImpl {
                 integrationInstanceProviderOid: sourceProvider.oid,
                 integrationProviderOid: sourceProvider.integrationProviderOid,
                 toolFilter: toolFilter ?? Prisma.JsonNull,
+                isOverrideToolFilter,
                 tenantOid: d.tenant.oid,
                 solutionOid: d.solution.oid,
                 environmentOid: d.environment.oid

--- a/src/systems/subspace/modules/integration/src/services/integrationInstanceProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstanceProvider.ts
@@ -75,6 +75,24 @@ let requireCurrentIntegrationProviderVersion = async (integrationProviderOid: bi
 let isAllowAllToolFilter = (toolFilter: PrismaJson.ToolFilter | null | undefined) =>
   normalizeIntegrationProviderToolFilter(toolFilter).type === 'v1.allow_all';
 
+let stripToolFilterOverrideFlag = (
+  toolFilter: PrismaJson.ToolFilter
+): PrismaJson.ToolFilter => {
+  if (toolFilter.type === 'v1.allow_all') return { type: 'v1.allow_all' };
+
+  return {
+    type: 'v1.filter',
+    filters: toolFilter.filters
+  };
+};
+
+let getInputOverrideToolFilter = (input: SetIntegrationInstanceProviderInput) => {
+  if (input.isOverrideToolFilter !== undefined) return input.isOverrideToolFilter;
+  if (input.toolFilters === undefined) return undefined;
+
+  return normalizeIntegrationProviderToolFilter(input.toolFilters).ignoreParentFilters;
+};
+
 let configOwnershipError = (kind: 'config' | 'auth_config', id: string) =>
   badRequestError({
     message: `Provider ${kind === 'config' ? 'config' : 'auth config'} is already connected to another integration instance provider.`,
@@ -378,7 +396,9 @@ class integrationInstanceProviderServiceImpl {
       let sharedConfigId = materialProvider.currentVersion!.config?.id;
       let existing = existingByIntegrationProviderOid.get(integrationProviders[idx]!.oid);
       let isOverrideToolFilter =
-        input.isOverrideToolFilter ?? existing?.currentVersion?.isOverrideToolFilter ?? false;
+        getInputOverrideToolFilter(input) ??
+        existing?.currentVersion?.isOverrideToolFilter ??
+        false;
 
       if (
         !integration.canAttachCustomProviderConfig &&
@@ -442,17 +462,23 @@ class integrationInstanceProviderServiceImpl {
     let toolFilters = d.input.map((input, idx) => {
       let existing = existingByIntegrationProviderOid.get(integrationProviders[idx]!.oid);
       let isOverrideToolFilter =
-        input.isOverrideToolFilter ?? existing?.currentVersion?.isOverrideToolFilter ?? false;
+        getInputOverrideToolFilter(input) ??
+        existing?.currentVersion?.isOverrideToolFilter ??
+        false;
 
       let toolFilter: PrismaJson.ToolFilter | null;
       if (input.toolFilters === undefined) {
         toolFilter = existing?.currentVersion?.toolFilter
-          ? normalizeIntegrationProviderToolFilter(
-              existing.currentVersion.toolFilter as PrismaJson.ToolFilter
+          ? stripToolFilterOverrideFlag(
+              normalizeIntegrationProviderToolFilter(
+                existing.currentVersion.toolFilter as PrismaJson.ToolFilter
+              )
             )
           : null;
       } else {
-        toolFilter = normalizeIntegrationProviderToolFilter(input.toolFilters);
+        toolFilter = stripToolFilterOverrideFlag(
+          normalizeIntegrationProviderToolFilter(input.toolFilters)
+        );
       }
 
       if (!isOverrideToolFilter && (!toolFilter || isAllowAllToolFilter(toolFilter))) {
@@ -464,7 +490,9 @@ class integrationInstanceProviderServiceImpl {
     let isOverrideToolFilters = d.input.map((input, idx) => {
       let existing = existingByIntegrationProviderOid.get(integrationProviders[idx]!.oid);
       return (
-        input.isOverrideToolFilter ?? existing?.currentVersion?.isOverrideToolFilter ?? false
+        getInputOverrideToolFilter(input) ??
+        existing?.currentVersion?.isOverrideToolFilter ??
+        false
       );
     });
 

--- a/src/systems/subspace/modules/provider-internal/src/lib/toolFilter.test.ts
+++ b/src/systems/subspace/modules/provider-internal/src/lib/toolFilter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { checkToolAccess } from './toolFilter';
+import { buildIntegrationProviderToolFilterChain, checkToolAccess } from './toolFilter';
 
 let createTool = (key: string) =>
   ({
@@ -67,6 +67,137 @@ describe('checkToolAccess', () => {
 
     expect(checkToolAccess(divideTool, sessionProviderWithRegex, 'list')).toEqual({
       allowed: true
+    });
+  });
+});
+
+let toolKeysFilter = (keys: string[]): PrismaJson.ToolFilter => ({
+  type: 'v1.filter',
+  filters: [{ type: 'tool_keys', keys }]
+});
+
+describe('buildIntegrationProviderToolFilterChain', () => {
+  it('stacks integration provider and instance provider filters as ANDed filters', () => {
+    let addTool = createTool('add');
+    let divideTool = createTool('divide');
+    let chain = buildIntegrationProviderToolFilterChain({
+      integrationProviderToolFilter: toolKeysFilter(['add', 'divide']),
+      integrationInstanceProviderToolFilter: toolKeysFilter(['add'])
+    });
+
+    expect(Array.isArray(chain)).toBe(true);
+    expect(checkToolAccess(addTool, chain as PrismaJson.ToolFilter[], 'list')).toEqual({
+      allowed: true
+    });
+    expect(checkToolAccess(divideTool, chain as PrismaJson.ToolFilter[], 'list')).toEqual({
+      allowed: false
+    });
+  });
+
+  it('lets instance provider overrides reset integration provider filters', () => {
+    let addTool = createTool('add');
+    let divideTool = createTool('divide');
+    let chain = buildIntegrationProviderToolFilterChain({
+      integrationProviderToolFilter: toolKeysFilter(['add']),
+      integrationInstanceProviderToolFilter: toolKeysFilter(['divide']),
+      integrationInstanceProviderIsOverride: true
+    });
+
+    expect(checkToolAccess(addTool, [chain as PrismaJson.ToolFilter], 'list')).toEqual({
+      allowed: false
+    });
+    expect(checkToolAccess(divideTool, [chain as PrismaJson.ToolFilter], 'list')).toEqual({
+      allowed: true
+    });
+  });
+
+  it('stacks delegated provider filters on top of source filters', () => {
+    let addTool = createTool('add');
+    let divideTool = createTool('divide');
+    let chain = buildIntegrationProviderToolFilterChain({
+      integrationProviderToolFilter: toolKeysFilter(['add', 'divide']),
+      integrationInstanceProviderToolFilter: toolKeysFilter(['add', 'divide']),
+      delegatedIntegrationInstanceProviderToolFilter: toolKeysFilter(['add'])
+    });
+
+    expect(checkToolAccess(addTool, chain as PrismaJson.ToolFilter[], 'list')).toEqual({
+      allowed: true
+    });
+    expect(checkToolAccess(divideTool, chain as PrismaJson.ToolFilter[], 'list')).toEqual({
+      allowed: false
+    });
+  });
+
+  it('lets delegated provider overrides reset integration and instance provider filters', () => {
+    let addTool = createTool('add');
+    let divideTool = createTool('divide');
+    let chain = buildIntegrationProviderToolFilterChain({
+      integrationProviderToolFilter: toolKeysFilter(['add']),
+      integrationInstanceProviderToolFilter: toolKeysFilter(['add']),
+      delegatedIntegrationInstanceProviderToolFilter: toolKeysFilter(['divide']),
+      delegatedIntegrationInstanceProviderIsOverride: true
+    });
+
+    expect(checkToolAccess(addTool, [chain as PrismaJson.ToolFilter], 'list')).toEqual({
+      allowed: false
+    });
+    expect(checkToolAccess(divideTool, [chain as PrismaJson.ToolFilter], 'list')).toEqual({
+      allowed: true
+    });
+  });
+
+  it('ignores instance and delegated provider filters when custom tool filters are disabled', () => {
+    let addTool = createTool('add');
+    let divideTool = createTool('divide');
+    let chain = buildIntegrationProviderToolFilterChain({
+      canAttachCustomToolFilters: false,
+      integrationProviderToolFilter: toolKeysFilter(['add']),
+      integrationInstanceProviderToolFilter: toolKeysFilter(['divide']),
+      delegatedIntegrationInstanceProviderToolFilter: toolKeysFilter(['divide'])
+    });
+
+    expect(checkToolAccess(addTool, [chain as PrismaJson.ToolFilter], 'list')).toEqual({
+      allowed: true
+    });
+    expect(checkToolAccess(divideTool, [chain as PrismaJson.ToolFilter], 'list')).toEqual({
+      allowed: false
+    });
+  });
+
+  it('stacks override filters when tool filter overrides are disabled', () => {
+    let addTool = createTool('add');
+    let divideTool = createTool('divide');
+    let chain = buildIntegrationProviderToolFilterChain({
+      canOverrideToolFilters: false,
+      integrationProviderToolFilter: toolKeysFilter(['add']),
+      integrationInstanceProviderToolFilter: toolKeysFilter(['add', 'divide']),
+      integrationInstanceProviderIsOverride: true
+    });
+
+    expect(checkToolAccess(addTool, chain as PrismaJson.ToolFilter[], 'list')).toEqual({
+      allowed: true
+    });
+    expect(checkToolAccess(divideTool, chain as PrismaJson.ToolFilter[], 'list')).toEqual({
+      allowed: false
+    });
+  });
+
+  it('evaluates a session provider carrying a materialized filter chain', () => {
+    let addTool = createTool('add');
+    let divideTool = createTool('divide');
+    let sessionProviderWithChain = {
+      ...sessionProvider,
+      toolFilter: buildIntegrationProviderToolFilterChain({
+        integrationProviderToolFilter: toolKeysFilter(['add', 'divide']),
+        integrationInstanceProviderToolFilter: toolKeysFilter(['add'])
+      })
+    } as any;
+
+    expect(checkToolAccess(addTool, sessionProviderWithChain, 'list')).toEqual({
+      allowed: true
+    });
+    expect(checkToolAccess(divideTool, sessionProviderWithChain, 'list')).toEqual({
+      allowed: false
     });
   });
 });

--- a/src/systems/subspace/modules/provider-internal/src/lib/toolFilter.ts
+++ b/src/systems/subspace/modules/provider-internal/src/lib/toolFilter.ts
@@ -2,9 +2,10 @@ import type { ProviderTool } from '@metorial-subspace/db';
 import safeRegex from 'safe-regex2';
 
 type ToolFilter = PrismaJson.ToolFilter;
+type ToolFilterChain = PrismaJson.ToolFilterChain;
 type ToolFilterRule = Extract<ToolFilter, { type: 'v1.filter' }>['filters'][number];
 type ToolFilterCarrier = {
-  toolFilter?: ToolFilter | null;
+  toolFilter?: ToolFilterChain | null;
   deployment?: {
     toolFilter?: ToolFilter | null;
   } | null;
@@ -21,6 +22,17 @@ type ToolFilterEnvelopeInput = {
 };
 
 let allowAllFilter = (): ToolFilter => ({ type: 'v1.allow_all' });
+
+let stripToolFilterControlFields = (filter: ToolFilter): ToolFilter => {
+  if (filter.type === 'v1.allow_all') {
+    return { type: 'v1.allow_all' };
+  }
+
+  return {
+    type: 'v1.filter',
+    filters: filter.filters
+  };
+};
 
 let validateAndUseRegex = (pattern: string, flags?: string) => {
   if (!safeRegex(pattern)) {
@@ -98,30 +110,94 @@ export let normalizeToolFilters = (
   };
 };
 
+export let normalizeToolFilterChain = (
+  input: ToolFilterChain | null | undefined
+): ToolFilter[] => {
+  if (!input) return [];
+
+  return (Array.isArray(input) ? input : [input]).map(filter => normalizeToolFilters(filter));
+};
+
+export let resolveStackedToolFilterChain = (
+  filters: (ToolFilterChain | null | undefined)[]
+): ToolFilter[] => {
+  let chain: ToolFilter[] = [];
+
+  for (let input of filters) {
+    for (let filter of normalizeToolFilterChain(input)) {
+      if (filter.ignoreParentFilters) chain = [];
+      chain.push(stripToolFilterControlFields(filter));
+    }
+  }
+
+  return chain;
+};
+
+let isNoopToolFilter = (filter: ToolFilter) =>
+  filter.type === 'v1.allow_all' || filter.filters.length === 0;
+
+export let buildIntegrationProviderToolFilterChain = (d: {
+  canAttachCustomToolFilters?: boolean | null;
+  canOverrideToolFilters?: boolean | null;
+  integrationProviderToolFilter?: ToolFilter | null;
+  integrationInstanceProviderToolFilter?: ToolFilter | null;
+  integrationInstanceProviderIsOverride?: boolean | null;
+  delegatedIntegrationInstanceProviderToolFilter?: ToolFilter | null;
+  delegatedIntegrationInstanceProviderIsOverride?: boolean | null;
+}): ToolFilterChain => {
+  let chain: ToolFilter[] = [];
+  let canAttachCustomToolFilters = d.canAttachCustomToolFilters ?? true;
+  let canOverrideToolFilters = d.canOverrideToolFilters ?? true;
+  let addFilter = (input: ToolFilter | null | undefined, isOverride?: boolean | null) => {
+    if (!input && !isOverride) return;
+
+    let filter = normalizeToolFilters(input);
+    if (canOverrideToolFilters && (isOverride || filter.ignoreParentFilters)) chain = [];
+
+    let storedFilter = stripToolFilterControlFields(filter);
+    if (isNoopToolFilter(storedFilter)) return;
+
+    chain.push(storedFilter);
+  };
+
+  addFilter(d.integrationProviderToolFilter);
+  if (canAttachCustomToolFilters) {
+    addFilter(
+      d.integrationInstanceProviderToolFilter,
+      d.integrationInstanceProviderIsOverride
+    );
+    addFilter(
+      d.delegatedIntegrationInstanceProviderToolFilter,
+      d.delegatedIntegrationInstanceProviderIsOverride
+    );
+  }
+
+  if (!chain.length) return allowAllFilter();
+  if (chain.length === 1) return chain[0]!;
+
+  return chain;
+};
+
 export let resolveToolFilterChain = (d: {
   providerConfigToolFilter?: ToolFilter | null;
   providerAuthConfigToolFilter?: ToolFilter | null;
   providerDeploymentToolFilter?: ToolFilter | null;
-  sessionProviderToolFilter?: ToolFilter | null;
+  sessionProviderToolFilter?: ToolFilterChain | null;
 }) => {
   let providerConfigToolFilter = normalizeToolFilters(d.providerConfigToolFilter);
   let providerAuthConfigToolFilter = normalizeToolFilters(d.providerAuthConfigToolFilter);
   let providerDeploymentToolFilter = normalizeToolFilters(d.providerDeploymentToolFilter);
-  let sessionProviderToolFilter = normalizeToolFilters(d.sessionProviderToolFilter);
-
-  if (sessionProviderToolFilter.ignoreParentFilters) {
-    return [sessionProviderToolFilter];
-  }
+  let sessionProviderToolFilterChain = normalizeToolFilterChain(d.sessionProviderToolFilter);
 
   if (providerDeploymentToolFilter.ignoreParentFilters) {
-    return [providerDeploymentToolFilter, sessionProviderToolFilter];
+    return [providerDeploymentToolFilter, ...sessionProviderToolFilterChain];
   }
 
   if (providerAuthConfigToolFilter.ignoreParentFilters) {
     return [
       providerAuthConfigToolFilter,
       providerDeploymentToolFilter,
-      sessionProviderToolFilter
+      ...sessionProviderToolFilterChain
     ];
   }
 
@@ -130,7 +206,7 @@ export let resolveToolFilterChain = (d: {
       providerConfigToolFilter,
       providerAuthConfigToolFilter,
       providerDeploymentToolFilter,
-      sessionProviderToolFilter
+      ...sessionProviderToolFilterChain
     ];
   }
 
@@ -138,7 +214,7 @@ export let resolveToolFilterChain = (d: {
     providerConfigToolFilter,
     providerAuthConfigToolFilter,
     providerDeploymentToolFilter,
-    sessionProviderToolFilter
+    ...sessionProviderToolFilterChain
   ];
 };
 

--- a/src/systems/subspace/modules/session/src/queues/lifecycle/linkedDelegatedIntegrationTemplate.ts
+++ b/src/systems/subspace/modules/session/src/queues/lifecycle/linkedDelegatedIntegrationTemplate.ts
@@ -1,10 +1,9 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db, getId, withTransaction } from '@metorial-subspace/db';
+import { buildIntegrationProviderToolFilterChain } from '@metorial-subspace/module-provider-internal';
 import { env } from '../../env';
 import { sessionTemplateArchivedQueue } from './sessionTemplate';
 import { sessionTemplateProviderCreatedQueue } from './sessionTemplateProvider';
-
-let defaultToolFilter = { type: 'v1.allow_all' } satisfies PrismaJson.ToolFilter;
 
 export let syncDelegatedIntegrationInstanceSessionTemplatesQueue = createQueue<{
   delegatedIntegrationInstanceId: string;
@@ -96,6 +95,7 @@ export let syncDelegatedIntegrationInstanceSessionTemplate = async (data: {
     },
     orderBy: { id: 'asc' },
     include: {
+      integration: true,
       integrationProvider: true,
       integrationInstanceProvider: {
         include: {
@@ -137,11 +137,18 @@ export let syncDelegatedIntegrationInstanceSessionTemplate = async (data: {
       let sourceProvider = delegatedProvider.integrationInstanceProvider;
       let currentVersion = sourceProvider.currentVersion!;
       let existing = existingByDelegatedProviderOid.get(delegatedProvider.oid);
-      let toolFilter =
-        (currentVersion.toolFilter as PrismaJson.ToolFilter | null) ??
-        (currentVersion.integrationProviderVersion
-          .toolFilter as PrismaJson.ToolFilter | null) ??
-        defaultToolFilter;
+      let toolFilter = buildIntegrationProviderToolFilterChain({
+        canAttachCustomToolFilters: delegatedProvider.integration.canAttachCustomToolFilters,
+        canOverrideToolFilters: delegatedProvider.integration.canOverrideToolFilters,
+        integrationProviderToolFilter: currentVersion.integrationProviderVersion
+          .toolFilter as PrismaJson.ToolFilter | null,
+        integrationInstanceProviderToolFilter:
+          currentVersion.toolFilter as PrismaJson.ToolFilter | null,
+        integrationInstanceProviderIsOverride: currentVersion.isOverrideToolFilter,
+        delegatedIntegrationInstanceProviderToolFilter:
+          delegatedProvider.toolFilter as PrismaJson.ToolFilter | null,
+        delegatedIntegrationInstanceProviderIsOverride: delegatedProvider.isOverrideToolFilter
+      });
 
       let data = {
         status: 'active' as const,

--- a/src/systems/subspace/modules/session/src/queues/lifecycle/linkedSessionTemplate.ts
+++ b/src/systems/subspace/modules/session/src/queues/lifecycle/linkedSessionTemplate.ts
@@ -1,10 +1,9 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db, getId, withTransaction } from '@metorial-subspace/db';
+import { buildIntegrationProviderToolFilterChain } from '@metorial-subspace/module-provider-internal';
 import { env } from '../../env';
 import { sessionTemplateArchivedQueue } from './sessionTemplate';
 import { sessionTemplateProviderCreatedQueue } from './sessionTemplateProvider';
-
-let defaultToolFilter = { type: 'v1.allow_all' } satisfies PrismaJson.ToolFilter;
 
 export let syncIntegrationInstanceSessionTemplatesQueue = createQueue<{
   integrationInstanceId: string;
@@ -87,6 +86,7 @@ export let syncIntegrationInstanceSessionTemplateQueueProcessor =
       },
       orderBy: { id: 'asc' },
       include: {
+        integration: true,
         integrationProvider: true,
         currentVersion: {
           include: {
@@ -125,11 +125,17 @@ export let syncIntegrationInstanceSessionTemplateQueueProcessor =
         let existing = existingByIntegrationInstanceProviderOid.get(
           integrationInstanceProvider.oid
         );
-        let toolFilter =
-          (currentVersion.toolFilter as PrismaJson.ToolFilter | null) ??
-          (currentVersion.integrationProviderVersion
-            .toolFilter as PrismaJson.ToolFilter | null) ??
-          defaultToolFilter;
+        let toolFilter = buildIntegrationProviderToolFilterChain({
+          canAttachCustomToolFilters:
+            integrationInstanceProvider.integration.canAttachCustomToolFilters,
+          canOverrideToolFilters:
+            integrationInstanceProvider.integration.canOverrideToolFilters,
+          integrationProviderToolFilter: currentVersion.integrationProviderVersion
+            .toolFilter as PrismaJson.ToolFilter | null,
+          integrationInstanceProviderToolFilter:
+            currentVersion.toolFilter as PrismaJson.ToolFilter | null,
+          integrationInstanceProviderIsOverride: currentVersion.isOverrideToolFilter
+        });
 
         let data = {
           status: 'active' as const,

--- a/src/systems/subspace/packages/presenters/src/delegatedIntegrationInstance.ts
+++ b/src/systems/subspace/packages/presenters/src/delegatedIntegrationInstance.ts
@@ -1,6 +1,27 @@
-import { delegatedIntegrationInstanceProviderPresenter } from './delegatedIntegrationInstanceProvider';
+import type {
+  DelegatedIntegrationInstance,
+  DelegatedIntegrationInstanceSource,
+  IntegrationInstance
+} from '@metorial-subspace/db';
+import {
+  delegatedIntegrationInstanceProviderPresenter,
+  type PresentedDelegatedIntegrationInstanceProvider
+} from './delegatedIntegrationInstanceProvider';
 
-export let delegatedIntegrationInstanceSourcePresenter = (source: any) => ({
+export type PresentedDelegatedIntegrationInstanceSource =
+  DelegatedIntegrationInstanceSource & {
+    delegatedIntegrationInstance?: DelegatedIntegrationInstance | null;
+    integrationInstance: IntegrationInstance;
+  };
+
+export type PresentedDelegatedIntegrationInstance = DelegatedIntegrationInstance & {
+  sources: PresentedDelegatedIntegrationInstanceSource[];
+  providers: PresentedDelegatedIntegrationInstanceProvider[];
+};
+
+export let delegatedIntegrationInstanceSourcePresenter = (
+  source: PresentedDelegatedIntegrationInstanceSource
+) => ({
   object: 'delegated.integration.instance.source',
 
   id: source.id,
@@ -14,7 +35,9 @@ export let delegatedIntegrationInstanceSourcePresenter = (source: any) => ({
   archivedAt: source.archivedAt
 });
 
-export let delegatedIntegrationInstancePresenter = (delegatedIntegrationInstance: any) => ({
+export let delegatedIntegrationInstancePresenter = (
+  delegatedIntegrationInstance: PresentedDelegatedIntegrationInstance
+) => ({
   object: 'delegated.integration.instance',
 
   id: delegatedIntegrationInstance.id,

--- a/src/systems/subspace/packages/presenters/src/delegatedIntegrationInstanceProvider.ts
+++ b/src/systems/subspace/packages/presenters/src/delegatedIntegrationInstanceProvider.ts
@@ -1,8 +1,62 @@
+import type {
+  DelegatedIntegrationInstance,
+  DelegatedIntegrationInstanceProvider,
+  DelegatedIntegrationInstanceSource,
+  Integration,
+  IntegrationInstance,
+  IntegrationProvider,
+  IntegrationProviderVersion,
+  Provider,
+  ProviderAuthCredentials,
+  ProviderAuthMethod,
+  ProviderConfig,
+  ProviderDeployment,
+  ProviderSpecification
+} from '@metorial-subspace/db';
 import { integrationInstanceProviderPresenter } from './integrationInstanceProvider';
 import { integrationProviderSnapshotPresenter } from './integrationProvider';
 import { providerPreviewPresenter } from './provider';
 
-export let delegatedIntegrationInstanceProviderPresenter = (provider: any) => ({
+let presentToolFilter = (
+  toolFilter: PrismaJson.ToolFilter | null,
+  isOverrideToolFilter?: boolean
+) => {
+  if (!toolFilter) return toolFilter;
+
+  return {
+    ...toolFilter,
+    ignoreParentFilters: isOverrideToolFilter || undefined
+  };
+};
+
+export type PresentedDelegatedIntegrationInstanceProvider =
+  DelegatedIntegrationInstanceProvider & {
+    delegatedIntegrationInstance: DelegatedIntegrationInstance;
+    delegatedIntegrationInstanceSource: DelegatedIntegrationInstanceSource & {
+      integrationInstance: IntegrationInstance;
+    };
+    integration: Integration;
+    integrationInstance: IntegrationInstance;
+    integrationInstanceProvider: Parameters<typeof integrationInstanceProviderPresenter>[0];
+    integrationProvider: IntegrationProvider & {
+      integration: Integration;
+      provider: Provider;
+      currentVersion:
+        | (IntegrationProviderVersion & {
+            deployment: ProviderDeployment;
+            authMethod:
+              | (ProviderAuthMethod & { specification: Omit<ProviderSpecification, 'value'> })
+              | null;
+            authCredentials: ProviderAuthCredentials | null;
+            config: ProviderConfig | null;
+          })
+        | null;
+    };
+  };
+
+export let delegatedIntegrationInstanceProviderPresenter = (
+  provider: PresentedDelegatedIntegrationInstanceProvider
+) => ({
   object: 'delegated.integration.instance.provider',
 
   id: provider.id,
@@ -20,7 +74,8 @@ export let delegatedIntegrationInstanceProviderPresenter = (provider: any) => ({
   integrationInstanceProviderId: provider.integrationInstanceProvider.id,
   integrationProviderId: provider.integrationProvider.id,
 
-  toolFilter: provider.toolFilter,
+  toolFilter: presentToolFilter(provider.toolFilter, provider.isOverrideToolFilter),
+  isOverrideToolFilter: provider.isOverrideToolFilter,
 
   provider: providerPreviewPresenter(provider.integrationProvider.provider),
 

--- a/src/systems/subspace/packages/presenters/src/integrationInstanceProvider.ts
+++ b/src/systems/subspace/packages/presenters/src/integrationInstanceProvider.ts
@@ -18,6 +18,18 @@ import { providerPreviewPresenter } from './provider';
 import { providerAuthConfigPreviewPresenter } from './providerAuthConfig';
 import { providerConfigPreviewPresenter } from './providerConfig';
 
+let presentToolFilter = (
+  toolFilter: PrismaJson.ToolFilter | null,
+  isOverrideToolFilter?: boolean
+) => {
+  if (!toolFilter) return toolFilter;
+
+  return {
+    ...toolFilter,
+    ignoreParentFilters: isOverrideToolFilter || undefined
+  };
+};
+
 export let integrationInstanceProviderVersionPresenter = (d: {
   provider: Provider;
   integrationProvider: IntegrationProvider & { provider: Provider };
@@ -85,7 +97,11 @@ export let integrationInstanceProviderPresenter = (
   integrationInstanceId: integrationInstanceProvider.integrationInstance.id,
   integrationProviderId: integrationInstanceProvider.integrationProvider.id,
 
-  toolFilter: integrationInstanceProvider.currentVersion!.toolFilter,
+  toolFilter: presentToolFilter(
+    integrationInstanceProvider.currentVersion!.toolFilter as PrismaJson.ToolFilter | null,
+    integrationInstanceProvider.currentVersion!.isOverrideToolFilter
+  ),
+  isOverrideToolFilter: integrationInstanceProvider.currentVersion!.isOverrideToolFilter,
 
   provider: providerPreviewPresenter(integrationInstanceProvider.integrationProvider.provider),
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new tool-filter chaining/override semantics and persists new `isOverrideToolFilter` state, which can affect authorization of tool calls and requires DB migration correctness.
> 
> **Overview**
> Adds support for **materialized tool filter chains** (`ToolFilterChain` = single filter or array) so integration-, instance-, and delegated-provider tool filters can be stacked (ANDed) with explicit override behavior.
> 
> Persists override state separately via a new `DelegatedIntegrationInstanceProvider.isOverrideToolFilter` column, strips `ignoreParentFilters` from stored JSON filters, and updates integration/delegated provider set flows plus session-template sync queues to compute and store the composed chain.
> 
> Updates API validation and presenters to accept/emit the new filter shapes and expose `isOverrideToolFilter`, and expands provider-internal tests to cover chaining/override scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 643fb8f3b83832c76d884cec6822be054670ac47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->