### PR TITLE
Fix setup session spinner

### DIFF
--- a/src/systems/subspace/apps/public/frontend/src/pages/setupSession/components/publicSetupChrome.tsx
+++ b/src/systems/subspace/apps/public/frontend/src/pages/setupSession/components/publicSetupChrome.tsx
@@ -152,4 +152,15 @@ export let PublicSetupStatusPage = ({
   );
 };
 
-export let PublicSetupLoadingPage = () => <CenteredSpinner size={32} />;
+let SpinnerCenter = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100dvh;
+`;
+
+export let PublicSetupLoadingPage = () => (
+  <SpinnerCenter>
+    <CenteredSpinner />
+  </SpinnerCenter>
+);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only change to the setup session loading state; low risk aside from potential minor layout/visual regressions on different viewport sizes.
> 
> **Overview**
> Updates the setup session loading page to properly center the spinner by wrapping `CenteredSpinner` in a new full-viewport flex container (`SpinnerCenter`) instead of rendering the spinner alone with an explicit `size` prop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c778d9b484d5fed423bfb759e60073c94481d2d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->