### PR TITLE
Fix integration ownership for magic

### DIFF
--- a/src/systems/subspace/modules/integration/src/services/integrationInstanceProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstanceProvider.ts
@@ -304,6 +304,7 @@ class integrationInstanceProviderServiceImpl {
     input: SetIntegrationInstanceProviderInput[];
     _canBreakIntegrationCanRules?: boolean;
     _allowMissingProviderAuthConfig?: boolean;
+    _canBypassProviderResourceOwnershipChecks?: boolean;
   }) {
     checkTenant(d, d.integrationInstance);
     checkDeletedRelation(d.integrationInstance);
@@ -591,12 +592,14 @@ class integrationInstanceProviderServiceImpl {
           materialProvider.currentVersion!.config?.oid === combination.config.oid;
 
         if (!isInheritedSharedConfig) {
-          assertCanUseOwnedResource({
-            kind: 'config',
-            resource: combination.config,
-            integrationInstanceOid: d.integrationInstance.oid,
-            integrationInstanceProviderOid: existing?.oid
-          });
+          if (!d._canBypassProviderResourceOwnershipChecks) {
+            assertCanUseOwnedResource({
+              kind: 'config',
+              resource: combination.config,
+              integrationInstanceOid: d.integrationInstance.oid,
+              integrationInstanceProviderOid: existing?.oid
+            });
+          }
         }
         if (
           combination.config.deploymentOid &&
@@ -606,12 +609,14 @@ class integrationInstanceProviderServiceImpl {
         }
 
         if (combination.authConfig) {
-          assertCanUseOwnedResource({
-            kind: 'auth_config',
-            resource: combination.authConfig,
-            integrationInstanceOid: d.integrationInstance.oid,
-            integrationInstanceProviderOid: existing?.oid
-          });
+          if (!d._canBypassProviderResourceOwnershipChecks) {
+            assertCanUseOwnedResource({
+              kind: 'auth_config',
+              resource: combination.authConfig,
+              integrationInstanceOid: d.integrationInstance.oid,
+              integrationInstanceProviderOid: existing?.oid
+            });
+          }
           if (
             combination.authConfig.deploymentOid &&
             combination.authConfig.deploymentOid !== deploymentOid
@@ -770,6 +775,7 @@ class integrationInstanceProviderServiceImpl {
     input: SetIntegrationInstanceProviderInput;
     _canBreakIntegrationCanRules?: boolean;
     _allowMissingProviderAuthConfig?: boolean;
+    _canBypassProviderResourceOwnershipChecks?: boolean;
   }) {
     let [integrationInstanceProvider] = await this.setIntegrationInstanceProviders({
       ...d,
@@ -836,6 +842,7 @@ class integrationInstanceProviderServiceImpl {
       // even when the linked integration would normally reject them.
       _canBreakIntegrationCanRules: true,
       _allowMissingProviderAuthConfig: d.isReconciliation,
+      _canBypassProviderResourceOwnershipChecks: d.isReconciliation,
       input: d.input.map((input, idx) => ({
         providerId: integrationProviders[idx]!.id,
         providerDeploymentId: input.providerDeploymentId,

--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/providerTemplate.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/providerTemplate.ts
@@ -146,7 +146,7 @@ class providerTemplateBackingServiceImpl {
             environment: d.environment,
             integration: existing?.integration,
             input: {
-              slug: `${slugify(d.input.name)}-${(await Hash.sha256(d.input.providerTemplateId)).slice(0, 6)}[template]`,
+              slug: `template-${slugify(d.input.name)}-${(await Hash.sha256(d.input.providerTemplateId)).slice(0, 6)}`,
               name: d.input.name,
               description: d.input.description,
               metadata: d.input.metadata,

--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/serverProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/serverProvider.ts
@@ -622,12 +622,29 @@ class magicMcpServerProviderServiceImpl {
             environment: d.environment,
             magicMcpServerBackingId: row.magicMcpServerBacking.id
           });
-          let materialInput = await resolveIntegrationProviderMaterialInput({
-            tenant: d.tenant,
-            solution: d.solution,
-            environment: d.environment,
-            input: d.input
-          });
+          let providerAuthMethodId: string | null | undefined;
+          let providerAuthCredentialsId: string | null | undefined;
+          let providerDeploymentId =
+            d.input.providerDeploymentId ??
+            row.integrationProvider.currentVersion?.deployment.id;
+
+          if (d.input.providerAuthConfigId === null) {
+            providerAuthMethodId = null;
+            providerAuthCredentialsId = null;
+          } else if (d.input.providerAuthConfigId !== undefined) {
+            let materialInput = await resolveIntegrationProviderMaterialInput({
+              tenant: d.tenant,
+              solution: d.solution,
+              environment: d.environment,
+              input: {
+                providerDeploymentId,
+                providerAuthConfigId: d.input.providerAuthConfigId
+              }
+            });
+            providerAuthMethodId = materialInput.providerAuthMethodId;
+            providerAuthCredentialsId = materialInput.providerAuthCredentialsId ?? null;
+            providerDeploymentId = materialInput.providerDeploymentId ?? providerDeploymentId;
+          }
 
           if (ownerType === 'server_owned') {
             await integrationProviderService.updateIntegrationProvider({
@@ -636,9 +653,9 @@ class magicMcpServerProviderServiceImpl {
               environment: d.environment,
               integrationProvider: row.integrationProvider,
               input: {
-                providerDeploymentId: materialInput.providerDeploymentId,
-                providerAuthMethodId: materialInput.providerAuthMethodId,
-                providerAuthCredentialsId: materialInput.providerAuthCredentialsId,
+                providerDeploymentId: d.input.providerDeploymentId,
+                providerAuthMethodId,
+                providerAuthCredentialsId,
                 providerConfigId:
                   d.input.providerConfigId === undefined
                     ? undefined
@@ -662,7 +679,7 @@ class magicMcpServerProviderServiceImpl {
             integrationInstance: backing.integrationInstance as IntegrationInstance,
             input: {
               providerId: row.integrationProvider.id,
-              providerDeploymentId: materialInput.providerDeploymentId,
+              providerDeploymentId: d.input.providerDeploymentId,
               providerConfigId:
                 d.input.providerConfigId === undefined ? undefined : d.input.providerConfigId,
               providerAuthConfigId: d.input.providerAuthConfigId ?? undefined,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches provider ownership enforcement and magic MCP provider update flows; a wrong bypass/default or auth-materialization regression could allow unintended config/auth-config reuse or misconfigure provider auth/deployment bindings.
> 
> **Overview**
> Relaxes provider `config`/`auth_config` ownership enforcement in `integrationInstanceProviderService.setIntegrationInstanceProviders` behind a new `_canBypassProviderResourceOwnershipChecks` flag, and enables this bypass during magic MCP reconciliation runs.
> 
> Adjusts magic MCP server provider updates to treat `providerAuthConfigId: null` as an explicit auth-clear, and to only resolve/update `providerAuthMethodId`/`providerAuthCredentialsId` when an auth config change is requested (otherwise leaving them unchanged).
> 
> Changes magic MCP provider-template integration slugs to a new `template-...` prefix format (dropping the prior `[template]` suffix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 915fa6c17dfd819fe28a1cc7096c1eea9be3a0af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->