### PR TITLE
Add api endpoint categories

### DIFF
--- a/src/backend/apis/core/src/controllers/index.ts
+++ b/src/backend/apis/core/src/controllers/index.ts
@@ -44,13 +44,16 @@ import { teamManagementController } from './management/team';
 import {
   callbackController,
   callbackDestinationController,
+  callbackDocsCategory,
   callbackEventController,
   callbackInstanceController,
   callbackNotificationController,
+  configurationDocsCategory,
   customProviderCodeController,
   customProviderCommitController,
   customProviderController,
   customProviderDeploymentController,
+  customProviderDocsCategory,
   customProviderEnvironmentController,
   customProviderVersionController,
   identityActorController,
@@ -59,6 +62,7 @@ import {
   identityDelegationConfigController,
   identityDelegationController,
   identityDelegationRequestController,
+  identityDocsCategory,
   magicMcpEndpointController,
   magicMcpGroupController,
   magicMcpServerController,
@@ -78,6 +82,7 @@ import {
   providerConfigVaultController,
   providerController,
   providerDeploymentController,
+  providerDocsCategory,
   providerGroupController,
   providerInvocationController,
   providerListingController,
@@ -90,6 +95,7 @@ import {
   publisherController,
   sessionConnectionController,
   sessionController,
+  sessionDocsCategory,
   sessionErrorController,
   sessionErrorGroupController,
   sessionEventController,
@@ -108,6 +114,108 @@ import {
   scmProvidersController,
   scmReposController
 } from './scm';
+
+let setControllerDocsMetadata = <
+  T extends { descriptor: Record<string, any>; handlers: Record<string, any> }
+>(
+  controller: T,
+  descriptor: Partial<T['descriptor']>
+) => {
+  Object.assign(controller.descriptor, descriptor);
+  return controller;
+};
+
+[
+  publisherController,
+  providerController,
+  providerCategoryController,
+  providerCollectionController,
+  providerGroupController,
+  providerListingController,
+  providerVersionController,
+  providerSpecificationController,
+  providerTriggerController,
+  providerToolController,
+  providerAuthMethodController
+].forEach(controller =>
+  setControllerDocsMetadata(controller, {
+    category: providerDocsCategory
+  })
+);
+
+[
+  customProviderController,
+  customProviderCodeController,
+  customProviderVersionController,
+  customProviderDeploymentController,
+  customProviderCommitController,
+  customProviderEnvironmentController
+].forEach(controller =>
+  setControllerDocsMetadata(controller, {
+    category: customProviderDocsCategory
+  })
+);
+
+[
+  sessionController,
+  sessionTemplateController,
+  sessionTemplateProviderController,
+  sessionProviderController,
+  sessionParticipantController,
+  sessionMessageController,
+  sessionConnectionController,
+  sessionErrorController,
+  sessionErrorGroupController,
+  sessionEventController,
+  toolCallController,
+  providerRunController
+].forEach(controller =>
+  setControllerDocsMetadata(controller, {
+    category: sessionDocsCategory
+  })
+);
+
+[
+  identityController,
+  identityActorController,
+  identityCredentialController,
+  identityDelegationController,
+  identityDelegationConfigController,
+  identityDelegationRequestController
+].forEach(controller =>
+  setControllerDocsMetadata(controller, {
+    category: identityDocsCategory
+  })
+);
+
+[
+  providerDeploymentController,
+  providerConfigController,
+  providerConfigVaultController,
+  providerAuthConfigController,
+  providerAuthConfigEventController,
+  providerAuthConfigErrorController,
+  providerAuthCredentialsController,
+  providerSetupSessionController,
+  providerAuthImportController,
+  providerAuthExportController
+].forEach(controller =>
+  setControllerDocsMetadata(controller, {
+    category: configurationDocsCategory
+  })
+);
+
+[
+  callbackController,
+  callbackDestinationController,
+  callbackEventController,
+  callbackInstanceController,
+  callbackNotificationController
+].forEach(controller =>
+  setControllerDocsMetadata(controller, {
+    category: callbackDocsCategory
+  })
+);
 
 export let magnetarController = Controller.create<any>(
   {

--- a/src/backend/apis/core/src/controllers/provider/customProviderCommit.ts
+++ b/src/backend/apis/core/src/controllers/provider/customProviderCommit.ts
@@ -32,7 +32,8 @@ export let customProviderCommitController = Controller.create(
   {
     name: 'Custom Provider Commits',
     description:
-      'Commits represent version promotions between environments. Merge versions from one environment to another or rollback to a previous version.'
+      'Commits represent version promotions between environments. Merge versions from one environment to another or rollback to a previous version.',
+    hideInDocs: true
   },
   {
     list: instanceGroup

--- a/src/backend/apis/core/src/controllers/provider/customProviderEnvironment.ts
+++ b/src/backend/apis/core/src/controllers/provider/customProviderEnvironment.ts
@@ -32,7 +32,8 @@ export let customProviderEnvironmentController = Controller.create(
   {
     name: 'Custom Provider Environments',
     description:
-      'Environments represent deployment targets for custom provider versions (e.g., staging, production).'
+      'Environments represent deployment targets for custom provider versions (e.g., staging, production).',
+    hideInDocs: true
   },
   {
     list: instanceGroup

--- a/src/backend/apis/core/src/controllers/provider/docsCategories.ts
+++ b/src/backend/apis/core/src/controllers/provider/docsCategories.ts
@@ -1,0 +1,37 @@
+import { createCategory } from '@metorial/rest';
+
+export let providerDocsCategory = createCategory({
+  id: 'provider',
+  name: 'Providers',
+  indexHint: 10
+});
+
+export let customProviderDocsCategory = createCategory({
+  id: 'custom-provider',
+  name: 'Custom Providers',
+  indexHint: 20
+});
+
+export let sessionDocsCategory = createCategory({
+  id: 'session',
+  name: 'Sessions',
+  indexHint: 30
+});
+
+export let identityDocsCategory = createCategory({
+  id: 'identity',
+  name: 'Identity',
+  indexHint: 40
+});
+
+export let configurationDocsCategory = createCategory({
+  id: 'configuration',
+  name: 'Configurations',
+  indexHint: 50
+});
+
+export let callbackDocsCategory = createCategory({
+  id: 'callback',
+  name: 'Callbacks',
+  indexHint: 60
+});

--- a/src/backend/apis/core/src/controllers/provider/index.ts
+++ b/src/backend/apis/core/src/controllers/provider/index.ts
@@ -9,6 +9,7 @@ export * from './customProviderCommit';
 export * from './customProviderDeployment';
 export * from './customProviderEnvironment';
 export * from './customProviderVersion';
+export * from './docsCategories';
 export * from './identity';
 export * from './identityActor';
 export * from './identityCredential';

--- a/src/backend/apis/core/src/controllers/provider/magicMcpEndpoint.ts
+++ b/src/backend/apis/core/src/controllers/provider/magicMcpEndpoint.ts
@@ -80,7 +80,8 @@ let resolveMagicMcpEndpointServers = (d: {
     throw new ServiceError(
       badRequestError({
         message: 'At least one server is required.',
-        description: 'Provide either `magic_mcp_server_ids` or `servers` with at least one entry.'
+        description:
+          'Provide either `magic_mcp_server_ids` or `servers` with at least one entry.'
       })
     );
   }
@@ -92,7 +93,8 @@ export let magicMcpEndpointController = Controller.create(
   {
     name: 'Magic MCP Endpoints',
     description:
-      'Magic MCP endpoints combine multiple Magic MCP servers behind one routed connection target.'
+      'Magic MCP endpoints combine multiple Magic MCP servers behind one routed connection target.',
+    hideInDocs: true
   },
   {
     list: instanceGroup

--- a/src/backend/apis/core/src/controllers/provider/magicMcpGroup.ts
+++ b/src/backend/apis/core/src/controllers/provider/magicMcpGroup.ts
@@ -34,7 +34,8 @@ let magicMcpGroupStatusValues = ['active', 'archived', 'deleted'] as const;
 export let magicMcpGroupController = Controller.create(
   {
     name: 'Magic MCP Groups',
-    description: 'Magic MCP groups categorize servers and can be bound to token access.'
+    description: 'Magic MCP groups categorize servers and can be bound to token access.',
+    hideInDocs: true
   },
   {
     list: instanceGroup

--- a/src/backend/apis/core/src/controllers/provider/magicMcpServer.ts
+++ b/src/backend/apis/core/src/controllers/provider/magicMcpServer.ts
@@ -3,9 +3,9 @@ import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
 import { MagicMcpServerStatus } from '@metorial/db';
 import {
-  grantConsumerOwnedMagicMcpServerAccess,
   consumerProfileService,
-  consumerService
+  consumerService,
+  grantConsumerOwnedMagicMcpServerAccess
 } from '@metorial/module-consumer';
 import { magicMcpServerService } from '@metorial/module-magic';
 import { subspaceSessionTemplateService } from '@metorial/module-subspace';
@@ -123,7 +123,8 @@ export let magicMcpServerController = Controller.create(
   {
     name: 'Magic MCP Servers',
     description:
-      'Magic MCP servers are stable MCP entrypoints backed by one Subspace session template.'
+      'Magic MCP servers are stable MCP entrypoints backed by one Subspace session template.',
+    hideInDocs: true
   },
   {
     list: instanceGroup

--- a/src/backend/apis/core/src/controllers/provider/magicMcpSession.ts
+++ b/src/backend/apis/core/src/controllers/provider/magicMcpSession.ts
@@ -33,7 +33,8 @@ export let magicMcpSessionController = Controller.create(
   {
     name: 'Magic MCP Sessions',
     description:
-      'Magic MCP sessions map a Magic MCP server to one Subspace session and are created on demand by the MCP connection API.'
+      'Magic MCP sessions map a Magic MCP server to one Subspace session and are created on demand by the MCP connection API.',
+    hideInDocs: true
   },
   {
     list: instanceGroup

--- a/src/backend/apis/core/src/controllers/provider/magicMcpToken.ts
+++ b/src/backend/apis/core/src/controllers/provider/magicMcpToken.ts
@@ -42,7 +42,8 @@ export let magicMcpTokenController = Controller.create(
   {
     name: 'Magic MCP Tokens',
     description:
-      'Magic MCP tokens authorize access to Magic MCP servers via the /magic connection API.'
+      'Magic MCP tokens authorize access to Magic MCP servers via the /magic connection API.',
+    hideInDocs: true
   },
   {
     list: instanceGroup

--- a/src/backend/apis/core/src/controllers/provider/providerPublisher.ts
+++ b/src/backend/apis/core/src/controllers/provider/providerPublisher.ts
@@ -29,7 +29,8 @@ export let publisherController = Controller.create(
   {
     name: 'Publishers',
     description:
-      'A publisher is the organization or individual who created and maintains a provider.'
+      'A publisher is the organization or individual who created and maintains a provider.',
+    hideInDocs: true
   },
   {
     list: instanceGroup

--- a/src/backend/apis/core/src/controllers/provider/providerTemplate.ts
+++ b/src/backend/apis/core/src/controllers/provider/providerTemplate.ts
@@ -57,7 +57,8 @@ export let providerTemplateController = Controller.create(
   {
     name: 'Provider Templates',
     description:
-      'Provider templates are reusable, consumer-facing wrappers around provider deployments.'
+      'Provider templates are reusable, consumer-facing wrappers around provider deployments.',
+    hideInDocs: true
   },
   {
     list: instanceGroup

--- a/src/backend/apis/core/src/controllers/provider/sessionErrorGroup.ts
+++ b/src/backend/apis/core/src/controllers/provider/sessionErrorGroup.ts
@@ -30,7 +30,8 @@ export let sessionErrorGroupController = Controller.create(
   {
     name: 'Session Error Groups',
     description:
-      'Session error groups aggregate similar errors that occurred during a session. This read-only resource helps identify patterns in errors.'
+      'Session error groups aggregate similar errors that occurred during a session. This read-only resource helps identify patterns in errors.',
+    hideInDocs: true
   },
   {
     list: instanceGroup

--- a/src/backend/apis/core/src/controllers/provider/sessionEvent.ts
+++ b/src/backend/apis/core/src/controllers/provider/sessionEvent.ts
@@ -45,7 +45,8 @@ export let sessionEventController = Controller.create(
   {
     name: 'Session Events',
     description:
-      'Session events represent significant occurrences during a session, such as errors or state changes. This read-only resource provides visibility into session activity.'
+      'Session events represent significant occurrences during a session, such as errors or state changes. This read-only resource provides visibility into session activity.',
+    hideInDocs: true
   },
   {
     list: instanceGroup

--- a/src/packages/server/rest/src/controller.ts
+++ b/src/packages/server/rest/src/controller.ts
@@ -29,6 +29,20 @@ export type EndpointDescriptor = {
   deprecated?: boolean;
 };
 
+export type ControllerCategory = {
+  id: string;
+  name: string;
+  description?: string;
+  indexHint?: number;
+};
+
+export type ControllerDescriptor = EndpointDescriptor & {
+  category?: ControllerCategory;
+};
+
+export let createCategory = <Category extends ControllerCategory>(category: Category): Category =>
+  category;
+
 export type GetHandlerContext<
   AuthInfo,
   Body,
@@ -168,11 +182,11 @@ export class Group<AuthInfo, Context extends { [key: string]: any } = {}> {
 export type IController<AuthInfo> = {
   [key: string]:
     | Handler<AuthInfo, any, any, any>
-    | { handlers: IController<AuthInfo>; descriptor: EndpointDescriptor };
+    | { handlers: IController<AuthInfo>; descriptor: ControllerDescriptor };
 };
 
 export class Controller {
-  static create<AuthInfo>(descriptor: EndpointDescriptor, handlers: IController<AuthInfo>) {
+  static create<AuthInfo>(descriptor: ControllerDescriptor, handlers: IController<AuthInfo>) {
     return {
       descriptor,
       handlers

--- a/src/packages/server/rest/src/index.ts
+++ b/src/packages/server/rest/src/index.ts
@@ -1,4 +1,4 @@
-export { Controller, Group, Path } from './controller';
+export { Controller, Group, Path, createCategory } from './controller';
 export * from './ratelimit';
 export * from './server';
 export * from './types';

--- a/src/packages/server/rest/src/introspect.ts
+++ b/src/packages/server/rest/src/introspect.ts
@@ -1,9 +1,9 @@
-import { EndpointDescriptor, Handler, IController } from './controller';
+import { ControllerDescriptor, Handler, IController } from './controller';
 
 export let introspectApi = (version: {
   rootController: {
     handlers: IController<any>;
-    descriptor: EndpointDescriptor;
+    descriptor: ControllerDescriptor;
   };
   displayVersion: string;
   version: string;
@@ -16,6 +16,7 @@ export let introspectApi = (version: {
     name: string;
     description: string;
     deprecated: boolean;
+    category?: ControllerDescriptor['category'];
   }[] = [];
 
   let endpoints: any[] = [];
@@ -40,14 +41,15 @@ export let introspectApi = (version: {
 
   let resolveController = (i: {
     handlers: IController<any>;
-    descriptor: EndpointDescriptor;
+    descriptor: ControllerDescriptor;
   }) => {
     let controller = {
       id: `controller_${idIndex++}`,
       name: i.descriptor.name,
       description: i.descriptor.description,
       deprecated: !!i.descriptor.deprecated,
-      hideInDocs: !!i.descriptor.hideInDocs
+      hideInDocs: !!i.descriptor.hideInDocs,
+      category: i.descriptor.category
     };
 
     controllers.push(controller);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the shared REST controller descriptor and API introspection output shape, which may affect any tooling consuming introspection results or controller typing.
> 
> **Overview**
> Adds first-class **controller categories** to the REST framework by extending controller descriptors with an optional `category` object (plus a `createCategory` helper) and emitting that category in `introspectApi` results.
> 
> In core API controllers, introduces shared docs categories (`Providers`, `Custom Providers`, `Sessions`, `Identity`, `Configurations`, `Callbacks`) and assigns them to groups of controllers via a helper, while also marking several internal controllers as `hideInDocs` (e.g., Magic MCP, provider templates, custom provider env/commit, session events/error groups, publishers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee198900fd993f6d4139d32b7f7fcf88e79f7e07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->