### PR TITLE
Add session template hash

### DIFF
--- a/src/systems/subspace/db/prisma/schema/session/template.prisma
+++ b/src/systems/subspace/db/prisma/schema/session/template.prisma
@@ -14,6 +14,7 @@ model SessionTemplate {
 
   name            String?
   description     String?
+  hash            String?
   metadata        Json?
   privateMetadata Json?
 

--- a/src/systems/subspace/modules/session/src/queues/lifecycle/index.ts
+++ b/src/systems/subspace/modules/session/src/queues/lifecycle/index.ts
@@ -23,7 +23,10 @@ import {
   sessionTemplateArchiveSessionsManyQueueProcessor,
   sessionTemplateDeletedQueueProcessor
 } from './sessionTemplate';
-import { sessionTemplateProviderCreatedQueueProcessor } from './sessionTemplateProvider';
+import {
+  sessionTemplateProviderCreatedQueueProcessor,
+  sessionTemplateSyncHashQueueProcessor
+} from './sessionTemplateProvider';
 
 export let lifecycleQueues = combineQueueProcessors([
   sessionCreatedQueueProcessor,
@@ -42,5 +45,6 @@ export let lifecycleQueues = combineQueueProcessors([
   sessionTemplateArchivedQueueProcessor,
   sessionTemplateArchiveSessionsManyQueueProcessor,
   sessionTemplateDeletedQueueProcessor,
-  sessionTemplateProviderCreatedQueueProcessor
+  sessionTemplateProviderCreatedQueueProcessor,
+  sessionTemplateSyncHashQueueProcessor
 ]);

--- a/src/systems/subspace/modules/session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate.ts
+++ b/src/systems/subspace/modules/session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate.ts
@@ -3,7 +3,10 @@ import { db, getId, withTransaction } from '@metorial-subspace/db';
 import { buildIntegrationProviderToolFilterChain } from '@metorial-subspace/module-provider-internal';
 import { env } from '../../env';
 import { sessionTemplateArchivedQueue } from './sessionTemplate';
-import { sessionTemplateProviderCreatedQueue } from './sessionTemplateProvider';
+import {
+  sessionTemplateProviderCreatedQueue,
+  sessionTemplateSyncHashQueue
+} from './sessionTemplateProvider';
 
 export let syncIntegrationInstanceGroupSessionTemplatesQueue = createQueue<{
   integrationInstanceGroupId: string;
@@ -207,6 +210,10 @@ export let syncIntegrationInstanceGroupSessionTemplate = async (data: {
       }))
     );
   }
+
+  await sessionTemplateSyncHashQueue.add({
+    sessionTemplateId: sessionTemplate.id
+  });
 };
 
 export let syncIntegrationInstanceGroupSessionTemplateQueueProcessor =

--- a/src/systems/subspace/modules/session/src/queues/lifecycle/linkedSessionTemplate.ts
+++ b/src/systems/subspace/modules/session/src/queues/lifecycle/linkedSessionTemplate.ts
@@ -3,7 +3,10 @@ import { db, getId, withTransaction } from '@metorial-subspace/db';
 import { buildIntegrationProviderToolFilterChain } from '@metorial-subspace/module-provider-internal';
 import { env } from '../../env';
 import { sessionTemplateArchivedQueue } from './sessionTemplate';
-import { sessionTemplateProviderCreatedQueue } from './sessionTemplateProvider';
+import {
+  sessionTemplateProviderCreatedQueue,
+  sessionTemplateSyncHashQueue
+} from './sessionTemplateProvider';
 
 export let syncIntegrationInstanceSessionTemplatesQueue = createQueue<{
   integrationInstanceId: string;
@@ -194,6 +197,10 @@ export let syncIntegrationInstanceSessionTemplateQueueProcessor =
         }))
       );
     }
+
+    await sessionTemplateSyncHashQueue.add({
+      sessionTemplateId: sessionTemplate.id
+    });
   });
 
 export let archiveIntegrationInstanceSessionTemplatesQueue = createQueue<{

--- a/src/systems/subspace/modules/session/src/queues/lifecycle/sessionTemplateProvider.ts
+++ b/src/systems/subspace/modules/session/src/queues/lifecycle/sessionTemplateProvider.ts
@@ -1,3 +1,5 @@
+import { canonicalize } from '@lowerdeck/canonicalize';
+import { Hash } from '@lowerdeck/hash';
 import { createQueue } from '@lowerdeck/queue';
 import { db, getId } from '@metorial-subspace/db';
 import { env } from '../../env';
@@ -42,3 +44,60 @@ export let sessionTemplateProviderCreatedQueueProcessor =
       }
     });
   });
