### PR TITLE
Add groups for files and portals

### DIFF
--- a/src/backend/apis/core/src/controllers/index.ts
+++ b/src/backend/apis/core/src/controllers/index.ts
@@ -12,6 +12,7 @@ import { dashboardUsageController } from './dashboard/usage';
 import { dashboardUserController } from './dashboard/user';
 import { consumerController } from './instance/consumer';
 import { consumerSurfaceController } from './instance/consumerSurface';
+import { fileCollectionDocsCategory, portalDocsCategory } from './instance/docsCategories';
 import { documentController } from './instance/document';
 import { documentParticipantController } from './instance/documentParticipant';
 import { documentVersionController } from './instance/documentVersion';
@@ -242,6 +243,38 @@ let setControllerDocsMetadata = <
 ].forEach(controller =>
   setControllerDocsMetadata(controller, {
     category: integrationDocsCategory
+  })
+);
+
+[
+  documentController,
+  documentVersionController,
+  documentParticipantController,
+  storeController,
+  storeItemController,
+  storeParticipantController,
+  fileController,
+  fileLinkController
+].forEach(controller =>
+  setControllerDocsMetadata(controller, {
+    category: fileCollectionDocsCategory
+  })
+);
+
+[
+  portalController,
+  portalAuthDashboardController,
+  portalConsumerAccessController,
+  portalConsumerAccessListingController,
+  portalConsumerAccessRequestController,
+  portalConsumerGroupController,
+  portalConsumerProfileController,
+  portalConsumerInviteController,
+  portalConsumerSurfaceProviderGroupController,
+  providerTemplateController
+].forEach(controller =>
+  setControllerDocsMetadata(controller, {
+    category: portalDocsCategory
   })
 );
 

--- a/src/backend/apis/core/src/controllers/instance/docsCategories.ts
+++ b/src/backend/apis/core/src/controllers/instance/docsCategories.ts
@@ -1,0 +1,13 @@
+import { createCategory } from '@metorial/rest';
+
+export let fileCollectionDocsCategory = createCategory({
+  id: 'file-collection',
+  name: 'File Collections',
+  indexHint: 18
+});
+
+export let portalDocsCategory = createCategory({
+  id: 'portal',
+  name: 'Portals',
+  indexHint: 19
+});

