### PR TITLE
Fix mcp response handling

### DIFF
--- a/src/systems/subspace/apps/controller/src/connection/api/mcp.ts
+++ b/src/systems/subspace/apps/controller/src/connection/api/mcp.ts
@@ -154,20 +154,15 @@ export let mcpRouter = createHono().all(`/:key?`, async c => {
       let res = await con.handleMessage(json, {
         waitForResponse: true
       });
-      if (!res) {
-        // return streamSSE(c, async stream => {
-        //   await delay(100); // ensure the message is sent before closing
-        // });
-
-        // if (!res) return c.text('No response');
-
-        return new Response(null, { status: 202 });
-      }
 
       if (con.connection) {
         c.res.headers.set('mcp-session-id', con.connection.token);
         c.res.headers.set('Metorial-Connection-Id', con.connection.id);
         c.res.headers.set('Metorial-Connection-Token', con.connection.token);
+      }
+
+      if (!res?.mcp) {
+        return new Response(null, { status: 202 });
       }
 
       return streamSSE(c, async stream => {

--- a/src/systems/subspace/apps/controller/src/connection/tests/mcp.e2e.test.ts
+++ b/src/systems/subspace/apps/controller/src/connection/tests/mcp.e2e.test.ts
@@ -76,6 +76,47 @@ describe('mcp.e2e', () => {
   );
 
   it(
+    'returns 202 Accepted with no body for streamable HTTP notifications',
+    { timeout: 120_000 },
+    async () => {
+      let ctx = await createMcpE2eContext(testDb, {
+        remoteServerBaseUrl: lifecycle.getRemoteServerBaseUrl(),
+        transportCase: defaultTransportCase
+      });
+
+      let mcp = createMcpTestClient({
+        baseUrl: ctx.proxyUrl,
+        transportType: defaultTransportCase.clientTransport,
+        fetch: localFetch
+      });
+
+      try {
+        await mcp.connect();
+
+        expect(mcp.transport).toBeInstanceOf(StreamableHTTPClientTransport);
+
+        let response = await localFetch(ctx.proxyUrl, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            'MCP-Session-ID': (mcp.transport as StreamableHTTPClientTransport).sessionId!
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'notifications/initialized'
+          })
+        });
+
+        expect(response.status).toBe(202);
+        expect(await response.text()).toBe('');
+      } finally {
+        await mcp.cleanup();
+      }
+    }
+  );
+
+  it(
     'continuously narrows deployment and session provider filters across tools, prompts, and resources',
     { timeout: 120_000 },
     async () => {

--- a/src/systems/subspace/modules/connection/src/mcp/sender.ts
+++ b/src/systems/subspace/modules/connection/src/mcp/sender.ts
@@ -128,6 +128,8 @@ export class McpSender {
         });
       }
 
+      if (res.mcp == null) return null;
+
       return {
         message,
         mcp: res.mcp


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts streamable HTTP MCP response semantics (returning `202` for notification/no-response cases), which can affect client compatibility and SSE behavior but is limited in scope and covered by a new e2e test.
> 
> **Overview**
> Fixes streamable HTTP MCP handling so `POST` requests that yield no MCP response (notably `notifications/*`) return **`202 Accepted` with an empty body** instead of attempting to open an SSE stream.
> 
> Propagates the “no MCP payload” case through the sender by treating `res.mcp == null` as *no response*, and adds an e2e test asserting the `202` behavior for `notifications/initialized`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f97c373a77745c76c3dc99b3fbaf0dafb66446e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->