### PR TITLE
Persist identity links

### DIFF
--- a/src/systems/subspace/db/prisma/schema/identity/actor.prisma
+++ b/src/systems/subspace/db/prisma/schema/identity/actor.prisma
@@ -43,6 +43,9 @@ model IdentityActor {
   identityDelegations        IdentityDelegation[]        @relation("delegations")
   subDelegations             IdentityDelegation[]        @relation("subDelegatedTo")
   integrationInstances       IntegrationInstance[]
+  integrationInstanceGroups  IntegrationInstanceGroup[]
+  sessionTemplates           SessionTemplate[]
+  sessions                   Session[]
   magicMcpEndpointBackings   MagicMcpEndpointBacking[]
   magicMcpServerBackings     MagicMcpServerBacking[]
   ephemeralManagedSessions   EphemeralManagedSession[]

--- a/src/systems/subspace/db/prisma/schema/identity/identity.prisma
+++ b/src/systems/subspace/db/prisma/schema/identity/identity.prisma
@@ -46,6 +46,10 @@ model Identity {
   identityDelegationRequests IdentityDelegationRequest[]
   delegatedIdentities        DelegatedIdentity[]
   integrationInstances       IntegrationInstance[]
+  integrationInstanceGroups  IntegrationInstanceGroup[]
+  sessionTemplates           SessionTemplate[]
+  sessions                   Session[]
+  ephemeralManagedSessions   EphemeralManagedSession[]
 
   @@index([createdAt])
   @@index([updatedAt])

--- a/src/systems/subspace/db/prisma/schema/intergration/instanceGroup.prisma
+++ b/src/systems/subspace/db/prisma/schema/intergration/instanceGroup.prisma
@@ -28,6 +28,12 @@ model IntegrationInstanceGroup {
   solutionOid Int
   solution    Solution @relation(fields: [solutionOid], references: [oid], onDelete: Cascade)
 
+  identityActorOid BigInt?
+  identityActor    IdentityActor? @relation(fields: [identityActorOid], references: [oid], onDelete: SetNull)
+
+  identityOid BigInt?
+  identity    Identity? @relation(fields: [identityOid], references: [oid], onDelete: SetNull)
+
   defaultSessionTemplate SessionTemplate? @relation("defaultSessionTemplateForIntegrationInstanceGroup")
 
   createdAt DateTime @default(now())
@@ -44,6 +50,8 @@ model IntegrationInstanceGroup {
   @@index([status])
   @@index([archivedAt])
   @@index([status, archivedAt])
+  @@index([identityActorOid])
+  @@index([identityOid])
 }
 
 enum IntegrationInstanceGroupSourceStatus {

--- a/src/systems/subspace/db/prisma/schema/session/ephemeralManaged.prisma
+++ b/src/systems/subspace/db/prisma/schema/session/ephemeralManaged.prisma
@@ -33,6 +33,9 @@ model EphemeralManagedSession {
   actorOid BigInt?
   actor    IdentityActor? @relation(fields: [actorOid], references: [oid], onDelete: SetNull)
 
+  identityOid BigInt?
+  identity    Identity? @relation(fields: [identityOid], references: [oid], onDelete: SetNull)
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
@@ -46,5 +49,6 @@ model EphemeralManagedSession {
   @@index([archivedAt])
   @@index([status, archivedAt])
   @@index([sessionTemplateOid])
+  @@index([identityOid])
   @@index([currentSessionOid, status])
 }

--- a/src/systems/subspace/db/prisma/schema/session/session.prisma
+++ b/src/systems/subspace/db/prisma/schema/session/session.prisma
@@ -35,6 +35,12 @@ model Session {
   solutionOid Int
   solution    Solution @relation(fields: [solutionOid], references: [oid], onDelete: Cascade)
 
+  identityActorOid BigInt?
+  identityActor    IdentityActor? @relation(fields: [identityActorOid], references: [oid], onDelete: SetNull)
+
+  identityOid BigInt?
+  identity    Identity? @relation(fields: [identityOid], references: [oid], onDelete: SetNull)
+
   ephemeralManagedSessionOid BigInt?
   ephemeralManagedSession    EphemeralManagedSession? @relation("EphemeralManagedSessionSessions", fields: [ephemeralManagedSessionOid], references: [oid])
 
@@ -67,6 +73,8 @@ model Session {
   @@index([status])
   @@index([archivedAt])
   @@index([status, archivedAt])
+  @@index([identityActorOid])
+  @@index([identityOid])
   @@index([isEphemeral])
   @@index([ephemeralManagedSessionOid])
 }

--- a/src/systems/subspace/db/prisma/schema/session/template.prisma
+++ b/src/systems/subspace/db/prisma/schema/session/template.prisma
@@ -27,6 +27,12 @@ model SessionTemplate {
   solutionOid Int
   solution    Solution @relation(fields: [solutionOid], references: [oid], onDelete: Cascade)
 
+  identityActorOid BigInt?
+  identityActor    IdentityActor? @relation(fields: [identityActorOid], references: [oid], onDelete: SetNull)
+
+  identityOid BigInt?
+  identity    Identity? @relation(fields: [identityOid], references: [oid], onDelete: SetNull)
+
   integrationInstanceOid BigInt?
   integrationInstance    IntegrationInstance? @relation(fields: [integrationInstanceOid], references: [oid], onDelete: Cascade)
 
@@ -53,6 +59,8 @@ model SessionTemplate {
   @@index([status])
   @@index([archivedAt])
   @@index([status, archivedAt])
+  @@index([identityActorOid])
+  @@index([identityOid])
   @@index([integrationInstanceOid, status])
   @@index([integrationInstanceGroupOid, status])
   @@index([defaultSessionTemplateForIntegrationInstanceOid, status], map: "stm_default_for_instance_status_idx")

--- a/src/systems/subspace/modules/integration/src/services/integrationInstanceGroup.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstanceGroup.ts
@@ -6,6 +6,7 @@ import {
   db,
   type Environment,
   getId,
+  type IntegrationInstance,
   type IntegrationInstanceGroup,
   type IntegrationInstanceGroupStatus,
   type Solution,
@@ -29,6 +30,7 @@ import {
   resolveProviders,
   resolveSessionTemplates
 } from '@metorial-subspace/list-utils';
+import { identityActorService, identityService } from '@metorial-subspace/module-identity';
 import { sessionTemplateService } from '@metorial-subspace/module-session';
 import { syncIntegrationInstanceGroupSessionTemplateQueue } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
 import { checkTenant } from '@metorial-subspace/module-tenant';
@@ -78,6 +80,8 @@ export let integrationInstanceGroupProviderInclude = {
 } as const;
 
 export let integrationInstanceGroupInclude = {
+  identityActor: true,
+  identity: true,
   defaultSessionTemplate: true,
   sources: {
     where: { status: 'active' as const, isParentDeleted: false },
@@ -98,9 +102,100 @@ type IntegrationInstanceGroupWriteInput = {
   description?: string | null;
   metadata?: Record<string, any> | null;
   privateMetadata?: Record<string, any> | null;
+  identityActorId?: string | null;
+  identityId?: string | null;
+  identitySourceIntegrationInstances?: Pick<
+    IntegrationInstance,
+    'identityActorOid' | 'identityOid'
+  >[];
 };
 
 class integrationInstanceGroupServiceImpl {
+  private async resolveIdentitySnapshot(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    current?: Pick<IntegrationInstanceGroup, 'identityActorOid' | 'identityOid'> | null;
+    input: Pick<
+      IntegrationInstanceGroupWriteInput,
+      'identityActorId' | 'identityId' | 'identitySourceIntegrationInstances'
+    >;
+  }) {
+    if (d.input.identityActorId !== undefined || d.input.identityId !== undefined) {
+      let identity = d.input.identityId
+        ? await identityService.getIdentityById({
+            tenant: d.tenant,
+            solution: d.solution,
+            environment: d.environment,
+            identityId: d.input.identityId
+          })
+        : null;
+
+      let actor = d.input.identityActorId
+        ? await identityActorService.getIdentityActorById({
+            tenant: d.tenant,
+            solution: d.solution,
+            environment: d.environment,
+            identityActorId: d.input.identityActorId
+          })
+        : null;
+
+      return {
+        identityActorOid: actor?.oid ?? identity?.actorOid ?? null,
+        identityOid: identity?.oid ?? null
+      };
+    }
+
+    let source = d.input.identitySourceIntegrationInstances?.find(
+      integrationInstance =>
+        integrationInstance.identityActorOid || integrationInstance.identityOid
+    );
+    if (source) {
+      return {
+        identityActorOid: source.identityActorOid ?? null,
+        identityOid: source.identityOid ?? null
+      };
+    }
+
+    return {
+      identityActorOid: d.current?.identityActorOid ?? null,
+      identityOid: d.current?.identityOid ?? null
+    };
+  }
+
+  private async applyIdentity(d: {
+    db: {
+      integrationInstanceGroup: typeof db.integrationInstanceGroup;
+    };
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    integrationInstanceGroup: IntegrationInstanceGroup & {
+      sources?: { integrationInstance: IntegrationInstance }[];
+    };
+    input: IntegrationInstanceGroupWriteInput;
+  }) {
+    let identity = await this.resolveIdentitySnapshot({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      current: d.integrationInstanceGroup,
+      input: {
+        identityActorId: d.input.identityActorId,
+        identityId: d.input.identityId,
+        identitySourceIntegrationInstances:
+          d.input.identitySourceIntegrationInstances ??
+          d.integrationInstanceGroup.sources?.map(source => source.integrationInstance)
+      }
+    });
+
+    return await d.db.integrationInstanceGroup.update({
+      where: { oid: d.integrationInstanceGroup.oid },
+      data: identity,
+      include: integrationInstanceGroupInclude
+    });
+  }
+
   private integrationInstanceGroupCreateData(d: {
     tenant: Tenant;
     solution: Solution;
@@ -299,6 +394,8 @@ class integrationInstanceGroupServiceImpl {
       description?: string;
       metadata?: Record<string, any>;
       privateMetadata?: Record<string, any>;
+      identityActorId?: string | null;
+      identityId?: string | null;
       providers?: SetIntegrationInstanceGroupProviderInput[];
     };
   }) {
@@ -330,6 +427,15 @@ class integrationInstanceGroupServiceImpl {
         });
       }
 
+      integrationInstanceGroup = await this.applyIdentity({
+        db,
+        tenant: d.tenant,
+        solution: d.solution,
+        environment: d.environment,
+        integrationInstanceGroup,
+        input: d.input
+      });
+
       await addAfterTransactionHook(async () =>
         integrationInstanceGroupCreatedQueue.add({
           integrationInstanceGroupId: integrationInstanceGroup.id
@@ -350,6 +456,12 @@ class integrationInstanceGroupServiceImpl {
       description?: string | null;
       metadata?: Record<string, any> | null;
       privateMetadata?: Record<string, any> | null;
+      identityActorId?: string | null;
+      identityId?: string | null;
+      identitySourceIntegrationInstances?: Pick<
+        IntegrationInstance,
+        'identityActorOid' | 'identityOid'
+      >[];
     };
   }) {
     return await withTransaction(async db => {
@@ -368,6 +480,15 @@ class integrationInstanceGroupServiceImpl {
             isMagicMcpBacking: true
           }),
           include: integrationInstanceGroupInclude
+        });
+
+        integrationInstanceGroup = await this.applyIdentity({
+          db,
+          tenant: d.tenant,
+          solution: d.solution,
+          environment: d.environment,
+          integrationInstanceGroup,
+          input: d.input
         });
 
         await addAfterTransactionHook(async () =>
@@ -392,6 +513,15 @@ class integrationInstanceGroupServiceImpl {
         include: integrationInstanceGroupInclude
       });
 
+      integrationInstanceGroup = await this.applyIdentity({
+        db,
+        tenant: d.tenant,
+        solution: d.solution,
+        environment: d.environment,
+        integrationInstanceGroup,
+        input: d.input
+      });
+
       await addAfterTransactionHook(async () =>
         integrationInstanceGroupCreatedQueue.add({
           integrationInstanceGroupId: integrationInstanceGroup.id
@@ -412,6 +542,8 @@ class integrationInstanceGroupServiceImpl {
       description?: string | null;
       metadata?: Record<string, any> | null;
       privateMetadata?: Record<string, any> | null;
+      identityActorId?: string | null;
+      identityId?: string | null;
       providers?: SetIntegrationInstanceGroupProviderInput[];
     };
   }) {
@@ -467,6 +599,25 @@ class integrationInstanceGroupServiceImpl {
         });
       }
 
+      integrationInstanceGroup = await this.applyIdentity({
+        db,
+        tenant: d.tenant,
+        solution: d.solution,
+        environment: d.environment,
+        integrationInstanceGroup,
+        input: {
+          name: integrationInstanceGroup.name,
+          description: integrationInstanceGroup.description,
+          metadata: integrationInstanceGroup.metadata as Record<string, any> | null,
+          privateMetadata: integrationInstanceGroup.privateMetadata as Record<
+            string,
+            any
+          > | null,
+          identityActorId: d.input.identityActorId,
+          identityId: d.input.identityId
+        }
+      });
+
       await addAfterTransactionHook(async () =>
         integrationInstanceGroupUpdatedQueue.add({
           integrationInstanceGroupId: integrationInstanceGroup.id
@@ -493,12 +644,11 @@ class integrationInstanceGroupServiceImpl {
     checkDeletedRelation(d.integrationInstanceGroup);
 
     return await withTransaction(async db => {
-      let currentIntegrationInstanceGroup = await db.integrationInstanceGroup.findUniqueOrThrow({
-        where: { oid: d.integrationInstanceGroup.oid },
-        include: {
-          defaultSessionTemplate: true
-        }
-      });
+      let currentIntegrationInstanceGroup =
+        await db.integrationInstanceGroup.findUniqueOrThrow({
+          where: { oid: d.integrationInstanceGroup.oid },
+          include: integrationInstanceGroupInclude
+        });
 
       let sessionTemplate = await sessionTemplateService.upsertInternalLinkedSessionTemplate({
         tenant: d.tenant,
@@ -510,7 +660,7 @@ class integrationInstanceGroupServiceImpl {
           description: d.input.description,
           metadata: d.input.metadata,
           privateMetadata: d.input.privateMetadata,
-          integrationInstanceGroup: d.integrationInstanceGroup
+          integrationInstanceGroup: currentIntegrationInstanceGroup
         }
       });
 

--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/endpoint.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/endpoint.ts
@@ -38,7 +38,11 @@ type UpsertMagicMcpEndpointBackingInput = {
 
 class magicMcpEndpointBackingServiceImpl {
   async upsertMagicMcpEndpointBacking(d: UpsertMagicMcpEndpointBackingInput) {
-    let actorOid = await resolveActorOid({ ...d, identityActorId: d.input.identityActorId });
+    let actorOid = await resolveActorOid({
+      ...d,
+      identityActorId: d.input.identityActorId,
+      identityId: d.input.identityId
+    });
 
     await withMagicMcpBackingLock(
       [
@@ -94,7 +98,12 @@ class magicMcpEndpointBackingServiceImpl {
                 name: d.input.name?.trim() || d.input.id,
                 description: d.input.description,
                 metadata: d.input.metadata,
-                privateMetadata: d.input.privateMetadata
+                privateMetadata: d.input.privateMetadata,
+                identityActorId: d.input.identityActorId,
+                identityId: d.input.identityId,
+                identitySourceIntegrationInstances: serverBackings.map(
+                  backing => backing.integrationInstance
+                )
               }
             });
 

--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/server.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/server.ts
@@ -75,7 +75,11 @@ class magicMcpServerBackingServiceImpl {
   }
 
   async upsertMagicMcpServerBacking(d: UpsertMagicMcpServerBackingInput) {
-    let actorOid = await resolveActorOid({ ...d, identityActorId: d.input.identityActorId });
+    let actorOid = await resolveActorOid({
+      ...d,
+      identityActorId: d.input.identityActorId,
+      identityId: d.input.identityId
+    });
     if (d.input.providerTemplateBackingId && d.input.ownerIntegrationId) {
       throw new ServiceError(
         notFoundError(

--- a/src/systems/subspace/modules/integration/test/sharedSessionTemplate.test.ts
+++ b/src/systems/subspace/modules/integration/test/sharedSessionTemplate.test.ts
@@ -110,11 +110,14 @@ vi.mock('@metorial-subspace/module-search', () => ({
   voyagerSource: Promise.resolve({ id: 'voyager-source' })
 }));
 
-vi.mock('@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate', () => ({
-  syncIntegrationInstanceSessionTemplateQueue: {
-    add: syncIntegrationInstanceSessionTemplateQueueAddMock
-  }
-}));
+vi.mock(
+  '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate',
+  () => ({
+    syncIntegrationInstanceSessionTemplateQueue: {
+      add: syncIntegrationInstanceSessionTemplateQueueAddMock
+    }
+  })
+);
 
 vi.mock(
   '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate',
@@ -163,7 +166,9 @@ import { integrationInstanceService } from '../src/services/integrationInstance'
 describe('shared integration session templates', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    withTransactionMock.mockImplementation(async (callback: (db: any) => Promise<any>) => callback(db));
+    withTransactionMock.mockImplementation(async (callback: (db: any) => Promise<any>) =>
+      callback(db)
+    );
     addAfterTransactionHookMock.mockImplementation(async (callback: () => Promise<void>) => {
       await callback();
     });
@@ -178,7 +183,12 @@ describe('shared integration session templates', () => {
     } as any);
     upsertInternalLinkedSessionTemplateMock.mockResolvedValue(createdTemplate);
 
-    let integrationInstance = { oid: 11n, id: 'int_instance_1' } as any;
+    let integrationInstance = {
+      oid: 11n,
+      id: 'int_instance_1',
+      identityActorOid: 501n,
+      identityOid: 601n
+    } as any;
 
     let result = await integrationInstanceService.createSessionTemplateForIntegrationInstance({
       tenant: { oid: 1n } as any,
@@ -214,13 +224,18 @@ describe('shared integration session templates', () => {
   it('upserts the default shared template for an integration instance group', async () => {
     let existingTemplate = { oid: 202n, id: 'stm_group_existing' };
     let createdTemplate = { id: 'stm_group_default' };
-
-    vi.mocked(db.integrationInstanceGroup.findUniqueOrThrow).mockResolvedValue({
-      defaultSessionTemplate: existingTemplate
-    } as any);
-    upsertInternalLinkedSessionTemplateMock.mockResolvedValue(createdTemplate);
-
     let integrationInstanceGroup = { oid: 22n, id: 'int_group_1' } as any;
+    let currentIntegrationInstanceGroup = {
+      ...integrationInstanceGroup,
+      identityActorOid: 502n,
+      identityOid: 602n,
+      defaultSessionTemplate: existingTemplate
+    };
+
+    vi.mocked(db.integrationInstanceGroup.findUniqueOrThrow).mockResolvedValue(
+      currentIntegrationInstanceGroup as any
+    );
+    upsertInternalLinkedSessionTemplateMock.mockResolvedValue(createdTemplate);
 
     let result =
       await integrationInstanceGroupService.createSessionTemplateForIntegrationInstanceGroup({
@@ -245,7 +260,7 @@ describe('shared integration session templates', () => {
         description: 'Used for grouped sessions',
         metadata: { region: 'eu-central' },
         privateMetadata: undefined,
-        integrationInstanceGroup
+        integrationInstanceGroup: currentIntegrationInstanceGroup
       }
     });
     expect(syncIntegrationInstanceGroupSessionTemplateQueueAddMock).toHaveBeenCalledWith({

--- a/src/systems/subspace/modules/session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate.ts
+++ b/src/systems/subspace/modules/session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate.ts
@@ -135,6 +135,14 @@ export let syncIntegrationInstanceGroupSessionTemplate = async (data: {
   let createdSessionTemplateProviderIds = await withTransaction(async db => {
     let createdSessionTemplateProviderIds: string[] = [];
 
+    await db.sessionTemplate.update({
+      where: { oid: sessionTemplate.oid },
+      data: {
+        identityActorOid: integrationInstanceGroup.identityActorOid ?? null,
+        identityOid: integrationInstanceGroup.identityOid ?? null
+      }
+    });
+
     for (let groupProvider of materialProviders) {
       let sourceProvider = groupProvider.integrationInstanceProvider;
       let currentVersion = sourceProvider.currentVersion!;

--- a/src/systems/subspace/modules/session/src/queues/lifecycle/linkedSessionTemplate.ts
+++ b/src/systems/subspace/modules/session/src/queues/lifecycle/linkedSessionTemplate.ts
@@ -123,6 +123,14 @@ export let syncIntegrationInstanceSessionTemplateQueueProcessor =
     let createdSessionTemplateProviderIds = await withTransaction(async db => {
       let createdSessionTemplateProviderIds: string[] = [];
 
+      await db.sessionTemplate.update({
+        where: { oid: sessionTemplate.oid },
+        data: {
+          identityActorOid: integrationInstance.identityActorOid ?? null,
+          identityOid: integrationInstance.identityOid ?? null
+        }
+      });
+
       for (let integrationInstanceProvider of materialProviders) {
         let currentVersion = integrationInstanceProvider.currentVersion!;
         let existing = existingByIntegrationInstanceProviderOid.get(

--- a/src/systems/subspace/modules/session/src/queues/lifecycle/sessionTemplateProvider.ts
+++ b/src/systems/subspace/modules/session/src/queues/lifecycle/sessionTemplateProvider.ts
@@ -80,6 +80,8 @@ export let syncSessionTemplateHash = async (data: { sessionTemplateId: string })
       sessionTemplate.status,
       sessionTemplate.integrationInstanceGroupOid?.toString() ?? null,
       sessionTemplate.integrationInstanceOid?.toString() ?? null,
+      sessionTemplate.identityActorOid?.toString() ?? null,
+      sessionTemplate.identityOid?.toString() ?? null,
       providers
         .map(provider => ({
           providerOid: provider.providerOid.toString(),

--- a/src/systems/subspace/modules/session/src/services/_shared/createSession.ts
+++ b/src/systems/subspace/modules/session/src/services/_shared/createSession.ts
@@ -14,6 +14,8 @@ import {
 } from '../sessionProviderInput';
 
 export let sessionInclude = {
+  identityActor: true,
+  identity: true,
   providers: {
     include: sessionProviderInclude,
     where: { status: 'active' as const }
@@ -23,10 +25,13 @@ export let sessionInclude = {
 export let createSessionRecord = async (d: {
   db: {
     session: typeof db.session;
+    sessionTemplate: typeof db.sessionTemplate;
   };
   tenant: Tenant;
   solution: Solution;
   environment: Environment;
+  identityActorOid?: bigint | null;
+  identityOid?: bigint | null;
   input: {
     name?: string;
     description?: string;
@@ -37,6 +42,26 @@ export let createSessionRecord = async (d: {
   isEphemeral: boolean;
   ephemeralManagedSessionOid?: bigint | null;
 }) => {
+  let templateId = d.input.providers.find(
+    provider => provider.sessionTemplateId
+  )?.sessionTemplateId;
+  let templateIdentity =
+    d.identityActorOid === undefined && d.identityOid === undefined && templateId
+      ? await d.db.sessionTemplate.findFirst({
+          where: {
+            id: templateId,
+            tenantOid: d.tenant.oid,
+            solutionOid: d.solution.oid,
+            environmentOid: d.environment.oid,
+            status: 'active'
+          },
+          select: {
+            identityActorOid: true,
+            identityOid: true
+          }
+        })
+      : null;
+
   let session = await d.db.session.create({
     data: {
       ...getId('session'),
@@ -52,6 +77,8 @@ export let createSessionRecord = async (d: {
       tenantOid: d.tenant.oid,
       solutionOid: d.solution.oid,
       environmentOid: d.environment.oid,
+      identityActorOid: d.identityActorOid ?? templateIdentity?.identityActorOid ?? null,
+      identityOid: d.identityOid ?? templateIdentity?.identityOid ?? null,
       ephemeralManagedSessionOid: d.ephemeralManagedSessionOid ?? undefined,
 
       sessionEvents: {

--- a/src/systems/subspace/modules/session/src/services/ephemeralManagedSession.ts
+++ b/src/systems/subspace/modules/session/src/services/ephemeralManagedSession.ts
@@ -32,6 +32,7 @@ let include = {
   tenant: true,
   solution: true,
   environment: true,
+  identity: true,
   sessionTemplate: true,
   currentSession: {
     include: {
@@ -128,6 +129,8 @@ class ephemeralManagedSessionServiceImpl {
           solutionOid: d.solution.oid,
           environmentOid: d.environment.oid,
           sessionTemplateOid: d.sessionTemplate.oid,
+          actorOid: d.sessionTemplate.identityActorOid ?? null,
+          identityOid: d.sessionTemplate.identityOid ?? null,
           maxSessionDurationInMinutes: d.input.maxSessionDurationInMinutes,
           templateHash: d.sessionTemplate.hash ?? null
         },
@@ -141,6 +144,8 @@ class ephemeralManagedSessionServiceImpl {
         environment: d.environment,
         isEphemeral: true,
         ephemeralManagedSessionOid: ephemeralManagedSession.oid,
+        identityActorOid: d.sessionTemplate.identityActorOid ?? null,
+        identityOid: d.sessionTemplate.identityOid ?? null,
         input: {
           name: d.sessionTemplate.name ?? undefined,
           description: d.sessionTemplate.description ?? undefined,
@@ -183,7 +188,8 @@ class ephemeralManagedSessionServiceImpl {
         archivedAt: null,
         maxSessionDurationInMinutes: d.input.maxSessionDurationInMinutes,
         sessionTemplateOid: d.sessionTemplate.oid,
-        actorOid: d.input.actorOid ?? null
+        actorOid: d.input.actorOid ?? d.sessionTemplate.identityActorOid ?? null,
+        identityOid: d.sessionTemplate.identityOid ?? null
       };
 
       if (d.ephemeralManagedSession) {
@@ -322,6 +328,8 @@ class ephemeralManagedSessionServiceImpl {
           environment: ephemeralManagedSession.environment,
           isEphemeral: true,
           ephemeralManagedSessionOid: ephemeralManagedSession.oid,
+          identityActorOid: ephemeralManagedSession.sessionTemplate.identityActorOid ?? null,
+          identityOid: ephemeralManagedSession.sessionTemplate.identityOid ?? null,
           input: {
             name: ephemeralManagedSession.sessionTemplate.name ?? undefined,
             description: ephemeralManagedSession.sessionTemplate.description ?? undefined,

--- a/src/systems/subspace/modules/session/src/services/sessionTemplate.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionTemplate.ts
@@ -44,6 +44,8 @@ import {
 import { sessionTemplateProviderInclude } from './sessionTemplateProvider';
 
 let include = {
+  identityActor: true,
+  identity: true,
   integrationInstance: true,
   integrationInstanceGroup: true,
   providers: {
@@ -326,6 +328,14 @@ class sessionTemplateServiceImpl {
         isInternal: true,
         integrationInstanceOid: d.input.integrationInstance?.oid ?? null,
         integrationInstanceGroupOid: d.input.integrationInstanceGroup?.oid ?? null,
+        identityActorOid:
+          d.input.integrationInstance?.identityActorOid ??
+          d.input.integrationInstanceGroup?.identityActorOid ??
+          null,
+        identityOid:
+          d.input.integrationInstance?.identityOid ??
+          d.input.integrationInstanceGroup?.identityOid ??
+          null,
         defaultSessionTemplateForIntegrationInstanceOid:
           d.input.integrationInstance?.oid ?? null,
         defaultSessionTemplateForIntegrationInstanceGroupOid:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new nullable identity foreign keys across several core session/integration tables and updates write paths/queues to propagate them, which carries migration and data-consistency risk. Behavior changes around session creation now infer identity from templates, so incorrect linkage could affect auditing/ownership semantics.
> 
> **Overview**
> **Persists identity context across session lifecycle.** Prisma models now store nullable `identityActorOid`/`identityOid` on `IntegrationInstanceGroup`, `SessionTemplate`, `Session`, and `EphemeralManagedSession` (with new relations and indexes), and `IdentityActor`/`Identity` expose back-relations to these entities.
> 
> **Propagates identity through services and background sync.** `integrationInstanceGroupService` accepts optional `identityActorId`/`identityId` (or derives from source integration instances) and applies it on create/update/upsert; Magic MCP server/endpoint backing upserts forward `identityId` and pass instance-derived identity into group upserts. Session-template sync queues now also update the template’s identity fields and include them in the template-provider hash, while session creation can inherit identity from the referenced `SessionTemplate` when not explicitly provided; ephemeral managed session creation/upsert now persists identity from its template.
> 
> Tests were adjusted to include identity fields when asserting linked session-template behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5362bab7ac8380a162d77f2bb520582f4c7a419. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->