--- a/src/backend/apis/core/src/controllers/instance/portal.ts
+++ b/src/backend/apis/core/src/controllers/instance/portal.ts
@@ -31,8 +31,7 @@ export let portalController = Controller.create(
   {
     name: 'Portal',
     description:
-      'Use Portals to create custom branded MCP server marketplaces for your organization.',
-    hideInDocs: true
+      'Use Portals to create custom branded MCP server marketplaces for your organization.'
   },
   {
     list: instanceGroup

--- a/src/backend/apis/core/src/controllers/instance/portalAuth.ts
+++ b/src/backend/apis/core/src/controllers/instance/portalAuth.ts
@@ -60,8 +60,7 @@ let portalAuthManagementSsoTenantGroup = portalAuthManagementGroup.use(async ctx
 export let portalAuthDashboardController = Controller.create(
   {
     name: 'Portal Auth',
-    description: 'Manage the Ares-backed authentication configuration for a portal.',
-    hideInDocs: true
+    description: 'Manage the Ares-backed authentication configuration for a portal.'
   },
   {
     getApp: portalAuthManagementGroup

--- a/src/backend/apis/core/src/controllers/instance/portalConsumerAccess.ts
+++ b/src/backend/apis/core/src/controllers/instance/portalConsumerAccess.ts
@@ -33,8 +33,7 @@ export let portalConsumerAccessController = Controller.create(
   {
     name: 'Portal Consumer Access',
     description:
-      'Manage which consumer groups can access portal provider templates and MCP servers.',
-    hideInDocs: true
+      'Manage which consumer groups can access portal provider templates and MCP servers.'
   },
   {
     list: portalGroup

--- a/src/backend/apis/core/src/controllers/instance/portalConsumerAccessListing.ts
+++ b/src/backend/apis/core/src/controllers/instance/portalConsumerAccessListing.ts
@@ -31,8 +31,7 @@ let consumerAccessListingGroup = portalGroup.use(async ctx => {
 export let portalConsumerAccessListingController = Controller.create(
   {
     name: 'Portal Consumer Access Listings',
-    description: 'Read the shared consumer access listings available on a portal surface.',
-    hideInDocs: true
+    description: 'Read the shared consumer access listings available on a portal surface.'
   },
   {
     list: portalGroup

--- a/src/backend/apis/core/src/controllers/instance/portalConsumerAccessRequest.ts
+++ b/src/backend/apis/core/src/controllers/instance/portalConsumerAccessRequest.ts
@@ -31,8 +31,7 @@ let portalConsumerAccessRequestGroup = portalGroup.use(async ctx => {
 export let portalConsumerAccessRequestController = Controller.create(
   {
     name: 'Portal Consumer Access Requests',
-    description: 'Review and resolve consumer access requests for a portal.',
-    hideInDocs: true
+    description: 'Review and resolve consumer access requests for a portal.'
   },
   {
     list: portalGroup

--- a/src/backend/apis/core/src/controllers/instance/portalConsumerGroup.ts
+++ b/src/backend/apis/core/src/controllers/instance/portalConsumerGroup.ts
@@ -31,8 +31,7 @@ export let consumerGroupGroup = portalGroup.use(async ctx => {
 export let portalConsumerGroupController = Controller.create(
   {
     name: 'Portal Consumer Groups',
-    description: 'Manage the consumer groups that drive portal visibility and access rules.',
-    hideInDocs: true
+    description: 'Manage the consumer groups that drive portal visibility and access rules.'
   },
   {
     list: portalGroup

--- a/src/backend/apis/core/src/controllers/instance/portalConsumerInvite.ts
+++ b/src/backend/apis/core/src/controllers/instance/portalConsumerInvite.ts
@@ -31,8 +31,7 @@ export let consumerInviteGroup = portalGroup.use(async ctx => {
 export let portalConsumerInviteController = Controller.create(
   {
     name: 'Portal Consumer Invites',
-    description: 'List and inspect consumer invites for a portal.',
-    hideInDocs: true
+    description: 'List and inspect consumer invites for a portal.'
   },
   {
     list: portalGroup

--- a/src/backend/apis/core/src/controllers/instance/portalConsumerProfile.ts
+++ b/src/backend/apis/core/src/controllers/instance/portalConsumerProfile.ts
@@ -31,8 +31,7 @@ export let consumerProfileGroup = portalGroup.use(async ctx => {
 export let portalConsumerProfileController = Controller.create(
   {
     name: 'Portal Consumer Profiles',
-    description: 'Manage the consumers and effective group assignments for a portal.',
-    hideInDocs: true
+    description: 'Manage the consumers and effective group assignments for a portal.'
   },
   {
     list: portalGroup

--- a/src/backend/apis/core/src/controllers/instance/portalConsumerSurfaceProviderGroup.ts
+++ b/src/backend/apis/core/src/controllers/instance/portalConsumerSurfaceProviderGroup.ts
@@ -34,8 +34,7 @@ export let portalConsumerSurfaceProviderGroupController = Controller.create(
   {
     name: 'Portal Consumer Surface Provider Groups',
     description:
-      'Manage the provider groups linked to a portal consumer surface for organizing providers.',
-    hideInDocs: true
+      'Manage the provider groups linked to a portal consumer surface for organizing providers.'
   },
   {
     list: portalGroup

--- a/src/backend/apis/core/src/controllers/provider/providerTemplate.ts
+++ b/src/backend/apis/core/src/controllers/provider/providerTemplate.ts
@@ -77,8 +77,7 @@ export let providerTemplateController = Controller.create(
   {
     name: 'Provider Templates',
     description:
-      'Provider templates are reusable, consumer-facing wrappers around provider deployments.',
-    hideInDocs: true
+      'Provider templates are reusable, consumer-facing wrappers around provider deployments.'
   },
   {
     list: instanceGroup

--- a/src/backend/apis/core/src/presenters/implementation/portalAuthApp.ts
+++ b/src/backend/apis/core/src/presenters/implementation/portalAuthApp.ts
@@ -6,10 +6,10 @@ export let v1PortalAuthAppPresenter = Presenter.create(portalAuthAppType)
   .presenter(async ({ app, consumerSurface }) => ({
     object: 'portal.auth.app' as const,
     id: app.id,
-    client_id: app.clientId,
+    // client_id: app.clientId,
     slug: app.slug ?? null,
-    default_redirect_url: app.defaultRedirectUrl,
-    redirect_domains: app.redirectDomains,
+    // default_redirect_url: app.defaultRedirectUrl,
+    // redirect_domains: app.redirectDomains,
     email_whitelist: consumerSurface.emailWhitelist,
     created_at: app.createdAt,
     updated_at: app.updatedAt
@@ -18,17 +18,17 @@ export let v1PortalAuthAppPresenter = Presenter.create(portalAuthAppType)
     v.object({
       object: v.literal('portal.auth.app'),
       id: v.string({ description: 'The Ares app identifier for this portal.' }),
-      client_id: v.string({ description: 'The Ares app client identifier.' }),
+      // client_id: v.string({ description: 'The Ares app client identifier.' }),
       slug: v.nullable(v.string({ description: 'The Ares app slug.' })),
-      default_redirect_url: v.string({
-        description: 'The default redirect URL configured for this portal auth app.',
-        modifiers: [v.url()]
-      }),
-      redirect_domains: v.array(
-        v.string({
-          description: 'A hostname or wildcard hostname allowed for redirect callbacks.'
-        })
-      ),
+      // default_redirect_url: v.string({
+      //   description: 'The default redirect URL configured for this portal auth app.',
+      //   modifiers: [v.url()]
+      // }),
+      // redirect_domains: v.array(
+      //   v.string({
+      //     description: 'A hostname or wildcard hostname allowed for redirect callbacks.'
+      //   })
+      // ),
       email_whitelist: v.array(
         v.string({
           description:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the documented/visible surface of several controllers and removes fields from the `portal.auth.app` presenter output/schema, which may be a breaking API-contract change for consumers.
> 
> **Overview**
> Introduces two new API documentation categories—**File Collections** and **Portals**—and assigns the relevant controllers to these categories via centralized metadata in `controllers/index.ts`.
> 
> Makes portal- and provider-template-related controllers visible in generated docs by removing `hideInDocs`, and trims the `portal.auth.app` response/schema by no longer exposing `client_id`, `default_redirect_url`, or `redirect_domains` in `portalAuthAppPresenter`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea5757950256014c484104caf16cda5818de9be8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->