### PR TITLE
Improve oauth discovery

### DIFF
--- a/src/systems/shuttle/service/src/lib/oauth/discovery.test.ts
+++ b/src/systems/shuttle/service/src/lib/oauth/discovery.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OAuthDiscovery } from './discovery';
+import { axiosWithoutSse } from '../http/sse';
+
+vi.mock('../http/sse', () => ({
+  axiosWithoutSse: vi.fn()
+}));
+
+let oauthConfig = {
+  issuer: 'https://api.avo.app',
+  authorization_endpoint: 'https://api.avo.app/oauth/authorize',
+  token_endpoint: 'https://api.avo.app/oauth/token',
+  scopes_supported: ['read', 'write']
+};
+
+describe('OAuthDiscovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('discovers authorization server metadata from protected resource metadata', async () => {
+    let axios = vi.mocked(axiosWithoutSse);
+
+    axios.mockImplementation(async url => {
+      if (url === 'https://mcp.avo.app/.well-known/oauth-protected-resource') {
+        return {
+          status: 200,
+          data: {
+            resource: 'https://mcp.avo.app/mcp',
+            authorization_servers: ['https://api.avo.app'],
+            scopes_supported: ['read', 'write'],
+            bearer_methods_supported: ['header']
+          },
+          headers: {}
+        } as any;
+      }
+
+      if (url === 'https://api.avo.app/.well-known/oauth-authorization-server') {
+        return {
+          status: 200,
+          data: oauthConfig,
+          headers: {}
+        } as any;
+      }
+
+      return {
+        status: 404,
+        data: {},
+        headers: {}
+      } as any;
+    });
+
+    await expect(OAuthDiscovery.discover('https://mcp.avo.app/mcp')).resolves.toEqual(
+      oauthConfig
+    );
+
+    expect(axios).toHaveBeenCalledWith(
+      'https://api.avo.app/.well-known/oauth-authorization-server',
+      expect.any(Object)
+    );
+  });
+});

--- a/src/systems/shuttle/service/src/lib/oauth/discovery.ts
+++ b/src/systems/shuttle/service/src/lib/oauth/discovery.ts
@@ -7,6 +7,7 @@ export class OAuthDiscovery {
     '/.well-known/openid-configuration',
     '/.well-known/oauth-authorization-server',
     '/.well-known/oauth-protected-resource',
+    '/.well-known/oauth-authorization-server',
     '/oauth/metadata.json'
   ];
 
@@ -72,6 +73,29 @@ export class OAuthDiscovery {
   private static async fetchDiscoveryDocument(
     url: string
   ): Promise<OAuthConfiguration | null> {
+    let config = await this.fetchJsonDocument(url);
+    if (!config) return null;
+
+    if (this.isValidOAuthConfig(config)) {
+      return config;
+    }
+
+    let authServers = this.getProtectedResourceAuthorizationServers(config);
+    if (!authServers || authServers.length === 0) return null;
+
+    for (let serverUrl of authServers) {
+      try {
+        let serverConfig = await this.fetchAuthorizationServerConfig(serverUrl);
+        if (serverConfig) return serverConfig;
+      } catch (error) {
+        console.debug(`Failed to discover authorization server ${serverUrl}:`, error);
+      }
+    }
+
+    return null;
+  }
+
+  private static async fetchJsonDocument(url: string): Promise<any | null> {
     try {
       let response = await axiosWithoutSse(url, {
         method: 'GET',
@@ -89,15 +113,52 @@ export class OAuthDiscovery {
         return null;
       }
 
-      let config = response.data;
-      if (this.isValidOAuthConfig(config)) {
-        return config;
-      }
-
-      return null;
+      return response.data;
     } catch (error) {
       return null;
     }
+  }
+
+  private static async fetchAuthorizationServerConfig(
+    authorizationServerUrl: string
+  ): Promise<OAuthConfiguration | null> {
+    let discoveryUrls = this.getAuthorizationServerDiscoveryUrls(authorizationServerUrl);
+
+    for (let discoveryUrl of discoveryUrls) {
+      let config = await this.fetchJsonDocument(discoveryUrl);
+      if (this.isValidOAuthConfig(config)) return config;
+    }
+
+    return null;
+  }
+
+  private static getAuthorizationServerDiscoveryUrls(authorizationServerUrl: string) {
+    let url: URL;
+
+    try {
+      url = new URL(authorizationServerUrl);
+    } catch (error) {
+      return [];
+    }
+
+    if (url.protocol !== 'https:') return [];
+
+    if (url.pathname.includes('/.well-known/')) {
+      return [url.toString()];
+    }
+
+    let baseUrl = `${url.protocol}//${url.host}`;
+    let pathname = url.pathname === '/' ? '' : url.pathname.replace(/\/$/, '');
+
+    return Array.from(
+      new Set([
+        `${baseUrl}/.well-known/oauth-authorization-server${pathname}`,
+        `${baseUrl}/.well-known/openid-configuration${pathname}`,
+        `${baseUrl}${pathname}/.well-known/oauth-authorization-server`,
+        `${baseUrl}${pathname}/.well-known/openid-configuration`,
+        url.toString()
+      ])
+    );
   }
 
   private static async wwwAuthenticateDiscovery(
@@ -138,7 +199,7 @@ export class OAuthDiscovery {
 
       for (let serverUrl of authServers) {
         try {
-          let config = await this.fetchDiscoveryDocument(serverUrl);
+          let config = await this.fetchAuthorizationServerConfig(serverUrl);
           if (config) {
             return config;
           }
@@ -178,6 +239,22 @@ export class OAuthDiscovery {
     }
 
     return null;
+  }
+
+  private static getProtectedResourceAuthorizationServers(config: any): string[] | null {
+    if (
+      !config ||
+      typeof config !== 'object' ||
+      !Array.isArray(config.authorization_servers)
+    ) {
+      return null;
+    }
+
+    let servers = config.authorization_servers.filter(
+      (server: unknown) => typeof server === 'string'
+    );
+
+    return servers.length > 0 ? servers : null;
   }
 
   private static isValidOAuthConfig(config: any): boolean {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes OAuth discovery behavior and URL probing logic, which could affect how remote OAuth providers are detected and may introduce new network requests/edge cases. Not security-critical auth itself, but impacts authentication setup flows.
> 
> **Overview**
> **Improves `OAuthDiscovery.discover` to handle OAuth 2.0 protected resource metadata.** When a fetched document isn’t a valid `OAuthConfiguration`, it now treats it as `/.well-known/oauth-protected-resource`, extracts `authorization_servers`, and then discovers the authorization server’s config.
> 
> Adds a dedicated `fetchAuthorizationServerConfig` flow that tries multiple well-known discovery URL permutations for an authorization server (while enforcing HTTPS) and reuses a new `fetchJsonDocument` helper. Updates `wwwAuthenticateDiscovery` to use the new authorization-server lookup, and adds a Vitest covering protected-resource → authorization-server discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47877e2aea9531fb2d7bd32740e6ea62656c6db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->