### PR TITLE
Implement integration frontend

### DIFF
--- a/src/backend/apis/core/src/controllers/provider/magicMcpServer.ts
+++ b/src/backend/apis/core/src/controllers/provider/magicMcpServer.ts
@@ -135,9 +135,7 @@ let getMagicMcpServerPresentationData = async (d: {
   portal?: Parameters<typeof magicMcpServerPresenter.present>[0]['portal'];
 }) => {
   let magicMcpServer =
-    !d.magicMcpServer.hasSubspaceBacking ||
-    !d.magicMcpServer.newSubspaceSessionTemplateId ||
-    !d.magicMcpServer.subspaceEphemeralManagedSessionId
+    !d.magicMcpServer.hasSubspaceBacking
       ? await ensureMagicMcpServerBacking({
           instance: d.instance,
           server: d.magicMcpServer

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrationSetupSession.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrationSetupSession.ts
@@ -90,7 +90,6 @@ export let v1IntegrationSetupSessionPresenter = Presenter.create(integrationSetu
         v.object({
           object: v.literal('integration.setup_session.step'),
           id: v.string(),
-          index: v.number(),
           status: v.enumOf([
             'configured',
             'pending',

--- a/src/backend/apis/core/src/presenters/implementation/provider/magicMcpServer.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/magicMcpServer.ts
@@ -4,8 +4,6 @@ import { getConfig } from '@metorial/config';
 import { Presenter } from '@metorial/presenter';
 import { magicMcpServerType } from '../../types';
 import { v1ConsumerIntegrationPresenter } from './consumerOwnership';
-import { v1IntegrationPresenter } from './integration';
-import { v1IntegrationInstancePresenter } from './integrationInstance';
 import {
   dashboardMagicMcpServerProviderPresenter,
   v1MagicMcpServerProviderPresenter
@@ -21,11 +19,6 @@ let magicMcpServerSchema = v.object({
     'inherited_from_provider_template',
     'inherited_from_integration'
   ]),
-  provider_template_id: v.nullable(v.string()),
-  provider_template_backing_id: v.nullable(v.string()),
-  owner_integration_id: v.nullable(v.string()),
-  integration_id: v.nullable(v.string()),
-  integration_instance_id: v.nullable(v.string()),
   endpoints: v.array(
     v.object({
       id: v.string(),
@@ -33,8 +26,6 @@ let magicMcpServerSchema = v.object({
       url: v.string()
     })
   ),
-  integration: v.nullable(v1IntegrationPresenter.schema),
-  integration_instance: v.nullable(v1IntegrationInstancePresenter.schema),
   providers: v.array(v1MagicMcpServerProviderPresenter.schema),
   name: v.nullable(v.string()),
   description: v.nullable(v.string()),

--- a/src/backend/modules/magic/src/queues/lifecycle/magicMcpEndpoint.ts
+++ b/src/backend/modules/magic/src/queues/lifecycle/magicMcpEndpoint.ts
@@ -62,13 +62,17 @@ export let magicMcpEndpointDeletedQueueProcessor = magicMcpEndpointDeletedQueue.
       select: { subspaceSessionTemplateId: true },
       distinct: ['subspaceSessionTemplateId']
     });
-    let uniqueSubspaceTemplateIds = uniqueSubspaceTemplatesRaw
-      .map(record => record.subspaceSessionTemplateId)
-      .concat([
-        magicMcpEndpoint.legacySubspaceSessionTemplateId,
-        magicMcpEndpoint.newSubspaceSessionTemplateId
-      ])
-      .filter((value): value is string => !!value);
+    let uniqueSubspaceTemplateIds = Array.from(
+      new Set(
+        uniqueSubspaceTemplatesRaw
+          .map(record => record.subspaceSessionTemplateId)
+          .concat([
+            magicMcpEndpoint.legacySubspaceSessionTemplateId,
+            magicMcpEndpoint.newSubspaceSessionTemplateId
+          ])
+          .filter((value): value is string => !!value)
+      )
+    );
 
     let uniqueSubspaceSessionsRaw = await db.magicMcpSession.findMany({
       where: { magicMcpEndpointOid: magicMcpEndpoint.oid },

--- a/src/backend/modules/magic/src/queues/reconcileMagicMcpServerBacking.ts
+++ b/src/backend/modules/magic/src/queues/reconcileMagicMcpServerBacking.ts
@@ -27,11 +27,7 @@ export let reconcileMagicMcpServerBackingManyQueueProcessor =
       where: {
         status: 'active',
         id: data.cursor ? { gt: data.cursor } : undefined,
-        OR: [
-          { hasSubspaceBacking: false },
-          { newSubspaceSessionTemplateId: null },
-          { subspaceEphemeralManagedSessionId: null }
-        ]
+        hasSubspaceBacking: false
       },
       select: { id: true },
       take: BATCH_SIZE,

--- a/src/backend/modules/magic/src/services/magicMcpEndpoint.ts
+++ b/src/backend/modules/magic/src/services/magicMcpEndpoint.ts
@@ -158,12 +158,7 @@ export let ensureMagicMcpEndpointBacking = async (d: {
   endpoint: MagicMcpEndpointWithRelations;
   force?: boolean;
 }) => {
-  if (
-    !d.force &&
-    d.endpoint.hasSubspaceBacking &&
-    d.endpoint.newSubspaceSessionTemplateId &&
-    d.endpoint.subspaceEphemeralManagedSessionId
-  ) {
+  if (!d.force && d.endpoint.hasSubspaceBacking) {
     return {
       ...d.endpoint,
       instance: d.instance

--- a/src/backend/modules/magic/src/services/magicMcpServer.ts
+++ b/src/backend/modules/magic/src/services/magicMcpServer.ts
@@ -147,9 +147,6 @@ let normalizeMagicMcpServerOwnerInput = (d: MagicMcpServerOwnerInput) => {
   };
 };
 
-let isInheritedMagicMcpServer = (server: Pick<MagicMcpServer, 'ownerType'>) =>
-  server.ownerType === 'provider_template' || server.ownerType === 'integration';
-
 let upsertProviderTemplateBackingForMagicMcpServer = async (d: {
   instance: Instance;
   providerTemplateId?: string | null;

--- a/src/backend/modules/magic/src/services/magicMcpServer.ts
+++ b/src/backend/modules/magic/src/services/magicMcpServer.ts
@@ -214,7 +214,7 @@ let listMagicMcpServerProviderInputsForSessionTemplate = async (d: {
     status: ['active'],
     sessionTemplateIds: [d.sessionTemplateId]
   });
-  let providers = (await paginator.run({ limit: 1000 })).items;
+  let providers = (await paginator.run({ limit: 100 })).items;
 
   return providers.map(provider => ({
     providerDeploymentId: provider.deployment.id,
@@ -259,12 +259,7 @@ export let ensureMagicMcpServerBacking = async (d: {
   providers?: MagicMcpServerProviderInput[];
   force?: boolean;
 }) => {
-  if (
-    !d.force &&
-    d.server.hasSubspaceBacking &&
-    d.server.newSubspaceSessionTemplateId &&
-    d.server.subspaceEphemeralManagedSessionId
-  ) {
+  if (!d.force && d.server.hasSubspaceBacking) {
     return d.server;
   }
 

--- a/src/backend/modules/magic/test/magicMcpServerBacking.test.ts
+++ b/src/backend/modules/magic/test/magicMcpServerBacking.test.ts
@@ -123,7 +123,7 @@ describe('ensureMagicMcpServerBacking', () => {
         ownerType: 'server_owned',
         providerTemplateId: null,
         subspaceOwnerIntegrationId: null,
-        hasSubspaceBacking: true,
+        hasSubspaceBacking: false,
         legacySubspaceSessionTemplateId: 'template-legacy',
         newSubspaceSessionTemplateId: null,
         subspaceEphemeralManagedSessionId: null,

--- a/src/backend/modules/subspace/src/services/sessionTemplate.ts
+++ b/src/backend/modules/subspace/src/services/sessionTemplate.ts
@@ -37,7 +37,15 @@ export let subspaceSessionTemplateService = createSubspaceService(
           ]
         }
       });
-      if ((magicMcpLink1 || magicMcpLink2) && !arg0._allowMagicMcpUpdate) {
+      let magicMcpLink3 = await db.magicMcpEndpoint.findFirst({
+        where: {
+          OR: [
+            { legacySubspaceSessionTemplateId: arg0.sessionTemplateId },
+            { newSubspaceSessionTemplateId: arg0.sessionTemplateId }
+          ]
+        }
+      });
+      if ((magicMcpLink1 || magicMcpLink2 || magicMcpLink3) && !arg0._allowMagicMcpUpdate) {
         throw new ServiceError(
           badRequestError({
             message: 'This session template cannot be updated.'
@@ -72,7 +80,15 @@ export let subspaceSessionTemplateService = createSubspaceService(
           ]
         }
       });
-      if ((magicMcpLink1 || magicMcpLink2) && !arg0._allowMagicMcpDelete) {
+      let magicMcpLink3 = await db.magicMcpEndpoint.findFirst({
+        where: {
+          OR: [
+            { legacySubspaceSessionTemplateId: arg0.sessionTemplateId },
+            { newSubspaceSessionTemplateId: arg0.sessionTemplateId }
+          ]
+        }
+      });
+      if ((magicMcpLink1 || magicMcpLink2 || magicMcpLink3) && !arg0._allowMagicMcpDelete) {
         throw new ServiceError(
           badRequestError({
             message: 'This session template cannot be deleted.'

--- a/src/frontend/apps/dashboard/src/slices/product/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/index.tsx
@@ -757,6 +757,10 @@ export let productIdentitySlice = createSlice([
             element: <IdentityListLayout />,
             children: [
               {
+                path: 'actors',
+                element: <IdentityActorsPage />
+              },
+              {
                 path: 'identities',
                 element: <IdentitiesPage />
               },
@@ -776,18 +780,9 @@ export let productIdentitySlice = createSlice([
               }
             ]
           },
-
           {
-            children: [
-              {
-                path: 'consumers',
-                element: <ConsumersPage />
-              },
-              {
-                path: 'actors',
-                element: <IdentityActorsPage />
-              }
-            ]
+            path: 'consumers',
+            element: <ConsumersPage />
           },
 
           {

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/(list)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/(list)/_layout.tsx
@@ -10,6 +10,7 @@ import {
 import { Button, Error, LinkTabs } from '@metorial/ui';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { Upgrade } from '../../../../../components/emptyState';
+import { showIdentityActorFormModal } from '../../../scenes/identity/actorModal';
 import { showIdentityDelegationConfigFormModal } from '../../../scenes/identity/delegationConfigModal';
 
 export let isIdentityEnabled = (flags: Record<string, boolean> | undefined) =>
@@ -43,7 +44,9 @@ export let IdentityListLayout = () => {
     ? 'delegation-configs'
     : pathname.endsWith('/delegations')
       ? 'delegations'
-      : 'actors';
+      : pathname.endsWith('/actors')
+        ? 'actors'
+        : 'identities';
 
   return renderWithLoader({ instance, organization, project, flags })(
     ({ instance, organization, project, flags }) => (
@@ -52,7 +55,27 @@ export let IdentityListLayout = () => {
           title="Identity"
           description="Manage identities and identity delegation to enable secure and flexible access control for agents and humans."
           actions={
-            activeTab === 'delegation-configs' ? (
+            activeTab === 'actors' ? (
+              <Button
+                size="2"
+                onClick={() =>
+                  showIdentityActorFormModal({
+                    instanceId: instance.data.id,
+                    onCreate: actor =>
+                      navigate(
+                        Paths.instance.identity.actor(
+                          organization.data,
+                          project.data,
+                          instance.data,
+                          actor.id
+                        )
+                      )
+                  })
+                }
+              >
+                Create Actor
+              </Button>
+            ) : activeTab === 'delegation-configs' ? (
               <Button
                 size="2"
                 onClick={() =>
@@ -82,6 +105,14 @@ export let IdentityListLayout = () => {
             {
               label: 'Identities',
               to: Paths.instance.identity.identities(
+                organization.data,
+                project.data,
+                instance.data
+              )
+            },
+            {
+              label: 'Actors',
+              to: Paths.instance.identity.actors(
                 organization.data,
                 project.data,
                 instance.data

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/(list)/actors.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/(list)/actors.tsx
@@ -1,71 +1,11 @@
 import { renderWithLoader } from '@metorial/data-hooks';
-import { Paths } from '@metorial/frontend-config';
-import { ContentLayout, PageHeader } from '@metorial/layout';
-import {
-  useCurrentInstance,
-  useCurrentOrganization,
-  useCurrentProject,
-  useDashboardFlags
-} from '@metorial/state';
-import { Button } from '@metorial/ui';
-import { useNavigate } from 'react-router-dom';
-import { showIdentityActorFormModal } from '../../../scenes/identity/actorModal';
+import { useCurrentInstance } from '@metorial/state';
 import { IdentityActorsTable } from '../../../scenes/identity/actorsTable';
-import {
-  getIdentityUnavailableError,
-  getIdentityUpgrade,
-  isIdentityEnabled,
-  isPaidIdentityEnabled
-} from './_layout';
 
 export let IdentityActorsPage = () => {
   let instance = useCurrentInstance();
-  let organization = useCurrentOrganization();
-  let project = useCurrentProject();
-  let flags = useDashboardFlags();
-  let navigate = useNavigate();
 
-  return (
-    <ContentLayout>
-      <PageHeader
-        title="Actors"
-        description="Manage the actors that can be assigned identities and delegated access."
-        actions={
-          <Button
-            size="2"
-            onClick={() => {
-              if (!instance.data) return;
-
-              showIdentityActorFormModal({
-                instanceId: instance.data.id,
-                onCreate: actor =>
-                  navigate(
-                    Paths.instance.identity.actor(
-                      organization.data,
-                      project.data,
-                      instance.data,
-                      actor.id
-                    )
-                  )
-              });
-            }}
-          >
-            Create Actor
-          </Button>
-        }
-      />
-
-      {renderWithLoader({ instance, flags })(({ instance, flags }) => (
-        <>
-          {!isIdentityEnabled(flags.data.flags) ? (
-            getIdentityUnavailableError()
-          ) : !isPaidIdentityEnabled(flags.data.flags) ? (
-            getIdentityUpgrade()
-          ) : (
-            <IdentityActorsTable instanceId={instance.data.id} />
-          )}
-        </>
-      ))}
-    </ContentLayout>
-  );
+  return renderWithLoader({ instance })(({ instance }) => (
+    <IdentityActorsTable instanceId={instance.data.id} />
+  ));
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/(list)/consumers.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/(list)/consumers.tsx
@@ -28,8 +28,8 @@ export let ConsumersPage = () => {
   return (
     <ContentLayout>
       <PageHeader
-        title="Consumers"
-        description="Manage the access that consumers have across Metorial."
+        title="Accounts"
+        description="Manage the access that accounts have across Metorial."
         actions={
           <Button
             size="2"
@@ -50,7 +50,7 @@ export let ConsumersPage = () => {
               });
             }}
           >
-            Create Consumer
+            Create Account
           </Button>
         }
       />

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/consumer/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/consumer/_layout.tsx
@@ -25,7 +25,7 @@ export let ConsumerLayout = () => {
         description={consumer.data?.email ?? undefined}
         pagination={[
           {
-            label: 'Consumers',
+            label: 'Accounts',
             href: Paths.instance.identity.consumers(
               organization.data,
               project.data,

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/consumer/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/consumer/index.tsx
@@ -70,7 +70,7 @@ export let ConsumerPage = () => {
 
         <Box
           title="Profiles"
-          description="Profiles linked to this consumer across consumer surfaces."
+          description="Profiles linked to this account across account surfaces."
         >
           {renderWithPagination(profiles)(profiles => (
             <>
@@ -100,7 +100,7 @@ export let ConsumerPage = () => {
 
               {profiles.data.items.length === 0 && (
                 <Text size="2" color="gray600" align="center" style={{ marginTop: 10 }}>
-                  No profiles for this consumer.
+                  No profiles for this account.
                 </Text>
               )}
             </>
@@ -109,7 +109,7 @@ export let ConsumerPage = () => {
 
         <Spacer size={20} />
 
-        <Box title="Actors" description="Identity actors linked to this consumer.">
+        <Box title="Actors" description="Identity actors linked to this account.">
           {renderWithPagination(actors)(actors => (
             <>
               <Table
@@ -142,7 +142,7 @@ export let ConsumerPage = () => {
 
               {actors.data.items.length === 0 && (
                 <Text size="2" color="gray600" align="center" style={{ marginTop: 10 }}>
-                  No actors for this consumer.
+                  No actors for this account.
                 </Text>
               )}
             </>

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/consumer/settings.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/consumer/settings.tsx
@@ -30,7 +30,7 @@ export let ConsumerSettingsPage = () => {
   });
 
   return renderWithLoader({ consumer })(() => (
-    <Box title="Consumer Settings" description="Update the saved details for this consumer.">
+    <Box title="Account Settings" description="Update the saved details for this account.">
       <form onSubmit={form.handleSubmit}>
         <Input label="Name" required {...form.getFieldProps('name')} />
         <form.RenderError field="name" />

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration/_layout.tsx
@@ -1,16 +1,126 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { renderWithLoader, useForm } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
+  IntegrationPreview,
+  useCreateIntegrationSetupSession,
   useCurrentInstance,
   useCurrentOrganization,
   useCurrentProject,
   useIntegration
 } from '@metorial/state';
-import { Button, Flex, LinkTabs } from '@metorial/ui';
+import {
+  Button,
+  Checkbox,
+  Copy,
+  Dialog,
+  Flex,
+  Input,
+  LinkTabs,
+  Spacer,
+  Text,
+  showModal
+} from '@metorial/ui';
+import { useState } from 'react';
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { DeletedRecordCallout } from '../../../scenes/deletedRecordCallout';
 import { showIntegrationInstanceFormModal } from '../../../scenes/integrations/instancesTable';
+
+let showIntegrationSetupSessionModal = (p: {
+  instanceId: string;
+  integration: IntegrationPreview;
+}) =>
+  showModal(({ dialogProps, close }) => {
+    let createSetupSession = useCreateIntegrationSetupSession();
+    let [toolFiltersEnabled, setToolFiltersEnabled] = useState(false);
+    let [createdUrl, setCreatedUrl] = useState<string | null>(null);
+    let form = useForm({
+      initialValues: {
+        name: `${p.integration.name} Setup`,
+        description: ''
+      },
+      onSubmit: async values => {
+        let [created] = await createSetupSession.mutate({
+          instanceId: p.instanceId,
+          integrationId: p.integration.id,
+          name: values.name.trim(),
+          description: values.description.trim() || undefined,
+          toolFiltersEnabled
+        });
+
+        if (!created) return;
+        setCreatedUrl(created.url);
+      },
+      schema: yup =>
+        yup.object({
+          name: yup.string().trim().required('Name is required'),
+          description: yup.string()
+        })
+    });
+
+    return (
+      <Dialog.Wrapper {...dialogProps} width={650}>
+        <Dialog.Title>Create Setup Session</Dialog.Title>
+        <Dialog.Description>
+          Create a shared setup link for configuring all providers in {p.integration.name}.
+        </Dialog.Description>
+
+        {createdUrl ? (
+          <>
+            <Text size="2" color="gray600">
+              Share this setup link with the user who should configure the integration.
+            </Text>
+            <Spacer size={12} />
+            <Copy label="Setup Link" value={createdUrl} />
+            <Spacer size={18} />
+            <Dialog.Actions>
+              <Button type="button" variant="outline" onClick={close}>
+                Close
+              </Button>
+              <Button
+                type="button"
+                onClick={() => window.open(createdUrl, '_blank', 'noopener,noreferrer')}
+              >
+                Open
+              </Button>
+            </Dialog.Actions>
+          </>
+        ) : (
+          <form onSubmit={form.handleSubmit}>
+            <Input label="Name" required {...form.getFieldProps('name')} />
+            <form.RenderError field="name" />
+
+            <Spacer size={10} />
+
+            <Input label="Description" {...form.getFieldProps('description')} />
+            <form.RenderError field="description" />
+
+            <Spacer size={12} />
+
+            <Checkbox
+              checked={toolFiltersEnabled}
+              label="Enable tool filters"
+              description="Let the setup flow collect tool filter settings when the integration allows it."
+              onCheckedChange={checked => setToolFiltersEnabled(!!checked)}
+            />
+
+            <Spacer size={18} />
+
+            <Dialog.Actions>
+              <Button type="button" variant="outline" onClick={close}>
+                Cancel
+              </Button>
+              <Button type="submit" loading={createSetupSession.isPending}>
+                Create Setup Session
+              </Button>
+            </Dialog.Actions>
+
+            <createSetupSession.RenderError />
+          </form>
+        )}
+      </Dialog.Wrapper>
+    );
+  });
 
 export let IntegrationLayout = () => {
   let instance = useCurrentInstance();
@@ -60,6 +170,20 @@ export let IntegrationLayout = () => {
               >
                 Edit
               </Button> */}
+
+              <Button
+                size="2"
+                variant="outline"
+                onClick={() =>
+                  instance.data &&
+                  showIntegrationSetupSessionModal({
+                    instanceId: instance.data.id,
+                    integration: integration.data!
+                  })
+                }
+              >
+                Create Setup Session
+              </Button>
 
               <Button
                 size="2"

--- a/src/frontend/apps/dashboard/src/slices/product/pages/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/_layout.tsx
@@ -228,7 +228,7 @@ export let ProjectPageLayout = () => {
           items: [
             {
               icon: <RiUser3Line />,
-              label: 'Consumers',
+              label: 'Accounts',
               to: Paths.instance.identity.consumers(...params),
               getProps: i => ({
                 isActive: checkPath(i) || i.pathname.includes('/identity/consumer/')

--- a/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/_layout.tsx
@@ -3,11 +3,13 @@ import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
   useCreateSession,
+  useCreateMagicMcpServerProvider,
   useCurrentInstance,
   useCurrentOrganization,
   useCurrentProject,
   useMagicMcpServer,
-  useSessionTemplateProviders
+  useMagicMcpServerProviders,
+  useUpdateMagicMcpServerProvider
 } from '@metorial/state';
 import { Button, Flex, LinkTabs } from '@metorial/ui';
 import { useState } from 'react';
@@ -22,11 +24,14 @@ export let MagicMcpServerLayout = () => {
   let navigate = useNavigate();
   let { magicMcpServerId } = useParams();
   let server = useMagicMcpServer(instance.data?.id, magicMcpServerId);
-  let providers = useSessionTemplateProviders(
+  let providers = useMagicMcpServerProviders(
     instance.data?.id,
-    server.data?.sessionTemplateId
+    magicMcpServerId,
+    { status: ['active'] }
   );
   let createSession = useCreateSession(instance.data?.id);
+  let createProvider = useCreateMagicMcpServerProvider();
+  let updateProvider = useUpdateMagicMcpServerProvider();
   let [isCreatingSession, setIsCreatingSession] = useState(false);
   let pathname = useLocation().pathname;
   let isTokensPage = pathname.endsWith('/tokens');
@@ -39,19 +44,26 @@ export let MagicMcpServerLayout = () => {
   ] as const;
 
   let handleOpenExplorer = async () => {
-    let activeSessionTemplateId = server.data?.sessionTemplateId;
-    if (
-      isCreatingSession ||
-      !instance.data ||
-      !activeSessionTemplateId ||
-      !providers.data?.items.length
-    )
+    let activeProviders =
+      server.data?.providers.filter(
+        provider => provider.status === 'active' && !!provider.deployment?.id
+      ) ?? [];
+    if (isCreatingSession || !instance.data || activeProviders.length === 0)
       return;
 
     setIsCreatingSession(true);
 
     let [res] = await createSession.mutate({
-      providers: [{ sessionTemplateId: activeSessionTemplateId }]
+      providers: activeProviders
+        .filter(provider => provider.deployment?.id)
+        .map(provider => ({
+          providerDeploymentId: provider.deployment!.id,
+          ...(provider.config?.id ? { providerConfigId: provider.config.id } : {}),
+          ...(provider.authConfig?.id
+            ? { providerAuthConfigId: provider.authConfig.id }
+            : {}),
+          ...(provider.toolFilter ? { toolFilters: provider.toolFilter } : {})
+        }))
     });
     setIsCreatingSession(false);
 
@@ -112,7 +124,36 @@ export let MagicMcpServerLayout = () => {
 
                       showAddProviderSidePanel({
                         instanceId: instance.data!.id,
-                        sessionTemplateId: server.data.sessionTemplateId!,
+                        excludeProviderIds: Array.from(
+                          new Set((server.data.providers ?? []).map(provider => provider.provider.id))
+                        ),
+                        onSubmitProvider: async (input, currentProviderId) => {
+                          if (currentProviderId) {
+                            let [, error] = await updateProvider.mutate({
+                              instanceId: instance.data!.id,
+                              magicMcpServerId: server.data.id,
+                              magicMcpServerProviderId: currentProviderId,
+                              providerDeploymentId: input.providerDeploymentId,
+                              providerConfigId: input.providerConfigId,
+                              providerAuthConfigId: input.providerAuthConfigId,
+                              toolFilters: input.toolFilters
+                            });
+
+                            return error ? { error } : { success: true };
+                          }
+
+                          let [, error] = await createProvider.mutate({
+                            instanceId: instance.data!.id,
+                            magicMcpServerId: server.data.id,
+                            providerId: input.providerId,
+                            providerDeploymentId: input.providerDeploymentId!,
+                            providerConfigId: input.providerConfigId,
+                            providerAuthConfigId: input.providerAuthConfigId,
+                            toolFilters: input.toolFilters
+                          });
+
+                          return error ? { error } : { success: true };
+                        },
                         onComplete: () => providers.refetch()
                       });
                     }}

--- a/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/overview.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/overview.tsx
@@ -1,14 +1,8 @@
 import { renderWithLoader } from '@metorial/data-hooks';
-import {
-  useCurrentInstance,
-  useMagicMcpServer,
-  useMagicMcpTokens,
-  useProviders,
-  useSessionTemplateProviders
-} from '@metorial/state';
+import { useCurrentInstance, useMagicMcpServer, useMagicMcpTokens } from '@metorial/state';
 import { Attributes, Flex, RenderDate, Text } from '@metorial/ui';
 import { Box, ID } from '@metorial/ui-product';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { McpConnectionInstructionsScene } from '../../../scenes/mcpConnectionInstructions';
 
@@ -25,10 +19,6 @@ export let MagicMcpServerOverviewPage = () => {
     }
   );
   let createToken = tokens.createMutator();
-  let templateProviders = useSessionTemplateProviders(
-    instance.data?.id,
-    server.data?.sessionTemplateId
-  );
   let initializingTokenRef = useRef<string | undefined>(undefined);
   let [creatingInitialToken, setCreatingInitialToken] = useState(false);
   let [createdInitialToken, setCreatedInitialToken] = useState<{
@@ -39,17 +29,6 @@ export let MagicMcpServerOverviewPage = () => {
     status: 'active';
     groups: [];
   } | null>(null);
-  let providerIds = useMemo(
-    () => [
-      ...new Set(
-        (templateProviders.data?.items ?? []).map(
-          p => p.providerId ?? p.deployment.providerId ?? p.id
-        )
-      )
-    ],
-    [templateProviders.data?.items]
-  );
-  let providers = useProviders(instance.data?.id, { id: providerIds });
   let existingServerTokenId = tokens.data?.items.find(
     t => t.status === 'active' && t.server?.id === server.data?.id
   )?.id;
@@ -103,77 +82,67 @@ export let MagicMcpServerOverviewPage = () => {
     tokens.isLoading
   ]);
 
-  return renderWithLoader({ server, tokens, templateProviders, providers })(
-    ({ server, tokens, templateProviders, providers }) => {
-      let streamableHttpUrl = server.data.endpoints[0]?.url;
-      let createdToken =
-        createdInitialToken?.instanceId === instance.data?.id &&
-        createdInitialToken?.serverId === server.data.id
-          ? createdInitialToken
-          : null;
-      let activeToken =
-        tokens.data.items.find(
-          t => t.status === 'active' && t.server?.id === server.data.id
-        ) ?? createdToken;
-      let activeTokenSecret = activeToken?.secret;
-      let fullUrl =
-        streamableHttpUrl && activeTokenSecret
-          ? `${streamableHttpUrl}?key=${activeTokenSecret}`
-          : null;
-      let hasRelatedActiveToken = tokens.data.items.length > 0;
-      let providerNameMap = new Map<string, string>();
-      for (let provider of providers.data?.items ?? []) {
-        if (provider.id && provider.name) providerNameMap.set(provider.id, provider.name);
-      }
+  return renderWithLoader({ server, tokens })(({ server, tokens }) => {
+    let streamableHttpUrl = server.data.endpoints[0]?.url;
+    let createdToken =
+      createdInitialToken?.instanceId === instance.data?.id &&
+      createdInitialToken?.serverId === server.data.id
+        ? createdInitialToken
+        : null;
+    let activeToken =
+      tokens.data.items.find(t => t.status === 'active' && t.server?.id === server.data.id) ??
+      createdToken;
+    let activeTokenSecret = activeToken?.secret;
+    let fullUrl =
+      streamableHttpUrl && activeTokenSecret
+        ? `${streamableHttpUrl}?key=${activeTokenSecret}`
+        : null;
+    let hasRelatedActiveToken = tokens.data.items.length > 0;
+    let detailsPathParams = [
+      instance.data?.organization,
+      instance.data?.project,
+      instance.data,
+      server.data.id
+    ] as const;
 
-      let providerPreviewItems = templateProviders.data.items.slice(0, 4);
-      let remainingProviderCount =
-        templateProviders.data.items.length - providerPreviewItems.length;
-      let detailsPathParams = [
-        instance.data?.organization,
-        instance.data?.project,
-        instance.data,
-        server.data.id
-      ] as const;
+    return (
+      <Flex direction="column" gap={16}>
+        <Box
+          title={
+            <Flex gap={8} style={{ alignItems: 'center', flexWrap: 'wrap' }}>
+              <span>{server.data.name ?? 'Magic MCP Server'}</span>
+            </Flex>
+          }
+          description="Magic MCP servers are reusable MCP servers linked to providers in Metorial."
+        >
+          <Attributes
+            itemWidth="280px"
+            attributes={[
+              {
+                label: 'ID',
+                content: <ID id={server.data.id} />
+              },
+              {
+                label: 'Server Identifier',
+                content: <ID id={server.data.endpoints[0]?.alias ?? '...'} />
+              },
+              {
+                label: 'Created At',
+                content: <RenderDate date={server.data.createdAt} />
+              }
+            ]}
+          />
 
-      return (
-        <Flex direction="column" gap={16}>
-          <Box
-            title={
-              <Flex gap={8} style={{ alignItems: 'center', flexWrap: 'wrap' }}>
-                <span>{server.data.name ?? 'Magic MCP Server'}</span>
-              </Flex>
-            }
-            description="Magic MCP servers are reusable MCP servers linked to providers in Metorial."
-          >
-            <Attributes
-              itemWidth="280px"
-              attributes={[
-                {
-                  label: 'ID',
-                  content: <ID id={server.data.id} />
-                },
-                {
-                  label: 'Server Identifier',
-                  content: <ID id={server.data.endpoints[0]?.alias ?? '...'} />
-                },
-                {
-                  label: 'Created At',
-                  content: <RenderDate date={server.data.createdAt} />
-                }
-              ]}
-            />
-
-            {/* <Spacer height={16} />
+          {/* <Spacer height={16} />
 
             <Copy
               label="Primary Endpoint"
               value={streamableHttpUrl ?? '...'}
               copyValue={streamableHttpUrl ?? ''}
             /> */}
-          </Box>
+        </Box>
 
-          {/* <Box
+        {/* <Box
             title="Providers"
             description="Sessions created through this server inherit providers from its session template."
             rightActions={
@@ -237,33 +206,32 @@ export let MagicMcpServerOverviewPage = () => {
             </Flex>
           </Box> */}
 
-          <Box
-            title={`Connect to ${server.data.name ?? 'Magic MCP Server'}`}
-            description="Use this Magic MCP endpoint to connect to your server."
-          >
-            <McpConnectionInstructionsScene
-              name={server.data.name ?? 'Magic MCP Server'}
-              tokenLabel="Magic MCP Token"
-              tokenValue={activeTokenSecret ?? null}
-              tokenCopyValue={activeTokenSecret ?? ''}
-              endpointLabel="Endpoint"
-              endpointValue={fullUrl ?? streamableHttpUrl ?? '...'}
-              endpointCopyValue={fullUrl ?? streamableHttpUrl ?? ''}
-              snippetUrl={streamableHttpUrl ?? null}
-              snippetToken={activeTokenSecret ?? null}
-              emptyState={
-                <Flex direction="column" gap={12} style={{ alignItems: 'flex-start' }}>
-                  <Text size="2">
-                    {creatingInitialToken
-                      ? 'Creating a Magic MCP token for this server...'
-                      : 'No active Magic MCP token found for this server. Create one from the Tokens tab to connect clients.'}
-                  </Text>
-                </Flex>
-              }
-            />
-          </Box>
-        </Flex>
-      );
-    }
-  );
+        <Box
+          title={`Connect to ${server.data.name ?? 'Magic MCP Server'}`}
+          description="Use this Magic MCP endpoint to connect to your server."
+        >
+          <McpConnectionInstructionsScene
+            name={server.data.name ?? 'Magic MCP Server'}
+            tokenLabel="Magic MCP Token"
+            tokenValue={activeTokenSecret ?? null}
+            tokenCopyValue={activeTokenSecret ?? ''}
+            endpointLabel="Endpoint"
+            endpointValue={fullUrl ?? streamableHttpUrl ?? '...'}
+            endpointCopyValue={fullUrl ?? streamableHttpUrl ?? ''}
+            snippetUrl={streamableHttpUrl ?? null}
+            snippetToken={activeTokenSecret ?? null}
+            emptyState={
+              <Flex direction="column" gap={12} style={{ alignItems: 'flex-start' }}>
+                <Text size="2">
+                  {creatingInitialToken
+                    ? 'Creating a Magic MCP token for this server...'
+                    : 'No active Magic MCP token found for this server. Create one from the Tokens tab to connect clients.'}
+                </Text>
+              </Flex>
+            }
+          />
+        </Box>
+      </Flex>
+    );
+  });
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/providers.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/providers.tsx
@@ -1,31 +1,277 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { DashboardInstanceMagicMcpServersProvidersListOutput } from '@metorial/dashboard-sdk';
+import { renderWithLoader, renderWithPagination } from '@metorial/data-hooks';
 import {
+  useCreateMagicMcpServerProvider,
   useCurrentInstance,
+  useDeleteMagicMcpServerProvider,
   useMagicMcpServer,
+  useMagicMcpServerProviders,
+  useProviderAuthConfigs,
   useProviderDeployments,
-  useSessionTemplateProviders
+  useProviderListings,
+  useUpdateMagicMcpServerProvider
 } from '@metorial/state';
+import { Button, confirm, Flex, Menu, Text, toast } from '@metorial/ui';
+import { Table } from '@metorial/ui-product';
+import { RiMore2Line } from '@remixicon/react';
+import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
-import { SessionTemplateProvidersManager } from '../../../scenes/sessionTemplates/providersManager';
+import { showAddProviderSidePanel } from '../../../scenes/sessionTemplates/providersManager';
+
+type MagicMcpServerProviderRow =
+  DashboardInstanceMagicMcpServersProvidersListOutput['items'][number];
+
+let getToolFilterSummary = (toolFilter: MagicMcpServerProviderRow['toolFilter']) => {
+  if (!toolFilter || toolFilter.type === 'allow_all') return 'All tools';
+
+  let selectedToolKeys = toolFilter.filters
+    .filter(filter => filter.type === 'tool_keys')
+    .flatMap(filter => filter.keys ?? []);
+
+  if (selectedToolKeys.length === 0) return 'No tools';
+  if (selectedToolKeys.length === 1) return '1 selected';
+  return `${selectedToolKeys.length} selected`;
+};
+
+let MagicMcpServerProvidersTable = (p: {
+  server: NonNullable<ReturnType<typeof useMagicMcpServer>['data']>;
+  providers: ReturnType<typeof useMagicMcpServerProviders>;
+  listingLookup: Record<string, { name: string; imageUrl: string }>;
+  deploymentLookup: Record<string, { name: string | null }>;
+  authConfigLookup: Record<string, string | null>;
+  openProviderPanel: (row?: MagicMcpServerProviderRow) => void;
+  removeProvider: (row: MagicMcpServerProviderRow) => void;
+}) =>
+  renderWithPagination(p.providers)(providers => (
+    <>
+      <Table
+        headers={['Provider', 'Config', 'Auth Config', 'Tools', '']}
+        data={providers.data.items.map(provider => {
+          let listing = p.listingLookup[provider.provider.id];
+          let deployment =
+            provider.deployment?.name ??
+            (provider.deployment?.id
+              ? p.deploymentLookup[provider.deployment.id]?.name
+              : null);
+          let authConfigName = provider.authConfig?.name
+            ? provider.authConfig.name
+            : provider.authConfig?.id
+              ? p.authConfigLookup[provider.authConfig.id]
+              : null;
+
+          return {
+            data: [
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                <Text size="2" weight="strong">
+                  {listing?.name ?? provider.provider.name}
+                </Text>
+                <Text size="1" color="gray600">
+                  {provider.provider.slug ?? provider.provider.id}
+                </Text>
+                {provider.providerManagementMode !== 'manual' ? (
+                  <Text size="1" color="gray600">
+                    {provider.providerManagementMode === 'inherited_from_integration'
+                      ? 'Inherited from integration'
+                      : 'Inherited from provider template'}
+                  </Text>
+                ) : null}
+              </div>,
+              provider.config ? (
+                <Text size="2">{provider.config.name ?? provider.config.id}</Text>
+              ) : (
+                <Text size="2" color="gray600">
+                  Default
+                </Text>
+              ),
+              authConfigName ? (
+                <Text size="2">{authConfigName}</Text>
+              ) : (
+                <Text size="2" color="gray600">
+                  None
+                </Text>
+              ),
+              <Text size="2">{getToolFilterSummary(provider.toolFilter)}</Text>,
+              <Flex style={{ width: '100%' }} justify="end">
+                <Menu
+                  items={[
+                    ...(provider.canUpdate
+                      ? [
+                          {
+                            id: 'edit',
+                            label: 'Edit'
+                          }
+                        ]
+                      : []),
+                    ...(provider.canDelete
+                      ? [
+                          {
+                            id: 'delete',
+                            label: 'Delete'
+                          }
+                        ]
+                      : [])
+                  ]}
+                  onItemClick={id => {
+                    if (id === 'edit') p.openProviderPanel(provider);
+                    if (id === 'delete') p.removeProvider(provider);
+                  }}
+                >
+                  <Button
+                    size="1"
+                    variant="outline"
+                    iconRight={<RiMore2Line />}
+                    onClick={e => e.preventDefault()}
+                  />
+                </Menu>
+              </Flex>
+            ]
+          };
+        })}
+      />
+
+      {providers.data.items.length === 0 ? (
+        <Text size="2" color="gray600" align="center" style={{ marginTop: 10 }}>
+          No providers configured for this magic MCP server.
+        </Text>
+      ) : null}
+    </>
+  ));
 
 export let MagicMcpServerProvidersPage = () => {
   let instance = useCurrentInstance();
   let { magicMcpServerId } = useParams();
   let server = useMagicMcpServer(instance.data?.id, magicMcpServerId);
-  let templateProviders = useSessionTemplateProviders(
-    instance.data?.id,
-    server.data?.sessionTemplateId
-  );
+  let providers = useMagicMcpServerProviders(instance.data?.id, magicMcpServerId, {
+    status: ['active']
+  });
   let deployments = useProviderDeployments(instance.data?.id);
+  let authConfigs = useProviderAuthConfigs(instance.data?.id);
+  let listings = useProviderListings(instance.data?.id, { limit: 100 });
+  let createProvider = useCreateMagicMcpServerProvider();
+  let updateProvider = useUpdateMagicMcpServerProvider();
+  let deleteProvider = useDeleteMagicMcpServerProvider();
 
-  return renderWithLoader({ server, templateProviders, deployments })(({ server }) =>
-    server.data.sessionTemplateId ? (
-      <>
-        <SessionTemplateProvidersManager
-          instanceId={instance.data!.id}
-          sessionTemplateId={server.data.sessionTemplateId}
-        />
-      </>
-    ) : null
+  let listingLookup = useMemo(
+    () =>
+      Object.fromEntries(
+        (listings.data?.items ?? []).map(listing => [
+          listing.provider.id,
+          {
+            name: listing.name,
+            imageUrl: listing.imageUrl
+          }
+        ])
+      ),
+    [listings.data?.items]
+  );
+  let deploymentLookup = useMemo(
+    () =>
+      Object.fromEntries(
+        (deployments.data?.items ?? []).map(deployment => [deployment.id, deployment])
+      ),
+    [deployments.data?.items]
+  );
+  let authConfigLookup = useMemo(
+    () =>
+      Object.fromEntries(
+        (authConfigs.data?.items ?? []).map(config => [config.id, config.name])
+      ),
+    [authConfigs.data?.items]
+  );
+  let linkedProviderIds = useMemo(
+    () =>
+      Array.from(new Set((providers.data?.items ?? []).map(provider => provider.provider.id))),
+    [providers.data?.items]
+  );
+
+  let openProviderPanel = (row?: MagicMcpServerProviderRow) => {
+    if (!instance.data || !magicMcpServerId) return;
+
+    showAddProviderSidePanel({
+      instanceId: instance.data.id,
+      excludeProviderIds: row
+        ? linkedProviderIds.filter(providerId => providerId !== row.provider.id)
+        : linkedProviderIds,
+      providerId: row?.provider.id,
+      hideProviderStep: !!row,
+      sessionTemplateProviderId: row?.id,
+      initialDeploymentId: row?.deployment?.id,
+      initialConfigId: row?.config?.id ?? undefined,
+      initialAuthConfigId: row?.authConfig?.id ?? undefined,
+      initialToolFilter: row?.toolFilter ?? null,
+      title: row ? 'Edit Provider' : 'Add Provider',
+      description: row
+        ? 'Update the configuration for this magic MCP server provider.'
+        : 'Select a provider and configure how it should be attached to this magic MCP server.',
+      action: row ? 'Save Changes' : 'Add Provider',
+      onSubmitProvider: async (input, currentProviderId) => {
+        if (!instance.data || !magicMcpServerId) return { success: false };
+
+        if (currentProviderId) {
+          let [, error] = await updateProvider.mutate({
+            instanceId: instance.data.id,
+            magicMcpServerId,
+            magicMcpServerProviderId: currentProviderId,
+            providerDeploymentId: input.providerDeploymentId,
+            providerConfigId: input.providerConfigId,
+            providerAuthConfigId: input.providerAuthConfigId,
+            toolFilters: input.toolFilters
+          });
+
+          return error ? { error } : { success: true };
+        }
+
+        let [, error] = await createProvider.mutate({
+          instanceId: instance.data.id,
+          magicMcpServerId,
+          providerId: input.providerId,
+          providerDeploymentId: input.providerDeploymentId!,
+          providerConfigId: input.providerConfigId,
+          providerAuthConfigId: input.providerAuthConfigId,
+          toolFilters: input.toolFilters
+        });
+
+        return error ? { error } : { success: true };
+      },
+      onComplete: () => {
+        void providers.refetch();
+        void server.refetch();
+      }
+    });
+  };
+
+  let removeProvider = (row: MagicMcpServerProviderRow) => {
+    if (!instance.data || !magicMcpServerId) return;
+
+    confirm({
+      title: 'Remove Provider',
+      description: `Are you sure you want to remove ${row.provider.name} from this magic MCP server?`,
+      onConfirm: async () => {
+        let [result, error] = await deleteProvider.mutate({
+          instanceId: instance.data.id,
+          magicMcpServerId,
+          magicMcpServerProviderId: row.id
+        });
+        if (!result || error) return;
+
+        toast.success('Provider removed');
+        void providers.refetch();
+        void server.refetch();
+      }
+    });
+  };
+
+  return renderWithLoader({ server, providers, deployments, authConfigs, listings })(
+    ({ server }) => (
+      <MagicMcpServerProvidersTable
+        server={server.data}
+        providers={providers}
+        listingLookup={listingLookup}
+        deploymentLookup={deploymentLookup}
+        authConfigLookup={authConfigLookup}
+        openProviderPanel={openProviderPanel}
+        removeProvider={removeProvider}
+      />
+    )
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/consumer/form.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/consumer/form.tsx
@@ -60,7 +60,7 @@ export let ConsumerForm = ({
           Cancel
         </Button>
         <Button type="submit" loading={createMutation.isLoading} size="2">
-          Create Consumer
+          Create Account
         </Button>
       </Dialog.Actions>
     </form>

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/consumer/modal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/consumer/modal.tsx
@@ -8,9 +8,9 @@ export let showConsumerFormModal = (p: {
 }) =>
   showModal(({ dialogProps, close }) => (
     <Dialog.Wrapper {...dialogProps} width={550}>
-      <Dialog.Title>Create Consumer</Dialog.Title>
+      <Dialog.Title>Create Account</Dialog.Title>
       <Dialog.Description>
-        Add a consumer to this instance so you can manage profiles across consumer surfaces.
+        Add an account to this instance so you can manage profiles across account surfaces.
       </Dialog.Description>
 
       <ConsumerForm {...p} close={close} onCreate={p.onCreate} />

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/consumer/table.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/consumer/table.tsx
@@ -45,7 +45,7 @@ let useConsumersTableState: TableStateProvider<
 
 let consumersTable = new DashboardTable<ConsumersTableProps, Consumer>('consumers')
   .state(useConsumersTableState)
-  .search('Search consumers...')
+  .search('Search accounts...')
   .columns([
     {
       id: 'name',
@@ -114,7 +114,7 @@ let consumersTable = new DashboardTable<ConsumersTableProps, Consumer>('consumer
     {
       id: 'id',
       isDefault: false,
-      header: 'Consumer ID',
+      header: 'Account ID',
       render: (consumer, _input) => <ID id={consumer.id} />
     }
   ])
@@ -138,6 +138,6 @@ export let ConsumersTable = ({ instanceId }: { instanceId: string }) => {
     instance,
     organization,
     project,
-    emptyState: 'No consumers found.'
+    emptyState: 'No accounts found.'
   });
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/grid.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/grid.tsx
@@ -2,7 +2,6 @@ import type { DashboardInstanceIntegrationsListQuery } from '@metorial/dashboard
 import { renderWithLoader, renderWithPagination } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import {
-  IntegrationPreview,
   useAllProviderListings,
   useCurrentInstance,
   useCurrentOrganization,
@@ -33,7 +32,6 @@ let Alias = styled.div`
 let ProviderAvatarStack = styled.div`
   display: flex;
   align-items: center;
-  padding-left: 8px;
 `;
 
 let ProviderAvatarItem = styled.div<{ $index: number }>`
@@ -43,12 +41,6 @@ let ProviderAvatarItem = styled.div<{ $index: number }>`
   border-radius: 999px;
   box-shadow: 0 0 0 2px ${theme.colors.background};
 `;
-
-let getStatusColor = (status: IntegrationPreview['status']) => {
-  if (status === 'active') return 'green';
-  if (status === 'archived') return 'gray';
-  return 'red';
-};
 
 export let IntegrationsGrid = (
   p: { instanceId: string } & Omit<
@@ -68,11 +60,13 @@ export let IntegrationsGrid = (
   });
   let providerIds = useMemo(
     () =>
-      [...new Set(
-        (integrations.data?.items ?? []).flatMap(integration =>
-          (integration.providers ?? []).map(provider => provider.provider.id)
+      [
+        ...new Set(
+          (integrations.data?.items ?? []).flatMap(integration =>
+            (integration.providers ?? []).map(provider => provider.provider.id)
+          )
         )
-      )].sort(),
+      ].sort(),
     [integrations.data?.items]
   );
   let providerListings = useAllProviderListings(instanceId, providerIds);
@@ -104,7 +98,7 @@ export let IntegrationsGrid = (
     });
   };
 
-  return renderWithPagination(integrations)(integrations => (
+  return renderWithPagination(integrations)(integrations =>
     renderWithLoader({ providerListings })(({ providerListings }) => {
       let listingLookup = new Map<
         string,
@@ -214,5 +208,5 @@ export let IntegrationsGrid = (
         </>
       );
     })
-  ));
+  );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/magicMcp/serversGrid.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/magicMcp/serversGrid.tsx
@@ -128,12 +128,6 @@ let magicServersTable = new DashboardTable<MagicMcpServersTableProps, Server>(
       )
     },
     {
-      id: 'sessionTemplateId',
-      isDefault: false,
-      header: 'Session Template ID',
-      render: server => <ID id={server.sessionTemplateId ?? undefined} />
-    },
-    {
       id: 'providerTemplateId',
       isDefault: false,
       header: 'Provider Template ID',

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/magicMcpForm.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/magicMcpForm.tsx
@@ -2,9 +2,11 @@ import { DashboardInstanceMagicMcpServersGetOutput } from '@metorial/dashboard-s
 import { renderWithLoader, useForm } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import {
+  useCreateMagicMcpServerProvider,
   useCreateMagicMcpServer,
   useCurrentInstance,
-  useMagicMcpServer
+  useMagicMcpServer,
+  useUpdateMagicMcpServerProvider
 } from '@metorial/state';
 import { Button, confirm, Input, Spacer, toast } from '@metorial/ui';
 import { Box } from '@metorial/ui-product';
@@ -27,6 +29,8 @@ export let MagicMcpServerForm = (
   let navigate = useNavigate();
 
   let createMutator = useCreateMagicMcpServer();
+  let createProviderMutator = useCreateMagicMcpServerProvider();
+  let updateProviderMutator = useUpdateMagicMcpServerProvider();
 
   let server = useMagicMcpServer(
     instance.data?.id,
@@ -68,8 +72,6 @@ export let MagicMcpServerForm = (
       });
       if (!res) return;
 
-      if (!res.sessionTemplateId) return;
-
       p.close?.();
 
       showAddProviderSidePanel({
@@ -78,8 +80,34 @@ export let MagicMcpServerForm = (
         action: 'Create Magic MCP Server',
 
         instanceId: instance.data.id,
-        sessionTemplateId: res.sessionTemplateId,
         providerId: p.type === 'create' ? p.for?.providerId : undefined,
+        onSubmitProvider: async (input, currentProviderId) => {
+          if (currentProviderId) {
+            let [, error] = await updateProviderMutator.mutate({
+              instanceId: instance.data!.id,
+              magicMcpServerId: res.id,
+              magicMcpServerProviderId: currentProviderId,
+              providerDeploymentId: input.providerDeploymentId,
+              providerConfigId: input.providerConfigId,
+              providerAuthConfigId: input.providerAuthConfigId,
+              toolFilters: input.toolFilters
+            });
+
+            return error ? { error } : { success: true };
+          }
+
+          let [, error] = await createProviderMutator.mutate({
+            instanceId: instance.data!.id,
+            magicMcpServerId: res.id,
+            providerId: input.providerId,
+            providerDeploymentId: input.providerDeploymentId!,
+            providerConfigId: input.providerConfigId,
+            providerAuthConfigId: input.providerAuthConfigId,
+            toolFilters: input.toolFilters
+          });
+
+          return error ? { error } : { success: true };
+        },
         onComplete: () => {
           if (p.onCreate) {
             p.onCreate(res);
@@ -183,6 +211,9 @@ export let MagicMcpServerForm = (
       <form.RenderError field="description" />
 
       <Spacer size={15} />
+
+      <createMutator.RenderError />
+      <updateMutator.RenderError />
 
       <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10 }}>
         {p.close && (

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/modal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/modal.tsx
@@ -45,7 +45,7 @@ export let showMagicMcpServerFormModal = (
         <Dialog.Description>
           {p.type == 'update'
             ? 'Update the Magic MCP server details.'
-            : 'Create a new Magic MCP server.'}
+            : 'Connect any provider on Metorial to any agent with a Magic MCP server.'}
         </Dialog.Description>
 
         <MagicMcpServerForm {...p} close={close} />

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
@@ -69,12 +69,30 @@ type InitialToolFilter =
     }
   | null;
 
+export type ProviderPanelSubmitInput = {
+  providerId: string;
+  providerDeploymentId?: string;
+  providerConfigId?: string;
+  providerConfigVaultId?: string;
+  providerAuthConfigId?: string;
+  toolFilters?:
+    | {
+        type: 'tool_keys';
+        keys: string[];
+      }
+    | {
+        type: 'tool_keys';
+        keys: string[];
+      }[];
+};
+
 type AddProviderPanelFlowProps = {
   close: () => void;
   setPanelWidth: (width: number) => void;
   instanceId: string;
-  sessionTemplateId: string;
+  sessionTemplateId?: string;
   sessionTemplateProviderId?: string;
+  excludeProviderIds?: string[];
   providerId?: string;
   hideProviderStep?: boolean;
   initialDeploymentId?: string;
@@ -84,6 +102,10 @@ type AddProviderPanelFlowProps = {
   title?: string;
   description?: string;
   action?: string;
+  onSubmitProvider?: (
+    input: ProviderPanelSubmitInput,
+    currentProviderId?: string
+  ) => Promise<{ error?: unknown; success?: boolean }>;
   onComplete: () => void;
 };
 
@@ -91,12 +113,15 @@ let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
   let createConfigMutation = useCreateProviderConfig();
   let createMutation = useCreateSessionTemplateProvider();
   let deleteMutation = useDeleteSessionTemplateProvider();
+  let [isSubmitting, setIsSubmitting] = useState(false);
+  let [submitError, setSubmitError] = useState<unknown>(null);
   let selectedProvider = useProvider(p.instanceId, p.providerId);
   let resolvedProviderName =
     selectedProvider.data?.name ?? selectedProvider.data?.slug ?? p.providerId ?? '';
   let selectedProviderRequiresConfig = selectedProvider.data?.type.config.status == 'enabled';
   let selectedProviderRequiresAuth = selectedProvider.data?.type.auth.status == 'enabled';
   let [step, setStep] = useState(p.hideProviderStep ? 0 : p.providerId ? 1 : 0);
+  let toolFilterHydrationKeyRef = useRef<string | null>(null);
   let initialSelectedToolKeys =
     p.initialToolFilter?.type === 'filter'
       ? p.initialToolFilter.filters
@@ -104,9 +129,7 @@ let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
           .flatMap(filter => filter.keys ?? [])
       : [];
   let initialToolFilterMode: 'all' | 'select' =
-    p.initialToolFilter?.type === 'filter' && initialSelectedToolKeys.length > 0
-      ? 'select'
-      : 'all';
+    p.initialToolFilter?.type === 'filter' ? 'select' : 'all';
 
   useEffect(() => {
     if (p.hideProviderStep || step === 1) {
@@ -130,6 +153,7 @@ let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
       selectedToolKeys: initialSelectedToolKeys
     },
     onSubmit: async values => {
+      setSubmitError(null);
       let fallbackProviderConfigId: string | undefined;
       let needsFallbackConfig =
         !values.selectedDeploymentId &&
@@ -153,9 +177,8 @@ let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
         fallbackProviderConfigId = config.id;
       }
 
-      let createInput = {
-        instanceId: p.instanceId,
-        sessionTemplateId: p.sessionTemplateId,
+      let submitInput: ProviderPanelSubmitInput = {
+        providerId: values.selectedProviderId,
         ...(values.selectedDeploymentId
           ? { providerDeploymentId: values.selectedDeploymentId }
           : {}),
@@ -179,14 +202,34 @@ let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
               providerAuthConfigId: values.selectedAuthConfigId
             }
           : {}),
-        ...(values.toolFilterMode === 'select'
-          ? {
-              toolFilters: {
+        toolFilters:
+          values.toolFilterMode === 'select'
+            ? {
                 type: 'tool_keys' as const,
                 keys: values.selectedToolKeys
               }
-            }
-          : {})
+            : []
+      };
+
+      if (p.onSubmitProvider) {
+        setIsSubmitting(true);
+        let result = await p.onSubmitProvider(submitInput, p.sessionTemplateProviderId);
+        setIsSubmitting(false);
+
+        if (result.success && !result.error) {
+          p.onComplete();
+          p.close();
+          return { success: true };
+        }
+
+        setSubmitError(result.error ?? null);
+        return { error: result.error };
+      }
+
+      let createInput = {
+        instanceId: p.instanceId,
+        sessionTemplateId: p.sessionTemplateId!,
+        ...submitInput
       };
 
       if (p.sessionTemplateProviderId) {
@@ -282,10 +325,6 @@ let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
       form.setFieldValue('selectedAuthConfigId', p.initialAuthConfigId);
     }
 
-    if (initialToolFilterMode === 'select' && form.values.selectedToolKeys.length === 0) {
-      form.setFieldValue('toolFilterMode', 'select');
-      form.setFieldValue('selectedToolKeys', initialSelectedToolKeys);
-    }
   }, [
     p.hideProviderStep,
     p.providerId,
@@ -295,14 +334,38 @@ let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
     selectedProviderRequiresConfig,
     selectedProviderRequiresAuth,
     resolvedProviderName,
-    initialToolFilterMode,
-    initialSelectedToolKeys,
     form.values.selectedProviderId,
     form.values.selectedProviderName,
     form.values.selectedDeploymentId,
     form.values.selectedConfiguration.kind,
-    form.values.selectedAuthConfigId,
-    form.values.selectedToolKeys.length
+    form.values.selectedAuthConfigId
+  ]);
+
+  useEffect(() => {
+    if (!p.hideProviderStep) {
+      toolFilterHydrationKeyRef.current = null;
+      return;
+    }
+
+    let hydrationKey = [
+      p.sessionTemplateProviderId ?? '',
+      p.providerId ?? '',
+      initialToolFilterMode,
+      ...initialSelectedToolKeys
+    ].join('::');
+
+    if (toolFilterHydrationKeyRef.current === hydrationKey) return;
+
+    toolFilterHydrationKeyRef.current = hydrationKey;
+    form.setFieldValue('toolFilterMode', initialToolFilterMode);
+    form.setFieldValue('selectedToolKeys', initialSelectedToolKeys);
+  }, [
+    p.hideProviderStep,
+    p.sessionTemplateProviderId,
+    p.providerId,
+    initialToolFilterMode,
+    initialSelectedToolKeys,
+    form
   ]);
 
   let resetConfigurationState = () => {
@@ -343,6 +406,7 @@ let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
               providerName={form.values.selectedProviderName}
               saving={
                 createConfigMutation.isLoading ||
+                isSubmitting ||
                 createMutation.isPending ||
                 deleteMutation.isPending
               }
@@ -372,6 +436,7 @@ let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
         render: () => (
           <PickProviderStep
             instanceId={p.instanceId}
+            excludeProviderIds={p.excludeProviderIds}
             selectedProviderId={form.values.selectedProviderId || undefined}
             onSelect={handleProviderSelect}
           />
@@ -386,6 +451,8 @@ let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
     form.values.selectedProviderName,
     resolvedProviderName,
     createConfigMutation.isLoading,
+    isSubmitting,
+    submitError,
     createMutation.isPending,
     deleteMutation.isPending,
     form.handleSubmit,
@@ -807,7 +874,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
   let sectionItems: ReactNode[] = [];
   let isConfigCompleted = p.selectedConfiguration.kind !== 'none';
   let isAuthCompleted = Boolean(p.selectedAuthConfigId);
-  let isToolsCompleted = toolFilterMode === 'all' || selectedToolKeys.length > 0;
+  let isToolsCompleted = toolFilterMode === 'all' || toolFilterMode === 'select';
   let providerDisplayName =
     providerListing.data?.name ??
     provider.data?.name ??
@@ -1220,6 +1287,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
 
 let PickProviderStep = (p: {
   instanceId: string;
+  excludeProviderIds?: string[];
   selectedProviderId?: string;
   onSelect: (providerId: string, providerName: string) => void;
 }) => {
@@ -1247,6 +1315,7 @@ let PickProviderStep = (p: {
         includeAllProviders
         prioritizeProvidersWithDeployments
         providerListingsFilter={providerListingsFilter}
+        excludeProviderIds={p.excludeProviderIds}
         hideSearch
         internalScroll
         internalScrollHeight="calc(100vh - 360px)"
@@ -1362,9 +1431,10 @@ let ConfigureStep = (p: {
 
 export let showAddProviderPanelFlow = (p: {
   instanceId: string;
-  sessionTemplateId: string;
+  sessionTemplateId?: string;
   onComplete: () => void;
   sessionTemplateProviderId?: string;
+  excludeProviderIds?: string[];
   providerId?: string;
   hideProviderStep?: boolean;
   initialDeploymentId?: string;
@@ -1374,6 +1444,10 @@ export let showAddProviderPanelFlow = (p: {
   title?: string;
   description?: string;
   action?: string;
+  onSubmitProvider?: (
+    input: ProviderPanelSubmitInput,
+    currentProviderId?: string
+  ) => Promise<{ error?: unknown; success?: boolean }>;
 }) =>
   showProviderCreationPanel(({ close, setWidth }) => (
     <AddProviderPanelFlow
@@ -1382,6 +1456,7 @@ export let showAddProviderPanelFlow = (p: {
       instanceId={p.instanceId}
       sessionTemplateId={p.sessionTemplateId}
       sessionTemplateProviderId={p.sessionTemplateProviderId}
+      excludeProviderIds={p.excludeProviderIds}
       providerId={p.providerId}
       hideProviderStep={p.hideProviderStep}
       initialDeploymentId={p.initialDeploymentId}
@@ -1391,6 +1466,7 @@ export let showAddProviderPanelFlow = (p: {
       title={p.title}
       description={p.description}
       action={p.action}
+      onSubmitProvider={p.onSubmitProvider}
       onComplete={p.onComplete}
     />
   ));

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/providersManager.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/providersManager.tsx
@@ -26,7 +26,10 @@ import {
   TableStateProvider,
   TableStateProviderResult
 } from '../../../../components/table/type';
-import { showAddProviderPanelFlow } from './addProviderPanelFlow';
+import {
+  type ProviderPanelSubmitInput,
+  showAddProviderPanelFlow
+} from './addProviderPanelFlow';
 
 type SessionTemplateProviderRow =
   DashboardInstanceSessionTemplatesProvidersListOutput['items'][number];
@@ -94,7 +97,7 @@ let getToolFilterSummary = (toolFilter: SessionTemplateProviderToolFilter) => {
   }
 
   if (summary.hasUnsupportedFilters) return 'Custom filter';
-  if (summary.selectedToolKeys.length === 0) return 'All tools';
+  if (summary.selectedToolKeys.length === 0) return 'No tools';
   if (summary.selectedToolKeys.length === 1) return '1 selected';
 
   return `${summary.selectedToolKeys.length} selected`;
@@ -122,9 +125,10 @@ let getProviderListing = (
 
 export let showAddProviderSidePanel = (p: {
   instanceId: string;
-  sessionTemplateId: string;
+  sessionTemplateId?: string;
   onComplete: () => void;
   sessionTemplateProviderId?: string;
+  excludeProviderIds?: string[];
   providerId?: string;
   hideProviderStep?: boolean;
   initialDeploymentId?: string;
@@ -134,6 +138,10 @@ export let showAddProviderSidePanel = (p: {
   title?: string;
   description?: string;
   action?: string;
+  onSubmitProvider?: (
+    input: ProviderPanelSubmitInput,
+    currentProviderId?: string
+  ) => Promise<{ error?: unknown; success?: boolean }>;
 }) => showAddProviderPanelFlow(p);
 
 export let showAddProviderModal = showAddProviderSidePanel;

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/usage/state.ts
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/usage/state.ts
@@ -25,7 +25,7 @@ export let useUsageState = (opts: {
   let toNormalized = useMemo(() => (to > now ? now : to), [to, now]);
 
   let [interval, setInterval] = useState(
-    () => opts.interval || { unit: 'hour' as const, count: 1 }
+    () => opts.interval || { unit: 'day' as const, count: 1 }
   );
 
   let usage = useUsage(

--- a/src/frontend/state/src/custom-provider/loaders/magicMcpServer.ts
+++ b/src/frontend/state/src/custom-provider/loaders/magicMcpServer.ts
@@ -1,5 +1,8 @@
 import {
   DashboardInstanceMagicMcpServersCreateBody,
+  DashboardInstanceMagicMcpServersProvidersCreateBody,
+  DashboardInstanceMagicMcpServersProvidersListQuery,
+  DashboardInstanceMagicMcpServersProvidersUpdateBody,
   DashboardInstanceMagicMcpServersListQuery,
   DashboardInstanceMagicMcpServersUpdateBody
 } from '@metorial/dashboard-sdk';
@@ -104,3 +107,86 @@ export let updateMagicMcpServer = (
   }
 ) =>
   withAuth(sdk => sdk.magicMcp.servers.update(body.instanceId, body.magicMcpServerId, body));
+
+export let magicMcpServerProvidersLoader = createLoader({
+  name: 'magicMcpServerProviders',
+  parents: [magicMcpServerLoader],
+  fetch: (
+    i: {
+      instanceId: string;
+      magicMcpServerId: string;
+    } & DashboardInstanceMagicMcpServersProvidersListQuery
+  ) =>
+    withAuth(sdk => {
+      let { instanceId, magicMcpServerId, ...query } = i;
+      return sdk.magicMcp.servers.providers.list(instanceId, magicMcpServerId, query);
+    }),
+  mutators: {}
+});
+
+export let useMagicMcpServerProviders = (
+  instanceId: string | null | undefined,
+  magicMcpServerId: string | null | undefined,
+  query?: DashboardInstanceMagicMcpServersProvidersListQuery
+) => {
+  let data = usePaginator(
+    pagination =>
+      magicMcpServerProvidersLoader.use(
+        instanceId && magicMcpServerId
+          ? { instanceId, magicMcpServerId, ...pagination, ...query }
+          : null
+      ),
+    instanceId && magicMcpServerId ? `${instanceId}:${magicMcpServerId}` : null
+  );
+
+  return data;
+};
+
+export let useCreateMagicMcpServerProvider =
+  magicMcpServerProvidersLoader.createExternalMutator(
+    (
+      i: {
+        instanceId: string;
+        magicMcpServerId: string;
+      } & DashboardInstanceMagicMcpServersProvidersCreateBody
+    ) =>
+      withAuth(sdk => {
+        let { instanceId, magicMcpServerId, ...body } = i;
+        return sdk.magicMcp.servers.providers.create(instanceId, magicMcpServerId, body);
+      }),
+    { disableToast: true }
+  );
+
+export let useUpdateMagicMcpServerProvider =
+  magicMcpServerProvidersLoader.createExternalMutator(
+    (
+      i: {
+        instanceId: string;
+        magicMcpServerId: string;
+        magicMcpServerProviderId: string;
+      } & DashboardInstanceMagicMcpServersProvidersUpdateBody
+    ) =>
+      withAuth(sdk => {
+        let { instanceId, magicMcpServerId, magicMcpServerProviderId, ...body } = i;
+        return sdk.magicMcp.servers.providers.update(
+          instanceId,
+          magicMcpServerId,
+          magicMcpServerProviderId,
+          body
+        );
+      }),
+    { disableToast: true }
+  );
+
+export let useDeleteMagicMcpServerProvider =
+  magicMcpServerProvidersLoader.createExternalMutator(
+    (i: { instanceId: string; magicMcpServerId: string; magicMcpServerProviderId: string }) =>
+      withAuth(sdk =>
+        sdk.magicMcp.servers.providers.delete(
+          i.instanceId,
+          i.magicMcpServerId,
+          i.magicMcpServerProviderId
+        )
+      ),
+    { disableToast: true }
+  );

--- a/src/frontend/state/src/integration/index.ts
+++ b/src/frontend/state/src/integration/index.ts
@@ -1,4 +1,5 @@
 export * from './loaders/integrationInstanceProviders';
 export * from './loaders/integrationInstances';
 export * from './loaders/integrationProviders';
+export * from './loaders/integrationSetupSessions';
 export * from './loaders/integrations';

--- a/src/frontend/state/src/integration/loaders/integrationSetupSessions.ts
+++ b/src/frontend/state/src/integration/loaders/integrationSetupSessions.ts
@@ -1,0 +1,74 @@
+import { awaitConfig } from '@metorial/frontend-config';
+import { useMutation } from '@metorial/data-hooks';
+import { useMemo } from 'react';
+import { withAuth } from '../../user';
+
+export type IntegrationSetupSessionCreateInput = {
+  instanceId: string;
+  integrationId: string;
+  name: string;
+  description?: string;
+  toolFiltersEnabled?: boolean;
+};
+
+export type IntegrationSetupSessionCreateOutput = {
+  id: string;
+  url: string;
+  status: string;
+};
+
+let getDashboardApiUrl = async (path: string) => {
+  let config = await awaitConfig();
+  let url = new URL(config.apiUrl);
+  let metorialInstance = url.searchParams.get('_metorial_instance') || 'external';
+  let basePath = url.pathname.replace(/\/$/, '');
+
+  url.pathname = `${basePath}/${path.replace(/^\//, '')}`;
+  url.search = '';
+  url.searchParams.set('_m', metorialInstance);
+
+  return url;
+};
+
+export let createIntegrationSetupSession = async (input: IntegrationSetupSessionCreateInput) =>
+  withAuth(async () => {
+    let url = await getDashboardApiUrl(
+      `dashboard/instances/${input.instanceId}/integration-setup-sessions`
+    );
+
+    let response = await fetch(url.toString(), {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'Metorial-Version': '2025-01-01-dashboard'
+      },
+      body: JSON.stringify({
+        integration_id: input.integrationId,
+        name: input.name,
+        description: input.description,
+        configuration: {
+          tool_filters: {
+            enabled: !!input.toolFiltersEnabled
+          }
+        }
+      })
+    });
+
+    if (!response.ok) {
+      let body = await response.json().catch(() => null);
+      throw new Error(body?.message ?? 'Failed to create integration setup session.');
+    }
+
+    return (await response.json()) as IntegrationSetupSessionCreateOutput;
+  });
+
+export let useCreateIntegrationSetupSession = () =>
+  useMutation(
+    useMemo(
+      () => (input: IntegrationSetupSessionCreateInput) =>
+        createIntegrationSetupSession(input),
+      []
+    ),
+    { disableToast: true }
+  );

--- a/src/packages/frontend/ui/src/optionToggle/index.tsx
+++ b/src/packages/frontend/ui/src/optionToggle/index.tsx
@@ -127,17 +127,32 @@ export let OptionToggle = ({
   let itemBorderRadius = `calc(${sizeStyles.borderRadius} - 2px)`;
 
   let selectedItem = useMemo(() => items.find(item => item.id == value), [items, value]);
+  let updateIndicator = (nextIndicator: { width: number; left: number } | null) => {
+    setIndicator(current => {
+      if (current === null && nextIndicator === null) return current;
+      if (current && nextIndicator) {
+        if (
+          current.width === nextIndicator.width &&
+          current.left === nextIndicator.left
+        ) {
+          return current;
+        }
+      }
+
+      return nextIndicator;
+    });
+  };
 
   useLayoutEffect(() => {
     let measure = () => {
       let root = rootRef.current;
       let item = selectedItem ? itemRefs.current[selectedItem.id] : null;
       if (!root || !item) {
-        setIndicator(null);
+        updateIndicator(null);
         return;
       }
 
-      setIndicator({
+      updateIndicator({
         width: item.offsetWidth,
         left: item.offsetLeft - 4
       });
@@ -165,9 +180,12 @@ export let OptionToggle = ({
     let handleResize = () => {
       let root = rootRef.current;
       let item = selectedItem ? itemRefs.current[selectedItem.id] : null;
-      if (!root || !item) return;
+      if (!root || !item) {
+        updateIndicator(null);
+        return;
+      }
 
-      setIndicator({
+      updateIndicator({
         width: item.offsetWidth,
         left: item.offsetLeft - 4
       });

--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/serverProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/serverProvider.ts
@@ -584,7 +584,8 @@ class magicMcpServerProviderServiceImpl {
             integrationInstance: backing.integrationInstance as IntegrationInstance,
             input: {
               providerId: row.integrationProvider.id,
-              providerConfigId: d.input.providerConfigId ?? null,
+              providerConfigId:
+                d.input.providerConfigId === undefined ? undefined : d.input.providerConfigId,
               providerAuthConfigId: d.input.providerAuthConfigId ?? undefined,
               toolFilters: d.input.toolFilters
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new Magic MCP server provider CRUD flows (frontend + backend) and relaxes several backing/reconcile conditions, which could affect how servers/endpoints are provisioned and displayed. Also introduces a new integration setup-session creation path via direct API fetch, which needs verification of auth/versioning and error handling in production.
> 
> **Overview**
> Adds an end-to-end UI + state layer to **create Integration Setup Sessions** from an integration page, including a modal that generates a shareable setup link (with optional tool-filter collection).
> 
> Refactors **Magic MCP server provider management** to be server-scoped (not session-template-scoped): introduces dashboard state loaders/mutators for listing/creating/updating/deleting server providers, updates Magic MCP server pages to create sessions from the server’s active providers, and replaces the providers page with a full table + edit/delete actions.
> 
> Simplifies Magic MCP backing reconciliation/ensuring by treating `hasSubspaceBacking` as the gating condition (dropping checks for template/session IDs), tightens some pagination limits, and extends session-template update/delete guards to also block when linked to Magic MCP endpoints. Includes assorted UI copy tweaks ("Consumers" → "Accounts"), a default usage interval change (hour → day), and small UI stability fixes (option toggle indicator updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee03b9e49f75a8620bf3623db92b6fd879953284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->