### PR TITLE
Harden session template provider sync

### DIFF
--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/serverProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/serverProvider.ts
@@ -653,7 +653,7 @@ class magicMcpServerProviderServiceImpl {
               environment: d.environment,
               integrationProvider: row.integrationProvider,
               input: {
-                providerDeploymentId: d.input.providerDeploymentId,
+                providerDeploymentId,
                 providerAuthMethodId,
                 providerAuthCredentialsId,
                 providerConfigId:

--- a/src/systems/subspace/modules/session/src/services/sessionTemplateProvider.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionTemplateProvider.ts
@@ -421,24 +421,108 @@ class sessionTemplateProviderServiceImpl {
       });
 
       let activeProviderOids = groupProviders.map(provider => provider.oid);
+      let activeInstanceProviderOids = groupProviders.map(
+        provider => provider.integrationInstanceProviderOid
+      );
       let createdIds: string[] = [];
 
       let existingProviders = await db.sessionTemplateProvider.findMany({
         where: {
           sessionTemplateOid: d.sessionTemplate.oid,
-          integrationInstanceGroupProviderOid: { in: activeProviderOids }
+          OR: [
+            { integrationInstanceGroupProviderOid: { in: activeProviderOids } },
+            { integrationInstanceProviderOid: { in: activeInstanceProviderOids } }
+          ]
         },
         select: {
+          oid: true,
           id: true,
+          integrationInstanceProviderOid: true,
           integrationInstanceGroupProviderOid: true
         }
       });
-      let existingByProviderOid = new Map(
-        existingProviders.map(provider => [
-          provider.integrationInstanceGroupProviderOid!.toString(),
-          provider
-        ])
+      let existingByGroupProviderOid = new Map(
+        existingProviders
+          .filter(provider => provider.integrationInstanceGroupProviderOid)
+          .map(provider => [
+            provider.integrationInstanceGroupProviderOid!.toString(),
+            provider
+          ])
       );
+      let existingByInstanceProviderOid = new Map(
+        existingProviders
+          .filter(provider => provider.integrationInstanceProviderOid)
+          .map(provider => [provider.integrationInstanceProviderOid!.toString(), provider])
+      );
+
+      let freeGroupProviderIdentity = async (input: {
+        groupProviderOid: bigint;
+        exceptSessionTemplateProviderOid?: bigint;
+      }) => {
+        await db.sessionTemplateProvider.updateMany({
+          where: {
+            sessionTemplateOid: d.sessionTemplate.oid,
+            integrationInstanceGroupProviderOid: input.groupProviderOid,
+            oid: input.exceptSessionTemplateProviderOid
+              ? { not: input.exceptSessionTemplateProviderOid }
+              : undefined
+          },
+          data: {
+            status: 'archived',
+            integrationInstanceGroupProviderOid: null
+          }
+        });
+      };
+
+      let updateOrCreateByInstanceProvider = async (d: {
+        existing?: (typeof existingProviders)[number];
+        data: {
+          status: 'active';
+          toolFilter: PrismaJson.ToolFilter;
+          sessionTemplateOid: bigint;
+          providerOid: bigint;
+          deploymentOid: bigint;
+          configOid: bigint;
+          authConfigOid: bigint | null;
+          integrationInstanceProviderOid: bigint;
+          integrationInstanceGroupProviderOid: bigint;
+          tenantOid: bigint;
+          solutionOid: number;
+          environmentOid: bigint;
+        };
+      }) => {
+        if (d.existing) {
+          await freeGroupProviderIdentity({
+            groupProviderOid: d.data.integrationInstanceGroupProviderOid,
+            exceptSessionTemplateProviderOid: d.existing.oid
+          });
+
+          return await db.sessionTemplateProvider.update({
+            where: { oid: d.existing.oid },
+            data: d.data,
+            select: { id: true }
+          });
+        }
+
+        await freeGroupProviderIdentity({
+          groupProviderOid: d.data.integrationInstanceGroupProviderOid
+        });
+
+        return await db.sessionTemplateProvider.upsert({
+          where: {
+            sessionTemplateOid_integrationInstanceProviderOid: {
+              sessionTemplateOid: d.data.sessionTemplateOid,
+              integrationInstanceProviderOid: d.data.integrationInstanceProviderOid
+            }
+          },
+          create: {
+            ...getId('sessionTemplateProvider'),
+            ...d.data
+          },
+          update: d.data,
+          select: { id: true }
+        });
+      };
 
       for (let provider of groupProviders) {
         let currentVersion = provider.integrationInstanceProvider.currentVersion!;
@@ -458,21 +542,12 @@ class sessionTemplateProviderServiceImpl {
           environmentOid: provider.environmentOid
         };
 
-        let createdBefore = existingByProviderOid.has(provider.oid.toString());
-        let synced = await db.sessionTemplateProvider.upsert({
-          where: {
-            sessionTemplateOid_integrationInstanceGroupProviderOid: {
-              sessionTemplateOid: d.sessionTemplate.oid,
-              integrationInstanceGroupProviderOid: provider.oid
-            }
-          },
-          create: {
-            ...getId('sessionTemplateProvider'),
-            ...data
-          },
-          update: data,
-          select: { id: true }
-        });
+        let existing =
+          existingByInstanceProviderOid.get(
+            provider.integrationInstanceProviderOid.toString()
+          ) ?? existingByGroupProviderOid.get(provider.oid.toString());
+        let createdBefore = !!existing;
+        let synced = await updateOrCreateByInstanceProvider({ existing, data });
         if (!createdBefore) createdIds.push(synced.id);
       }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches provider/session sync logic and performs additional archival/identity re-assignment in the database, which could affect existing session template provider rows if the matching logic is wrong. Scope is contained to sync/update paths but impacts production data consistency.
> 
> **Overview**
> Fixes magic MCP server provider updates so `integrationProviderService.updateIntegrationProvider` uses the resolved `providerDeploymentId` (including auth-config-driven deployment changes) instead of always using the raw input.
> 
> Hardens `syncForIntegrationInstanceGroup` to reconcile `sessionTemplateProvider` rows by *either* `integrationInstanceProviderOid` or `integrationInstanceGroupProviderOid`, and to prevent duplicate group-provider identities by archiving/clearing conflicting rows before updating or upserting by instance-provider identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64015f2a2c5cfe3b3824615ef9b717d895ac1710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->