+
+export let sessionTemplateSyncHashQueue = createQueue<{
+  sessionTemplateId: string;
+}>({
+  name: 'sub/ses/lc/sessionTemplate/syncHash',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let syncSessionTemplateHash = async (data: { sessionTemplateId: string }) => {
+  let sessionTemplate = await db.sessionTemplate.findUnique({
+    where: { id: data.sessionTemplateId }
+  });
+  if (!sessionTemplate || sessionTemplate.status !== 'active') {
+    return;
+  }
+
+  let providers = await db.sessionTemplateProvider.findMany({
+    where: {
+      sessionTemplateOid: sessionTemplate.oid,
+      status: 'active'
+    },
+    select: {
+      providerOid: true,
+      deploymentOid: true,
+      configOid: true,
+      authConfigOid: true,
+      toolFilter: true
+    }
+  });
+
+  let hash = await Hash.sha256(
+    canonicalize([
+      sessionTemplate.oid.toString(),
+      sessionTemplate.status,
+      sessionTemplate.integrationInstanceGroupOid?.toString() ?? null,
+      sessionTemplate.integrationInstanceOid?.toString() ?? null,
+      providers
+        .map(provider => ({
+          providerOid: provider.providerOid.toString(),
+          deploymentOid: provider.deploymentOid.toString(),
+          configOid: provider.configOid.toString(),
+          authConfigOid: provider.authConfigOid?.toString() ?? null,
+          toolFilter: provider.toolFilter
+        }))
+        .map(p => canonicalize(p))
+        .sort()
+    ])
+  );
+
+  await db.sessionTemplate.update({
+    where: { oid: sessionTemplate.oid },
+    data: { hash }
+  });
+};
+
+export let sessionTemplateSyncHashQueueProcessor =
+  sessionTemplateSyncHashQueue.process(syncSessionTemplateHash);

--- a/src/systems/subspace/modules/session/src/services/sessionProviderInput.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionProviderInput.ts
@@ -13,7 +13,10 @@ import {
 } from '@metorial-subspace/db';
 import { providerCombinationService } from '@metorial-subspace/module-provider-internal';
 import { sessionProviderCreatedQueue } from '../queues/lifecycle/sessionProvider';
-import { sessionTemplateProviderCreatedQueue } from '../queues/lifecycle/sessionTemplateProvider';
+import {
+  sessionTemplateProviderCreatedQueue,
+  sessionTemplateSyncHashQueue
+} from '../queues/lifecycle/sessionTemplateProvider';
 import { sessionProviderInclude } from './sessionProvider';
 import { sessionTemplateProviderInclude } from './sessionTemplateProvider';
 
@@ -258,6 +261,12 @@ class sessionProviderInputServiceImpl {
           sessionTemplateProviderCreatedQueue.add({ sessionTemplateProviderId: stp.id })
         );
       }
+
+      await addAfterTransactionHook(async () =>
+        sessionTemplateSyncHashQueue.add({
+          sessionTemplateId: d.template.id
+        })
+      );
 
       return sessionTemplateProviders;
     });

--- a/src/systems/subspace/modules/session/src/services/sessionTemplateProvider.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionTemplateProvider.ts
@@ -30,6 +30,7 @@ import {
   type DateFilter
 } from '@metorial-subspace/list-utils';
 import { checkTenant } from '@metorial-subspace/module-tenant';
+import { sessionTemplateSyncHashQueue } from '../queues/lifecycle/sessionTemplateProvider';
 import {
   sessionProviderInputService,
   type SessionProviderInput,
@@ -211,8 +212,7 @@ class sessionTemplateProviderServiceImpl {
                   : undefined!,
                 integrationInstanceGroupProviders
                   ? {
-                      integrationInstanceGroupProviderOid:
-                        integrationInstanceGroupProviders.in
+                      integrationInstanceGroupProviderOid: integrationInstanceGroupProviders.in
                     }
                   : undefined!,
 
@@ -323,7 +323,7 @@ class sessionTemplateProviderServiceImpl {
       assertCanWriteSessionTemplateProvider(d.sessionTemplateProvider, 'update');
     }
 
-    return await db.sessionTemplateProvider.update({
+    let sessionTemplateProvider = await db.sessionTemplateProvider.update({
       where: {
         oid: d.sessionTemplateProvider.oid,
         tenantOid: d.tenant.oid,
@@ -335,6 +335,12 @@ class sessionTemplateProviderServiceImpl {
       },
       include
     });
+
+    await sessionTemplateSyncHashQueue.add({
+      sessionTemplateId: sessionTemplateProvider.sessionTemplate.id
+    });
+
+    return sessionTemplateProvider;
   }
 
   async archiveSessionTemplateProvider(d: {
@@ -350,7 +356,7 @@ class sessionTemplateProviderServiceImpl {
       assertCanWriteSessionTemplateProvider(d.sessionTemplateProvider, 'archive');
     }
 
-    return await db.sessionTemplateProvider.update({
+    let sessionTemplateProvider = await db.sessionTemplateProvider.update({
       where: {
         oid: d.sessionTemplateProvider.oid,
         tenantOid: d.tenant.oid,
@@ -362,6 +368,12 @@ class sessionTemplateProviderServiceImpl {
       },
       include
     });
+
+    await sessionTemplateSyncHashQueue.add({
+      sessionTemplateId: sessionTemplateProvider.sessionTemplate.id
+    });
+
+    return sessionTemplateProvider;
   }
 }
 

--- a/src/systems/subspace/packages/presenters/src/sessionTemplate.ts
+++ b/src/systems/subspace/packages/presenters/src/sessionTemplate.ts
@@ -31,6 +31,7 @@ export let sessionTemplatePresenter = (
   id: sessionTemplate.id,
 
   status: sessionTemplate.status,
+  hash: sessionTemplate.hash,
 
   name: sessionTemplate.name,
   description: sessionTemplate.description,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new database column plus asynchronous recomputation logic; incorrect queueing/hash inputs could lead to stale or unexpected hashes, but changes are localized to session template/provider lifecycle.
> 
> **Overview**
> Adds a persisted `hash` field to `SessionTemplate` and exposes it via the `sessionTemplatePresenter` API output.
> 
> Introduces a new lifecycle queue (`sessionTemplateSyncHashQueue`) that computes a deterministic SHA-256 hash (via `canonicalize`) from the session template’s linkage + active providers/tool filters, and enqueues hash recomputation whenever session template providers are created/synced, updated, or archived; the new processor is registered in `lifecycleQueues`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b03a0b07b764529e366c35d4f3e70f497aa727f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->