### PR TITLE
Extended cargo versioning

### DIFF
--- a/src/backend/apis/core/src/controllers/dashboard/assistant.ts
+++ b/src/backend/apis/core/src/controllers/dashboard/assistant.ts
@@ -220,7 +220,7 @@ export let dashboardAssistantController = Controller.create(
 
     updateConversation: assistantConversationGroup
       .use(isDashboardGroup())
-      .post(
+      .patch(
         organizationManagementPath(
           'instances/:instanceId/conversations/:assistantConversationId',
           'conversations.update'
@@ -292,7 +292,8 @@ export let dashboardAssistantController = Controller.create(
         ),
         {
           name: 'Create assistant message',
-          description: 'Create a user message and assistant request in a specific conversation.'
+          description:
+            'Create a user message and assistant request in a specific conversation.'
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.provider.session:write'] }))

--- a/src/backend/apis/files/src/index.ts
+++ b/src/backend/apis/files/src/index.ts
@@ -1,14 +1,17 @@
-import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, forbiddenError, ServiceError } from '@lowerdeck/error';
 import { createExecutionContext, provideExecutionContext } from '@lowerdeck/execution-context';
 import { extractIp } from '@lowerdeck/forwarded-for';
 import { Context, cors, createHono } from '@lowerdeck/hono';
 import { authenticate } from '@metorial/auth';
 import { generatePlainId } from '@metorial/id';
+import { upgradeWebSocket, websocket } from 'hono/bun';
 import {
+  documentService,
   fileLinkService,
   getOssFilesBucketName,
   getStorage,
   purposeSlugs,
+  resolveCargoAccess,
   uploadCargoFile
 } from '@metorial/module-file';
 import { resolveUploadTarget } from './uploadAccess';
@@ -23,6 +26,8 @@ type FileApiOptions = {
     auth: FileApiAuthResult['auth'];
   }>;
 };
+
+export { websocket };
 
 let createFileUploadHandler =
   (authenticateRequest: NonNullable<FileApiOptions['authenticateRequest']>) =>
@@ -153,6 +158,164 @@ let getFileContentHandler = async (c: Context) => {
   });
 };
 
+let getQueryParam = (url: URL, keys: string[]) => {
+  for (let key of keys) {
+    let value = url.searchParams.get(key);
+    if (value) return value;
+  }
+
+  return null;
+};
+
+let getCargoDocumentLiveUrl = (d: { actorId: string; documentId: string }) => {
+  if (!process.env.CARGO_API_URL) {
+    throw new Error('CARGO_API_URL is required');
+  }
+
+  let url = new URL(process.env.CARGO_API_URL);
+
+  if (url.pathname.endsWith('/metorial-cargo')) {
+    url.pathname = url.pathname.slice(0, -'/metorial-cargo'.length) || '/';
+  }
+
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/document-live`;
+  url.search = '';
+  url.searchParams.set('actorId', d.actorId);
+  url.searchParams.set('documentId', d.documentId);
+
+  return url.toString();
+};
+
+let createDocumentsLiveHandler =
+  (authenticateRequest: NonNullable<FileApiOptions['authenticateRequest']>) =>
+  createHono()
+    .use(async (c, next) => {
+      c.res.headers.set('Access-Control-Allow-Origin', c.req.header('Origin') || '*');
+      c.res.headers.set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+      c.res.headers.set(
+        'Access-Control-Allow-Headers',
+        'Content-Type, Authorization, Cookies, metorial-version, metorial-instance-id, metorial-consumer-profile-id, metorial-organization-id, baggage, sentry-trace, metorial-client, metorial-consumer-session-client-secret'
+      );
+      c.res.headers.set('Access-Control-Allow-Credentials', 'true');
+      c.res.headers.set('Access-Control-Max-Age', '86400');
+
+      if (c.req.method === 'OPTIONS') {
+        return c.text('OK', 200);
+      }
+
+      await next();
+    })
+    .options('*', c => c.text(''))
+    .get(
+      '/documents-live',
+      upgradeWebSocket(async c => {
+        let url = new URL(c.req.url);
+        let documentId = getQueryParam(url, ['documentId', 'document_id']);
+        let instanceId = getQueryParam(url, ['instanceId', 'instance_id']);
+        let organizationId = getQueryParam(url, ['organizationId', 'organization_id']);
+
+        if (!documentId) {
+          throw new ServiceError(
+            badRequestError({
+              message: 'Missing documentId query parameter'
+            })
+          );
+        }
+
+        let { auth } = await authenticateRequest(c.req.raw, url);
+        let target = await resolveUploadTarget({
+          auth,
+          instanceId,
+          organizationId
+        });
+
+        if (!target.cargoAccess?.accessActor) {
+          throw new ServiceError(
+            forbiddenError({
+              message: 'Actor context is required',
+              description:
+                'Live document connections require an organization actor or consumer actor context.'
+            })
+          );
+        }
+
+        await documentService.getDocumentById({
+          owner: target.owner,
+          documentId,
+          ...target.cargoAccess
+        });
+
+        let { actorId } = await resolveCargoAccess({
+          owner: target.owner,
+          ...target.cargoAccess
+        });
+        if (!actorId) {
+          throw new ServiceError(
+            forbiddenError({
+              message: 'Actor context is required'
+            })
+          );
+        }
+
+        let upstreamUrl = getCargoDocumentLiveUrl({
+          actorId,
+          documentId
+        });
+        let upstream: WebSocket | null = null;
+
+        return {
+          onOpen: async (_, ws) => {
+            upstream = new WebSocket(upstreamUrl);
+
+            upstream.onmessage = event => {
+              ws.send(typeof event.data === 'string' ? event.data : event.data.toString());
+            };
+
+            upstream.onerror = () => {
+              try {
+                ws.close(1011, 'upstream_error');
+              } catch {}
+            };
+
+            upstream.onclose = event => {
+              try {
+                ws.close(event.code || 1000, event.reason);
+              } catch {}
+            };
+          },
+
+          onMessage: async event => {
+            if (!upstream || upstream.readyState !== WebSocket.OPEN) {
+              return;
+            }
+
+            upstream.send(event.data.toString());
+          },
+
+          onClose: async () => {
+            if (!upstream) return;
+            if (
+              upstream.readyState === WebSocket.OPEN ||
+              upstream.readyState === WebSocket.CONNECTING
+            ) {
+              upstream.close();
+            }
+          },
+
+          onError: async () => {
+            if (!upstream) return;
+            if (
+              upstream.readyState === WebSocket.OPEN ||
+              upstream.readyState === WebSocket.CONNECTING
+            ) {
+              upstream.close();
+            }
+          }
+        };
+      })
+    );
+
 export let createFileUploadApi = (d?: FileApiOptions) => {
   let authenticateRequest = d?.authenticateRequest ?? authenticate;
 
@@ -172,6 +335,11 @@ export let createFileUploadApi = (d?: FileApiOptions) => {
       })
     )
     .post('/files', createFileUploadHandler(authenticateRequest));
+};
+
+export let createDocumentsLiveApi = (d?: FileApiOptions) => {
+  let authenticateRequest = d?.authenticateRequest ?? authenticate;
+  return createDocumentsLiveHandler(authenticateRequest);
 };
 
 export let createFileContentApi = () =>
@@ -195,3 +363,4 @@ export let createFileContentApi = () =>
 
 export let fileUploadApi = createFileUploadApi();
 export let fileContentApi = createFileContentApi();
+export let documentsLiveApi = createDocumentsLiveApi();

--- a/src/backend/modules/file/src/services/index.ts
+++ b/src/backend/modules/file/src/services/index.ts
@@ -14,7 +14,9 @@ export type {
   CargoStoreItem,
   CargoStoreParticipant
 } from '../cargo';
+export type { CargoAccessActor, CargoAccessInput, CargoStorePermission } from './access';
 export { uploadCargoFile } from '../cargo';
+export * from './access';
 export * from './document';
 export * from './documentParticipant';
 export * from './documentVersion';

--- a/src/systems/_clients/cargo/src/index.ts
+++ b/src/systems/_clients/cargo/src/index.ts
@@ -10,6 +10,10 @@ export type CargoHttpEndpoints = {
   headers?: CargoHeaders;
 };
 
+export type CargoDocumentLiveEndpoints = {
+  liveEndpoint: string;
+};
+
 export type CargoUploadInput = {
   tenantId: string;
   environmentId: string;
@@ -45,6 +49,76 @@ export type CargoUploadResult = {
   updatedAt: string | Date;
 };
 
+export type CargoDocumentLiveInput = {
+  documentId: string;
+  actorId?: string;
+  instanceId?: string;
+  organizationId?: string;
+};
+
+export type CargoDocumentLiveClientMessage =
+  | {
+      type: 'ping';
+    }
+  | {
+      type: 'document_update';
+      data: {
+        content: string;
+        title?: string;
+      };
+    };
+
+export type CargoDocumentLiveServerMessage =
+  | {
+      type: 'document_snapshot';
+      data: {
+        object: 'cargo#document';
+        id: string;
+        title: string;
+        status: string;
+        fileId: string;
+        file: unknown;
+        parentDocumentId: string | null;
+        currentVersionId: string | null;
+        content: string;
+        createdAt: string | Date;
+        updatedAt: string | Date;
+      };
+    }
+  | {
+      type: 'participant_list';
+      data: Array<{
+        object: 'cargo#documentParticipant';
+        id: string;
+        documentId: string;
+        role: 'editor' | 'viewer';
+        editCount: number;
+        lastEditedAt: string | Date | null;
+        lastViewedAt: string | Date | null;
+        actor: {
+          object: 'cargo#actor';
+          id: string;
+          identifier: string;
+          type: string;
+          name: string;
+          organizationActorId?: string | null;
+          consumerId?: string | null;
+          createdAt: string | Date;
+        };
+        createdAt: string | Date;
+      }>;
+    }
+  | {
+      type: 'pong';
+      data: {
+        documentId: string;
+      };
+    }
+  | {
+      type: 'error';
+      data: unknown;
+    };
+
 export let createCargoClient = (o: RpcClientOpts): CargoClient => createClient<CargoClient>(o);
 
 export let getFileDownloadUrl = (d: {
@@ -52,6 +126,27 @@ export let getFileDownloadUrl = (d: {
   fileId: string;
   key: string;
 }) => `${d.contentEndpoint.replace(/\/$/, '')}/files/${d.fileId}/${d.key}`;
+
+export let getDocumentLiveUrl = (
+  endpoints: CargoDocumentLiveEndpoints,
+  input: CargoDocumentLiveInput
+) => {
+  let url = new URL(`${endpoints.liveEndpoint.replace(/\/$/, '')}/documents-live`);
+  if (url.protocol === 'https:') url.protocol = 'wss:';
+  if (url.protocol === 'http:') url.protocol = 'ws:';
+
+  url.searchParams.set('documentId', input.documentId);
+  if (input.actorId) url.searchParams.set('actorId', input.actorId);
+  if (input.instanceId) url.searchParams.set('instanceId', input.instanceId);
+  if (input.organizationId) url.searchParams.set('organizationId', input.organizationId);
+
+  return url.toString();
+};
+
+export let createDocumentLiveConnection = (
+  endpoints: CargoDocumentLiveEndpoints,
+  input: CargoDocumentLiveInput
+) => new WebSocket(getDocumentLiveUrl(endpoints, input));
 
 export let uploadFile = async (
   endpoints: CargoHttpEndpoints,

--- a/src/systems/cargo/service/prisma/schema/docs.prisma
+++ b/src/systems/cargo/service/prisma/schema/docs.prisma
@@ -43,8 +43,10 @@ model Document {
   documentParticipants DocumentParticipant[]
   documentVersions     DocumentVersion[]
   storeItems           StoreItem[]
+  storeVersionItems    StoreVersionItem[]
 
   @@index([tenantOid, environmentOid])
+  @@index([isContentOwner])
 }
 
 enum DocumentParticipantRole {
@@ -101,6 +103,7 @@ model DocumentVersion {
 
   createdAt              DateTime                 @default(now())
   documentVersionEditors DocumentVersionEditors[]
+  storeVersionItems      StoreVersionItem[]
 
   @@unique([tenantOid, environmentOid, documentOid, versionNumber])
 }

--- a/src/systems/cargo/service/prisma/schema/file.prisma
+++ b/src/systems/cargo/service/prisma/schema/file.prisma
@@ -55,6 +55,7 @@ model File {
   links      FileLink[]
   document   Document?
   storeItems StoreItem[]
+  storeVersionItems StoreVersionItem[]
 
   @@index([tenantOid, environmentOid, status])
   @@index([tenantOid, environmentOid, createdByTenantActorOid, status])

--- a/src/systems/cargo/service/prisma/schema/store.prisma
+++ b/src/systems/cargo/service/prisma/schema/store.prisma
@@ -9,6 +9,7 @@ model Store {
 
   name      String
   itemCount Int    @default(0)
+  dirtyAt   DateTime?
 
   tenantOid BigInt
   tenant    Tenant @relation(fields: [tenantOid], references: [oid], onDelete: Cascade)
@@ -24,8 +25,11 @@ model Store {
   updatedAt DateTime @default(now()) @updatedAt
 
   items             StoreItem[]
+  versions          StoreVersion[]
   storeParticipants StoreParticipant[]
   skill             Skill?
+
+  @@index([tenantOid, environmentOid, dirtyAt])
 }
 
 model StoreItem {
@@ -53,6 +57,52 @@ model StoreItem {
   updatedAt DateTime @default(now()) @updatedAt
 
   @@unique([storeOid, path])
+  @@index([documentOid])
+}
+
+model StoreVersion {
+  oid BigInt @id
+  id  String @unique
+
+  versionNumber Int
+  sourceDirtyAt DateTime
+
+  storeOid BigInt
+  store    Store   @relation(fields: [storeOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  items StoreVersionItem[]
+
+  @@unique([storeOid, versionNumber])
+  @@unique([storeOid, sourceDirtyAt])
+  @@index([storeOid, createdAt])
+}
+
+model StoreVersionItem {
+  oid BigInt @id
+  id  String @unique
+
+  path String
+
+  storeVersionOid BigInt
+  storeVersion    StoreVersion @relation(fields: [storeVersionOid], references: [oid], onDelete: Cascade)
+
+  fileOid BigInt
+  file    File   @relation(fields: [fileOid], references: [oid], onDelete: Cascade)
+
+  documentOid BigInt?
+  document    Document? @relation(fields: [documentOid], references: [oid], onDelete: Cascade)
+
+  documentVersionOid BigInt?
+  documentVersion    DocumentVersion? @relation(fields: [documentVersionOid], references: [oid], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+
+  @@unique([storeVersionOid, path])
+  @@index([fileOid])
+  @@index([documentOid])
+  @@index([documentVersionOid])
 }
 
 enum StoreParticipantPermissions {

--- a/src/systems/cargo/service/src/controllers/tests/document.e2e.test.ts
+++ b/src/systems/cargo/service/src/controllers/tests/document.e2e.test.ts
@@ -54,6 +54,7 @@ let flushDocument = async (documentId: string) =>
 
 let syncChildVersions = async (parentDocumentVersionId: string, limit = 100) => {
   let cursor: string | undefined;
+  let downstreamVersionIds: string[] = [];
 
   while (true) {
     let result = await documentService.listSyncableChildDocumentIdsForVersionSync({
@@ -63,15 +64,23 @@ let syncChildVersions = async (parentDocumentVersionId: string, limit = 100) => 
     });
 
     for (let childDocumentId of result.childDocumentIds) {
-      await documentService.syncChildDocumentVersionFromParentVersion({
+      let syncResult = await documentService.syncChildDocumentVersionFromParentVersion({
         parentDocumentVersionId,
         childDocumentId
       });
+
+      if (syncResult?.createdVersionId) {
+        downstreamVersionIds.push(syncResult.createdVersionId);
+      }
     }
 
-    if (!result.nextCursor) return;
+    if (!result.nextCursor) break;
 
     cursor = result.nextCursor;
+  }
+
+  for (let downstreamVersionId of downstreamVersionIds) {
+    await syncChildVersions(downstreamVersionId, limit);
   }
 };
 
@@ -557,6 +566,121 @@ describe('cargo document.e2e', () => {
     expect(sourceBeforeWrite?.contentOid).not.toBe(cloneAfterWrite?.contentOid);
   });
 
+  it('keeps parent sync when a child writes the same content as the parent', async () => {
+    let { tenant, environment } = await createScope();
+
+    let parent = await cargoClient.document.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      title: 'Parent',
+      content: 'first'
+    });
+
+    let child = await cargoClient.document.clone({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: parent.id,
+      title: 'Child'
+    });
+
+    await db.documentVersion.update({
+      where: {
+        id: parent.currentVersionId!
+      },
+      data: {
+        createdAt: subtractHours(new Date(), 4)
+      }
+    });
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: parent.id,
+      content: 'second'
+    });
+    let flushedParent = await flushDocument(parent.id);
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id,
+      content: 'second'
+    });
+    await flushDocument(child.id);
+
+    let childAfterMatchingWrite = await cargoClient.document.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id
+    });
+    let childRecordAfterMatchingWrite = await db.document.findUnique({
+      where: {
+        id: child.id
+      }
+    });
+    let childVersionsAfterMatchingWrite = await cargoClient.documentVersion.list({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id,
+      limit: 10
+    });
+    let parentRecordAfterFirstUpdate = await db.document.findUnique({
+      where: {
+        id: parent.id
+      }
+    });
+
+    expect(flushedParent!.content).toBe('second');
+    expect(childAfterMatchingWrite.content).toBe('second');
+    expect(childRecordAfterMatchingWrite?.isContentOwner).toBe(false);
+    expect(childRecordAfterMatchingWrite?.contentOid).toBe(parentRecordAfterFirstUpdate?.contentOid);
+    expect(childVersionsAfterMatchingWrite.items).toHaveLength(1);
+
+    await db.documentVersion.update({
+      where: {
+        id: flushedParent!.currentVersion!.id
+      },
+      data: {
+        createdAt: subtractHours(new Date(), 4)
+      }
+    });
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: parent.id,
+      content: 'third'
+    });
+    let flushedParentAgain = await flushDocument(parent.id);
+
+    await syncChildVersions(flushedParentAgain!.currentVersion!.id);
+
+    let childAfterLaterSync = await cargoClient.document.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id
+    });
+    let childRecordAfterLaterSync = await db.document.findUnique({
+      where: {
+        id: child.id
+      }
+    });
+    let childVersionsAfterLaterSync = await cargoClient.documentVersion.list({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id,
+      limit: 10
+    });
+
+    expect(childAfterLaterSync.content).toBe('third');
+    expect(childRecordAfterLaterSync?.isContentOwner).toBe(false);
+    expect(childVersionsAfterLaterSync.items).toHaveLength(2);
+    expect(childVersionsAfterLaterSync.items[0]).toMatchObject({
+      previousVersionId: child.currentVersionId!,
+      content: 'third'
+    });
+  });
+
   it('syncs a new parent version to cloned children that still follow the parent', async () => {
     let { tenant, environment } = await createScope();
 
@@ -628,6 +752,85 @@ describe('cargo document.e2e', () => {
     expect(childVersions.items[1]).toMatchObject({
       id: child.currentVersionId!,
       content: 'first'
+    });
+  });
+
+  it('cascades synced versions to descendants at arbitrary depth', async () => {
+    let { tenant, environment } = await createScope();
+
+    let root = await cargoClient.document.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      title: 'Root',
+      content: 'first'
+    });
+
+    let child = await cargoClient.document.clone({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: root.id,
+      title: 'Child'
+    });
+    let grandchild = await cargoClient.document.clone({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id,
+      title: 'Grandchild'
+    });
+
+    await db.documentVersion.update({
+      where: {
+        id: root.currentVersionId!
+      },
+      data: {
+        createdAt: subtractHours(new Date(), 4)
+      }
+    });
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: root.id,
+      content: 'second'
+    });
+    let flushedRoot = await flushDocument(root.id);
+
+    await syncChildVersions(flushedRoot!.currentVersion!.id);
+
+    let childAfterSync = await cargoClient.document.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id
+    });
+    let grandchildAfterSync = await cargoClient.document.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: grandchild.id
+    });
+    let childVersions = await cargoClient.documentVersion.list({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id,
+      limit: 10
+    });
+    let grandchildVersions = await cargoClient.documentVersion.list({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: grandchild.id,
+      limit: 10
+    });
+
+    expect(childAfterSync.content).toBe('second');
+    expect(grandchildAfterSync.content).toBe('second');
+    expect(childVersions.items).toHaveLength(2);
+    expect(grandchildVersions.items).toHaveLength(2);
+    expect(childVersions.items[0]).toMatchObject({
+      previousVersionId: child.currentVersionId!,
+      content: 'second'
+    });
+    expect(grandchildVersions.items[0]).toMatchObject({
+      previousVersionId: grandchild.currentVersionId!,
+      content: 'second'
     });
   });
 

--- a/src/systems/cargo/service/src/controllers/tests/document.e2e.test.ts
+++ b/src/systems/cargo/service/src/controllers/tests/document.e2e.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { db } from '../../db';
-import { documentCleanupService, documentService } from '../../services';
+import { documentCleanupService, documentDraftService, documentService } from '../../services';
 import { cargoClient } from '../../test/client';
 import { cleanDatabase } from '../../test/setup';
 
@@ -51,6 +51,29 @@ let flushDocument = async (documentId: string) =>
     documentId,
     force: true
   });
+
+let syncChildVersions = async (parentDocumentVersionId: string, limit = 100) => {
+  let cursor: string | undefined;
+
+  while (true) {
+    let result = await documentService.listSyncableChildDocumentIdsForVersionSync({
+      parentDocumentVersionId,
+      cursor,
+      limit
+    });
+
+    for (let childDocumentId of result.childDocumentIds) {
+      await documentService.syncChildDocumentVersionFromParentVersion({
+        parentDocumentVersionId,
+        childDocumentId
+      });
+    }
+
+    if (!result.nextCursor) return;
+
+    cursor = result.nextCursor;
+  }
+};
 
 describe('cargo document.e2e', () => {
   beforeEach(async () => {
@@ -534,6 +557,285 @@ describe('cargo document.e2e', () => {
     expect(sourceBeforeWrite?.contentOid).not.toBe(cloneAfterWrite?.contentOid);
   });
 
+  it('syncs a new parent version to cloned children that still follow the parent', async () => {
+    let { tenant, environment } = await createScope();
+
+    let parent = await cargoClient.document.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      title: 'Parent',
+      content: 'first'
+    });
+
+    let child = await cargoClient.document.clone({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: parent.id,
+      title: 'Child'
+    });
+
+    await db.documentVersion.update({
+      where: {
+        id: parent.currentVersionId!
+      },
+      data: {
+        createdAt: subtractHours(new Date(), 4)
+      }
+    });
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: parent.id,
+      content: 'second'
+    });
+    let flushedParent = await flushDocument(parent.id);
+
+    await syncChildVersions(flushedParent!.currentVersion!.id);
+
+    let parentAfterSync = await cargoClient.document.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: parent.id
+    });
+    let childAfterSync = await cargoClient.document.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id
+    });
+    let childVersions = await cargoClient.documentVersion.list({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id,
+      limit: 10
+    });
+    let childRecord = await db.document.findUnique({
+      where: {
+        id: child.id
+      }
+    });
+
+    expect(parentAfterSync.currentVersionId).toBe(flushedParent!.currentVersion!.id);
+    expect(parentAfterSync.content).toBe('second');
+    expect(childAfterSync.content).toBe('second');
+    expect(childRecord?.isContentOwner).toBe(false);
+    expect(childVersions.items).toHaveLength(2);
+    expect(childVersions.items[0]).toMatchObject({
+      content: 'second',
+      previousVersionId: child.currentVersionId!,
+      listEditedAt: expect.any(Date)
+    });
+    expect(childVersions.items[1]).toMatchObject({
+      id: child.currentVersionId!,
+      content: 'first'
+    });
+  });
+
+  it('does not sync children that already have a local draft', async () => {
+    let { tenant, environment } = await createScope();
+
+    let parent = await cargoClient.document.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      title: 'Parent',
+      content: 'first'
+    });
+
+    let child = await cargoClient.document.clone({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: parent.id,
+      title: 'Child'
+    });
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id,
+      content: 'child draft'
+    });
+
+    await db.documentVersion.update({
+      where: {
+        id: parent.currentVersionId!
+      },
+      data: {
+        createdAt: subtractHours(new Date(), 4)
+      }
+    });
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: parent.id,
+      content: 'second'
+    });
+    let flushedParent = await flushDocument(parent.id);
+
+    let firstPage = await documentService.listSyncableChildDocumentIdsForVersionSync({
+      parentDocumentVersionId: flushedParent!.currentVersion!.id,
+      limit: 100
+    });
+    let syncResult = await documentService.syncChildDocumentVersionFromParentVersion({
+      parentDocumentVersionId: flushedParent!.currentVersion!.id,
+      childDocumentId: child.id
+    });
+    let childAfterAttempt = await cargoClient.document.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id
+    });
+    let childVersions = await cargoClient.documentVersion.list({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id,
+      limit: 10
+    });
+
+    expect(firstPage.childDocumentIds).not.toContain(child.id);
+    expect(syncResult).toBeNull();
+    expect(childAfterAttempt.content).toBe('child draft');
+    expect(childVersions.items).toHaveLength(1);
+  });
+
+  it('does not sync children that already forked into their own content', async () => {
+    let { tenant, environment } = await createScope();
+
+    let parent = await cargoClient.document.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      title: 'Parent',
+      content: 'first'
+    });
+
+    let child = await cargoClient.document.clone({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: parent.id,
+      title: 'Child'
+    });
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id,
+      content: 'child edit'
+    });
+    await flushDocument(child.id);
+
+    await db.documentVersion.update({
+      where: {
+        id: parent.currentVersionId!
+      },
+      data: {
+        createdAt: subtractHours(new Date(), 4)
+      }
+    });
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: parent.id,
+      content: 'second'
+    });
+    let flushedParent = await flushDocument(parent.id);
+
+    let firstPage = await documentService.listSyncableChildDocumentIdsForVersionSync({
+      parentDocumentVersionId: flushedParent!.currentVersion!.id,
+      limit: 100
+    });
+    let childAfterAttempt = await cargoClient.document.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id
+    });
+    let childRecord = await db.document.findUnique({
+      where: {
+        id: child.id
+      }
+    });
+
+    expect(firstPage.childDocumentIds).not.toContain(child.id);
+    expect(childRecord?.isContentOwner).toBe(true);
+    expect(childAfterAttempt.content).toBe('child edit');
+  });
+
+  it('paginates follower children when syncing parent versions', async () => {
+    let { tenant, environment } = await createScope();
+
+    let parent = await cargoClient.document.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      title: 'Parent',
+      content: 'first'
+    });
+
+    let children = await Promise.all(
+      ['Child A', 'Child B', 'Child C'].map(title =>
+        cargoClient.document.clone({
+          tenantId: tenant.id,
+          environmentId: environment.id,
+          documentId: parent.id,
+          title
+        })
+      )
+    );
+
+    await db.documentVersion.update({
+      where: {
+        id: parent.currentVersionId!
+      },
+      data: {
+        createdAt: subtractHours(new Date(), 4)
+      }
+    });
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: parent.id,
+      content: 'second'
+    });
+    let flushedParent = await flushDocument(parent.id);
+
+    let firstPage = await documentService.listSyncableChildDocumentIdsForVersionSync({
+      parentDocumentVersionId: flushedParent!.currentVersion!.id,
+      limit: 2
+    });
+    let secondPage = await documentService.listSyncableChildDocumentIdsForVersionSync({
+      parentDocumentVersionId: flushedParent!.currentVersion!.id,
+      cursor: firstPage.nextCursor,
+      limit: 2
+    });
+
+    expect(firstPage.childDocumentIds).toHaveLength(2);
+    expect(secondPage.childDocumentIds).toHaveLength(1);
+
+    await syncChildVersions(flushedParent!.currentVersion!.id, 2);
+
+    let syncedChildren = await Promise.all(
+      children.map(async child => ({
+        child,
+        document: await cargoClient.document.get({
+          tenantId: tenant.id,
+          environmentId: environment.id,
+          documentId: child.id
+        }),
+        versions: await cargoClient.documentVersion.list({
+          tenantId: tenant.id,
+          environmentId: environment.id,
+          documentId: child.id,
+          limit: 10
+        })
+      }))
+    );
+
+    for (let item of syncedChildren) {
+      expect(item.document.content).toBe('second');
+      expect(item.versions.items).toHaveLength(2);
+    }
+  });
+
   it('cleans up stale versions and orphaned document content', async () => {
     let { tenant, environment } = await createScope();
     let actor = await createActor(tenant.id);
@@ -604,5 +906,58 @@ describe('cargo document.e2e', () => {
       listEditedAt: expect.any(Date)
     });
     expect(contentCountAfter).toBe(contentCountBefore - 1);
+  });
+
+  it('keeps dirty backstop markers until the latest claimed revision is flushed', async () => {
+    let { tenant, environment } = await createScope();
+    let actor = await createActor(tenant.id);
+
+    let created = await cargoClient.document.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      title: 'Dirty Backstop',
+      content: 'first',
+      actorId: actor.id
+    });
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: created.id,
+      content: 'second',
+      actorId: actor.id
+    });
+
+    expect(await documentDraftService.listDirtyDocumentIds()).toContain(created.id);
+
+    let claimedRevision = await documentDraftService.claimDirtyDocumentRevision(created.id);
+
+    expect(claimedRevision).toBe(1);
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: created.id,
+      content: 'third',
+      actorId: actor.id
+    });
+
+    let flushed = await documentService.flushDocumentDraft({
+      documentId: created.id,
+      force: true,
+      queuedRevision: claimedRevision!
+    });
+
+    let fetched = await cargoClient.document.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: created.id
+    });
+
+    expect(flushed?.id).toBe(created.id);
+    expect(fetched.content).toBe('third');
+    expect(await documentDraftService.getDraftByDocumentId(created.id)).toBeNull();
+    expect(await documentDraftService.listDirtyDocumentIds()).not.toContain(created.id);
+    expect(await documentDraftService.claimDirtyDocumentRevision(created.id)).toBeNull();
   });
 });

--- a/src/systems/cargo/service/src/controllers/tests/document.e2e.test.ts
+++ b/src/systems/cargo/service/src/controllers/tests/document.e2e.test.ts
@@ -539,6 +539,11 @@ describe('cargo document.e2e', () => {
       documentId: cloned.id,
       content: 'clone-only'
     });
+    let cloneAfterFirstWrite = await db.document.findUnique({
+      where: {
+        id: cloned.id
+      }
+    });
     await flushDocument(cloned.id);
 
     let sourceAfterWrite = await cargoClient.document.get({
@@ -557,13 +562,94 @@ describe('cargo document.e2e', () => {
       }
     });
 
+    expect(cloned.file.storeId).toBe(source.file.storeId);
     expect(cloneBeforeWrite?.isContentOwner).toBe(false);
     expect(sourceBeforeWrite?.contentOid).toBe(cloneBeforeWrite?.contentOid);
     expect(updatedClone.currentVersionId).toBe(cloned.currentVersionId);
     expect(updatedClone.content).toBe('clone-only');
+    expect(cloneAfterFirstWrite?.isContentOwner).toBe(true);
     expect(sourceAfterWrite.content).toBe('shared');
     expect(cloneAfterWrite?.isContentOwner).toBe(true);
     expect(sourceBeforeWrite?.contentOid).not.toBe(cloneAfterWrite?.contentOid);
+  });
+
+  it('does not flip ownership on title-only updates for linked children', async () => {
+    let { tenant, environment } = await createScope();
+
+    let parent = await cargoClient.document.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      title: 'Parent',
+      content: 'shared'
+    });
+
+    let child = await cargoClient.document.clone({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: parent.id,
+      title: 'Child'
+    });
+
+    let updatedChild = await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id,
+      title: 'Child Renamed'
+    });
+    let childRecord = await db.document.findUnique({
+      where: {
+        id: child.id
+      }
+    });
+
+    expect(updatedChild.title).toBe('Child Renamed');
+    expect(updatedChild.file.storeId).toBe(parent.file.storeId);
+    expect(childRecord?.isContentOwner).toBe(false);
+  });
+
+  it('stops treating a child as linked immediately after a divergent write', async () => {
+    let { tenant, environment } = await createScope();
+
+    let parent = await cargoClient.document.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      title: 'Parent',
+      content: 'shared'
+    });
+
+    let child = await cargoClient.document.clone({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: parent.id,
+      title: 'Child'
+    });
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id,
+      content: 'child-owned'
+    });
+
+    let childRecord = await db.document.findUnique({
+      where: {
+        id: child.id
+      }
+    });
+
+    await documentDraftService.clearDocumentState(child.id);
+
+    let linkedChildren = await documentService.listLinkedChildDocumentsForLiveSync({
+      parentDocumentId: parent.id
+    });
+    let syncableChildren = await documentService.listSyncableChildDocumentIdsForVersionSync({
+      parentDocumentVersionId: parent.currentVersionId!,
+      limit: 10
+    });
+
+    expect(childRecord?.isContentOwner).toBe(true);
+    expect(linkedChildren.map(document => document.id)).not.toContain(child.id);
+    expect(syncableChildren.childDocumentIds).not.toContain(child.id);
   });
 
   it('keeps parent sync when a child writes the same content as the parent', async () => {

--- a/src/systems/cargo/service/src/controllers/tests/file.e2e.test.ts
+++ b/src/systems/cargo/service/src/controllers/tests/file.e2e.test.ts
@@ -340,6 +340,75 @@ describe('cargo file.e2e', () => {
     ).rejects.toThrow();
   });
 
+  it('uses the parent store for linked document files until the first divergent write', async () => {
+    let tenant = await cargoClient.tenant.upsert({
+      identifier: 'tenant-file-linked-document-store',
+      name: 'Tenant File Linked Document Store'
+    });
+
+    let environment = await cargoClient.environment.upsert({
+      tenantId: tenant.id,
+      identifier: 'prod',
+      name: 'Production',
+      type: 'production'
+    });
+
+    let parent = await cargoClient.document.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      title: 'Parent',
+      content: 'shared'
+    });
+
+    let child = await cargoClient.document.clone({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: parent.id,
+      title: 'Child'
+    });
+    let childFileRecord = await db.file.findUnique({
+      where: {
+        id: child.fileId
+      }
+    });
+
+    let childFileBeforeFork = await cargoClient.file.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      fileId: child.fileId
+    });
+    let listedBeforeFork = await cargoClient.file.list({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      limit: 10
+    });
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: child.id,
+      content: 'child-owned'
+    });
+
+    let childFileAfterFork = await cargoClient.file.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      fileId: child.fileId
+    });
+    let listedAfterFork = await cargoClient.file.list({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      limit: 10
+    });
+    let listedChildBeforeFork = listedBeforeFork.items.find(item => item.id === child.fileId);
+    let listedChildAfterFork = listedAfterFork.items.find(item => item.id === child.fileId);
+
+    expect(childFileBeforeFork.storeId).toBe(parent.file.storeId);
+    expect(listedChildBeforeFork?.storeId).toBe(parent.file.storeId);
+    expect(childFileAfterFork.storeId).toBe(childFileRecord?.storeId);
+    expect(listedChildAfterFork?.storeId).toBe(childFileRecord?.storeId);
+  });
+
   it('attaches files to stores on create when write access is available', async () => {
     let tenant = await cargoClient.tenant.upsert({
       identifier: 'tenant-file-store-shortcut',

--- a/src/systems/cargo/service/src/controllers/tests/storeVersion.e2e.test.ts
+++ b/src/systems/cargo/service/src/controllers/tests/storeVersion.e2e.test.ts
@@ -1,0 +1,457 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { db } from '../../db';
+import { documentService, storeVersionService } from '../../services';
+import { cargoClient } from '../../test/client';
+import { cleanDatabase } from '../../test/setup';
+
+let subtractHours = (date: Date, hours: number) =>
+  new Date(date.getTime() - hours * 60 * 60 * 1000);
+
+let createScope = async () => {
+  let tenant = await cargoClient.tenant.upsert({
+    identifier: 'tenant-store-versions',
+    name: 'Tenant Store Versions'
+  });
+
+  let environment = await cargoClient.environment.upsert({
+    tenantId: tenant.id,
+    identifier: 'prod',
+    name: 'Production',
+    type: 'production'
+  });
+
+  return {
+    tenant,
+    environment
+  };
+};
+
+let createPurpose = async () =>
+  await cargoClient.filePurpose.upsert({
+    slug: 'store_version_assets',
+    name: 'Store Version Assets',
+    ownerType: 'organization',
+    canHaveLinks: true
+  });
+
+let createFile = async (d: {
+  tenantId: string;
+  environmentId: string;
+  purposeId: string;
+  id?: string;
+  storeId: string;
+  name: string;
+}) =>
+  await cargoClient.file.create({
+    tenantId: d.tenantId,
+    environmentId: d.environmentId,
+    fileId: d.id,
+    purpose: d.purposeId,
+    storeId: d.storeId,
+    name: d.name,
+    mimeType: 'image/png',
+    size: 128,
+    title: d.name
+  });
+
+let flushDocument = async (documentId: string) =>
+  await documentService.flushDocumentDraft({
+    documentId,
+    force: true
+  });
+
+describe('cargo storeVersion.e2e', () => {
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  it('marks stores dirty once for direct item changes', async () => {
+    let { tenant, environment } = await createScope();
+    let purpose = await createPurpose();
+    let firstFile = await createFile({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      purposeId: purpose.id,
+      id: 'cfi_store_version_dirty_1',
+      storeId: 'store-version-dirty-1',
+      name: 'avatar-1.png'
+    });
+    let secondFile = await createFile({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      purposeId: purpose.id,
+      id: 'cfi_store_version_dirty_2',
+      storeId: 'store-version-dirty-2',
+      name: 'avatar-2.png'
+    });
+    let store = await cargoClient.store.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: 'cst_store_version_dirty',
+      name: 'Dirty Store'
+    });
+
+    await cargoClient.store.modifyItems({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: store.id,
+      operations: [
+        {
+          fileId: firstFile.id,
+          path: '/assets/avatar.png'
+        }
+      ]
+    });
+
+    let firstDirtyStore = await db.store.findUnique({
+      where: {
+        id: store.id
+      }
+    });
+
+    expect(firstDirtyStore?.dirtyAt).toBeTruthy();
+
+    await cargoClient.store.modifyItems({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: store.id,
+      operations: [
+        {
+          fileId: secondFile.id,
+          path: '/assets/avatar-2.png'
+        }
+      ]
+    });
+
+    let secondDirtyStore = await db.store.findUnique({
+      where: {
+        id: store.id
+      }
+    });
+
+    expect(secondDirtyStore?.dirtyAt?.toISOString()).toBe(firstDirtyStore?.dirtyAt?.toISOString());
+  });
+
+  it('marks linked stores dirty when document versions are created without overwriting dirtyAt', async () => {
+    let { tenant, environment } = await createScope();
+    let store = await cargoClient.store.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: 'cst_store_version_doc_dirty',
+      name: 'Document Dirty Store'
+    });
+    let created = await cargoClient.document.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      title: 'Readme',
+      content: 'hello world',
+      store: {
+        id: store.id,
+        path: '/docs/readme.md'
+      }
+    });
+
+    await db.store.update({
+      where: {
+        id: store.id
+      },
+      data: {
+        dirtyAt: null
+      }
+    });
+
+    let documentRecord = await db.document.findUnique({
+      where: {
+        id: created.id
+      }
+    });
+
+    await db.documentVersion.update({
+      where: {
+        oid: documentRecord!.currentVersionOid!
+      },
+      data: {
+        createdAt: subtractHours(new Date(), 4)
+      }
+    });
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: created.id,
+      content: 'hello world v2'
+    });
+    await flushDocument(created.id);
+
+    let firstDirtyStore = await db.store.findUnique({
+      where: {
+        id: store.id
+      }
+    });
+
+    expect(firstDirtyStore?.dirtyAt).toBeTruthy();
+
+    let updatedDocument = await db.document.findUnique({
+      where: {
+        id: created.id
+      }
+    });
+
+    await db.documentVersion.update({
+      where: {
+        oid: updatedDocument!.currentVersionOid!
+      },
+      data: {
+        createdAt: subtractHours(new Date(), 4)
+      }
+    });
+
+    await cargoClient.document.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: created.id,
+      content: 'hello world v3'
+    });
+    await flushDocument(created.id);
+
+    let secondDirtyStore = await db.store.findUnique({
+      where: {
+        id: store.id
+      }
+    });
+
+    expect(secondDirtyStore?.dirtyAt?.toISOString()).toBe(firstDirtyStore?.dirtyAt?.toISOString());
+  });
+
+  it('lists stores ready for versioning and snapshots document version ids', async () => {
+    let { tenant, environment } = await createScope();
+    let purpose = await createPurpose();
+    let file = await createFile({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      purposeId: purpose.id,
+      id: 'cfi_store_version_snapshot_file',
+      storeId: 'store-version-snapshot-file',
+      name: 'logo.png'
+    });
+    let readyStore = await cargoClient.store.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: 'cst_store_version_ready',
+      name: 'Ready Store'
+    });
+    let waitingStore = await cargoClient.store.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: 'cst_store_version_waiting',
+      name: 'Waiting Store'
+    });
+    let document = await cargoClient.document.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      title: 'Guide',
+      content: 'snapshot me',
+      store: {
+        id: readyStore.id,
+        path: '/docs/guide.md'
+      }
+    });
+
+    await cargoClient.store.modifyItems({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: readyStore.id,
+      operations: [
+        {
+          fileId: file.id,
+          path: '/assets/logo.png'
+        }
+      ]
+    });
+
+    let documentRecord = await db.document.findUnique({
+      where: {
+        id: document.id
+      },
+      include: {
+        currentVersion: true
+      }
+    });
+
+    let staleDirtyAt = subtractHours(new Date(), 2);
+    let tenantRecord = (await db.tenant.findUnique({
+      where: {
+        id: tenant.id
+      },
+      select: {
+        id: true,
+        oid: true
+      }
+    }))!;
+    let environmentRecord = (await db.environment.findUnique({
+      where: {
+        id: environment.id
+      },
+      select: {
+        id: true,
+        oid: true
+      }
+    }))!;
+
+    await db.store.update({
+      where: {
+        id: readyStore.id
+      },
+      data: {
+        dirtyAt: staleDirtyAt
+      }
+    });
+    await db.store.update({
+      where: {
+        id: waitingStore.id
+      },
+      data: {
+        dirtyAt: subtractHours(new Date(), 0.5)
+      }
+    });
+
+    let readyResult = await storeVersionService.listStoreIdsReadyForVersioning({
+      limit: 10,
+      dirtyBefore: subtractHours(new Date(), 1)
+    });
+
+    expect(readyResult.stores).toEqual([
+      {
+        storeId: readyStore.id,
+        dirtyAt: staleDirtyAt
+      }
+    ]);
+
+    let snapshotResult = await storeVersionService.createStoreVersionSnapshot({
+      storeId: readyStore.id,
+      expectedDirtyAt: staleDirtyAt
+    });
+
+    expect(snapshotResult?.alreadyExisted).toBe(false);
+    expect(snapshotResult?.didClearDirtyAt).toBe(true);
+    expect(snapshotResult?.version).toMatchObject({
+      kind: 'snapshot',
+      storeId: readyStore.id,
+      versionNumber: 1,
+      itemCount: 2
+    });
+
+    let documentSnapshotItem = snapshotResult!.version.items.find(
+      item => item.documentId === document.id
+    );
+
+    expect(documentSnapshotItem?.documentVersionId).toBe(documentRecord?.currentVersion?.id);
+
+    let listedVersions = await (
+      await storeVersionService.listStoreVersions({
+        tenant: tenantRecord,
+        environment: environmentRecord,
+        storeId: readyStore.id
+      })
+    ).run({
+      limit: 10
+    });
+
+    expect(listedVersions.items).toHaveLength(1);
+    expect(listedVersions.items[0]?.id).toBe(snapshotResult?.version.id);
+
+    let latestVersion = await storeVersionService.getResolvedStoreVersion({
+      tenant: tenantRecord,
+      environment: environmentRecord,
+      storeId: readyStore.id,
+      storeVersionId: 'latest'
+    });
+
+    expect(latestVersion).toMatchObject({
+      id: 'latest',
+      kind: 'latest',
+      storeId: readyStore.id,
+      itemCount: 2
+    });
+
+    let refreshedReadyStore = await db.store.findUnique({
+      where: {
+        id: readyStore.id
+      }
+    });
+    let refreshedWaitingStore = await db.store.findUnique({
+      where: {
+        id: waitingStore.id
+      }
+    });
+
+    expect(refreshedReadyStore?.dirtyAt).toBeNull();
+    expect(refreshedWaitingStore?.dirtyAt).toBeTruthy();
+  });
+
+  it('keeps dirtyAt when live store state has moved past the snapshot start', async () => {
+    let { tenant, environment } = await createScope();
+    let purpose = await createPurpose();
+    let file = await createFile({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      purposeId: purpose.id,
+      id: 'cfi_store_version_race_file',
+      storeId: 'store-version-race-file',
+      name: 'banner.png'
+    });
+    let store = await cargoClient.store.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: 'cst_store_version_race',
+      name: 'Race Store'
+    });
+
+    let added = await cargoClient.store.modifyItems({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: store.id,
+      operations: [
+        {
+          fileId: file.id,
+          path: '/assets/banner.png'
+        }
+      ]
+    });
+
+    let staleDirtyAt = subtractHours(new Date(), 2);
+
+    await db.store.update({
+      where: {
+        id: store.id
+      },
+      data: {
+        dirtyAt: staleDirtyAt
+      }
+    });
+    await db.storeItem.update({
+      where: {
+        id: added[0]!.item.id
+      },
+      data: {
+        updatedAt: new Date(Date.now() + 60_000)
+      }
+    });
+
+    let snapshotResult = await storeVersionService.createStoreVersionSnapshot({
+      storeId: store.id,
+      expectedDirtyAt: staleDirtyAt
+    });
+
+    expect(snapshotResult?.version.versionNumber).toBe(1);
+    expect(snapshotResult?.didClearDirtyAt).toBe(false);
+
+    let refreshedStore = await db.store.findUnique({
+      where: {
+        id: store.id
+      }
+    });
+
+    expect(refreshedStore?.dirtyAt?.toISOString()).toBe(staleDirtyAt.toISOString());
+  });
+});

--- a/src/systems/cargo/service/src/db.ts
+++ b/src/systems/cargo/service/src/db.ts
@@ -1,5 +1,11 @@
+import {
+  provideExecutionContext,
+  withExecutionContextOptional
+} from '@lowerdeck/execution-context';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { readReplicas } from '@prisma/extension-read-replicas';
+import { AsyncLocalStorage } from 'async_hooks';
+import PQueue from 'p-queue';
 import { PrismaClient } from '../prisma/generated/client';
 
 let mainAdapter = new PrismaPg({
@@ -29,3 +35,66 @@ if (replicaClient) {
 }
 
 export let db = baseClient;
+
+export type TransactionDB = Parameters<Parameters<typeof db.$transaction>[0]>[0];
+
+let tdbStorage = new AsyncLocalStorage<{
+  tdb: TransactionDB;
+  afterHooks: Array<() => Promise<void | any>>;
+}>();
+
+let afterQueue = new PQueue({ concurrency: Infinity });
+
+export let withTransaction = async <T>(
+  cb: (tdb: TransactionDB) => Promise<T>,
+  opts?: { ifExists?: boolean }
+): Promise<T> => {
+  let tdb = tdbStorage.getStore();
+
+  if (tdb || opts?.ifExists) {
+    return await cb(tdb?.tdb ?? db);
+  } else {
+    let afterHooks: Array<() => Promise<void | any>> = [];
+
+    let res = await db.$transaction(async tdb => {
+      return await tdbStorage.run(
+        {
+          tdb,
+          afterHooks
+        },
+        async () => {
+          return await cb(tdb);
+        }
+      );
+    });
+
+    afterQueue.add(async () => {
+      let inner = async () => await Promise.all(afterHooks.map(hook => hook()));
+
+      await inner();
+    });
+
+    return res;
+  }
+};
+
+export let addAfterTransactionHook = (hook: () => any) =>
+  withExecutionContextOptional(async ctx => {
+    let tdb = tdbStorage.getStore();
+
+    if (tdb) {
+      tdb.afterHooks.push(() => {
+        if (ctx) return provideExecutionContext(ctx, hook);
+        return hook();
+      });
+    } else {
+      setTimeout(
+        () =>
+          afterQueue.add(async () => {
+            if (ctx) await provideExecutionContext(ctx, hook);
+            else await hook();
+          }),
+        5000
+      );
+    }
+  });

--- a/src/systems/cargo/service/src/endpoints.ts
+++ b/src/systems/cargo/service/src/endpoints.ts
@@ -5,8 +5,16 @@ import { CargoRPC } from './controllers';
 import { db } from './db';
 import { env } from './env';
 import { cargoContentApi, cargoUploadApi } from './http';
+import { documentLiveApi, websocket } from './live/document';
 
 let combinedApi = apiMux([
+  {
+    endpoint: {
+      path: '/document-live',
+      fetch: documentLiveApi.fetch as any
+    }
+  },
+
   {
     methods: ['POST', 'OPTIONS'],
     endpoint: {
@@ -23,7 +31,9 @@ let combinedApi = apiMux([
 
 let apiServer = Bun.serve({
   fetch: combinedApi,
-  port: env.service.CARGO_API_PORT
+  port: env.service.CARGO_API_PORT,
+  websocket,
+  idleTimeout: 240
 });
 
 let contentServer = Bun.serve({

--- a/src/systems/cargo/service/src/id.ts
+++ b/src/systems/cargo/service/src/id.ts
@@ -12,6 +12,8 @@ export let ID = createIdGenerator({
   store: idType.sorted('cst_'),
   skill: idType.sorted('csk_'),
   storeItem: idType.sorted('csti_'),
+  storeVersion: idType.sorted('cstv_'),
+  storeVersionItem: idType.sorted('cstvi_'),
   storeParticipant: idType.sorted('cstp_'),
   document: idType.sorted('cdoc_'),
   documentContent: idType.sorted('cdocn_'),

--- a/src/systems/cargo/service/src/live/document.ts
+++ b/src/systems/cargo/service/src/live/document.ts
@@ -1,0 +1,312 @@
+import { createHono } from '@lowerdeck/hono';
+import { internalServerError, isServiceError } from '@lowerdeck/error';
+import { generatePlainId } from '@lowerdeck/id';
+import { upgradeWebSocket, websocket } from 'hono/bun';
+import type { WSContext } from 'hono/ws';
+import { db } from '../db';
+import { documentParticipantPresenter, documentPresenter } from '../presenters';
+import { documentService } from '../services';
+
+export { websocket };
+
+let participantTimeoutMs = 60 * 1000;
+let participantCleanupIntervalMs = 10 * 1000;
+
+type DocumentLiveClientMessage =
+  | {
+      type: 'ping';
+    }
+  | {
+      type: 'document_update';
+      data: {
+        content: string;
+        title?: string;
+      };
+    };
+
+type LiveSession = {
+  id: string;
+  documentId: string;
+  actorId: string;
+  lastPingAt: number;
+};
+
+let liveSessions = new Map<string, LiveSession>();
+let socketsBySessionId = new Map<string, WSContext<any>>();
+let sessionIdsByDocumentId = new Map<string, Set<string>>();
+let lastParticipantPayloadByDocumentId = new Map<string, string>();
+
+let getRoomSessionIds = (documentId: string) => {
+  let existing = sessionIdsByDocumentId.get(documentId);
+  if (existing) return existing;
+
+  let created = new Set<string>();
+  sessionIdsByDocumentId.set(documentId, created);
+  return created;
+};
+
+let getActiveSessionIds = (documentId: string) => {
+  let now = Date.now();
+  let sessionIds = sessionIdsByDocumentId.get(documentId);
+  if (!sessionIds) return [];
+
+  return [...sessionIds].filter(sessionId => {
+    let session = liveSessions.get(sessionId);
+    return !!session && now - session.lastPingAt <= participantTimeoutMs;
+  });
+};
+
+let getActiveActorIds = (documentId: string) =>
+  [...new Set(getActiveSessionIds(documentId).map(sessionId => liveSessions.get(sessionId)?.actorId))].filter(
+    (actorId): actorId is string => !!actorId
+  );
+
+let send = (ws: WSContext<any>, type: string, data: any) => {
+  ws.send(JSON.stringify({ type, data }));
+};
+
+let sendError = (ws: WSContext<any>, error: unknown) => {
+  if (isServiceError(error)) {
+    send(ws, 'error', error.toResponse());
+    return;
+  }
+
+  send(ws, 'error', internalServerError().toResponse());
+};
+
+let broadcastToDocument = (documentId: string, type: string, data: any) => {
+  for (let sessionId of getActiveSessionIds(documentId)) {
+    let ws = socketsBySessionId.get(sessionId);
+    if (!ws) continue;
+    send(ws, type, data);
+  }
+};
+
+let buildDocumentPayload = (
+  document: Awaited<ReturnType<typeof documentService.getScopedDocumentById>>['document'],
+  d?: {
+    content?: string;
+    updatedAt?: Date;
+  }
+) => ({
+  ...documentPresenter(document),
+  ...(d?.content !== undefined ? { content: d.content } : {}),
+  ...(d?.updatedAt ? { updatedAt: d.updatedAt } : {})
+});
+
+let broadcastParticipantList = async (documentId: string) => {
+  let actorIds = getActiveActorIds(documentId);
+  let payload =
+    actorIds.length === 0
+      ? []
+      : (
+          await db.documentParticipant.findMany({
+            where: {
+              document: {
+                id: documentId
+              },
+              tenantActor: {
+                id: {
+                  in: actorIds
+                }
+              }
+            },
+            include: {
+              document: true,
+              tenantActor: true
+            },
+            orderBy: [
+              {
+                role: 'asc'
+              },
+              {
+                createdAt: 'asc'
+              }
+            ]
+          })
+        )
+          .map(documentParticipantPresenter)
+          .sort((left, right) => left.actor.name.localeCompare(right.actor.name) || left.id.localeCompare(right.id));
+
+  let serialized = JSON.stringify(payload);
+  if (lastParticipantPayloadByDocumentId.get(documentId) === serialized) {
+    return;
+  }
+
+  lastParticipantPayloadByDocumentId.set(documentId, serialized);
+  broadcastToDocument(documentId, 'participant_list', payload);
+};
+
+let removeSession = async (sessionId: string) => {
+  let session = liveSessions.get(sessionId);
+  if (!session) return;
+
+  liveSessions.delete(sessionId);
+  socketsBySessionId.delete(sessionId);
+
+  let room = sessionIdsByDocumentId.get(session.documentId);
+  if (room) {
+    room.delete(sessionId);
+    if (room.size === 0) {
+      sessionIdsByDocumentId.delete(session.documentId);
+      lastParticipantPayloadByDocumentId.delete(session.documentId);
+    }
+  }
+
+  await broadcastParticipantList(session.documentId);
+};
+
+let cleanupExpiredSessions = async () => {
+  let now = Date.now();
+  let expired = [...liveSessions.values()].filter(
+    session => now - session.lastPingAt > participantTimeoutMs
+  );
+
+  for (let session of expired) {
+    let ws = socketsBySessionId.get(session.id);
+    if (ws) {
+      try {
+        ws.close(4001, 'heartbeat_timeout');
+      } catch {}
+    }
+
+    await removeSession(session.id);
+  }
+};
+
+let cleanupTimer = setInterval(() => {
+  cleanupExpiredSessions().catch(error => {
+    console.error('Failed to cleanup expired live document sessions', error);
+  });
+}, participantCleanupIntervalMs);
+cleanupTimer.unref?.();
+
+export let documentLiveApi = createHono()
+  .get('/ping', c => c.text('OK'))
+  .get(
+    '/document-live',
+    upgradeWebSocket(async c => {
+      let url = new URL(c.req.url);
+      let documentId = url.searchParams.get('documentId');
+      let actorId = url.searchParams.get('actorId');
+
+      if (!documentId || !actorId) {
+        throw new Error('documentId and actorId query params are required');
+      }
+
+      let scopedDocument = await documentService.getScopedDocumentById({
+        documentId
+      });
+
+      await documentService.getDocumentById({
+        tenant: scopedDocument.tenant,
+        environment: scopedDocument.environment,
+        documentId,
+        actorId
+      });
+
+      let sessionId = generatePlainId(20);
+
+      return {
+        onOpen: async (_, ws) => {
+          liveSessions.set(sessionId, {
+            id: sessionId,
+            documentId,
+            actorId,
+            lastPingAt: Date.now()
+          });
+          socketsBySessionId.set(sessionId, ws);
+          getRoomSessionIds(documentId).add(sessionId);
+
+          send(ws, 'document_snapshot', buildDocumentPayload(scopedDocument.document));
+          await broadcastParticipantList(documentId);
+        },
+
+        onMessage: async event => {
+          let session = liveSessions.get(sessionId);
+          if (!session) return;
+
+          session.lastPingAt = Date.now();
+
+          try {
+            let parsed = JSON.parse(event.data.toString()) as DocumentLiveClientMessage;
+
+            if (parsed.type === 'ping') {
+              let ws = socketsBySessionId.get(sessionId);
+              if (ws) {
+                send(ws, 'pong', {
+                  documentId: session.documentId
+                });
+              }
+              return;
+            }
+
+            if (parsed.type !== 'document_update' || typeof parsed.data?.content !== 'string') {
+              throw new Error('Invalid live document payload');
+            }
+
+            let currentScopedDocument = await documentService.getScopedDocumentById({
+              documentId: session.documentId
+            });
+
+            await documentService.getDocumentById({
+              tenant: currentScopedDocument.tenant,
+              environment: currentScopedDocument.environment,
+              documentId: session.documentId,
+              actorId: session.actorId
+            });
+
+            let updatedDocument = await documentService.updateDocument({
+              tenant: currentScopedDocument.tenant,
+              environment: currentScopedDocument.environment,
+              document: currentScopedDocument.document,
+              input: {
+                actorId: session.actorId,
+                title: parsed.data.title,
+                content: parsed.data.content
+              }
+            });
+
+            broadcastToDocument(
+              updatedDocument.id,
+              'document_snapshot',
+              buildDocumentPayload(updatedDocument)
+            );
+
+            let childDocuments = await documentService.listLinkedChildDocumentsForLiveSync({
+              parentDocumentId: updatedDocument.id
+            });
+            let sharedContent = updatedDocument.resolvedContent ?? updatedDocument.content.content;
+            let sharedUpdatedAt = updatedDocument.draftUpdatedAt ?? updatedDocument.updatedAt;
+
+            for (let childDocument of childDocuments) {
+              broadcastToDocument(
+                childDocument.id,
+                'document_snapshot',
+                buildDocumentPayload(childDocument, {
+                  content: sharedContent,
+                  updatedAt: sharedUpdatedAt
+                })
+              );
+            }
+
+            await broadcastParticipantList(updatedDocument.id);
+          } catch (error) {
+            let ws = socketsBySessionId.get(sessionId);
+            if (ws) {
+              sendError(ws, error);
+            }
+          }
+        },
+
+        onClose: async () => {
+          await removeSession(sessionId);
+        },
+
+        onError: async error => {
+          console.error('Cargo live document websocket error', error);
+          await removeSession(sessionId);
+        }
+      };
+    })
+  );

--- a/src/systems/cargo/service/src/presenters/document.ts
+++ b/src/systems/cargo/service/src/presenters/document.ts
@@ -18,6 +18,7 @@ export let documentPresenter = (
     draftUpdatedAt?: Date;
     draftRevision?: number;
     file: File & {
+      effectiveStoreId?: string;
       purpose: FilePurpose;
     };
   }

--- a/src/systems/cargo/service/src/presenters/file.ts
+++ b/src/systems/cargo/service/src/presenters/file.ts
@@ -6,6 +6,7 @@ export let filePresenter = (
   file: File & {
     purpose: FilePurpose;
     document: Pick<Document, 'id'> | null;
+    effectiveStoreId?: string;
   }
 ) => ({
   object: 'cargo#file',
@@ -13,7 +14,7 @@ export let filePresenter = (
   type: file.document ? 'document' : 'file',
   status: file.status,
   documentId: file.document?.id,
-  storeId: file.storeId,
+  storeId: file.effectiveStoreId ?? file.storeId,
   fileName: file.fileName,
   fileSize: file.fileSize,
   fileType: file.fileType,

--- a/src/systems/cargo/service/src/queues/documentFlush.ts
+++ b/src/systems/cargo/service/src/queues/documentFlush.ts
@@ -1,9 +1,12 @@
-import { createQueue } from '@lowerdeck/queue';
+import { createCron } from '@lowerdeck/cron';
+import { combineQueueProcessors, createQueue } from '@lowerdeck/queue';
 import { env } from '../env';
-import { documentService } from '../services';
+import { documentDraftService, documentService } from '../services';
 
-export let documentFlushQueue = createQueue<{ documentId: string }>({
-  redisUrl: env.service.REDIS_URL,
+let redisUrl = env.service.REDIS_URL;
+
+export let documentFlushQueue = createQueue<{ documentId: string; queuedRevision?: number }>({
+  redisUrl,
   name: 'cargo/doc/flush',
   workerOpts: {
     concurrency: 5
@@ -12,6 +15,49 @@ export let documentFlushQueue = createQueue<{ documentId: string }>({
 
 export let documentFlushProcessor = documentFlushQueue.process(async data => {
   await documentService.flushDocumentDraft({
-    documentId: data.documentId
+    documentId: data.documentId,
+    queuedRevision: data.queuedRevision
   });
 });
+
+export let documentFlushDirtyQueue = createQueue<{ documentId: string }>({
+  redisUrl,
+  name: 'cargo/doc/flush/dirty',
+  workerOpts: {
+    concurrency: 5
+  }
+});
+
+export let documentFlushDirtyProcessor = documentFlushDirtyQueue.process(async data => {
+  let queuedRevision = await documentDraftService.claimDirtyDocumentRevision(data.documentId);
+  if (queuedRevision === null) return;
+
+  await documentFlushQueue.add({
+    documentId: data.documentId,
+    queuedRevision
+  });
+});
+
+export let documentFlushDirtyCron = createCron(
+  {
+    redisUrl,
+    name: 'cargo/doc/flush/dirty/cron',
+    cron: '*/1 * * * *'
+  },
+  async () => {
+    let documentIds = await documentDraftService.listDirtyDocumentIds();
+    if (documentIds.length === 0) return;
+
+    await documentFlushDirtyQueue.addMany(
+      documentIds.map(documentId => ({
+        documentId
+      }))
+    );
+  }
+);
+
+export let documentFlushProcessors = combineQueueProcessors([
+  documentFlushProcessor,
+  documentFlushDirtyProcessor,
+  documentFlushDirtyCron
+]);

--- a/src/systems/cargo/service/src/queues/documentVersionSync.ts
+++ b/src/systems/cargo/service/src/queues/documentVersionSync.ts
@@ -53,10 +53,16 @@ export let documentVersionSyncManyProcessor = documentVersionSyncManyQueue.proce
 
 export let documentVersionSyncSingleProcessor = documentVersionSyncSingleQueue.process(
   async data => {
-    await documentService.syncChildDocumentVersionFromParentVersion({
+    let result = await documentService.syncChildDocumentVersionFromParentVersion({
       parentDocumentVersionId: data.parentDocumentVersionId,
       childDocumentId: data.childDocumentId
     });
+
+    if (result?.createdVersionId) {
+      await documentVersionSyncManyQueue.add({
+        parentDocumentVersionId: result.createdVersionId
+      });
+    }
   }
 );
 

--- a/src/systems/cargo/service/src/queues/documentVersionSync.ts
+++ b/src/systems/cargo/service/src/queues/documentVersionSync.ts
@@ -1,0 +1,66 @@
+import { combineQueueProcessors, createQueue } from '@lowerdeck/queue';
+import { env } from '../env';
+import { documentService } from '../services';
+
+let redisUrl = env.service.REDIS_URL;
+let batchSize = 100;
+
+export let documentVersionSyncManyQueue = createQueue<{
+  parentDocumentVersionId: string;
+  cursor?: string;
+}>({
+  redisUrl,
+  name: 'cargo/doc/version-sync/many',
+  workerOpts: {
+    concurrency: 1
+  }
+});
+
+export let documentVersionSyncSingleQueue = createQueue<{
+  parentDocumentVersionId: string;
+  childDocumentId: string;
+}>({
+  redisUrl,
+  name: 'cargo/doc/version-sync/single',
+  workerOpts: {
+    concurrency: 5
+  }
+});
+
+export let documentVersionSyncManyProcessor = documentVersionSyncManyQueue.process(async data => {
+  let result = await documentService.listSyncableChildDocumentIdsForVersionSync({
+    parentDocumentVersionId: data.parentDocumentVersionId,
+    cursor: data.cursor,
+    limit: batchSize
+  });
+
+  if (result.childDocumentIds.length > 0) {
+    await documentVersionSyncSingleQueue.addMany(
+      result.childDocumentIds.map(childDocumentId => ({
+        parentDocumentVersionId: data.parentDocumentVersionId,
+        childDocumentId
+      }))
+    );
+  }
+
+  if (result.nextCursor) {
+    await documentVersionSyncManyQueue.add({
+      parentDocumentVersionId: data.parentDocumentVersionId,
+      cursor: result.nextCursor
+    });
+  }
+});
+
+export let documentVersionSyncSingleProcessor = documentVersionSyncSingleQueue.process(
+  async data => {
+    await documentService.syncChildDocumentVersionFromParentVersion({
+      parentDocumentVersionId: data.parentDocumentVersionId,
+      childDocumentId: data.childDocumentId
+    });
+  }
+);
+
+export let documentVersionSyncProcessors = combineQueueProcessors([
+  documentVersionSyncManyProcessor,
+  documentVersionSyncSingleProcessor
+]);

--- a/src/systems/cargo/service/src/queues/storeVersion.ts
+++ b/src/systems/cargo/service/src/queues/storeVersion.ts
@@ -1,0 +1,76 @@
+import { createCron } from '@lowerdeck/cron';
+import { combineQueueProcessors, createQueue } from '@lowerdeck/queue';
+import { env } from '../env';
+import { storeVersionService } from '../services';
+
+let redisUrl = env.service.REDIS_URL;
+let batchSize = 100;
+let dirtyAgeMs = 60 * 60 * 1000;
+
+export let storeVersionManyQueue = createQueue<{
+  cursorOid?: string;
+}>({
+  redisUrl,
+  name: 'cargo/store/version/many',
+  workerOpts: {
+    concurrency: 1
+  }
+});
+
+export let storeVersionSingleQueue = createQueue<{
+  storeId: string;
+  expectedDirtyAt: string;
+}>({
+  redisUrl,
+  name: 'cargo/store/version/single',
+  workerOpts: {
+    concurrency: 5
+  }
+});
+
+export let storeVersionManyProcessor = storeVersionManyQueue.process(async data => {
+  let result = await storeVersionService.listStoreIdsReadyForVersioning({
+    cursorOid: data.cursorOid,
+    limit: batchSize,
+    dirtyBefore: new Date(Date.now() - dirtyAgeMs)
+  });
+
+  if (result.stores.length > 0) {
+    await storeVersionSingleQueue.addMany(
+      result.stores.map(store => ({
+        storeId: store.storeId,
+        expectedDirtyAt: store.dirtyAt.toISOString()
+      }))
+    );
+  }
+
+  if (result.nextCursorOid) {
+    await storeVersionManyQueue.add({
+      cursorOid: result.nextCursorOid
+    });
+  }
+});
+
+export let storeVersionSingleProcessor = storeVersionSingleQueue.process(async data => {
+  await storeVersionService.createStoreVersionSnapshot({
+    storeId: data.storeId,
+    expectedDirtyAt: new Date(data.expectedDirtyAt)
+  });
+});
+
+export let storeVersionCron = createCron(
+  {
+    redisUrl,
+    name: 'cargo/store/version/cron',
+    cron: '*/15 * * * *'
+  },
+  async () => {
+    await storeVersionManyQueue.add({});
+  }
+);
+
+export let storeVersionProcessors = combineQueueProcessors([
+  storeVersionManyProcessor,
+  storeVersionSingleProcessor,
+  storeVersionCron
+]);

--- a/src/systems/cargo/service/src/server.ts
+++ b/src/systems/cargo/service/src/server.ts
@@ -7,6 +7,7 @@ async function main() {
   await import('./init');
   await import('./instrument');
   await import('./endpoints');
+  await import('./worker');
 }
 
 main().catch(err => {

--- a/src/systems/cargo/service/src/services/document.ts
+++ b/src/systems/cargo/service/src/services/document.ts
@@ -19,11 +19,13 @@ import { getId } from '../id';
 import { documentFlushQueue } from '../queues/documentFlush';
 import { documentVersionSyncManyQueue } from '../queues/documentVersionSync';
 import { actorService } from './actor';
+import { getEffectiveDocumentStoreSource } from './documentContentStore';
 import { documentDraftService, type DocumentDraft } from './documentDraft';
 import { fileService } from './file';
 import { filePurposeService, type CargoTenantEnvironment } from './filePurpose';
 import { storeAccessService, storeReadPermission, storeWritePermission } from './storeAccess';
 import { storeItemMutationService } from './storeItemMutation';
+import { storeVersionService } from './storeVersion';
 
 let activeVersionWindowMs = 3 * 60 * 60 * 1000;
 let draftFlushDelayMs = 60 * 1000;
@@ -73,6 +75,11 @@ type DocumentRecord = Prisma.DocumentGetPayload<{
 type VersionContext = {
   tenant: { oid: bigint };
   environment: { oid: bigint };
+};
+type DocumentWithEffectiveStoreId<T extends { file: { storeId: string } }> = T & {
+  file: T['file'] & {
+    effectiveStoreId?: string;
+  };
 };
 type DocumentAccessInput = {
   actorId?: string;
@@ -128,15 +135,75 @@ class DocumentServiceImpl {
 
   private async resolveDocument(document: DocumentRecord): Promise<ResolvedDocumentRecord> {
     let draft = await documentDraftService.getDraftByDocumentId(document.id);
-    if (!draft) return document;
+    if (!draft) return await this.withEffectiveFileStore(document);
 
-    return {
+    return await this.withEffectiveFileStore({
       ...document,
       resolvedTitle: draft.title,
       resolvedContent: draft.content,
       hasDraft: true,
       draftRevision: draft.revision,
       draftUpdatedAt: new Date(draft.updatedAt)
+    });
+  }
+
+  private async withEffectiveFileStore<T extends DocumentRecord | ResolvedDocumentRecord>(document: T) {
+    let effectiveStoreSource = await getEffectiveDocumentStoreSource(document);
+    if (effectiveStoreSource.file.storeId === document.file.storeId) {
+      return document as DocumentWithEffectiveStoreId<T>;
+    }
+
+    return {
+      ...document,
+      file: {
+        ...document.file,
+        effectiveStoreId: effectiveStoreSource.file.storeId
+      }
+    } satisfies DocumentWithEffectiveStoreId<T>;
+  }
+
+  private async getParentLiveContent(
+    client: PrismaClient | TransactionClient,
+    document: Pick<DocumentRecord, 'isContentOwner' | 'parentDocumentOid'>
+  ) {
+    if (!document.parentDocumentOid) {
+      return null;
+    }
+
+    return await client.document.findFirst({
+      where: {
+        oid: document.parentDocumentOid,
+        file: {
+          status: 'active'
+        }
+      },
+      select: {
+        contentOid: true,
+        content: {
+          select: {
+            content: true
+          }
+        }
+      }
+    });
+  }
+
+  private async getParentSyncState(
+    client: PrismaClient | TransactionClient,
+    d: {
+      document: Pick<DocumentRecord, 'isContentOwner' | 'parentDocumentOid'>;
+      nextContent: string;
+    }
+  ) {
+    let parentLiveContent = await this.getParentLiveContent(client, d.document);
+    let shouldKeepParentSync =
+      !d.document.isContentOwner &&
+      !!parentLiveContent &&
+      parentLiveContent.content.content === d.nextContent;
+
+    return {
+      parentLiveContent,
+      shouldKeepParentSync
     };
   }
 
@@ -370,29 +437,14 @@ class DocumentServiceImpl {
     let activeVersion = d.document.currentVersion;
     let nextVersionNumber = d.document.maxVersionNumber;
     let didCreateVersion = false;
-    let parentLiveContent =
-      !d.document.isContentOwner && d.document.parentDocumentOid
-        ? await tx.document.findFirst({
-            where: {
-              oid: d.document.parentDocumentOid,
-              file: {
-                status: 'active'
-              }
-            },
-            select: {
-              contentOid: true,
-              content: {
-                select: {
-                  content: true
-                }
-              }
-            }
-          })
-        : null;
-    let shouldKeepParentSync =
-      !d.document.isContentOwner &&
+    let { parentLiveContent, shouldKeepParentSync } = await this.getParentSyncState(tx, {
+      document: d.document,
+      nextContent: d.nextContent
+    });
+    let shouldDetachOwnedContent =
+      d.document.isContentOwner &&
       !!parentLiveContent &&
-      parentLiveContent.content.content === d.nextContent;
+      parentLiveContent.contentOid === d.document.contentOid;
 
     if (shouldCreateNewVersion) {
       if (d.document.currentVersion) {
@@ -416,14 +468,27 @@ class DocumentServiceImpl {
       }
 
       if (d.document.isContentOwner) {
-        await tx.documentContent.update({
-          where: {
-            oid: d.document.contentOid
-          },
-          data: {
-            content: d.nextContent
-          }
-        });
+        if (shouldDetachOwnedContent) {
+          let liveContentIds = getId('documentContent');
+
+          await tx.documentContent.create({
+            data: {
+              oid: liveContentIds.oid,
+              content: d.nextContent
+            }
+          });
+
+          liveContentOid = liveContentIds.oid;
+        } else {
+          await tx.documentContent.update({
+            where: {
+              oid: d.document.contentOid
+            },
+            data: {
+              content: d.nextContent
+            }
+          });
+        }
       } else if (shouldKeepParentSync) {
         liveContentOid = parentLiveContent!.contentOid;
       } else {
@@ -452,14 +517,54 @@ class DocumentServiceImpl {
       });
       didCreateVersion = true;
     } else if (d.document.isContentOwner) {
-      await tx.documentContent.update({
-        where: {
-          oid: d.document.contentOid
-        },
-        data: {
-          content: d.nextContent
+      if (shouldDetachOwnedContent) {
+        let liveContentIds = getId('documentContent');
+
+        await tx.documentContent.create({
+          data: {
+            oid: liveContentIds.oid,
+            content: d.nextContent
+          }
+        });
+
+        liveContentOid = liveContentIds.oid;
+
+        if (!d.document.currentVersion) {
+          activeVersion = await this.createVersion(tx, {
+            tenant: d.tenant,
+            environment: d.environment,
+            document: d.document,
+            versionNumber: d.document.maxVersionNumber + 1,
+            contentOid: liveContentOid,
+            listEditedAt: d.listEditedAt
+          });
+
+          nextVersionNumber += 1;
+          didCreateVersion = true;
+        } else {
+          activeVersion = await tx.documentVersion.update({
+            where: {
+              id: d.document.currentVersion.id
+            },
+            data: {
+              contentOid: liveContentOid,
+              listEditedAt: d.listEditedAt
+            },
+            include: {
+              content: true
+            }
+          });
         }
-      });
+      } else {
+        await tx.documentContent.update({
+          where: {
+            oid: d.document.contentOid
+          },
+          data: {
+            content: d.nextContent
+          }
+        });
+      }
     } else if (shouldKeepParentSync) {
       liveContentOid = parentLiveContent!.contentOid;
 
@@ -954,6 +1059,7 @@ class DocumentServiceImpl {
 
     let resolved = await documentDraftService.withDocumentLock(d.document.id, async () => {
       let currentDraft = await documentDraftService.getDraftByDocumentId(d.document.id);
+      let currentContent = currentDraft?.content ?? d.document.resolvedContent ?? d.document.content.content;
       let nextDraft: DocumentDraft = {
         documentId: d.document.id,
         title:
@@ -968,6 +1074,32 @@ class DocumentServiceImpl {
         updatedAt: new Date().toISOString(),
         flushAfter: new Date(Date.now() + draftFlushDelayMs).toISOString()
       };
+      let nextIsContentOwner = d.document.isContentOwner;
+
+      if (
+        d.input.content !== undefined &&
+        currentContent !== nextDraft.content &&
+        !d.document.isContentOwner
+      ) {
+        let { shouldKeepParentSync } = await this.getParentSyncState(db, {
+          document: d.document,
+          nextContent: nextDraft.content
+        });
+
+        if (!shouldKeepParentSync) {
+          await db.document.updateMany({
+            where: {
+              id: d.document.id,
+              isContentOwner: false
+            },
+            data: {
+              isContentOwner: true
+            }
+          });
+
+          nextIsContentOwner = true;
+        }
+      }
 
       if (actor) {
         nextDraft.actorIds = [...new Set([...nextDraft.actorIds, actor.id])];
@@ -978,6 +1110,7 @@ class DocumentServiceImpl {
 
       return {
         ...d.document,
+        isContentOwner: nextIsContentOwner,
         resolvedTitle: nextDraft.title,
         resolvedContent: nextDraft.content,
         hasDraft: true,
@@ -998,7 +1131,7 @@ class DocumentServiceImpl {
 
     await this.queueDocumentFlush(d.document.id, draftFlushDelayMs);
 
-    return resolved;
+    return await this.withEffectiveFileStore(resolved);
   }
 
   async flushDocumentDraft(d: { documentId: string; force?: boolean; queuedRevision?: number }) {
@@ -1061,6 +1194,9 @@ class DocumentServiceImpl {
       await documentDraftService.deleteDraft(d.documentId);
       await documentDraftService.clearDocumentMarkersUpToRevision(d.documentId, draft.revision);
       if (result.createdVersionId) {
+        await storeVersionService.markStoresDirtyForDocument({
+          documentOid: result.document.oid
+        });
         await this.queueDocumentVersionSync(result.createdVersionId);
       }
 
@@ -1173,7 +1309,7 @@ class DocumentServiceImpl {
     parentDocumentVersionId: string;
     childDocumentId: string;
   }) {
-    return await documentDraftService.withDocumentLock(d.childDocumentId, async () => {
+    let result = await documentDraftService.withDocumentLock(d.childDocumentId, async () => {
       let draft = await documentDraftService.getDraftByDocumentId(d.childDocumentId);
       if (draft) return null;
 
@@ -1265,6 +1401,14 @@ class DocumentServiceImpl {
         };
       });
     });
+
+    if (result?.createdVersionId) {
+      await storeVersionService.markStoresDirtyForDocument({
+        documentOid: result.document.oid
+      });
+    }
+
+    return result;
   }
 
   async cloneDocument(
@@ -1374,10 +1518,10 @@ class DocumentServiceImpl {
     };
 
     if (d.client) {
-      return await cloneWithClient(d.client);
+      return await this.withEffectiveFileStore(await cloneWithClient(d.client));
     }
 
-    return await db.$transaction(async tx => await cloneWithClient(tx));
+    return await this.withEffectiveFileStore(await db.$transaction(async tx => await cloneWithClient(tx)));
   }
 
   async deleteDocument(

--- a/src/systems/cargo/service/src/services/document.ts
+++ b/src/systems/cargo/service/src/services/document.ts
@@ -17,6 +17,7 @@ import type {
 import { db } from '../db';
 import { getId } from '../id';
 import { documentFlushQueue } from '../queues/documentFlush';
+import { documentVersionSyncManyQueue } from '../queues/documentVersionSync';
 import { actorService } from './actor';
 import { documentDraftService, type DocumentDraft } from './documentDraft';
 import { fileService } from './file';
@@ -57,6 +58,10 @@ type TransactionClient = Prisma.TransactionClient;
 type DocumentRecord = Prisma.DocumentGetPayload<{
   include: typeof documentInclude;
 }>;
+type VersionContext = {
+  tenant: { oid: bigint };
+  environment: { oid: bigint };
+};
 type DocumentAccessInput = {
   actorId?: string;
   defaultPermissions?: StoreParticipantPermissions[];
@@ -74,6 +79,15 @@ class DocumentServiceImpl {
       {
         id: documentId,
         delay: Math.max(delayMs, 0)
+      }
+    );
+  }
+
+  private async queueDocumentVersionSync(parentDocumentVersionId: string) {
+    await documentVersionSyncManyQueue.add(
+      { parentDocumentVersionId },
+      {
+        id: parentDocumentVersionId
       }
     );
   }
@@ -299,7 +313,7 @@ class DocumentServiceImpl {
 
   private async createVersion(
     tx: TransactionClient,
-    d: CargoTenantEnvironment & {
+    d: VersionContext & {
       document: { oid: bigint };
       versionNumber: number;
       contentOid: bigint;
@@ -343,6 +357,7 @@ class DocumentServiceImpl {
     let liveContentOid = d.document.contentOid;
     let activeVersion = d.document.currentVersion;
     let nextVersionNumber = d.document.maxVersionNumber;
+    let didCreateVersion = false;
 
     if (shouldCreateNewVersion) {
       if (d.document.currentVersion) {
@@ -398,6 +413,7 @@ class DocumentServiceImpl {
         previousVersionOid: d.document.currentVersion?.oid,
         listEditedAt: d.listEditedAt
       });
+      didCreateVersion = true;
     } else if (d.document.isContentOwner) {
       await tx.documentContent.update({
         where: {
@@ -430,6 +446,7 @@ class DocumentServiceImpl {
         });
 
         nextVersionNumber += 1;
+        didCreateVersion = true;
       } else {
         activeVersion = await tx.documentVersion.update({
           where: {
@@ -450,7 +467,8 @@ class DocumentServiceImpl {
       activeVersion,
       liveContentOid,
       nextVersionNumber,
-      isContentOwner: true
+      isContentOwner: true,
+      didCreateVersion
     };
   }
 
@@ -468,13 +486,17 @@ class DocumentServiceImpl {
     let hasTitleChange = nextTitle !== d.document.title;
 
     if (!hasContentChange && !hasTitleChange) {
-      return d.document;
+      return {
+        document: d.document,
+        createdVersionId: null
+      };
     }
 
     let activeVersion = d.document.currentVersion;
     let liveContentOid = d.document.contentOid;
     let maxVersionNumber = d.document.maxVersionNumber;
     let isContentOwner = d.document.isContentOwner;
+    let createdVersionId: string | null = null;
 
     if (hasContentChange) {
       let listEditedAt = new Date();
@@ -491,6 +513,7 @@ class DocumentServiceImpl {
       liveContentOid = writeResult.liveContentOid;
       maxVersionNumber = writeResult.nextVersionNumber;
       isContentOwner = writeResult.isContentOwner;
+      createdVersionId = writeResult.didCreateVersion ? (writeResult.activeVersion?.id ?? null) : null;
     }
 
     await tx.file.update({
@@ -536,7 +559,10 @@ class DocumentServiceImpl {
       }
     }
 
-    return updatedDocument;
+    return {
+      document: updatedDocument,
+      createdVersionId
+    };
   }
 
   async createDocument(
@@ -846,6 +872,7 @@ class DocumentServiceImpl {
       }
 
       await documentDraftService.setDraft(nextDraft);
+      await documentDraftService.markDocumentDirty(d.document.id, nextDraft.revision);
 
       return {
         ...d.document,
@@ -872,10 +899,19 @@ class DocumentServiceImpl {
     return resolved;
   }
 
-  async flushDocumentDraft(d: { documentId: string; force?: boolean }) {
+  async flushDocumentDraft(d: { documentId: string; force?: boolean; queuedRevision?: number }) {
     return await documentDraftService.withDocumentLock(d.documentId, async () => {
       let draft = await documentDraftService.getDraftByDocumentId(d.documentId);
-      if (!draft) return null;
+      if (!draft) {
+        if (d.queuedRevision !== undefined) {
+          await documentDraftService.clearDocumentMarkersUpToRevision(
+            d.documentId,
+            d.queuedRevision
+          );
+        }
+
+        return null;
+      }
 
       let flushAfterMs = new Date(draft.flushAfter).getTime();
       if (!d.force && flushAfterMs > Date.now()) {
@@ -883,7 +919,7 @@ class DocumentServiceImpl {
         return null;
       }
 
-      let document = await db.$transaction(async tx => {
+      let result = await db.$transaction(async tx => {
         let currentDocument = await tx.document.findFirst({
           where: {
             id: d.documentId
@@ -921,8 +957,164 @@ class DocumentServiceImpl {
       });
 
       await documentDraftService.deleteDraft(d.documentId);
+      await documentDraftService.clearDocumentMarkersUpToRevision(d.documentId, draft.revision);
+      if (result.createdVersionId) {
+        await this.queueDocumentVersionSync(result.createdVersionId);
+      }
 
-      return await this.resolveDocument(document);
+      return await this.resolveDocument(result.document);
+    });
+  }
+
+  async listSyncableChildDocumentIdsForVersionSync(d: {
+    parentDocumentVersionId: string;
+    cursor?: string;
+    limit: number;
+  }) {
+    let parentVersion = await db.documentVersion.findFirst({
+      where: {
+        id: d.parentDocumentVersionId,
+        document: {
+          file: {
+            status: 'active'
+          }
+        }
+      },
+      select: {
+        documentOid: true
+      }
+    });
+    if (!parentVersion) {
+      return {
+        childDocumentIds: [],
+        nextCursor: undefined
+      };
+    }
+
+    let children = await db.document.findMany({
+      where: {
+        parentDocumentOid: parentVersion.documentOid,
+        isContentOwner: false,
+        file: {
+          status: 'active'
+        },
+        ...(d.cursor
+          ? {
+              id: {
+                gt: d.cursor
+              }
+            }
+          : {})
+      },
+      orderBy: {
+        id: 'asc'
+      },
+      take: d.limit,
+      select: {
+        id: true
+      }
+    });
+
+    let childDrafts = await Promise.all(
+      children.map(async child => ({
+        childId: child.id,
+        draft: await documentDraftService.getDraftByDocumentId(child.id)
+      }))
+    );
+
+    return {
+      childDocumentIds: childDrafts.filter(child => child.draft === null).map(child => child.childId),
+      nextCursor: children.length === d.limit ? children[children.length - 1]!.id : undefined
+    };
+  }
+
+  async syncChildDocumentVersionFromParentVersion(d: {
+    parentDocumentVersionId: string;
+    childDocumentId: string;
+  }) {
+    return await documentDraftService.withDocumentLock(d.childDocumentId, async () => {
+      let draft = await documentDraftService.getDraftByDocumentId(d.childDocumentId);
+      if (draft) return null;
+
+      return await db.$transaction(async tx => {
+        let parentVersion = await tx.documentVersion.findFirst({
+          where: {
+            id: d.parentDocumentVersionId,
+            document: {
+              file: {
+                status: 'active'
+              }
+            }
+          },
+          include: {
+            content: true
+          }
+        });
+        if (!parentVersion) return null;
+
+        let childDocument = await tx.document.findFirst({
+          where: {
+            id: d.childDocumentId,
+            tenantOid: parentVersion.tenantOid,
+            environmentOid: parentVersion.environmentOid,
+            parentDocumentOid: parentVersion.documentOid,
+            isContentOwner: false,
+            file: {
+              status: 'active'
+            }
+          },
+          include: documentInclude
+        });
+        if (!childDocument) return null;
+
+        let currentVersion = childDocument.currentVersion;
+        let currentListEditedAt = currentVersion?.listEditedAt?.getTime() ?? null;
+        let parentListEditedAt = parentVersion.listEditedAt?.getTime() ?? null;
+        if (
+          currentVersion &&
+          currentVersion.contentOid === parentVersion.contentOid &&
+          currentListEditedAt === parentListEditedAt
+        ) {
+          return childDocument;
+        }
+
+        let nextVersionNumber = childDocument.maxVersionNumber + 1;
+        let nextVersion = await this.createVersion(tx, {
+          tenant: {
+            oid: parentVersion.tenantOid
+          },
+          environment: {
+            oid: parentVersion.environmentOid
+          },
+          document: childDocument,
+          versionNumber: nextVersionNumber,
+          contentOid: parentVersion.contentOid,
+          previousVersionOid: currentVersion?.oid,
+          listEditedAt: parentVersion.listEditedAt ?? new Date()
+        });
+
+        await tx.file.update({
+          where: {
+            id: childDocument.file.id
+          },
+          data: {
+            fileSize: getTextByteSize(parentVersion.content.content)
+          }
+        });
+
+        return await tx.document.update({
+          where: {
+            id: childDocument.id
+          },
+          data: {
+            contentOid: parentVersion.contentOid,
+            currentVersionOid: nextVersion.oid,
+            maxVersionNumber: nextVersionNumber,
+            isContentOwner: false
+          },
+          include: documentInclude
+        });
+      });
     });
   }
 

--- a/src/systems/cargo/service/src/services/document.ts
+++ b/src/systems/cargo/service/src/services/document.ts
@@ -54,6 +54,18 @@ export type ResolvedDocumentRecord = Prisma.DocumentGetPayload<{
   draftRevision?: number;
 };
 
+export type ScopedResolvedDocumentRecord = {
+  tenant: {
+    id: string;
+    oid: bigint;
+  };
+  environment: {
+    id: string;
+    oid: bigint;
+  };
+  document: ResolvedDocumentRecord;
+};
+
 type TransactionClient = Prisma.TransactionClient;
 type DocumentRecord = Prisma.DocumentGetPayload<{
   include: typeof documentInclude;
@@ -358,6 +370,29 @@ class DocumentServiceImpl {
     let activeVersion = d.document.currentVersion;
     let nextVersionNumber = d.document.maxVersionNumber;
     let didCreateVersion = false;
+    let parentLiveContent =
+      !d.document.isContentOwner && d.document.parentDocumentOid
+        ? await tx.document.findFirst({
+            where: {
+              oid: d.document.parentDocumentOid,
+              file: {
+                status: 'active'
+              }
+            },
+            select: {
+              contentOid: true,
+              content: {
+                select: {
+                  content: true
+                }
+              }
+            }
+          })
+        : null;
+    let shouldKeepParentSync =
+      !d.document.isContentOwner &&
+      !!parentLiveContent &&
+      parentLiveContent.content.content === d.nextContent;
 
     if (shouldCreateNewVersion) {
       if (d.document.currentVersion) {
@@ -389,6 +424,8 @@ class DocumentServiceImpl {
             content: d.nextContent
           }
         });
+      } else if (shouldKeepParentSync) {
+        liveContentOid = parentLiveContent!.contentOid;
       } else {
         let liveContentIds = getId('documentContent');
 
@@ -423,6 +460,35 @@ class DocumentServiceImpl {
           content: d.nextContent
         }
       });
+    } else if (shouldKeepParentSync) {
+      liveContentOid = parentLiveContent!.contentOid;
+
+      if (!d.document.currentVersion) {
+        activeVersion = await this.createVersion(tx, {
+          tenant: d.tenant,
+          environment: d.environment,
+          document: d.document,
+          versionNumber: d.document.maxVersionNumber + 1,
+          contentOid: liveContentOid,
+          listEditedAt: d.listEditedAt
+        });
+
+        nextVersionNumber += 1;
+        didCreateVersion = true;
+      } else {
+        activeVersion = await tx.documentVersion.update({
+          where: {
+            id: d.document.currentVersion.id
+          },
+          data: {
+            contentOid: liveContentOid,
+            listEditedAt: d.listEditedAt
+          },
+          include: {
+            content: true
+          }
+        });
+      }
     } else {
       let liveContentIds = getId('documentContent');
 
@@ -467,7 +533,7 @@ class DocumentServiceImpl {
       activeVersion,
       liveContentOid,
       nextVersionNumber,
-      isContentOwner: true,
+      isContentOwner: d.document.isContentOwner || !shouldKeepParentSync,
       didCreateVersion
     };
   }
@@ -755,6 +821,42 @@ class DocumentServiceImpl {
     return await this.resolveDocument(document);
   }
 
+  async getScopedDocumentById(d: { documentId: string; includeDeleted?: boolean }) {
+    let scopedDocument = await db.document.findFirst({
+      where: {
+        id: d.documentId,
+        ...(d.includeDeleted ? {} : { file: { status: 'active' } })
+      },
+      include: {
+        ...documentInclude,
+        tenant: {
+          select: {
+            id: true,
+            oid: true
+          }
+        },
+        environment: {
+          select: {
+            id: true,
+            oid: true
+          }
+        }
+      }
+    });
+
+    if (!scopedDocument) {
+      throw new ServiceError(notFoundError('document', d.documentId));
+    }
+
+    let { tenant, environment, ...document } = scopedDocument;
+
+    return {
+      tenant,
+      environment,
+      document: await this.resolveDocument(document)
+    } satisfies ScopedResolvedDocumentRecord;
+  }
+
   async listDocuments(d: CargoTenantEnvironment & DocumentAccessInput) {
     if (!d.actorId) {
       return Paginator.create(({ prisma }) =>
@@ -1028,6 +1130,45 @@ class DocumentServiceImpl {
     };
   }
 
+  async listLinkedChildDocumentsForLiveSync(d: { parentDocumentId: string }) {
+    let parentDocument = await db.document.findFirst({
+      where: {
+        id: d.parentDocumentId,
+        file: {
+          status: 'active'
+        }
+      },
+      select: {
+        oid: true
+      }
+    });
+    if (!parentDocument) {
+      throw new ServiceError(notFoundError('document', d.parentDocumentId));
+    }
+
+    let children = await db.document.findMany({
+      where: {
+        parentDocumentOid: parentDocument.oid,
+        isContentOwner: false,
+        file: {
+          status: 'active'
+        }
+      },
+      include: documentInclude
+    });
+
+    let childDrafts = await Promise.all(
+      children.map(async child => ({
+        child,
+        draft: await documentDraftService.getDraftByDocumentId(child.id)
+      }))
+    );
+
+    return childDrafts
+      .filter(child => child.draft === null)
+      .map(child => child.child);
+  }
+
   async syncChildDocumentVersionFromParentVersion(d: {
     parentDocumentVersionId: string;
     childDocumentId: string;
@@ -1075,7 +1216,10 @@ class DocumentServiceImpl {
           currentVersion.contentOid === parentVersion.contentOid &&
           currentListEditedAt === parentListEditedAt
         ) {
-          return childDocument;
+          return {
+            document: childDocument,
+            createdVersionId: null
+          };
         }
 
         let nextVersionNumber = childDocument.maxVersionNumber + 1;
@@ -1102,7 +1246,7 @@ class DocumentServiceImpl {
           }
         });
 
-        return await tx.document.update({
+        let syncedDocument = await tx.document.update({
           where: {
             id: childDocument.id
           },
@@ -1114,6 +1258,11 @@ class DocumentServiceImpl {
           },
           include: documentInclude
         });
+
+        return {
+          document: syncedDocument,
+          createdVersionId: nextVersion.id
+        };
       });
     });
   }

--- a/src/systems/cargo/service/src/services/document.ts
+++ b/src/systems/cargo/service/src/services/document.ts
@@ -10,11 +10,10 @@ import type {
   Document,
   DocumentParticipantRole,
   Prisma,
-  PrismaClient,
   StoreParticipantPermissions,
   TenantActor
 } from '../../prisma/generated/client';
-import { db } from '../db';
+import { db, withTransaction } from '../db';
 import { getId } from '../id';
 import { documentFlushQueue } from '../queues/documentFlush';
 import { documentVersionSyncManyQueue } from '../queues/documentVersionSync';
@@ -68,7 +67,6 @@ export type ScopedResolvedDocumentRecord = {
   document: ResolvedDocumentRecord;
 };
 
-type TransactionClient = Prisma.TransactionClient;
 type DocumentRecord = Prisma.DocumentGetPayload<{
   include: typeof documentInclude;
 }>;
@@ -112,25 +110,29 @@ class DocumentServiceImpl {
   }
 
   private async getDocumentRecord(
-    client: PrismaClient | TransactionClient,
     d: CargoTenantEnvironment & {
       documentId: string;
       includeDeleted?: boolean;
     }
   ) {
-    let document = await client.document.findFirst({
-      where: {
-        tenantOid: d.tenant.oid,
-        environmentOid: d.environment.oid,
-        id: d.documentId,
-        ...(d.includeDeleted ? {} : { file: { status: 'active' } })
+    return await withTransaction(
+      async db => {
+        let document = await db.document.findFirst({
+          where: {
+            tenantOid: d.tenant.oid,
+            environmentOid: d.environment.oid,
+            id: d.documentId,
+            ...(d.includeDeleted ? {} : { file: { status: 'active' } })
+          },
+          include: documentInclude
+        });
+
+        if (!document) throw new ServiceError(notFoundError('document', d.documentId));
+
+        return document;
       },
-      include: documentInclude
-    });
-
-    if (!document) throw new ServiceError(notFoundError('document', d.documentId));
-
-    return document;
+      { ifExists: true }
+    );
   }
 
   private async resolveDocument(document: DocumentRecord): Promise<ResolvedDocumentRecord> {
@@ -162,40 +164,39 @@ class DocumentServiceImpl {
     } satisfies DocumentWithEffectiveStoreId<T>;
   }
 
-  private async getParentLiveContent(
-    client: PrismaClient | TransactionClient,
-    document: Pick<DocumentRecord, 'isContentOwner' | 'parentDocumentOid'>
-  ) {
-    if (!document.parentDocumentOid) {
-      return null;
-    }
+  private async getParentLiveContent(document: Pick<DocumentRecord, 'isContentOwner' | 'parentDocumentOid'>) {
+    return await withTransaction(
+      async db => {
+        if (!document.parentDocumentOid) {
+          return null;
+        }
 
-    return await client.document.findFirst({
-      where: {
-        oid: document.parentDocumentOid,
-        file: {
-          status: 'active'
-        }
-      },
-      select: {
-        contentOid: true,
-        content: {
+        return await db.document.findFirst({
+          where: {
+            oid: document.parentDocumentOid,
+            file: {
+              status: 'active'
+            }
+          },
           select: {
-            content: true
+            contentOid: true,
+            content: {
+              select: {
+                content: true
+              }
+            }
           }
-        }
-      }
-    });
+        });
+      },
+      { ifExists: true }
+    );
   }
 
-  private async getParentSyncState(
-    client: PrismaClient | TransactionClient,
-    d: {
-      document: Pick<DocumentRecord, 'isContentOwner' | 'parentDocumentOid'>;
-      nextContent: string;
-    }
-  ) {
-    let parentLiveContent = await this.getParentLiveContent(client, d.document);
+  private async getParentSyncState(d: {
+    document: Pick<DocumentRecord, 'isContentOwner' | 'parentDocumentOid'>;
+    nextContent: string;
+  }) {
+    let parentLiveContent = await this.getParentLiveContent(d.document);
     let shouldKeepParentSync =
       !d.document.isContentOwner &&
       !!parentLiveContent &&
@@ -218,31 +219,50 @@ class DocumentServiceImpl {
   }
 
   private async upsertParticipant(
-    tx: TransactionClient,
     d: {
       document: { oid: bigint };
       actor: { oid: bigint };
       mode: 'view' | 'edit';
     }
   ) {
-    let now = new Date();
-    let existing = await tx.documentParticipant.findFirst({
-      where: {
-        documentOid: d.document.oid,
-        tenantActorOid: d.actor.oid
-      }
-    });
-
-    let role: DocumentParticipantRole =
-      d.mode === 'edit' || existing?.role === 'editor' ? 'editor' : 'viewer';
-
-    if (existing) {
-      return await tx.documentParticipant.update({
+    return await withTransaction(async tx => {
+      let now = new Date();
+      let existing = await tx.documentParticipant.findFirst({
         where: {
-          id: existing.id
-        },
+          documentOid: d.document.oid,
+          tenantActorOid: d.actor.oid
+        }
+      });
+
+      let role: DocumentParticipantRole =
+        d.mode === 'edit' || existing?.role === 'editor' ? 'editor' : 'viewer';
+
+      if (existing) {
+        return await tx.documentParticipant.update({
+          where: {
+            id: existing.id
+          },
+          data: {
+            role,
+            lastViewedAt: now,
+            ...(d.mode === 'edit'
+              ? {
+                  lastEditedAt: now
+                }
+              : {})
+          }
+        });
+      }
+
+      let generated = getId('documentParticipant');
+
+      return await tx.documentParticipant.create({
         data: {
+          oid: generated.oid,
+          id: generated.id,
           role,
+          documentOid: d.document.oid,
+          tenantActorOid: d.actor.oid,
           lastViewedAt: now,
           ...(d.mode === 'edit'
             ? {
@@ -251,24 +271,6 @@ class DocumentServiceImpl {
             : {})
         }
       });
-    }
-
-    let generated = getId('documentParticipant');
-
-    return await tx.documentParticipant.create({
-      data: {
-        oid: generated.oid,
-        id: generated.id,
-        role,
-        documentOid: d.document.oid,
-        tenantActorOid: d.actor.oid,
-        lastViewedAt: now,
-        ...(d.mode === 'edit'
-          ? {
-              lastEditedAt: now
-            }
-          : {})
-      }
     });
   }
 
@@ -276,122 +278,104 @@ class DocumentServiceImpl {
     document: { oid: bigint };
     actor: { oid: bigint };
     mode: 'view' | 'edit';
-    client?: TransactionClient;
   }) {
-    if (d.client) {
-      return await this.upsertParticipant(d.client, d);
-    }
-
-    return await db.$transaction(async tx => await this.upsertParticipant(tx, d));
+    return await this.upsertParticipant(d);
   }
 
   async materializeDocumentParticipantsFromStores(d: {
     document: Document;
-    client?: TransactionClient;
   }) {
-    let client = d.client ?? db;
-    let storeActors = await storeAccessService.listStoreParticipantActorsForDocument({
-      document: d.document,
-      client
-    });
-
-    if (d.document.createdByTenantActorOid) {
-      let creator = await client.tenantActor.findFirst({
-        where: {
-          oid: d.document.createdByTenantActorOid
-        }
+    return await withTransaction(async client => {
+      let storeActors = await storeAccessService.listStoreParticipantActorsForDocument({
+        document: d.document
       });
 
-      if (creator) {
-        storeActors.push({
-          actor: creator,
-          mode: 'edit'
+      if (d.document.createdByTenantActorOid) {
+        let creator = await client.tenantActor.findFirst({
+          where: {
+            oid: d.document.createdByTenantActorOid
+          }
         });
-      }
-    }
 
-    let actorsById = new Map<
-      bigint,
-      {
-        actor: TenantActor;
-        mode: 'view' | 'edit';
-      }
-    >();
-
-    for (let item of storeActors) {
-      let existing = actorsById.get(item.actor.oid);
-      if (existing?.mode === 'edit') continue;
-
-      actorsById.set(item.actor.oid, {
-        actor: item.actor,
-        mode: item.mode === 'edit' ? 'edit' : 'view'
-      });
-    }
-
-    if (!d.client) {
-      return await db.$transaction(async transactionClient => {
-        for (let item of actorsById.values()) {
-          await this.upsertParticipant(transactionClient, {
-            document: d.document,
-            actor: item.actor,
-            mode: item.mode
+        if (creator) {
+          storeActors.push({
+            actor: creator,
+            mode: 'edit'
           });
         }
-      });
-    }
+      }
 
-    for (let item of actorsById.values()) {
-      await this.upsertParticipant(d.client, {
-        document: d.document,
-        actor: item.actor,
-        mode: item.mode
-      });
-    }
+      let actorsById = new Map<
+        bigint,
+        {
+          actor: TenantActor;
+          mode: 'view' | 'edit';
+        }
+      >();
+
+      for (let item of storeActors) {
+        let existing = actorsById.get(item.actor.oid);
+        if (existing?.mode === 'edit') continue;
+
+        actorsById.set(item.actor.oid, {
+          actor: item.actor,
+          mode: item.mode === 'edit' ? 'edit' : 'view'
+        });
+      }
+
+      for (let item of actorsById.values()) {
+        await this.upsertParticipant({
+          document: d.document,
+          actor: item.actor,
+          mode: item.mode
+        });
+      }
+    });
   }
 
   private async ensureVersionEditor(
-    tx: TransactionClient,
     d: {
       version: { oid: bigint };
       document: { oid: bigint };
       actor: { oid: bigint };
     }
   ) {
-    let existing = await tx.documentVersionEditors.findFirst({
-      where: {
-        documentVersionOid: d.version.oid,
-        tenantActorOid: d.actor.oid
-      }
-    });
-
-    if (existing) return existing;
-
-    let generated = getId('documentVersionEditor');
-
-    await tx.documentParticipant.updateMany({
-      where: {
-        documentOid: d.document.oid,
-        tenantActorOid: d.actor.oid
-      },
-      data: {
-        editCount: {
-          increment: 1
+    return await withTransaction(async tx => {
+      let existing = await tx.documentVersionEditors.findFirst({
+        where: {
+          documentVersionOid: d.version.oid,
+          tenantActorOid: d.actor.oid
         }
-      }
-    });
+      });
 
-    return await tx.documentVersionEditors.create({
-      data: {
-        oid: generated.oid,
-        id: generated.id,
-        documentVersionOid: d.version.oid,
-        tenantActorOid: d.actor.oid
-      }
+      if (existing) return existing;
+
+      let generated = getId('documentVersionEditor');
+
+      await tx.documentParticipant.updateMany({
+        where: {
+          documentOid: d.document.oid,
+          tenantActorOid: d.actor.oid
+        },
+        data: {
+          editCount: {
+            increment: 1
+          }
+        }
+      });
+
+      return await tx.documentVersionEditors.create({
+        data: {
+          oid: generated.oid,
+          id: generated.id,
+          documentVersionOid: d.version.oid,
+          tenantActorOid: d.actor.oid
+        }
+      });
     });
   }
 
   private async createVersion(
-    tx: TransactionClient,
     d: VersionContext & {
       document: { oid: bigint };
       versionNumber: number;
@@ -400,74 +384,125 @@ class DocumentServiceImpl {
       listEditedAt?: Date;
     }
   ) {
-    let generated = getId('documentVersion');
+    return await withTransaction(async tx => {
+      let generated = getId('documentVersion');
 
-    return await tx.documentVersion.create({
-      data: {
-        oid: generated.oid,
-        id: generated.id,
-        tenantOid: d.tenant.oid,
-        environmentOid: d.environment.oid,
-        documentOid: d.document.oid,
-        versionNumber: d.versionNumber,
-        contentOid: d.contentOid,
-        previousVersionOid: d.previousVersionOid ?? null,
-        listEditedAt: d.listEditedAt
-      },
-      include: {
-        content: true
-      }
+      return await tx.documentVersion.create({
+        data: {
+          oid: generated.oid,
+          id: generated.id,
+          tenantOid: d.tenant.oid,
+          environmentOid: d.environment.oid,
+          documentOid: d.document.oid,
+          versionNumber: d.versionNumber,
+          contentOid: d.contentOid,
+          previousVersionOid: d.previousVersionOid ?? null,
+          listEditedAt: d.listEditedAt
+        },
+        include: {
+          content: true
+        }
+      });
     });
   }
 
   private async writeDocumentContent(
-    tx: TransactionClient,
     d: CargoTenantEnvironment & {
       document: DocumentRecord;
       nextContent: string;
       listEditedAt?: Date;
     }
   ) {
-    let now = new Date();
-    let shouldCreateNewVersion =
-      !d.document.currentVersion ||
-      now.getTime() - d.document.currentVersion.createdAt.getTime() >= activeVersionWindowMs;
+    return await withTransaction(async tx => {
+      let now = new Date();
+      let shouldCreateNewVersion =
+        !d.document.currentVersion ||
+        now.getTime() - d.document.currentVersion.createdAt.getTime() >= activeVersionWindowMs;
 
-    let liveContentOid = d.document.contentOid;
-    let activeVersion = d.document.currentVersion;
-    let nextVersionNumber = d.document.maxVersionNumber;
-    let didCreateVersion = false;
-    let { parentLiveContent, shouldKeepParentSync } = await this.getParentSyncState(tx, {
-      document: d.document,
-      nextContent: d.nextContent
-    });
-    let shouldDetachOwnedContent =
-      d.document.isContentOwner &&
-      !!parentLiveContent &&
-      parentLiveContent.contentOid === d.document.contentOid;
+      let liveContentOid = d.document.contentOid;
+      let activeVersion = d.document.currentVersion;
+      let nextVersionNumber = d.document.maxVersionNumber;
+      let didCreateVersion = false;
+      let { parentLiveContent, shouldKeepParentSync } = await this.getParentSyncState({
+        document: d.document,
+        nextContent: d.nextContent
+      });
+      let shouldDetachOwnedContent =
+        d.document.isContentOwner &&
+        !!parentLiveContent &&
+        parentLiveContent.contentOid === d.document.contentOid;
 
-    if (shouldCreateNewVersion) {
-      if (d.document.currentVersion) {
-        let retiredContentIds = getId('documentContent');
+      if (shouldCreateNewVersion) {
+        if (d.document.currentVersion) {
+          let retiredContentIds = getId('documentContent');
 
-        await tx.documentContent.create({
-          data: {
-            oid: retiredContentIds.oid,
-            content: d.document.content.content
+          await tx.documentContent.create({
+            data: {
+              oid: retiredContentIds.oid,
+              content: d.document.content.content
+            }
+          });
+
+          await tx.documentVersion.update({
+            where: {
+              id: d.document.currentVersion.id
+            },
+            data: {
+              contentOid: retiredContentIds.oid
+            }
+          });
+        }
+
+        if (d.document.isContentOwner) {
+          if (shouldDetachOwnedContent) {
+            let liveContentIds = getId('documentContent');
+
+            await tx.documentContent.create({
+              data: {
+                oid: liveContentIds.oid,
+                content: d.nextContent
+              }
+            });
+
+            liveContentOid = liveContentIds.oid;
+          } else {
+            await tx.documentContent.update({
+              where: {
+                oid: d.document.contentOid
+              },
+              data: {
+                content: d.nextContent
+              }
+            });
           }
-        });
+        } else if (shouldKeepParentSync) {
+          liveContentOid = parentLiveContent!.contentOid;
+        } else {
+          let liveContentIds = getId('documentContent');
 
-        await tx.documentVersion.update({
-          where: {
-            id: d.document.currentVersion.id
-          },
-          data: {
-            contentOid: retiredContentIds.oid
-          }
-        });
-      }
+          await tx.documentContent.create({
+            data: {
+              oid: liveContentIds.oid,
+              content: d.nextContent
+            }
+          });
 
-      if (d.document.isContentOwner) {
+          liveContentOid = liveContentIds.oid;
+        }
+
+        nextVersionNumber += 1;
+
+        activeVersion = await this.createVersion({
+          tenant: d.tenant,
+          environment: d.environment,
+          document: d.document,
+          versionNumber: nextVersionNumber,
+          contentOid: liveContentOid,
+          previousVersionOid: d.document.currentVersion?.oid,
+          listEditedAt: d.listEditedAt
+        });
+        didCreateVersion = true;
+      } else if (d.document.isContentOwner) {
         if (shouldDetachOwnedContent) {
           let liveContentIds = getId('documentContent');
 
@@ -479,6 +514,33 @@ class DocumentServiceImpl {
           });
 
           liveContentOid = liveContentIds.oid;
+
+          if (!d.document.currentVersion) {
+            activeVersion = await this.createVersion({
+              tenant: d.tenant,
+              environment: d.environment,
+              document: d.document,
+              versionNumber: d.document.maxVersionNumber + 1,
+              contentOid: liveContentOid,
+              listEditedAt: d.listEditedAt
+            });
+
+            nextVersionNumber += 1;
+            didCreateVersion = true;
+          } else {
+            activeVersion = await tx.documentVersion.update({
+              where: {
+                id: d.document.currentVersion.id
+              },
+              data: {
+                contentOid: liveContentOid,
+                listEditedAt: d.listEditedAt
+              },
+              include: {
+                content: true
+              }
+            });
+          }
         } else {
           await tx.documentContent.update({
             where: {
@@ -491,46 +553,9 @@ class DocumentServiceImpl {
         }
       } else if (shouldKeepParentSync) {
         liveContentOid = parentLiveContent!.contentOid;
-      } else {
-        let liveContentIds = getId('documentContent');
-
-        await tx.documentContent.create({
-          data: {
-            oid: liveContentIds.oid,
-            content: d.nextContent
-          }
-        });
-
-        liveContentOid = liveContentIds.oid;
-      }
-
-      nextVersionNumber += 1;
-
-      activeVersion = await this.createVersion(tx, {
-        tenant: d.tenant,
-        environment: d.environment,
-        document: d.document,
-        versionNumber: nextVersionNumber,
-        contentOid: liveContentOid,
-        previousVersionOid: d.document.currentVersion?.oid,
-        listEditedAt: d.listEditedAt
-      });
-      didCreateVersion = true;
-    } else if (d.document.isContentOwner) {
-      if (shouldDetachOwnedContent) {
-        let liveContentIds = getId('documentContent');
-
-        await tx.documentContent.create({
-          data: {
-            oid: liveContentIds.oid,
-            content: d.nextContent
-          }
-        });
-
-        liveContentOid = liveContentIds.oid;
 
         if (!d.document.currentVersion) {
-          activeVersion = await this.createVersion(tx, {
+          activeVersion = await this.createVersion({
             tenant: d.tenant,
             environment: d.environment,
             document: d.document,
@@ -556,184 +581,147 @@ class DocumentServiceImpl {
           });
         }
       } else {
-        await tx.documentContent.update({
-          where: {
-            oid: d.document.contentOid
-          },
+        let liveContentIds = getId('documentContent');
+
+        await tx.documentContent.create({
           data: {
+            oid: liveContentIds.oid,
             content: d.nextContent
           }
         });
-      }
-    } else if (shouldKeepParentSync) {
-      liveContentOid = parentLiveContent!.contentOid;
 
-      if (!d.document.currentVersion) {
-        activeVersion = await this.createVersion(tx, {
-          tenant: d.tenant,
-          environment: d.environment,
-          document: d.document,
-          versionNumber: d.document.maxVersionNumber + 1,
-          contentOid: liveContentOid,
-          listEditedAt: d.listEditedAt
-        });
+        liveContentOid = liveContentIds.oid;
 
-        nextVersionNumber += 1;
-        didCreateVersion = true;
-      } else {
-        activeVersion = await tx.documentVersion.update({
-          where: {
-            id: d.document.currentVersion.id
-          },
-          data: {
+        if (!d.document.currentVersion) {
+          activeVersion = await this.createVersion({
+            tenant: d.tenant,
+            environment: d.environment,
+            document: d.document,
+            versionNumber: d.document.maxVersionNumber + 1,
             contentOid: liveContentOid,
             listEditedAt: d.listEditedAt
-          },
-          include: {
-            content: true
-          }
-        });
-      }
-    } else {
-      let liveContentIds = getId('documentContent');
+          });
 
-      await tx.documentContent.create({
-        data: {
-          oid: liveContentIds.oid,
-          content: d.nextContent
+          nextVersionNumber += 1;
+          didCreateVersion = true;
+        } else {
+          activeVersion = await tx.documentVersion.update({
+            where: {
+              id: d.document.currentVersion.id
+            },
+            data: {
+              contentOid: liveContentOid,
+              listEditedAt: d.listEditedAt
+            },
+            include: {
+              content: true
+            }
+          });
         }
-      });
-
-      liveContentOid = liveContentIds.oid;
-
-      if (!d.document.currentVersion) {
-        activeVersion = await this.createVersion(tx, {
-          tenant: d.tenant,
-          environment: d.environment,
-          document: d.document,
-          versionNumber: d.document.maxVersionNumber + 1,
-          contentOid: liveContentOid,
-          listEditedAt: d.listEditedAt
-        });
-
-        nextVersionNumber += 1;
-        didCreateVersion = true;
-      } else {
-        activeVersion = await tx.documentVersion.update({
-          where: {
-            id: d.document.currentVersion.id
-          },
-          data: {
-            contentOid: liveContentOid,
-            listEditedAt: d.listEditedAt
-          },
-          include: {
-            content: true
-          }
-        });
       }
-    }
 
-    return {
-      activeVersion,
-      liveContentOid,
-      nextVersionNumber,
-      isContentOwner: d.document.isContentOwner || !shouldKeepParentSync,
-      didCreateVersion
-    };
+      return {
+        activeVersion,
+        liveContentOid,
+        nextVersionNumber,
+        isContentOwner: d.document.isContentOwner || !shouldKeepParentSync,
+        didCreateVersion
+      };
+    });
   }
 
   private async persistDraftToDocument(
-    tx: TransactionClient,
     d: CargoTenantEnvironment & {
       document: DocumentRecord;
       draft: DocumentDraft;
       actors: TenantActor[];
     }
   ) {
-    let nextTitle = d.draft.title;
-    let nextContent = d.draft.content;
-    let hasContentChange = nextContent !== d.document.content.content;
-    let hasTitleChange = nextTitle !== d.document.title;
+    return await withTransaction(async tx => {
+      let nextTitle = d.draft.title;
+      let nextContent = d.draft.content;
+      let hasContentChange = nextContent !== d.document.content.content;
+      let hasTitleChange = nextTitle !== d.document.title;
 
-    if (!hasContentChange && !hasTitleChange) {
-      return {
-        document: d.document,
-        createdVersionId: null
-      };
-    }
+      if (!hasContentChange && !hasTitleChange) {
+        return {
+          document: d.document,
+          createdVersionId: null
+        };
+      }
 
-    let activeVersion = d.document.currentVersion;
-    let liveContentOid = d.document.contentOid;
-    let maxVersionNumber = d.document.maxVersionNumber;
-    let isContentOwner = d.document.isContentOwner;
-    let createdVersionId: string | null = null;
+      let activeVersion = d.document.currentVersion;
+      let liveContentOid = d.document.contentOid;
+      let maxVersionNumber = d.document.maxVersionNumber;
+      let isContentOwner = d.document.isContentOwner;
+      let createdVersionId: string | null = null;
 
-    if (hasContentChange) {
-      let listEditedAt = new Date();
+      if (hasContentChange) {
+        let listEditedAt = new Date();
 
-      let writeResult = await this.writeDocumentContent(tx, {
-        tenant: d.tenant,
-        environment: d.environment,
-        document: d.document,
-        nextContent,
-        listEditedAt
+        let writeResult = await this.writeDocumentContent({
+          tenant: d.tenant,
+          environment: d.environment,
+          document: d.document,
+          nextContent,
+          listEditedAt
+        });
+
+        activeVersion = writeResult.activeVersion;
+        liveContentOid = writeResult.liveContentOid;
+        maxVersionNumber = writeResult.nextVersionNumber;
+        isContentOwner = writeResult.isContentOwner;
+        createdVersionId = writeResult.didCreateVersion ? (writeResult.activeVersion?.id ?? null) : null;
+      }
+
+      await tx.file.update({
+        where: {
+          id: d.document.file.id
+        },
+        data: {
+          fileName: nextTitle,
+          title: nextTitle,
+          ...(hasContentChange
+            ? {
+                fileSize: getTextByteSize(nextContent)
+              }
+            : {})
+        }
       });
 
-      activeVersion = writeResult.activeVersion;
-      liveContentOid = writeResult.liveContentOid;
-      maxVersionNumber = writeResult.nextVersionNumber;
-      isContentOwner = writeResult.isContentOwner;
-      createdVersionId = writeResult.didCreateVersion ? (writeResult.activeVersion?.id ?? null) : null;
-    }
+      let updatedDocument = await tx.document.update({
+        where: {
+          id: d.document.id
+        },
+        data: {
+          title: nextTitle,
+          ...(hasContentChange
+            ? {
+                contentOid: liveContentOid,
+                isContentOwner,
+                maxVersionNumber,
+                currentVersionOid: activeVersion?.oid ?? null
+              }
+            : {})
+        },
+        include: documentInclude
+      });
 
-    await tx.file.update({
-      where: {
-        id: d.document.file.id
-      },
-      data: {
-        fileName: nextTitle,
-        title: nextTitle,
-        ...(hasContentChange
-          ? {
-              fileSize: getTextByteSize(nextContent)
-            }
-          : {})
+      for (let actor of d.actors) {
+        if (hasContentChange && activeVersion) {
+          await this.ensureVersionEditor({
+            version: activeVersion,
+            document: updatedDocument,
+            actor
+          });
+        }
       }
+
+      return {
+        document: updatedDocument,
+        createdVersionId
+      };
     });
-
-    let updatedDocument = await tx.document.update({
-      where: {
-        id: d.document.id
-      },
-      data: {
-        title: nextTitle,
-        ...(hasContentChange
-          ? {
-              contentOid: liveContentOid,
-              isContentOwner,
-              maxVersionNumber,
-              currentVersionOid: activeVersion?.oid ?? null
-            }
-          : {})
-      },
-      include: documentInclude
-    });
-
-    for (let actor of d.actors) {
-      if (hasContentChange && activeVersion) {
-        await this.ensureVersionEditor(tx, {
-          version: activeVersion,
-          document: updatedDocument,
-          actor
-        });
-      }
-    }
-
-    return {
-      document: updatedDocument,
-      createdVersionId
-    };
   }
 
   async createDocument(
@@ -761,7 +749,7 @@ class DocumentServiceImpl {
         })
       : undefined;
 
-    return await db.$transaction(async tx => {
+    return await withTransaction(async tx => {
       let documentIds = d.input.id
         ? { oid: getId('document').oid, id: d.input.id }
         : getId('document');
@@ -773,7 +761,6 @@ class DocumentServiceImpl {
         purpose: purpose.id,
         storeId: getDocumentStoreId(documentIds.id),
         _isDocument: true,
-        client: tx,
         input: {
           name: d.input.title,
           mimeType: documentMimeType,
@@ -806,7 +793,7 @@ class DocumentServiceImpl {
         include: documentInclude
       });
 
-      let version = await this.createVersion(tx, {
+      let version = await this.createVersion({
         tenant: d.tenant,
         environment: d.environment,
         document,
@@ -816,13 +803,13 @@ class DocumentServiceImpl {
       });
 
       if (actor) {
-        await this.upsertParticipant(tx, {
+        await this.upsertParticipant({
           document,
           actor,
           mode: 'edit'
         });
 
-        await this.ensureVersionEditor(tx, {
+        await this.ensureVersionEditor({
           version,
           document,
           actor
@@ -843,8 +830,7 @@ class DocumentServiceImpl {
         let store = await storeAccessService.getStoreById({
           tenant: d.tenant,
           environment: d.environment,
-          storeId: d.input.store.id,
-          client: tx
+          storeId: d.input.store.id
         });
 
         await storeAccessService.assertStoreAccessForStore({
@@ -854,8 +840,7 @@ class DocumentServiceImpl {
           actorId: d.input.actorId,
           defaultPermissions: d.input.defaultPermissions,
           overridePermissions: d.input.overridePermissions,
-          requiredPermission: storeWritePermission,
-          client: tx
+          requiredPermission: storeWritePermission
         });
 
         await storeItemMutationService.attachTargetToStore({
@@ -870,8 +855,7 @@ class DocumentServiceImpl {
               id: createdDocument.id
             }
           },
-          actor,
-          client: tx
+          actor
         });
       }
 
@@ -888,7 +872,7 @@ class DocumentServiceImpl {
       overridePermissions?: boolean;
     }
   ) {
-    let document = await this.getDocumentRecord(db, d);
+    let document = await this.getDocumentRecord(d);
     let access = await storeAccessService.assertStoreAccessForDocument({
       tenant: d.tenant,
       environment: d.environment,
@@ -900,8 +884,8 @@ class DocumentServiceImpl {
     });
 
     if (access.actor) {
-      await db.$transaction(async tx => {
-        await this.upsertParticipant(tx, {
+      await withTransaction(async () => {
+        await this.upsertParticipant({
           document,
           actor: access.actor!,
           mode: 'view'
@@ -1081,7 +1065,7 @@ class DocumentServiceImpl {
         currentContent !== nextDraft.content &&
         !d.document.isContentOwner
       ) {
-        let { shouldKeepParentSync } = await this.getParentSyncState(db, {
+        let { shouldKeepParentSync } = await this.getParentSyncState({
           document: d.document,
           nextContent: nextDraft.content
         });
@@ -1120,8 +1104,8 @@ class DocumentServiceImpl {
     });
 
     if (actor) {
-      await db.$transaction(async tx => {
-        await this.upsertParticipant(tx, {
+      await withTransaction(async () => {
+        await this.upsertParticipant({
           document: d.document,
           actor,
           mode: 'edit'
@@ -1154,7 +1138,7 @@ class DocumentServiceImpl {
         return null;
       }
 
-      let result = await db.$transaction(async tx => {
+      let result = await withTransaction(async tx => {
         let currentDocument = await tx.document.findFirst({
           where: {
             id: d.documentId
@@ -1182,7 +1166,7 @@ class DocumentServiceImpl {
               })
             : [];
 
-        return await this.persistDraftToDocument(tx, {
+        return await this.persistDraftToDocument({
           tenant: currentDocument.tenant,
           environment: currentDocument.environment,
           document: currentDocument,
@@ -1313,7 +1297,7 @@ class DocumentServiceImpl {
       let draft = await documentDraftService.getDraftByDocumentId(d.childDocumentId);
       if (draft) return null;
 
-      return await db.$transaction(async tx => {
+      return await withTransaction(async tx => {
         let parentVersion = await tx.documentVersion.findFirst({
           where: {
             id: d.parentDocumentVersionId,
@@ -1359,7 +1343,7 @@ class DocumentServiceImpl {
         }
 
         let nextVersionNumber = childDocument.maxVersionNumber + 1;
-        let nextVersion = await this.createVersion(tx, {
+        let nextVersion = await this.createVersion({
           tenant: {
             oid: parentVersion.tenantOid
           },
@@ -1414,7 +1398,6 @@ class DocumentServiceImpl {
   async cloneDocument(
     d: CargoTenantEnvironment & {
       document: ResolvedDocumentRecord;
-      client?: TransactionClient;
       input: {
         id?: string;
         title?: string;
@@ -1431,8 +1414,7 @@ class DocumentServiceImpl {
       actorId: d.input.actorId,
       defaultPermissions: d.input.defaultPermissions,
       overridePermissions: d.input.overridePermissions,
-      requiredPermission: storeReadPermission,
-      client: d.client
+      requiredPermission: storeReadPermission
     });
     let actor = access.actor;
 
@@ -1440,7 +1422,7 @@ class DocumentServiceImpl {
 
     let purpose = await filePurposeService.ensureDocumentFilePurpose();
 
-    let cloneWithClient = async (tx: TransactionClient) => {
+    let cloneWithClient = async (tx: Prisma.TransactionClient) => {
       let documentIds = d.input.id
         ? { oid: getId('document').oid, id: d.input.id }
         : getId('document');
@@ -1454,7 +1436,6 @@ class DocumentServiceImpl {
         purpose: purpose.id,
         storeId: getDocumentStoreId(documentIds.id),
         _isDocument: true,
-        client: tx,
         input: {
           name: nextTitle,
           mimeType: documentMimeType,
@@ -1481,7 +1462,7 @@ class DocumentServiceImpl {
         include: documentInclude
       });
 
-      let version = await this.createVersion(tx, {
+      let version = await this.createVersion({
         tenant: d.tenant,
         environment: d.environment,
         document,
@@ -1501,13 +1482,13 @@ class DocumentServiceImpl {
       });
 
       if (actor) {
-        await this.upsertParticipant(tx, {
+        await this.upsertParticipant({
           document: clonedDocument,
           actor,
           mode: 'edit'
         });
 
-        await this.ensureVersionEditor(tx, {
+        await this.ensureVersionEditor({
           version,
           document: clonedDocument,
           actor
@@ -1517,11 +1498,7 @@ class DocumentServiceImpl {
       return clonedDocument;
     };
 
-    if (d.client) {
-      return await this.withEffectiveFileStore(await cloneWithClient(d.client));
-    }
-
-    return await this.withEffectiveFileStore(await db.$transaction(async tx => await cloneWithClient(tx)));
+    return await this.withEffectiveFileStore(await withTransaction(async tx => await cloneWithClient(tx)));
   }
 
   async deleteDocument(
@@ -1544,13 +1521,12 @@ class DocumentServiceImpl {
 
     this.ensureDocumentActive(d.document);
 
-    let deletedDocument = await db.$transaction(async tx => {
+    let deletedDocument = await withTransaction(async tx => {
       await fileService.deleteFile({
-        file: d.document.file,
-        client: tx
+        file: d.document.file
       });
 
-      return await this.getDocumentRecord(tx, {
+      return await this.getDocumentRecord({
         tenant: {
           oid: d.document.tenantOid,
           id: d.document.id

--- a/src/systems/cargo/service/src/services/documentCleanup.ts
+++ b/src/systems/cargo/service/src/services/documentCleanup.ts
@@ -1,5 +1,5 @@
 import { Service } from '@lowerdeck/service';
-import { db } from '../db';
+import { db, withTransaction } from '../db';
 
 let documentVersionRetentionMs = 30 * 24 * 60 * 60 * 1000;
 
@@ -74,7 +74,7 @@ class DocumentCleanupServiceImpl {
 
     let contentOid = version.contentOid;
 
-    await db.$transaction(async tx => {
+    await withTransaction(async tx => {
       await tx.documentVersion.updateMany({
         where: {
           previousVersionOid: version.oid

--- a/src/systems/cargo/service/src/services/documentContentStore.ts
+++ b/src/systems/cargo/service/src/services/documentContentStore.ts
@@ -1,7 +1,5 @@
-import type { Prisma, PrismaClient } from '../../prisma/generated/client';
-import { db } from '../db';
-
-type DbClient = PrismaClient | Prisma.TransactionClient;
+import type { Prisma } from '../../prisma/generated/client';
+import { withTransaction } from '../db';
 
 type DocumentStoreSource = {
   id: string;
@@ -27,54 +25,57 @@ let effectiveDocumentStoreSelect = {
   }
 } satisfies Prisma.DocumentSelect;
 
-let getClient = (client?: DbClient) => client ?? db;
-
 let getEffectiveDocumentStoreSource = async (
-  document: DocumentStoreSource,
-  client?: DbClient
-): Promise<DocumentStoreSource> => {
-  let resolved = document;
-  let dbClient = getClient(client);
+  document: DocumentStoreSource
+): Promise<DocumentStoreSource> =>
+  await withTransaction(
+    async db => {
+      let resolved = document;
 
-  while (!resolved.isContentOwner && resolved.parentDocumentOid) {
-    let parent = await dbClient.document.findFirst({
-      where: {
-        oid: resolved.parentDocumentOid,
-        file: {
-          status: 'active'
+      while (!resolved.isContentOwner && resolved.parentDocumentOid) {
+        let parent = await db.document.findFirst({
+          where: {
+            oid: resolved.parentDocumentOid,
+            file: {
+              status: 'active'
+            }
+          },
+          select: effectiveDocumentStoreSelect
+        });
+
+        if (!parent) {
+          return resolved;
         }
-      },
-      select: effectiveDocumentStoreSelect
-    });
 
-    if (!parent) {
+        resolved = parent;
+      }
+
       return resolved;
-    }
-
-    resolved = parent;
-  }
-
-  return resolved;
-};
+    },
+    { ifExists: true }
+  );
 
 let getEffectiveDocumentStoreSourceByDocumentId = async (
-  documentId: string,
-  client?: DbClient
-): Promise<DocumentStoreSource | null> => {
-  let document = await getClient(client).document.findFirst({
-    where: {
-      id: documentId,
-      file: {
-        status: 'active'
-      }
+  documentId: string
+): Promise<DocumentStoreSource | null> =>
+  await withTransaction(
+    async db => {
+      let document = await db.document.findFirst({
+        where: {
+          id: documentId,
+          file: {
+            status: 'active'
+          }
+        },
+        select: effectiveDocumentStoreSelect
+      });
+
+      if (!document) return null;
+
+      return await getEffectiveDocumentStoreSource(document);
     },
-    select: effectiveDocumentStoreSelect
-  });
-
-  if (!document) return null;
-
-  return await getEffectiveDocumentStoreSource(document, client);
-};
+    { ifExists: true }
+  );
 
 export {
   effectiveDocumentStoreSelect,

--- a/src/systems/cargo/service/src/services/documentContentStore.ts
+++ b/src/systems/cargo/service/src/services/documentContentStore.ts
@@ -1,0 +1,83 @@
+import type { Prisma, PrismaClient } from '../../prisma/generated/client';
+import { db } from '../db';
+
+type DbClient = PrismaClient | Prisma.TransactionClient;
+
+type DocumentStoreSource = {
+  id: string;
+  oid: bigint;
+  isContentOwner: boolean;
+  parentDocumentOid: bigint | null;
+  file: {
+    id: string;
+    storeId: string;
+  };
+};
+
+let effectiveDocumentStoreSelect = {
+  id: true,
+  oid: true,
+  isContentOwner: true,
+  parentDocumentOid: true,
+  file: {
+    select: {
+      id: true,
+      storeId: true
+    }
+  }
+} satisfies Prisma.DocumentSelect;
+
+let getClient = (client?: DbClient) => client ?? db;
+
+let getEffectiveDocumentStoreSource = async (
+  document: DocumentStoreSource,
+  client?: DbClient
+): Promise<DocumentStoreSource> => {
+  let resolved = document;
+  let dbClient = getClient(client);
+
+  while (!resolved.isContentOwner && resolved.parentDocumentOid) {
+    let parent = await dbClient.document.findFirst({
+      where: {
+        oid: resolved.parentDocumentOid,
+        file: {
+          status: 'active'
+        }
+      },
+      select: effectiveDocumentStoreSelect
+    });
+
+    if (!parent) {
+      return resolved;
+    }
+
+    resolved = parent;
+  }
+
+  return resolved;
+};
+
+let getEffectiveDocumentStoreSourceByDocumentId = async (
+  documentId: string,
+  client?: DbClient
+): Promise<DocumentStoreSource | null> => {
+  let document = await getClient(client).document.findFirst({
+    where: {
+      id: documentId,
+      file: {
+        status: 'active'
+      }
+    },
+    select: effectiveDocumentStoreSelect
+  });
+
+  if (!document) return null;
+
+  return await getEffectiveDocumentStoreSource(document, client);
+};
+
+export {
+  effectiveDocumentStoreSelect,
+  getEffectiveDocumentStoreSource,
+  getEffectiveDocumentStoreSourceByDocumentId
+};

--- a/src/systems/cargo/service/src/services/documentDraft.ts
+++ b/src/systems/cargo/service/src/services/documentDraft.ts
@@ -18,16 +18,51 @@ let draftTtlSeconds = 7 * 24 * 60 * 60;
 let lockTtlMs = 15000;
 let maxLockAttempts = 100;
 let lockRetryDelayMs = 25;
+let dirtyDocumentsHash = 'cargo:document:dirty';
+let queuedDocumentsHash = 'cargo:document:queued';
 
 let redisFactory = createRedisClient({
   redisUrl: env.service.REDIS_URL
 });
 let redisClientPromise: Promise<any> | undefined;
 
+let claimDirtyDocumentScript = `
+local dirtyRevision = redis.call("HGET", KEYS[1], ARGV[1])
+if dirtyRevision then
+    redis.call("HDEL", KEYS[1], ARGV[1])
+    redis.call("HSET", KEYS[2], ARGV[1], dirtyRevision)
+    return dirtyRevision
+end
+
+local queuedRevision = redis.call("HGET", KEYS[2], ARGV[1])
+return queuedRevision
+`;
+
+let clearDocumentMarkersUpToRevisionScript = `
+local flushedRevision = tonumber(ARGV[2])
+
+local dirtyRevision = redis.call("HGET", KEYS[1], ARGV[1])
+if dirtyRevision and tonumber(dirtyRevision) <= flushedRevision then
+    redis.call("HDEL", KEYS[1], ARGV[1])
+end
+
+local queuedRevision = redis.call("HGET", KEYS[2], ARGV[1])
+if queuedRevision and tonumber(queuedRevision) <= flushedRevision then
+    redis.call("HDEL", KEYS[2], ARGV[1])
+end
+
+return 1
+`;
+
 let getRedis = async () => {
   redisClientPromise ??= redisFactory.eager();
   return await redisClientPromise;
 };
+
+let claimDirtyDocumentScriptSha = getRedis().then(redis => redis.scriptLoad(claimDirtyDocumentScript));
+let clearDocumentMarkersUpToRevisionScriptSha = getRedis().then(redis =>
+  redis.scriptLoad(clearDocumentMarkersUpToRevisionScript)
+);
 
 let draftKeys = (documentId: string) => ({
   draft: `cargo:document:draft:${documentId}`,
@@ -52,6 +87,50 @@ class DocumentDraftServiceImpl {
   async deleteDraft(documentId: string) {
     let redis = await getRedis();
     await redis.del(draftKeys(documentId).draft);
+  }
+
+  async markDocumentDirty(documentId: string, revision: number) {
+    let redis = await getRedis();
+    await redis.hSet(dirtyDocumentsHash, documentId, revision.toString());
+  }
+
+  async listDirtyDocumentIds() {
+    let redis = await getRedis();
+    let [dirtyDocumentIds, queuedDocumentIds] = await Promise.all([
+      redis.hKeys(dirtyDocumentsHash),
+      redis.hKeys(queuedDocumentsHash)
+    ]);
+
+    return [...new Set([...dirtyDocumentIds, ...queuedDocumentIds])];
+  }
+
+  async claimDirtyDocumentRevision(documentId: string) {
+    let redis = await getRedis();
+    let result = await redis.evalSha(await claimDirtyDocumentScriptSha, {
+      keys: [dirtyDocumentsHash, queuedDocumentsHash],
+      arguments: [documentId]
+    });
+
+    if (!result) return null;
+
+    return typeof result == 'string' ? parseInt(result, 10) : Number(result);
+  }
+
+  async clearDocumentMarkersUpToRevision(documentId: string, revision: number) {
+    let redis = await getRedis();
+    await redis.evalSha(await clearDocumentMarkersUpToRevisionScriptSha, {
+      keys: [dirtyDocumentsHash, queuedDocumentsHash],
+      arguments: [documentId, revision.toString()]
+    });
+  }
+
+  async clearDocumentState(documentId: string) {
+    let redis = await getRedis();
+    await Promise.all([
+      redis.del(draftKeys(documentId).draft),
+      redis.hDel(dirtyDocumentsHash, documentId),
+      redis.hDel(queuedDocumentsHash, documentId)
+    ]);
   }
 
   async withDocumentLock<T>(documentId: string, cb: () => Promise<T>) {

--- a/src/systems/cargo/service/src/services/file.ts
+++ b/src/systems/cargo/service/src/services/file.ts
@@ -10,6 +10,7 @@ import type { File, Prisma, PrismaClient, StoreParticipantPermissions } from '..
 import { db } from '../db';
 import { getId } from '../id';
 import { actorService } from './actor';
+import { getEffectiveDocumentStoreSourceByDocumentId } from './documentContentStore';
 import { documentDraftService } from './documentDraft';
 import {
   documentFilePurposeSlug,
@@ -46,6 +47,22 @@ type FileAccessInput = {
 };
 
 class FileServiceImpl {
+  private async withEffectiveStoreId<T extends FileRecord>(file: T) {
+    if (!file.document?.id) {
+      return file as T & { effectiveStoreId?: string };
+    }
+
+    let effectiveStoreSource = await getEffectiveDocumentStoreSourceByDocumentId(file.document.id);
+    if (!effectiveStoreSource || effectiveStoreSource.file.storeId === file.storeId) {
+      return file as T & { effectiveStoreId?: string };
+    }
+
+    return {
+      ...file,
+      effectiveStoreId: effectiveStoreSource.file.storeId
+    } satisfies T & { effectiveStoreId?: string };
+  }
+
   private async ensureFileActive(file: File) {
     if (file.status !== 'active') {
       throw new ServiceError(
@@ -167,7 +184,7 @@ class FileServiceImpl {
         });
       }
 
-      return updatedFile;
+      return await this.withEffectiveStoreId(updatedFile);
     }
 
     let generated = getId('file');
@@ -222,7 +239,7 @@ class FileServiceImpl {
       });
     }
 
-    return createdFile;
+    return await this.withEffectiveStoreId(createdFile);
   }
 
   async getFileById(
@@ -251,7 +268,7 @@ class FileServiceImpl {
       requiredPermission: storeReadPermission
     });
 
-    return file;
+    return await this.withEffectiveStoreId(file);
   }
 
   async updateFile(d: {
@@ -383,22 +400,25 @@ class FileServiceImpl {
 
     if (!d.actorId) {
       return Paginator.create(({ prisma }) =>
-        prisma(
-          async opts =>
-            await db.file.findMany({
-              ...opts,
-              where: {
-                tenantOid: d.tenant.oid,
-                environmentOid: d.environment.oid,
-                status: d.includeDeleted ? undefined : 'active',
-                purposeOid: purposes
-                  ? {
-                      in: purposes.map(purpose => purpose.oid)
-                    }
-                  : undefined
-              },
-              include
-            })
+        prisma(async opts =>
+          await Promise.all(
+            (
+              await db.file.findMany({
+                ...opts,
+                where: {
+                  tenantOid: d.tenant.oid,
+                  environmentOid: d.environment.oid,
+                  status: d.includeDeleted ? undefined : 'active',
+                  purposeOid: purposes
+                    ? {
+                        in: purposes.map(purpose => purpose.oid)
+                      }
+                    : undefined
+                },
+                include
+              })
+            ).map(async file => await this.withEffectiveStoreId(file))
+          )
         )
       );
     }
@@ -413,36 +433,39 @@ class FileServiceImpl {
     });
 
     return Paginator.create(({ prisma }) =>
-      prisma(
-        async opts =>
-          await db.file.findMany({
-            ...opts,
-            where: {
-              tenantOid: d.tenant.oid,
-              environmentOid: d.environment.oid,
-              status: d.includeDeleted ? undefined : 'active',
-              purposeOid: purposes
-                ? {
-                    in: purposes.map(purpose => purpose.oid)
-                  }
-                : undefined,
-              OR: [
-                {
-                  createdByTenantActorOid: access.actor?.oid
-                },
-                {
-                  storeItems: {
-                    some: {
-                      storeOid: {
-                        in: access.accessibleStoreOids
+      prisma(async opts =>
+        await Promise.all(
+          (
+            await db.file.findMany({
+              ...opts,
+              where: {
+                tenantOid: d.tenant.oid,
+                environmentOid: d.environment.oid,
+                status: d.includeDeleted ? undefined : 'active',
+                purposeOid: purposes
+                  ? {
+                      in: purposes.map(purpose => purpose.oid)
+                    }
+                  : undefined,
+                OR: [
+                  {
+                    createdByTenantActorOid: access.actor?.oid
+                  },
+                  {
+                    storeItems: {
+                      some: {
+                        storeOid: {
+                          in: access.accessibleStoreOids
+                        }
                       }
                     }
                   }
-                }
-              ]
-            },
-            include
-          })
+                ]
+              },
+              include
+            })
+          ).map(async file => await this.withEffectiveStoreId(file))
+        )
       )
     );
   }

--- a/src/systems/cargo/service/src/services/file.ts
+++ b/src/systems/cargo/service/src/services/file.ts
@@ -333,7 +333,7 @@ class FileServiceImpl {
         : await this.deleteFileWithClient(client, d.file);
 
     if (document) {
-      await documentDraftService.deleteDraft(document.id);
+      await documentDraftService.clearDocumentState(document.id);
     }
 
     return file;

--- a/src/systems/cargo/service/src/services/file.ts
+++ b/src/systems/cargo/service/src/services/file.ts
@@ -6,8 +6,8 @@ import {
 } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import type { File, Prisma, PrismaClient, StoreParticipantPermissions } from '../../prisma/generated/client';
-import { db } from '../db';
+import type { File, Prisma, StoreParticipantPermissions } from '../../prisma/generated/client';
+import { db, withTransaction } from '../db';
 import { getId } from '../id';
 import { actorService } from './actor';
 import { getEffectiveDocumentStoreSourceByDocumentId } from './documentContentStore';
@@ -36,7 +36,6 @@ let include = {
   environment: true
 } satisfies Prisma.FileInclude;
 
-type DbClient = PrismaClient | Prisma.TransactionClient;
 type FileRecord = Prisma.FileGetPayload<{
   include: typeof include;
 }>;
@@ -78,7 +77,6 @@ class FileServiceImpl {
       purpose: string;
       storeId: string;
       _isDocument?: boolean;
-      client?: DbClient;
       input: {
         id?: string;
         name: string;
@@ -95,58 +93,101 @@ class FileServiceImpl {
       };
     }
   ): Promise<FileRecord> {
-    if (d.input.store && !d.client) {
-      return await db.$transaction(async tx =>
-        await this.createFile({
-          ...d,
-          client: tx
-        })
-      );
-    }
+    return await withTransaction(async db => {
+      let purpose = await filePurposeService.getFilePurposeById({
+        id: d.purpose
+      });
+      if (purpose.slug === documentFilePurposeSlug && !d._isDocument) {
+        throw new ServiceError(
+          badRequestError({
+            message: 'Document purpose cannot be used for normal file creation'
+          })
+        );
+      }
 
-    let purpose = await filePurposeService.getFilePurposeById({
-      id: d.purpose
-    });
-    if (purpose.slug === documentFilePurposeSlug && !d._isDocument) {
-      throw new ServiceError(
-        badRequestError({
-          message: 'Document purpose cannot be used for normal file creation'
-        })
-      );
-    }
+      let actor = d.input.actorId
+        ? await actorService.getActorById({
+            tenant: d.tenant,
+            actorId: d.input.actorId
+          })
+        : undefined;
 
-    let client = d.client ?? db;
-    let actor = d.input.actorId
-      ? await actorService.getActorById({
-          tenant: d.tenant,
-          actorId: d.input.actorId
-        })
-      : undefined;
+      let existing = d.input.id
+        ? await db.file.findFirst({
+            where: {
+              tenantOid: d.tenant.oid,
+              environmentOid: d.environment.oid,
+              id: d.input.id
+            }
+          })
+        : undefined;
 
-    let existing = d.input.id
-      ? await client.file.findFirst({
+      if (existing) {
+        let updatedFile = await db.file.update({
           where: {
-            tenantOid: d.tenant.oid,
-            environmentOid: d.environment.oid,
-            id: d.input.id
-          }
-        })
-      : undefined;
+            id: existing.id
+          },
+          data: {
+            storeId: d.storeId,
+            fileName: d.input.name,
+            fileSize: d.input.size,
+            fileType: d.input.mimeType,
+            title: d.input.title,
+            status: 'active',
+            purposeOid: purpose.oid,
+            createdByTenantActorOid: existing.createdByTenantActorOid ?? actor?.oid
+          },
+          include
+        });
 
-    if (existing) {
-      let updatedFile = await client.file.update({
-        where: {
-          id: existing.id
-        },
+        if (d.input.store) {
+          let store = await storeAccessService.getStoreById({
+            tenant: d.tenant,
+            environment: d.environment,
+            storeId: d.input.store.id
+          });
+
+          await storeAccessService.assertStoreAccessForStore({
+            tenant: d.tenant,
+            environment: d.environment,
+            store,
+            actorId: d.input.actorId,
+            defaultPermissions: d.input.defaultPermissions,
+            overridePermissions: d.input.overridePermissions,
+            requiredPermission: storeWritePermission
+          });
+
+          await storeItemMutationService.attachTargetToStore({
+            tenant: d.tenant,
+            environment: d.environment,
+            store,
+            path: d.input.store.path,
+            target: {
+              file: updatedFile,
+              document: null
+            },
+            actor
+          });
+        }
+
+        return await this.withEffectiveStoreId(updatedFile);
+      }
+
+      let generated = getId('file');
+
+      let createdFile = await db.file.create({
         data: {
+          oid: generated.oid,
+          id: d.input.id ?? generated.id,
+          tenantOid: d.tenant.oid,
+          environmentOid: d.environment.oid,
+          purposeOid: purpose.oid,
           storeId: d.storeId,
           fileName: d.input.name,
           fileSize: d.input.size,
           fileType: d.input.mimeType,
           title: d.input.title,
-          status: 'active',
-          purposeOid: purpose.oid,
-          createdByTenantActorOid: existing.createdByTenantActorOid ?? actor?.oid
+          createdByTenantActorOid: actor?.oid
         },
         include
       });
@@ -155,8 +196,7 @@ class FileServiceImpl {
         let store = await storeAccessService.getStoreById({
           tenant: d.tenant,
           environment: d.environment,
-          storeId: d.input.store.id,
-          client
+          storeId: d.input.store.id
         });
 
         await storeAccessService.assertStoreAccessForStore({
@@ -166,8 +206,7 @@ class FileServiceImpl {
           actorId: d.input.actorId,
           defaultPermissions: d.input.defaultPermissions,
           overridePermissions: d.input.overridePermissions,
-          requiredPermission: storeWritePermission,
-          client
+          requiredPermission: storeWritePermission
         });
 
         await storeItemMutationService.attachTargetToStore({
@@ -176,70 +215,15 @@ class FileServiceImpl {
           store,
           path: d.input.store.path,
           target: {
-            file: updatedFile,
+            file: createdFile,
             document: null
           },
-          actor,
-          client
+          actor
         });
       }
 
-      return await this.withEffectiveStoreId(updatedFile);
-    }
-
-    let generated = getId('file');
-
-    let createdFile = await client.file.create({
-      data: {
-        oid: generated.oid,
-        id: d.input.id ?? generated.id,
-        tenantOid: d.tenant.oid,
-        environmentOid: d.environment.oid,
-        purposeOid: purpose.oid,
-        storeId: d.storeId,
-        fileName: d.input.name,
-        fileSize: d.input.size,
-        fileType: d.input.mimeType,
-        title: d.input.title,
-        createdByTenantActorOid: actor?.oid
-      },
-      include
+      return await this.withEffectiveStoreId(createdFile);
     });
-
-    if (d.input.store) {
-      let store = await storeAccessService.getStoreById({
-        tenant: d.tenant,
-        environment: d.environment,
-        storeId: d.input.store.id,
-        client
-      });
-
-      await storeAccessService.assertStoreAccessForStore({
-        tenant: d.tenant,
-        environment: d.environment,
-        store,
-        actorId: d.input.actorId,
-        defaultPermissions: d.input.defaultPermissions,
-        overridePermissions: d.input.overridePermissions,
-        requiredPermission: storeWritePermission,
-        client
-      });
-
-      await storeItemMutationService.attachTargetToStore({
-        tenant: d.tenant,
-        environment: d.environment,
-        store,
-        path: d.input.store.path,
-        target: {
-          file: createdFile,
-          document: null
-        },
-        actor,
-        client
-      });
-    }
-
-    return await this.withEffectiveStoreId(createdFile);
   }
 
   async getFileById(
@@ -293,7 +277,6 @@ class FileServiceImpl {
   async deleteFileById(
     d: CargoTenantEnvironment & {
       fileId: string;
-      client?: DbClient;
     } & FileAccessInput
   ) {
     let file = await db.file.findFirst({
@@ -323,12 +306,11 @@ class FileServiceImpl {
     }
 
     return await this.deleteFile({
-      file,
-      client: d.client
+      file
     });
   }
 
-  async deleteFile(d: { file: File; client?: DbClient }) {
+  async deleteFile(d: { file: File }) {
     await this.ensureFileActive(d.file);
     let hasRefs = await fileReferenceService.hasReferencesForFile({
       file: d.file
@@ -342,12 +324,7 @@ class FileServiceImpl {
       );
     }
 
-    let client = d.client ?? db;
-
-    let { file, document } =
-      client === db
-        ? await db.$transaction(async tx => await this.deleteFileWithClient(tx, d.file))
-        : await this.deleteFileWithClient(client, d.file);
+    let { file, document } = await this.deleteFileWithClient(d.file);
 
     if (document) {
       await documentDraftService.clearDocumentState(document.id);
@@ -356,30 +333,32 @@ class FileServiceImpl {
     return file;
   }
 
-  private async deleteFileWithClient(client: DbClient, file: File) {
-    let document = await client.document.findFirst({
-      where: {
-        fileOid: file.oid
-      },
-      select: {
-        id: true
-      }
-    });
+  private async deleteFileWithClient(file: File) {
+    return await withTransaction(async db => {
+      let document = await db.document.findFirst({
+        where: {
+          fileOid: file.oid
+        },
+        select: {
+          id: true
+        }
+      });
 
-    let deletedFile = await client.file.update({
-      where: {
-        id: file.id
-      },
-      data: {
-        status: 'deleted'
-      },
-      include
-    });
+      let deletedFile = await db.file.update({
+        where: {
+          id: file.id
+        },
+        data: {
+          status: 'deleted'
+        },
+        include
+      });
 
-    return {
-      file: deletedFile,
-      document
-    };
+      return {
+        file: deletedFile,
+        document
+      };
+    });
   }
 
   async listFiles(

--- a/src/systems/cargo/service/src/services/fileLink.ts
+++ b/src/systems/cargo/service/src/services/fileLink.ts
@@ -7,8 +7,8 @@ import {
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import { generatePlainId } from '@lowerdeck/id';
-import type { FileLink, Prisma, PrismaClient } from '../../prisma/generated/client';
-import { db } from '../db';
+import type { FileLink, Prisma } from '../../prisma/generated/client';
+import { db, withTransaction } from '../db';
 import { env } from '../env';
 import { getId } from '../id';
 import { actorService } from './actor';
@@ -30,8 +30,6 @@ let include = {
   environment: true
 };
 
-type DbClient = PrismaClient | Prisma.TransactionClient;
-
 class FileLinkServiceImpl {
   private getGeneratedKey() {
     return `${generatePlainId(30)}_${env.service.CARGO_REGION ?? 'ext'}`;
@@ -52,7 +50,6 @@ class FileLinkServiceImpl {
         expiresAt?: Date;
         actorId?: string;
       };
-      client?: DbClient;
     }
   ) {
     if (!d.file.purpose.canHaveLinks) {
@@ -63,61 +60,62 @@ class FileLinkServiceImpl {
       );
     }
 
-    let client = d.client ?? db;
-    let actor = d.input.actorId
-      ? await actorService.getActorById({
-          tenant: d.tenant,
-          actorId: d.input.actorId
-        })
-      : undefined;
-
-    let existing = d.input.id
-      ? await client.fileLink.findFirst({
-          where: {
-            tenantOid: d.tenant.oid,
-            environmentOid: d.environment.oid,
-            OR: [{ id: d.input.id }, ...(d.input.key ? [{ key: d.input.key }] : [])]
-          }
-        })
-      : d.input.key
-        ? await client.fileLink.findFirst({
-            where: {
-              tenantOid: d.tenant.oid,
-              environmentOid: d.environment.oid,
-              key: d.input.key
-            }
+    return await withTransaction(async db => {
+      let actor = d.input.actorId
+        ? await actorService.getActorById({
+            tenant: d.tenant,
+            actorId: d.input.actorId
           })
         : undefined;
 
-    if (existing) {
-      return await client.fileLink.update({
-        where: {
-          id: existing.id
-        },
+      let existing = d.input.id
+        ? await db.fileLink.findFirst({
+            where: {
+              tenantOid: d.tenant.oid,
+              environmentOid: d.environment.oid,
+              OR: [{ id: d.input.id }, ...(d.input.key ? [{ key: d.input.key }] : [])]
+            }
+          })
+        : d.input.key
+          ? await db.fileLink.findFirst({
+              where: {
+                tenantOid: d.tenant.oid,
+                environmentOid: d.environment.oid,
+                key: d.input.key
+              }
+            })
+          : undefined;
+
+      if (existing) {
+        return await db.fileLink.update({
+          where: {
+            id: existing.id
+          },
+          data: {
+            fileOid: d.file.oid,
+            expiresAt: d.input.expiresAt,
+            key: d.input.key ?? existing.key,
+            createdByTenantActorOid: existing.createdByTenantActorOid ?? actor?.oid
+          },
+          include
+        });
+      }
+
+      let generated = getId('fileLink');
+
+      return await db.fileLink.create({
         data: {
+          oid: generated.oid,
+          id: d.input.id ?? generated.id,
+          key: d.input.key ?? this.getGeneratedKey(),
           fileOid: d.file.oid,
+          tenantOid: d.tenant.oid,
+          environmentOid: d.environment.oid,
           expiresAt: d.input.expiresAt,
-          key: d.input.key ?? existing.key,
-          createdByTenantActorOid: existing.createdByTenantActorOid ?? actor?.oid
+          createdByTenantActorOid: actor?.oid
         },
         include
       });
-    }
-
-    let generated = getId('fileLink');
-
-    return await client.fileLink.create({
-      data: {
-        oid: generated.oid,
-        id: d.input.id ?? generated.id,
-        key: d.input.key ?? this.getGeneratedKey(),
-        fileOid: d.file.oid,
-        tenantOid: d.tenant.oid,
-        environmentOid: d.environment.oid,
-        expiresAt: d.input.expiresAt,
-        createdByTenantActorOid: actor?.oid
-      },
-      include
     });
   }
 

--- a/src/systems/cargo/service/src/services/fileReference.ts
+++ b/src/systems/cargo/service/src/services/fileReference.ts
@@ -5,10 +5,9 @@ import type {
   File,
   FileLink,
   FileReference,
-  Prisma,
-  PrismaClient
+  Prisma
 } from '../../prisma/generated/client';
-import { db } from '../db';
+import { db, withTransaction } from '../db';
 import { getId } from '../id';
 import type { CargoTenantEnvironment } from './filePurpose';
 
@@ -22,8 +21,6 @@ let include = {
   environment: true
 };
 
-type DbClient = PrismaClient | Prisma.TransactionClient;
-
 class FileReferenceServiceImpl {
   async upsertFileReference(
     d: CargoTenantEnvironment & {
@@ -33,63 +30,62 @@ class FileReferenceServiceImpl {
         entityType: string;
         entityId: string;
       };
-      client?: DbClient;
     }
   ) {
-    let client = d.client ?? db;
+    return await withTransaction(async db => {
+      let existing = d.input.id
+        ? await db.fileReference.findFirst({
+            where: {
+              tenantOid: d.tenant.oid,
+              environmentOid: d.environment.oid,
+              OR: [
+                { id: d.input.id },
+                {
+                  fileLinkOid: d.fileLink.oid,
+                  entityType: d.input.entityType,
+                  entityId: d.input.entityId
+                }
+              ]
+            }
+          })
+        : await db.fileReference.findFirst({
+            where: {
+              tenantOid: d.tenant.oid,
+              environmentOid: d.environment.oid,
+              fileLinkOid: d.fileLink.oid,
+              entityType: d.input.entityType,
+              entityId: d.input.entityId
+            }
+          });
 
-    let existing = d.input.id
-      ? await client.fileReference.findFirst({
+      if (existing) {
+        return await db.fileReference.update({
           where: {
-            tenantOid: d.tenant.oid,
-            environmentOid: d.environment.oid,
-            OR: [
-              { id: d.input.id },
-              {
-                fileLinkOid: d.fileLink.oid,
-                entityType: d.input.entityType,
-                entityId: d.input.entityId
-              }
-            ]
-          }
-        })
-      : await client.fileReference.findFirst({
-          where: {
-            tenantOid: d.tenant.oid,
-            environmentOid: d.environment.oid,
+            id: existing.id
+          },
+          data: {
             fileLinkOid: d.fileLink.oid,
             entityType: d.input.entityType,
             entityId: d.input.entityId
-          }
+          },
+          include
         });
+      }
 
-    if (existing) {
-      return await client.fileReference.update({
-        where: {
-          id: existing.id
-        },
+      let generated = getId('fileRef');
+
+      return await db.fileReference.create({
         data: {
+          oid: generated.oid,
+          id: d.input.id ?? generated.id,
           fileLinkOid: d.fileLink.oid,
+          tenantOid: d.tenant.oid,
+          environmentOid: d.environment.oid,
           entityType: d.input.entityType,
           entityId: d.input.entityId
         },
         include
       });
-    }
-
-    let generated = getId('fileRef');
-
-    return await client.fileReference.create({
-      data: {
-        oid: generated.oid,
-        id: d.input.id ?? generated.id,
-        fileLinkOid: d.fileLink.oid,
-        tenantOid: d.tenant.oid,
-        environmentOid: d.environment.oid,
-        entityType: d.input.entityType,
-        entityId: d.input.entityId
-      },
-      include
     });
   }
 
@@ -172,35 +168,28 @@ class FileReferenceServiceImpl {
 
   async deleteReferenceAndLinkIfUnused(d: {
     fileReference: FileReference;
-    client?: DbClient;
   }) {
-    let runCleanup = async (client: DbClient) => {
-      await client.fileReference.delete({
+    return await withTransaction(async db => {
+      await db.fileReference.delete({
         where: {
           id: d.fileReference.id
         }
       });
 
-      let remainingReferences = await client.fileReference.count({
+      let remainingReferences = await db.fileReference.count({
         where: {
           fileLinkOid: d.fileReference.fileLinkOid
         }
       });
 
       if (remainingReferences === 0) {
-        await client.fileLink.deleteMany({
+        await db.fileLink.deleteMany({
           where: {
             oid: d.fileReference.fileLinkOid
           }
         });
       }
-    };
-
-    if (d.client) {
-      return await runCleanup(d.client);
-    }
-
-    return await db.$transaction(async client => await runCleanup(client));
+    });
   }
 
   async deleteFileReferenceByIdAndCleanup(d: { fileReferenceId: string }) {

--- a/src/systems/cargo/service/src/services/index.ts
+++ b/src/systems/cargo/service/src/services/index.ts
@@ -16,4 +16,5 @@ export * from './storeAccess';
 export * from './storeItem';
 export * from './storeItemMutation';
 export * from './storeParticipant';
+export * from './storeVersion';
 export * from './tenant';

--- a/src/systems/cargo/service/src/services/skill.ts
+++ b/src/systems/cargo/service/src/services/skill.ts
@@ -1,8 +1,8 @@
 import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import type { Prisma, PrismaClient } from '../../prisma/generated/client';
-import { db } from '../db';
+import type { Prisma } from '../../prisma/generated/client';
+import { db, withTransaction } from '../db';
 import { getId } from '../id';
 import type { CargoTenantEnvironment } from './filePurpose';
 import { storeService } from './store';
@@ -15,27 +15,25 @@ export type SkillRecord = Prisma.SkillGetPayload<{
   include: typeof skillInclude;
 }>;
 
-type DbClient = PrismaClient | Prisma.TransactionClient;
-
 class SkillServiceImpl {
-  private async getSkillRecord(
-    client: DbClient,
-    d: CargoTenantEnvironment & {
-      skillId: string;
-    }
-  ) {
-    let skill = await client.skill.findFirst({
-      where: {
-        tenantOid: d.tenant.oid,
-        environmentOid: d.environment.oid,
-        id: d.skillId
+  private async getSkillRecord(d: CargoTenantEnvironment & { skillId: string }) {
+    return await withTransaction(
+      async db => {
+        let skill = await db.skill.findFirst({
+          where: {
+            tenantOid: d.tenant.oid,
+            environmentOid: d.environment.oid,
+            id: d.skillId
+          },
+          include: skillInclude
+        });
+
+        if (!skill) throw new ServiceError(notFoundError('skill', d.skillId));
+
+        return skill;
       },
-      include: skillInclude
-    });
-
-    if (!skill) throw new ServiceError(notFoundError('skill', d.skillId));
-
-    return skill;
+      { ifExists: true }
+    );
   }
 
   async createSkill(
@@ -55,19 +53,18 @@ class SkillServiceImpl {
       );
     }
 
-    return await db.$transaction(async client => {
+    return await withTransaction(async db => {
       let skillIds = d.input.id ? { oid: getId('skill').oid, id: d.input.id } : getId('skill');
       let store = await storeService.createStore({
         tenant: d.tenant,
         environment: d.environment,
-        client,
         input: {
           id: d.input.storeId,
           name: d.input.name
         }
       });
 
-      return await client.skill.create({
+      return await db.skill.create({
         data: {
           oid: skillIds.oid,
           id: skillIds.id,
@@ -101,7 +98,7 @@ class SkillServiceImpl {
       skillId: string;
     }
   ) {
-    return await this.getSkillRecord(db, d);
+    return await this.getSkillRecord(d);
   }
 
   async updateSkill(

--- a/src/systems/cargo/service/src/services/store.ts
+++ b/src/systems/cargo/service/src/services/store.ts
@@ -1,7 +1,7 @@
 import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import type { Prisma, Store } from '../../prisma/generated/client';
+import type { Store } from '../../prisma/generated/client';
 import { db, withTransaction } from '../db';
 import { getId } from '../id';
 import { storeCleanupManyQueue } from '../queues/storeCleanup';
@@ -173,7 +173,7 @@ class StoreServiceImpl {
       requiredPermission: storeReadPermission
     });
 
-    return await withTransaction(async () => {
+    return await withTransaction(async db => {
       let clonedStore = await this.createStore({
         tenant: d.tenant,
         environment: d.environment,

--- a/src/systems/cargo/service/src/services/store.ts
+++ b/src/systems/cargo/service/src/services/store.ts
@@ -1,8 +1,8 @@
 import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import type { Prisma, PrismaClient, Store } from '../../prisma/generated/client';
-import { db } from '../db';
+import type { Prisma, Store } from '../../prisma/generated/client';
+import { db, withTransaction } from '../db';
 import { getId } from '../id';
 import { storeCleanupManyQueue } from '../queues/storeCleanup';
 import { documentInclude, documentService } from './document';
@@ -18,31 +18,28 @@ import { storeItemInclude, type StoreItemRecord } from './storeItem';
 import { storeItemMutationService, type StoreItemOperationInput } from './storeItemMutation';
 import { storeVersionService } from './storeVersion';
 
-type DbClient = PrismaClient | Prisma.TransactionClient;
-
 class StoreServiceImpl {
-  private async getStoreRecord(
-    client: DbClient,
-    d: CargoTenantEnvironment & {
-      storeId: string;
-    }
-  ) {
-    let store = await client.store.findFirst({
-      where: {
-        tenantOid: d.tenant.oid,
-        environmentOid: d.environment.oid,
-        id: d.storeId
-      }
-    });
+  private async getStoreRecord(d: CargoTenantEnvironment & { storeId: string }) {
+    return await withTransaction(
+      async db => {
+        let store = await db.store.findFirst({
+          where: {
+            tenantOid: d.tenant.oid,
+            environmentOid: d.environment.oid,
+            id: d.storeId
+          }
+        });
 
-    if (!store) throw new ServiceError(notFoundError('store', d.storeId));
+        if (!store) throw new ServiceError(notFoundError('store', d.storeId));
 
-    return store;
+        return store;
+      },
+      { ifExists: true }
+    );
   }
 
   async createStore(
     d: CargoTenantEnvironment & {
-      client?: DbClient;
       input: {
         id?: string;
         name: string;
@@ -50,19 +47,20 @@ class StoreServiceImpl {
       };
     }
   ) {
-    let storeIds = d.input.id ? { oid: getId('store').oid, id: d.input.id } : getId('store');
-    let client = d.client ?? db;
+    return await withTransaction(async db => {
+      let storeIds = d.input.id ? { oid: getId('store').oid, id: d.input.id } : getId('store');
 
-    return await client.store.create({
-      data: {
-        oid: storeIds.oid,
-        id: storeIds.id,
-        name: d.input.name,
-        itemCount: 0,
-        tenantOid: d.tenant.oid,
-        environmentOid: d.environment.oid,
-        parentStoreOid: d.input.parentStore?.oid
-      }
+      return await db.store.create({
+        data: {
+          oid: storeIds.oid,
+          id: storeIds.id,
+          name: d.input.name,
+          itemCount: 0,
+          tenantOid: d.tenant.oid,
+          environmentOid: d.environment.oid,
+          parentStoreOid: d.input.parentStore?.oid
+        }
+      });
     });
   }
 
@@ -104,7 +102,7 @@ class StoreServiceImpl {
         storeId: string;
       }
   ) {
-    let store = await this.getStoreRecord(db, d);
+    let store = await this.getStoreRecord(d);
     await storeAccessService.assertStoreAccessForStore({
       tenant: d.tenant,
       environment: d.environment,
@@ -175,11 +173,10 @@ class StoreServiceImpl {
       requiredPermission: storeReadPermission
     });
 
-    return await db.$transaction(async tx => {
+    return await withTransaction(async () => {
       let clonedStore = await this.createStore({
         tenant: d.tenant,
         environment: d.environment,
-        client: tx,
         input: {
           id: d.input.id,
           name: d.input.name ?? d.store.name,
@@ -187,7 +184,7 @@ class StoreServiceImpl {
         }
       });
 
-      let items = await tx.storeItem.findMany({
+      let items = await db.storeItem.findMany({
         where: {
           storeOid: d.store.oid
         },
@@ -198,7 +195,7 @@ class StoreServiceImpl {
       });
 
       for (let item of items) {
-        await this.cloneStoreItemIntoStore(tx, {
+        await this.cloneStoreItemIntoStore({
           tenant: d.tenant,
           environment: d.environment,
           targetStore: clonedStore,
@@ -211,11 +208,10 @@ class StoreServiceImpl {
       }
 
       await storeVersionService.markStoreDirtyIfNeeded({
-        storeOid: clonedStore.oid,
-        client: tx
+        storeOid: clonedStore.oid
       });
 
-      return (await tx.store.findUnique({
+      return (await db.store.findUnique({
         where: {
           id: clonedStore.id
         }
@@ -259,8 +255,8 @@ class StoreServiceImpl {
       }
     }
 
-    let { deletedStore, fileReferenceIds } = await db.$transaction(async client => {
-      let items = await client.storeItem.findMany({
+    let { deletedStore, fileReferenceIds } = await withTransaction(async db => {
+      let items = await db.storeItem.findMany({
         where: {
           storeOid: d.store.oid
         },
@@ -273,7 +269,7 @@ class StoreServiceImpl {
         }
       });
 
-      let deletedStore = await client.store.delete({
+      let deletedStore = await db.store.delete({
         where: {
           id: d.store.id
         }
@@ -327,7 +323,6 @@ class StoreServiceImpl {
   }
 
   private async cloneStoreItemIntoStore(
-    client: DbClient,
     d: CargoTenantEnvironment &
       StoreAccessInput & {
         targetStore: Store;
@@ -337,27 +332,45 @@ class StoreServiceImpl {
         >['actor'];
       }
   ) {
-    if (d.item.document) {
-      let sourceDocument = await client.document.findFirst({
-        where: {
-          tenantOid: d.tenant.oid,
-          environmentOid: d.environment.oid,
-          id: d.item.document.id
-        },
-        include: documentInclude
-      });
+    return await withTransaction(async db => {
+      if (d.item.document) {
+        let sourceDocument = await db.document.findFirst({
+          where: {
+            tenantOid: d.tenant.oid,
+            environmentOid: d.environment.oid,
+            id: d.item.document.id
+          },
+          include: documentInclude
+        });
 
-      if (!sourceDocument) {
-        throw new ServiceError(notFoundError('document', d.item.document.id));
+        if (!sourceDocument) {
+          throw new ServiceError(notFoundError('document', d.item.document.id));
+        }
+
+        let clonedDocument = await documentService.cloneDocument({
+          tenant: d.tenant,
+          environment: d.environment,
+          document: sourceDocument,
+          input: {}
+        });
+
+        await storeItemMutationService.attachTargetToStore({
+          tenant: d.tenant,
+          environment: d.environment,
+          store: d.targetStore,
+          path: d.item.path,
+          target: {
+            file: clonedDocument.file,
+            document: {
+              oid: clonedDocument.oid,
+              id: clonedDocument.id
+            }
+          },
+          actor: d.actor
+        });
+
+        return;
       }
-
-      let clonedDocument = await documentService.cloneDocument({
-        tenant: d.tenant,
-        environment: d.environment,
-        document: sourceDocument,
-        client,
-        input: {}
-      });
 
       await storeItemMutationService.attachTargetToStore({
         tenant: d.tenant,
@@ -365,30 +378,11 @@ class StoreServiceImpl {
         store: d.targetStore,
         path: d.item.path,
         target: {
-          file: clonedDocument.file,
-          document: {
-            oid: clonedDocument.oid,
-            id: clonedDocument.id
-          }
+          file: d.item.file,
+          document: null
         },
-        actor: d.actor,
-        client
+        actor: d.actor
       });
-
-      return;
-    }
-
-    await storeItemMutationService.attachTargetToStore({
-      tenant: d.tenant,
-      environment: d.environment,
-      store: d.targetStore,
-      path: d.item.path,
-      target: {
-        file: d.item.file,
-        document: null
-      },
-      actor: d.actor,
-      client
     });
   }
 }

--- a/src/systems/cargo/service/src/services/store.ts
+++ b/src/systems/cargo/service/src/services/store.ts
@@ -16,6 +16,7 @@ import {
 } from './storeAccess';
 import { storeItemInclude, type StoreItemRecord } from './storeItem';
 import { storeItemMutationService, type StoreItemOperationInput } from './storeItemMutation';
+import { storeVersionService } from './storeVersion';
 
 type DbClient = PrismaClient | Prisma.TransactionClient;
 
@@ -208,6 +209,11 @@ class StoreServiceImpl {
           actor: access.actor
         });
       }
+
+      await storeVersionService.markStoreDirtyIfNeeded({
+        storeOid: clonedStore.oid,
+        client: tx
+      });
 
       return (await tx.store.findUnique({
         where: {

--- a/src/systems/cargo/service/src/services/storeAccess.ts
+++ b/src/systems/cargo/service/src/services/storeAccess.ts
@@ -2,18 +2,15 @@ import { forbiddenError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Service } from '@lowerdeck/service';
 import type {
   Prisma,
-  PrismaClient,
   Store,
   StoreParticipant,
   StoreParticipantPermissions,
   TenantActor
 } from '../../prisma/generated/client';
-import { db } from '../db';
+import { withTransaction } from '../db';
 import { getId } from '../id';
 import { actorService } from './actor';
 import type { CargoTenantEnvironment } from './filePurpose';
-
-type DbClient = PrismaClient | Prisma.TransactionClient;
 
 export type StoreAccessInput = {
   actorId?: string;
@@ -40,10 +37,6 @@ let samePermissions = (
   JSON.stringify([...(left ?? [])].sort()) === JSON.stringify([...(right ?? [])].sort());
 
 class StoreAccessServiceImpl {
-  private getClient(client?: DbClient) {
-    return client ?? db;
-  }
-
   async getActorForAccess(d: Pick<CargoTenantEnvironment, 'tenant'> & StoreAccessInput) {
     if (!d.actorId) return undefined;
 
@@ -56,21 +49,24 @@ class StoreAccessServiceImpl {
   async getStoreById(
     d: CargoTenantEnvironment & {
       storeId: string;
-      client?: DbClient;
     }
   ) {
-    let client = this.getClient(d.client);
-    let store = await client.store.findFirst({
-      where: {
-        tenantOid: d.tenant.oid,
-        environmentOid: d.environment.oid,
-        id: d.storeId
-      }
-    });
+    return await withTransaction(
+      async db => {
+        let store = await db.store.findFirst({
+          where: {
+            tenantOid: d.tenant.oid,
+            environmentOid: d.environment.oid,
+            id: d.storeId
+          }
+        });
 
-    if (!store) throw new ServiceError(notFoundError('store', d.storeId));
+        if (!store) throw new ServiceError(notFoundError('store', d.storeId));
 
-    return store;
+        return store;
+      },
+      { ifExists: true }
+    );
   }
 
   async listRelevantStoreOidsForDocument(d: {
@@ -78,46 +74,52 @@ class StoreAccessServiceImpl {
       oid: bigint;
       fileOid: bigint;
     };
-    client?: DbClient;
   }) {
-    let client = this.getClient(d.client);
-    let stores = await client.store.findMany({
-      where: {
-        items: {
-          some: {
-            OR: [{ documentOid: d.document.oid }, { fileOid: d.document.fileOid }]
+    return await withTransaction(
+      async db => {
+        let stores = await db.store.findMany({
+          where: {
+            items: {
+              some: {
+                OR: [{ documentOid: d.document.oid }, { fileOid: d.document.fileOid }]
+              }
+            }
+          },
+          select: {
+            oid: true
           }
-        }
-      },
-      select: {
-        oid: true
-      }
-    });
+        });
 
-    return stores.map(store => store.oid);
+        return stores.map(store => store.oid);
+      },
+      { ifExists: true }
+    );
   }
 
   async listRelevantStoreOidsForFile(d: {
     file: {
       oid: bigint;
     };
-    client?: DbClient;
   }) {
-    let client = this.getClient(d.client);
-    let stores = await client.store.findMany({
-      where: {
-        items: {
-          some: {
-            fileOid: d.file.oid
+    return await withTransaction(
+      async db => {
+        let stores = await db.store.findMany({
+          where: {
+            items: {
+              some: {
+                fileOid: d.file.oid
+              }
+            }
+          },
+          select: {
+            oid: true
           }
-        }
-      },
-      select: {
-        oid: true
-      }
-    });
+        });
 
-    return stores.map(store => store.oid);
+        return stores.map(store => store.oid);
+      },
+      { ifExists: true }
+    );
   }
 
   async listStoreParticipantActorsForDocument(d: {
@@ -125,134 +127,141 @@ class StoreAccessServiceImpl {
       oid: bigint;
       fileOid: bigint;
     };
-    client?: DbClient;
   }) {
-    let client = this.getClient(d.client);
-    let storeOids = await this.listRelevantStoreOidsForDocument(d);
-    if (storeOids.length === 0) return [];
+    return await withTransaction(
+      async db => {
+        let storeOids = await this.listRelevantStoreOidsForDocument(d);
+        if (storeOids.length === 0) return [];
 
-    let participants = await client.storeParticipant.findMany({
-      where: {
-        storeOid: {
-          in: storeOids
-        }
-      },
-      include: {
-        tenantActor: true
-      }
-    });
-
-    let permissionsByActor = new Map<
-      bigint,
-      {
-        actor: TenantActor;
-        permissions: Set<StoreParticipantPermissions>;
-      }
-    >();
-
-    for (let participant of participants) {
-      let existing = permissionsByActor.get(participant.tenantActorOid);
-      if (existing) {
-        for (let permission of participant.permissions) {
-          existing.permissions.add(permission);
-        }
-        continue;
-      }
-
-      permissionsByActor.set(participant.tenantActorOid, {
-        actor: participant.tenantActor,
-        permissions: new Set(participant.permissions)
-      });
-    }
-
-    return [...permissionsByActor.values()].map(item => ({
-      actor: item.actor,
-      mode: item.permissions.has(storeWritePermission) ? 'edit' : 'view'
-    }));
-  }
-
-  private async upsertStoreParticipants(
-    client: DbClient,
-    d: {
-      storeOids: bigint[];
-      actor: TenantActor;
-      defaultPermissions?: StoreParticipantPermissions[];
-      overridePermissions?: boolean;
-    }
-  ) {
-    if (d.storeOids.length === 0) return [] as StoreParticipant[];
-
-    let participants = await client.storeParticipant.findMany({
-      where: {
-        storeOid: {
-          in: d.storeOids
-        },
-        tenantActorOid: d.actor.oid
-      }
-    });
-
-    let byStoreOid = new Map(participants.map(participant => [participant.storeOid.toString(), participant]));
-    let nextPermissions = d.defaultPermissions ?? [];
-
-    if (d.overridePermissions) {
-      let updatedParticipants: StoreParticipant[] = [];
-
-      for (let storeOid of d.storeOids) {
-        let existing = byStoreOid.get(storeOid.toString());
-
-        if (existing) {
-          if (!samePermissions(existing.permissions, nextPermissions)) {
-            existing = await client.storeParticipant.update({
-              where: {
-                id: existing.id
-              },
-              data: {
-                permissions: nextPermissions
-              }
-            });
-          }
-
-          updatedParticipants.push(existing);
-          continue;
-        }
-
-        let ids = getId('storeParticipant');
-        updatedParticipants.push(
-          await client.storeParticipant.create({
-            data: {
-              oid: ids.oid,
-              id: ids.id,
-              storeOid,
-              tenantActorOid: d.actor.oid,
-              permissions: nextPermissions
+        let participants = await db.storeParticipant.findMany({
+          where: {
+            storeOid: {
+              in: storeOids
             }
-          })
-        );
-      }
-
-      return updatedParticipants;
-    }
-
-    if (d.defaultPermissions !== undefined) {
-      for (let storeOid of d.storeOids) {
-        if (byStoreOid.has(storeOid.toString())) continue;
-
-        let ids = getId('storeParticipant');
-        let participant = await client.storeParticipant.create({
-          data: {
-            oid: ids.oid,
-            id: ids.id,
-            storeOid,
-            tenantActorOid: d.actor.oid,
-            permissions: nextPermissions
+          },
+          include: {
+            tenantActor: true
           }
         });
 
-        participants.push(participant);
-      }
-    }
+        let permissionsByActor = new Map<
+          bigint,
+          {
+            actor: TenantActor;
+            permissions: Set<StoreParticipantPermissions>;
+          }
+        >();
 
-    return participants;
+        for (let participant of participants) {
+          let existing = permissionsByActor.get(participant.tenantActorOid);
+          if (existing) {
+            for (let permission of participant.permissions) {
+              existing.permissions.add(permission);
+            }
+            continue;
+          }
+
+          permissionsByActor.set(participant.tenantActorOid, {
+            actor: participant.tenantActor,
+            permissions: new Set(participant.permissions)
+          });
+        }
+
+        return [...permissionsByActor.values()].map(item => ({
+          actor: item.actor,
+          mode: item.permissions.has(storeWritePermission) ? 'edit' : 'view'
+        }));
+      },
+      { ifExists: true }
+    );
+  }
+
+  private async upsertStoreParticipants(d: {
+    storeOids: bigint[];
+    actor: TenantActor;
+    defaultPermissions?: StoreParticipantPermissions[];
+    overridePermissions?: boolean;
+  }) {
+    return await withTransaction(
+      async client => {
+        if (d.storeOids.length === 0) return [] as StoreParticipant[];
+
+        let participants = await client.storeParticipant.findMany({
+          where: {
+            storeOid: {
+              in: d.storeOids
+            },
+            tenantActorOid: d.actor.oid
+          }
+        });
+
+        let byStoreOid = new Map(
+          participants.map(participant => [participant.storeOid.toString(), participant])
+        );
+        let nextPermissions = d.defaultPermissions ?? [];
+
+        if (d.overridePermissions) {
+          let updatedParticipants: StoreParticipant[] = [];
+
+          for (let storeOid of d.storeOids) {
+            let existing = byStoreOid.get(storeOid.toString());
+
+            if (existing) {
+              if (!samePermissions(existing.permissions, nextPermissions)) {
+                existing = await client.storeParticipant.update({
+                  where: {
+                    id: existing.id
+                  },
+                  data: {
+                    permissions: nextPermissions
+                  }
+                });
+              }
+
+              updatedParticipants.push(existing);
+              continue;
+            }
+
+            let ids = getId('storeParticipant');
+            updatedParticipants.push(
+              await client.storeParticipant.create({
+                data: {
+                  oid: ids.oid,
+                  id: ids.id,
+                  storeOid,
+                  tenantActorOid: d.actor.oid,
+                  permissions: nextPermissions
+                }
+              })
+            );
+          }
+
+          return updatedParticipants;
+        }
+
+        if (d.defaultPermissions !== undefined) {
+          for (let storeOid of d.storeOids) {
+            if (byStoreOid.has(storeOid.toString())) continue;
+
+            let ids = getId('storeParticipant');
+            let participant = await client.storeParticipant.create({
+              data: {
+                oid: ids.oid,
+                id: ids.id,
+                storeOid,
+                tenantActorOid: d.actor.oid,
+                permissions: nextPermissions
+              }
+            });
+
+            participants.push(participant);
+          }
+        }
+
+        return participants;
+      },
+      { ifExists: true }
+    );
   }
 
   private getAccessibleStoreOids(
@@ -269,64 +278,69 @@ class StoreAccessServiceImpl {
       StoreAccessInput & {
         requiredPermission: StoreParticipantPermissions;
         storeOids: bigint[];
-        client?: DbClient;
       }
   ) {
-    let relevantStoreOids = uniqueBigInts(d.storeOids);
-    if (!d.actorId) {
-      return {
-        actor: undefined,
-        relevantStoreOids,
-        accessibleStoreOids: relevantStoreOids
-      };
-    }
+    return await withTransaction(
+      async db => {
+        let relevantStoreOids = uniqueBigInts(d.storeOids);
+        if (!d.actorId) {
+          return {
+            actor: undefined,
+            relevantStoreOids,
+            accessibleStoreOids: relevantStoreOids
+          };
+        }
 
-    let actor = await this.getActorForAccess(d);
-    let client = this.getClient(d.client);
-    let participants = actor
-      ? await this.upsertStoreParticipants(client, {
-          storeOids: relevantStoreOids,
+        let actor = await this.getActorForAccess(d);
+        let participants = actor
+          ? await this.upsertStoreParticipants({
+              storeOids: relevantStoreOids,
+              actor,
+              defaultPermissions: d.defaultPermissions,
+              overridePermissions: d.overridePermissions
+            })
+          : [];
+
+        return {
           actor,
-          defaultPermissions: d.defaultPermissions,
-          overridePermissions: d.overridePermissions
-        })
-      : [];
-
-    return {
-      actor,
-      relevantStoreOids,
-      accessibleStoreOids: this.getAccessibleStoreOids(participants, d.requiredPermission)
-    };
+          relevantStoreOids,
+          accessibleStoreOids: this.getAccessibleStoreOids(participants, d.requiredPermission)
+        };
+      },
+      { ifExists: true }
+    );
   }
 
   async listAccessibleStoreOidsForTenantEnvironment(
     d: CargoTenantEnvironment &
       StoreAccessInput & {
         requiredPermission: StoreParticipantPermissions;
-        client?: DbClient;
       }
   ) {
-    let client = this.getClient(d.client);
-    let stores = await client.store.findMany({
-      where: {
-        tenantOid: d.tenant.oid,
-        environmentOid: d.environment.oid
-      },
-      select: {
-        oid: true
-      }
-    });
+    return await withTransaction(
+      async db => {
+        let stores = await db.store.findMany({
+          where: {
+            tenantOid: d.tenant.oid,
+            environmentOid: d.environment.oid
+          },
+          select: {
+            oid: true
+          }
+        });
 
-    return await this.resolveAccessibleStoreOids({
-      tenant: d.tenant,
-      environment: d.environment,
-      actorId: d.actorId,
-      defaultPermissions: d.defaultPermissions,
-      overridePermissions: d.overridePermissions,
-      requiredPermission: d.requiredPermission,
-      storeOids: stores.map(store => store.oid),
-      client
-    });
+        return await this.resolveAccessibleStoreOids({
+          tenant: d.tenant,
+          environment: d.environment,
+          actorId: d.actorId,
+          defaultPermissions: d.defaultPermissions,
+          overridePermissions: d.overridePermissions,
+          requiredPermission: d.requiredPermission,
+          storeOids: stores.map(store => store.oid)
+        });
+      },
+      { ifExists: true }
+    );
   }
 
   async assertStoreAccessForStore(
@@ -334,7 +348,6 @@ class StoreAccessServiceImpl {
       StoreAccessInput & {
         store: Pick<Store, 'oid' | 'id'>;
         requiredPermission: StoreParticipantPermissions;
-        client?: DbClient;
       }
   ) {
     let result = await this.resolveAccessibleStoreOids({
@@ -344,8 +357,7 @@ class StoreAccessServiceImpl {
       defaultPermissions: d.defaultPermissions,
       overridePermissions: d.overridePermissions,
       requiredPermission: d.requiredPermission,
-      storeOids: [d.store.oid],
-      client: d.client
+      storeOids: [d.store.oid]
     });
 
     if (
@@ -375,15 +387,12 @@ class StoreAccessServiceImpl {
           createdByTenantActorOid?: bigint | null;
         };
         requiredPermission: StoreParticipantPermissions;
-        client?: DbClient;
       }
   ) {
     let actor = await this.getActorForAccess(d);
     let isOwner = !!actor && d.document.createdByTenantActorOid === actor.oid;
-    let client = this.getClient(d.client);
     let relevantStoreOids = await this.listRelevantStoreOidsForDocument({
-      document: d.document,
-      client
+      document: d.document
     });
     let access = await this.resolveAccessibleStoreOids({
       tenant: d.tenant,
@@ -392,8 +401,7 @@ class StoreAccessServiceImpl {
       defaultPermissions: d.defaultPermissions,
       overridePermissions: d.overridePermissions,
       requiredPermission: d.requiredPermission,
-      storeOids: relevantStoreOids,
-      client
+      storeOids: relevantStoreOids
     });
 
     if (d.actorId && !isOwner && access.accessibleStoreOids.length === 0) {
@@ -421,15 +429,12 @@ class StoreAccessServiceImpl {
           createdByTenantActorOid?: bigint | null;
         };
         requiredPermission: StoreParticipantPermissions;
-        client?: DbClient;
       }
   ) {
     let actor = await this.getActorForAccess(d);
     let isOwner = !!actor && d.file.createdByTenantActorOid === actor.oid;
-    let client = this.getClient(d.client);
     let relevantStoreOids = await this.listRelevantStoreOidsForFile({
-      file: d.file,
-      client
+      file: d.file
     });
     let access = await this.resolveAccessibleStoreOids({
       tenant: d.tenant,
@@ -438,8 +443,7 @@ class StoreAccessServiceImpl {
       defaultPermissions: d.defaultPermissions,
       overridePermissions: d.overridePermissions,
       requiredPermission: d.requiredPermission,
-      storeOids: relevantStoreOids,
-      client
+      storeOids: relevantStoreOids
     });
 
     if (d.actorId && !isOwner && access.accessibleStoreOids.length === 0) {
@@ -466,7 +470,6 @@ class StoreAccessServiceImpl {
           storeOid: bigint;
         };
         requiredPermission: StoreParticipantPermissions;
-        client?: DbClient;
       }
   ) {
     let access = await this.resolveAccessibleStoreOids({
@@ -476,8 +479,7 @@ class StoreAccessServiceImpl {
       defaultPermissions: d.defaultPermissions,
       overridePermissions: d.overridePermissions,
       requiredPermission: d.requiredPermission,
-      storeOids: [d.item.storeOid],
-      client: d.client
+      storeOids: [d.item.storeOid]
     });
 
     if (d.actorId && access.accessibleStoreOids.length === 0) {

--- a/src/systems/cargo/service/src/services/storeItem.ts
+++ b/src/systems/cargo/service/src/services/storeItem.ts
@@ -3,6 +3,7 @@ import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import type { Prisma, StoreParticipantPermissions } from '../../prisma/generated/client';
 import { db } from '../db';
+import { getEffectiveDocumentStoreSource } from './documentContentStore';
 import type { CargoTenantEnvironment } from './filePurpose';
 import { storeAccessService, storeReadPermission } from './storeAccess';
 
@@ -42,6 +43,28 @@ export type StoreItemRecord = Prisma.StoreItemGetPayload<{
 }>;
 
 class StoreItemServiceImpl {
+  private async withEffectiveDocumentStore<T extends StoreItemRecord>(item: T) {
+    if (!item.document) {
+      return item as T;
+    }
+
+    let effectiveStoreSource = await getEffectiveDocumentStoreSource(item.document);
+    if (effectiveStoreSource.file.storeId === item.document.file.storeId) {
+      return item as T;
+    }
+
+    return {
+      ...item,
+      document: {
+        ...item.document,
+        file: {
+          ...item.document.file,
+          effectiveStoreId: effectiveStoreSource.file.storeId
+        }
+      }
+    };
+  }
+
   async getStoreItemById(
     d: CargoTenantEnvironment & {
       itemId: string;
@@ -73,7 +96,7 @@ class StoreItemServiceImpl {
       requiredPermission: storeReadPermission
     });
 
-    return item;
+    return await this.withEffectiveDocumentStore(item);
   }
 
   async listStoreItems(
@@ -120,38 +143,41 @@ class StoreItemServiceImpl {
       : undefined;
 
     return Paginator.create(({ prisma }) =>
-      prisma(
-        async opts =>
-          await db.storeItem.findMany({
-            ...opts,
-            where: {
-              store: {
-                tenantOid: d.tenant.oid,
-                environmentOid: d.environment.oid,
-                oid: accessibleStoreOids
+      prisma(async opts =>
+        await Promise.all(
+          (
+            await db.storeItem.findMany({
+              ...opts,
+              where: {
+                store: {
+                  tenantOid: d.tenant.oid,
+                  environmentOid: d.environment.oid,
+                  oid: accessibleStoreOids
+                    ? {
+                        in: accessibleStoreOids
+                      }
+                    : undefined,
+                  ...(d.storeId
+                    ? {
+                        id: d.storeId
+                      }
+                    : {})
+                },
+                file: d.fileId
                   ? {
-                      in: accessibleStoreOids
+                      id: d.fileId
                     }
                   : undefined,
-                ...(d.storeId
+                document: d.documentId
                   ? {
-                      id: d.storeId
+                      id: d.documentId
                     }
-                  : {})
+                  : undefined
               },
-              file: d.fileId
-                ? {
-                    id: d.fileId
-                  }
-                : undefined,
-              document: d.documentId
-                ? {
-                    id: d.documentId
-                  }
-                : undefined
-            },
-            include: storeItemInclude
-          })
+              include: storeItemInclude
+            })
+          ).map(async item => await this.withEffectiveDocumentStore(item))
+        )
       )
     );
   }

--- a/src/systems/cargo/service/src/services/storeItemMutation.ts
+++ b/src/systems/cargo/service/src/services/storeItemMutation.ts
@@ -1,7 +1,7 @@
 import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Service } from '@lowerdeck/service';
 import type { Prisma, PrismaClient, Store, TenantActor } from '../../prisma/generated/client';
-import { db } from '../db';
+import { db, withTransaction } from '../db';
 import { getId } from '../id';
 import { fileLinkService } from './fileLink';
 import type { CargoTenantEnvironment } from './filePurpose';
@@ -287,7 +287,6 @@ class StoreItemMutationServiceImpl {
     let link = await fileLinkService.createFileLink({
       tenant: d.tenant,
       environment: d.environment,
-      client,
       file: d.target.file,
       input: {}
     });
@@ -295,7 +294,6 @@ class StoreItemMutationServiceImpl {
     return await fileReferenceService.upsertFileReference({
       tenant: d.tenant,
       environment: d.environment,
-      client,
       fileLink: link,
       input: {
         entityType: 'store_item',
@@ -309,7 +307,6 @@ class StoreItemMutationServiceImpl {
     fileReference: StoreItemRecord['reference']
   ) {
     await fileReferenceService.deleteReferenceAndLinkIfUnused({
-      client,
       fileReference
     });
   }
@@ -468,34 +465,9 @@ class StoreItemMutationServiceImpl {
       path: string;
       target: ResolvedStoreItemTarget;
       actor?: Pick<TenantActor, 'oid'>;
-      client?: DbClient;
     }
   ) {
-    if (d.client) {
-      let result = await this.addStoreItem(d.client, d);
-
-      if (result.created) {
-        await d.client.store.update({
-          where: {
-            id: d.store.id
-          },
-          data: {
-            itemCount: {
-              increment: 1
-            }
-          }
-        });
-      }
-
-      await storeVersionService.markStoreDirtyIfNeeded({
-        storeOid: d.store.oid,
-        client: d.client
-      });
-
-      return result.item;
-    }
-
-    return await db.$transaction(async client => {
+    return await withTransaction(async client => {
       let result = await this.addStoreItem(client, d);
 
       if (result.created) {
@@ -512,8 +484,7 @@ class StoreItemMutationServiceImpl {
       }
 
       await storeVersionService.markStoreDirtyIfNeeded({
-        storeOid: d.store.oid,
-        client
+        storeOid: d.store.oid
       });
 
       return result.item;
@@ -580,7 +551,7 @@ class StoreItemMutationServiceImpl {
       );
     }
 
-    return await db.$transaction(async client => {
+    return await withTransaction(async client => {
       let results: StoreItemMutationResult[] = [];
 
       for (let operation of operations) {
@@ -656,8 +627,7 @@ class StoreItemMutationServiceImpl {
 
       if (results.length > 0) {
         await storeVersionService.markStoreDirtyIfNeeded({
-          storeOid: d.store.oid,
-          client
+          storeOid: d.store.oid
         });
       }
 

--- a/src/systems/cargo/service/src/services/storeItemMutation.ts
+++ b/src/systems/cargo/service/src/services/storeItemMutation.ts
@@ -7,6 +7,7 @@ import { fileLinkService } from './fileLink';
 import type { CargoTenantEnvironment } from './filePurpose';
 import { fileReferenceService } from './fileReference';
 import { storeItemInclude, type StoreItemRecord } from './storeItem';
+import { storeVersionService } from './storeVersion';
 
 type DbClient = PrismaClient | Prisma.TransactionClient;
 
@@ -486,6 +487,11 @@ class StoreItemMutationServiceImpl {
         });
       }
 
+      await storeVersionService.markStoreDirtyIfNeeded({
+        storeOid: d.store.oid,
+        client: d.client
+      });
+
       return result.item;
     }
 
@@ -504,6 +510,11 @@ class StoreItemMutationServiceImpl {
           }
         });
       }
+
+      await storeVersionService.markStoreDirtyIfNeeded({
+        storeOid: d.store.oid,
+        client
+      });
 
       return result.item;
     });
@@ -640,6 +651,13 @@ class StoreItemMutationServiceImpl {
             target: operation.target,
             actor: d.actor
           })
+        });
+      }
+
+      if (results.length > 0) {
+        await storeVersionService.markStoreDirtyIfNeeded({
+          storeOid: d.store.oid,
+          client
         });
       }
 

--- a/src/systems/cargo/service/src/services/storeVersion.ts
+++ b/src/systems/cargo/service/src/services/storeVersion.ts
@@ -1,0 +1,559 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import type { Prisma, PrismaClient } from '../../prisma/generated/client';
+import { db } from '../db';
+import { getId } from '../id';
+import type { CargoTenantEnvironment } from './filePurpose';
+import {
+  storeAccessService,
+  storeReadPermission,
+  type StoreAccessInput
+} from './storeAccess';
+
+type DbClient = PrismaClient | Prisma.TransactionClient;
+
+let currentStoreVersionItemInclude = {
+  file: {
+    select: {
+      id: true
+    }
+  },
+  document: {
+    select: {
+      id: true,
+      currentVersion: {
+        select: {
+          oid: true,
+          id: true
+        }
+      }
+    }
+  }
+} satisfies Prisma.StoreItemInclude;
+
+let storeVersionInclude = {
+  store: {
+    select: {
+      oid: true,
+      id: true,
+      name: true,
+      dirtyAt: true,
+      createdAt: true,
+      updatedAt: true
+    }
+  },
+  items: {
+    include: {
+      file: {
+        select: {
+          id: true
+        }
+      },
+      document: {
+        select: {
+          id: true
+        }
+      },
+      documentVersion: {
+        select: {
+          id: true
+        }
+      }
+    },
+    orderBy: [
+      {
+        path: 'asc'
+      },
+      {
+        id: 'asc'
+      }
+    ]
+  }
+} satisfies Prisma.StoreVersionInclude;
+
+type CurrentStoreVersionItemRecord = Prisma.StoreItemGetPayload<{
+  include: typeof currentStoreVersionItemInclude;
+}>;
+
+type StoreVersionRecord = Prisma.StoreVersionGetPayload<{
+  include: typeof storeVersionInclude;
+}>;
+
+export type ResolvedStoreVersionItem = {
+  id: string;
+  path: string;
+  fileId: string;
+  documentId?: string;
+  documentVersionId?: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type ResolvedStoreVersion = {
+  id: string;
+  kind: 'latest' | 'snapshot';
+  storeId: string;
+  storeName: string;
+  versionNumber: number | null;
+  sourceDirtyAt: Date | null;
+  dirtyAt: Date | null;
+  itemCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+  items: ResolvedStoreVersionItem[];
+};
+
+export type ResolvedStoreVersionSummary = Omit<ResolvedStoreVersion, 'items'>;
+
+let toCurrentStoreVersionItem = (item: CurrentStoreVersionItemRecord): ResolvedStoreVersionItem => ({
+  id: item.id,
+  path: item.path,
+  fileId: item.file.id,
+  documentId: item.document?.id ?? undefined,
+  documentVersionId: item.document?.currentVersion?.id ?? undefined,
+  createdAt: item.createdAt,
+  updatedAt: item.updatedAt
+});
+
+let toSnapshotStoreVersionItem = (
+  item: StoreVersionRecord['items'][number]
+): ResolvedStoreVersionItem => ({
+  id: item.id,
+  path: item.path,
+  fileId: item.file.id,
+  documentId: item.document?.id ?? undefined,
+  documentVersionId: item.documentVersion?.id ?? undefined,
+  createdAt: item.createdAt,
+  updatedAt: item.createdAt
+});
+
+let toStoreVersionSummary = (version: StoreVersionRecord): ResolvedStoreVersionSummary => ({
+  id: version.id,
+  kind: 'snapshot',
+  storeId: version.store.id,
+  storeName: version.store.name,
+  versionNumber: version.versionNumber,
+  sourceDirtyAt: version.sourceDirtyAt,
+  dirtyAt: version.store.dirtyAt,
+  itemCount: version.items.length,
+  createdAt: version.createdAt,
+  updatedAt: version.createdAt
+});
+
+let toResolvedStoreVersion = (version: StoreVersionRecord): ResolvedStoreVersion => ({
+  ...toStoreVersionSummary(version),
+  items: version.items.map(toSnapshotStoreVersionItem)
+});
+
+class StoreVersionServiceImpl {
+  async markStoreDirtyIfNeeded(d: {
+    storeOid: bigint;
+    at?: Date;
+    client?: DbClient;
+  }) {
+    let client = d.client ?? db;
+    let dirtyAt = d.at ?? new Date();
+
+    return await client.store.updateMany({
+      where: {
+        oid: d.storeOid,
+        dirtyAt: null
+      },
+      data: {
+        dirtyAt
+      }
+    });
+  }
+
+  async markStoresDirtyForDocument(d: {
+    documentOid: bigint;
+    at?: Date;
+    client?: DbClient;
+  }) {
+    let client = d.client ?? db;
+    let dirtyAt = d.at ?? new Date();
+
+    return await client.store.updateMany({
+      where: {
+        dirtyAt: null,
+        items: {
+          some: {
+            documentOid: d.documentOid
+          }
+        }
+      },
+      data: {
+        dirtyAt
+      }
+    });
+  }
+
+  async listStoreIdsReadyForVersioning(d: {
+    limit: number;
+    dirtyBefore: Date;
+    cursorOid?: string;
+  }) {
+    let cursorOid = d.cursorOid ? BigInt(d.cursorOid) : undefined;
+    let stores = await db.store.findMany({
+      where: {
+        dirtyAt: {
+          not: null,
+          lte: d.dirtyBefore
+        },
+        ...(cursorOid
+          ? {
+              oid: {
+                gt: cursorOid
+              }
+            }
+          : {})
+      },
+      orderBy: {
+        oid: 'asc'
+      },
+      take: d.limit,
+      select: {
+        oid: true,
+        id: true,
+        dirtyAt: true
+      }
+    });
+
+    return {
+      stores: stores.map(store => ({
+        storeId: store.id,
+        dirtyAt: store.dirtyAt!
+      })),
+      nextCursorOid:
+        stores.length === d.limit ? stores[stores.length - 1]!.oid.toString() : undefined
+    };
+  }
+
+  private async hasStoreLiveChangesSince(
+    client: DbClient,
+    d: {
+      storeOid: bigint;
+      since: Date;
+    }
+  ) {
+    let changedStoreItem = await client.storeItem.findFirst({
+      where: {
+        storeOid: d.storeOid,
+        OR: [
+          {
+            createdAt: {
+              gt: d.since
+            }
+          },
+          {
+            updatedAt: {
+              gt: d.since
+            }
+          },
+          {
+            document: {
+              currentVersion: {
+                createdAt: {
+                  gt: d.since
+                }
+              }
+            }
+          }
+        ]
+      },
+      select: {
+        id: true
+      }
+    });
+
+    return !!changedStoreItem;
+  }
+
+  async createStoreVersionSnapshot(d: {
+    storeId: string;
+    expectedDirtyAt: Date;
+  }) {
+    let snapshotStartedAt = new Date();
+
+    return await db.$transaction(async tx => {
+      let store = await tx.store.findUnique({
+        where: {
+          id: d.storeId
+        },
+        select: {
+          oid: true,
+          id: true,
+          name: true,
+          itemCount: true,
+          dirtyAt: true,
+          createdAt: true,
+          updatedAt: true
+        }
+      });
+
+      if (!store?.dirtyAt) return null;
+      if (store.dirtyAt.getTime() !== d.expectedDirtyAt.getTime()) return null;
+
+      let existingVersion = await tx.storeVersion.findFirst({
+        where: {
+          storeOid: store.oid,
+          sourceDirtyAt: store.dirtyAt
+        },
+        include: storeVersionInclude
+      });
+
+      if (existingVersion) {
+        return {
+          version: toResolvedStoreVersion(existingVersion),
+          didClearDirtyAt: false,
+          alreadyExisted: true
+        };
+      }
+
+      let currentItems = await tx.storeItem.findMany({
+        where: {
+          storeOid: store.oid
+        },
+        include: currentStoreVersionItemInclude,
+        orderBy: [
+          {
+            path: 'asc'
+          },
+          {
+            id: 'asc'
+          }
+        ]
+      });
+
+      let latestVersion = await tx.storeVersion.findFirst({
+        where: {
+          storeOid: store.oid
+        },
+        orderBy: {
+          versionNumber: 'desc'
+        },
+        select: {
+          versionNumber: true
+        }
+      });
+
+      let versionIds = getId('storeVersion');
+      let version = await tx.storeVersion.create({
+        data: {
+          oid: versionIds.oid,
+          id: versionIds.id,
+          storeOid: store.oid,
+          versionNumber: (latestVersion?.versionNumber ?? 0) + 1,
+          sourceDirtyAt: store.dirtyAt
+        }
+      });
+
+      if (currentItems.length > 0) {
+        await tx.storeVersionItem.createMany({
+          data: currentItems.map(item => {
+            let itemIds = getId('storeVersionItem');
+
+            return {
+              oid: itemIds.oid,
+              id: itemIds.id,
+              storeVersionOid: version.oid,
+              path: item.path,
+              fileOid: item.fileOid,
+              documentOid: item.documentOid,
+              documentVersionOid: item.document?.currentVersion?.oid ?? null
+            };
+          })
+        });
+      }
+
+      let shouldKeepDirty = await this.hasStoreLiveChangesSince(tx, {
+        storeOid: store.oid,
+        since: snapshotStartedAt
+      });
+
+      let didClearDirtyAt = false;
+
+      if (!shouldKeepDirty) {
+        let cleared = await tx.store.updateMany({
+          where: {
+            oid: store.oid,
+            dirtyAt: d.expectedDirtyAt
+          },
+          data: {
+            dirtyAt: null
+          }
+        });
+
+        didClearDirtyAt = cleared.count > 0;
+      }
+
+      let createdVersion = await tx.storeVersion.findUnique({
+        where: {
+          id: version.id
+        },
+        include: storeVersionInclude
+      });
+
+      return {
+        version: toResolvedStoreVersion(createdVersion!),
+        didClearDirtyAt,
+        alreadyExisted: false
+      };
+    });
+  }
+
+  async listStoreVersions(
+    d: CargoTenantEnvironment &
+      StoreAccessInput & {
+        storeId: string;
+      }
+  ) {
+    let store = await storeAccessService.getStoreById({
+      tenant: d.tenant,
+      environment: d.environment,
+      storeId: d.storeId
+    });
+
+    await storeAccessService.assertStoreAccessForStore({
+      tenant: d.tenant,
+      environment: d.environment,
+      store,
+      actorId: d.actorId,
+      defaultPermissions: d.defaultPermissions,
+      overridePermissions: d.overridePermissions,
+      requiredPermission: storeReadPermission
+    });
+
+    return Paginator.create(({ prisma }) =>
+      prisma(async opts =>
+        await db.storeVersion.findMany({
+          ...opts,
+          where: {
+            storeOid: store.oid
+          },
+          include: storeVersionInclude,
+          orderBy: {
+            versionNumber: 'desc'
+          }
+        })
+      )
+    );
+  }
+
+  async getStoreVersionById(
+    d: CargoTenantEnvironment &
+      StoreAccessInput & {
+        storeVersionId: string;
+      }
+  ) {
+    let version = await db.storeVersion.findFirst({
+      where: {
+        id: d.storeVersionId,
+        store: {
+          tenantOid: d.tenant.oid,
+          environmentOid: d.environment.oid
+        }
+      },
+      include: storeVersionInclude
+    });
+
+    if (!version) throw new ServiceError(notFoundError('storeVersion', d.storeVersionId));
+
+    await storeAccessService.assertStoreAccessForStore({
+      tenant: d.tenant,
+      environment: d.environment,
+      store: version.store,
+      actorId: d.actorId,
+      defaultPermissions: d.defaultPermissions,
+      overridePermissions: d.overridePermissions,
+      requiredPermission: storeReadPermission
+    });
+
+    return toResolvedStoreVersion(version);
+  }
+
+  async getLatestStoreVersion(
+    d: CargoTenantEnvironment &
+      StoreAccessInput & {
+        storeId: string;
+      }
+  ) {
+    let store = await storeAccessService.getStoreById({
+      tenant: d.tenant,
+      environment: d.environment,
+      storeId: d.storeId
+    });
+
+    await storeAccessService.assertStoreAccessForStore({
+      tenant: d.tenant,
+      environment: d.environment,
+      store,
+      actorId: d.actorId,
+      defaultPermissions: d.defaultPermissions,
+      overridePermissions: d.overridePermissions,
+      requiredPermission: storeReadPermission
+    });
+
+    let items = await db.storeItem.findMany({
+      where: {
+        storeOid: store.oid
+      },
+      include: currentStoreVersionItemInclude,
+      orderBy: [
+        {
+          path: 'asc'
+        },
+        {
+          id: 'asc'
+        }
+      ]
+    });
+
+    return {
+      id: 'latest',
+      kind: 'latest',
+      storeId: store.id,
+      storeName: store.name,
+      versionNumber: null,
+      sourceDirtyAt: null,
+      dirtyAt: store.dirtyAt,
+      itemCount: items.length,
+      createdAt: store.createdAt,
+      updatedAt: store.updatedAt,
+      items: items.map(toCurrentStoreVersionItem)
+    } satisfies ResolvedStoreVersion;
+  }
+
+  async getResolvedStoreVersion(
+    d: CargoTenantEnvironment &
+      StoreAccessInput & {
+        storeId: string;
+        storeVersionId: string;
+      }
+  ) {
+    if (d.storeVersionId === 'latest') {
+      return await this.getLatestStoreVersion(d);
+    }
+
+    let version = await this.getStoreVersionById({
+      tenant: d.tenant,
+      environment: d.environment,
+      actorId: d.actorId,
+      defaultPermissions: d.defaultPermissions,
+      overridePermissions: d.overridePermissions,
+      storeVersionId: d.storeVersionId
+    });
+
+    if (version.storeId !== d.storeId) {
+      throw new ServiceError(notFoundError('storeVersion', d.storeVersionId));
+    }
+
+    return version;
+  }
+}
+
+export let storeVersionService = Service.create(
+  'cargoStoreVersionService',
+  () => new StoreVersionServiceImpl()
+).build();

--- a/src/systems/cargo/service/src/services/storeVersion.ts
+++ b/src/systems/cargo/service/src/services/storeVersion.ts
@@ -1,8 +1,8 @@
 import { notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import type { Prisma, PrismaClient } from '../../prisma/generated/client';
-import { db } from '../db';
+import type { Prisma } from '../../prisma/generated/client';
+import { db, withTransaction } from '../db';
 import { getId } from '../id';
 import type { CargoTenantEnvironment } from './filePurpose';
 import {
@@ -10,8 +10,6 @@ import {
   storeReadPermission,
   type StoreAccessInput
 } from './storeAccess';
-
-type DbClient = PrismaClient | Prisma.TransactionClient;
 
 let currentStoreVersionItemInclude = {
   file: {
@@ -150,43 +148,49 @@ class StoreVersionServiceImpl {
   async markStoreDirtyIfNeeded(d: {
     storeOid: bigint;
     at?: Date;
-    client?: DbClient;
   }) {
-    let client = d.client ?? db;
-    let dirtyAt = d.at ?? new Date();
+    return await withTransaction(
+      async db => {
+        let dirtyAt = d.at ?? new Date();
 
-    return await client.store.updateMany({
-      where: {
-        oid: d.storeOid,
-        dirtyAt: null
+        return await db.store.updateMany({
+          where: {
+            oid: d.storeOid,
+            dirtyAt: null
+          },
+          data: {
+            dirtyAt
+          }
+        });
       },
-      data: {
-        dirtyAt
-      }
-    });
+      { ifExists: true }
+    );
   }
 
   async markStoresDirtyForDocument(d: {
     documentOid: bigint;
     at?: Date;
-    client?: DbClient;
   }) {
-    let client = d.client ?? db;
-    let dirtyAt = d.at ?? new Date();
+    return await withTransaction(
+      async db => {
+        let dirtyAt = d.at ?? new Date();
 
-    return await client.store.updateMany({
-      where: {
-        dirtyAt: null,
-        items: {
-          some: {
-            documentOid: d.documentOid
+        return await db.store.updateMany({
+          where: {
+            dirtyAt: null,
+            items: {
+              some: {
+                documentOid: d.documentOid
+              }
+            }
+          },
+          data: {
+            dirtyAt
           }
-        }
+        });
       },
-      data: {
-        dirtyAt
-      }
-    });
+      { ifExists: true }
+    );
   }
 
   async listStoreIdsReadyForVersioning(d: {
@@ -230,44 +234,43 @@ class StoreVersionServiceImpl {
     };
   }
 
-  private async hasStoreLiveChangesSince(
-    client: DbClient,
-    d: {
-      storeOid: bigint;
-      since: Date;
-    }
-  ) {
-    let changedStoreItem = await client.storeItem.findFirst({
-      where: {
-        storeOid: d.storeOid,
-        OR: [
-          {
-            createdAt: {
-              gt: d.since
-            }
-          },
-          {
-            updatedAt: {
-              gt: d.since
-            }
-          },
-          {
-            document: {
-              currentVersion: {
+  private async hasStoreLiveChangesSince(d: { storeOid: bigint; since: Date }) {
+    return await withTransaction(
+      async db => {
+        let changedStoreItem = await db.storeItem.findFirst({
+          where: {
+            storeOid: d.storeOid,
+            OR: [
+              {
                 createdAt: {
                   gt: d.since
                 }
+              },
+              {
+                updatedAt: {
+                  gt: d.since
+                }
+              },
+              {
+                document: {
+                  currentVersion: {
+                    createdAt: {
+                      gt: d.since
+                    }
+                  }
+                }
               }
-            }
+            ]
+          },
+          select: {
+            id: true
           }
-        ]
-      },
-      select: {
-        id: true
-      }
-    });
+        });
 
-    return !!changedStoreItem;
+        return !!changedStoreItem;
+      },
+      { ifExists: true }
+    );
   }
 
   async createStoreVersionSnapshot(d: {
@@ -276,8 +279,8 @@ class StoreVersionServiceImpl {
   }) {
     let snapshotStartedAt = new Date();
 
-    return await db.$transaction(async tx => {
-      let store = await tx.store.findUnique({
+    return await withTransaction(async db => {
+      let store = await db.store.findUnique({
         where: {
           id: d.storeId
         },
@@ -295,7 +298,7 @@ class StoreVersionServiceImpl {
       if (!store?.dirtyAt) return null;
       if (store.dirtyAt.getTime() !== d.expectedDirtyAt.getTime()) return null;
 
-      let existingVersion = await tx.storeVersion.findFirst({
+      let existingVersion = await db.storeVersion.findFirst({
         where: {
           storeOid: store.oid,
           sourceDirtyAt: store.dirtyAt
@@ -311,7 +314,7 @@ class StoreVersionServiceImpl {
         };
       }
 
-      let currentItems = await tx.storeItem.findMany({
+      let currentItems = await db.storeItem.findMany({
         where: {
           storeOid: store.oid
         },
@@ -326,7 +329,7 @@ class StoreVersionServiceImpl {
         ]
       });
 
-      let latestVersion = await tx.storeVersion.findFirst({
+      let latestVersion = await db.storeVersion.findFirst({
         where: {
           storeOid: store.oid
         },
@@ -339,7 +342,7 @@ class StoreVersionServiceImpl {
       });
 
       let versionIds = getId('storeVersion');
-      let version = await tx.storeVersion.create({
+      let version = await db.storeVersion.create({
         data: {
           oid: versionIds.oid,
           id: versionIds.id,
@@ -350,7 +353,7 @@ class StoreVersionServiceImpl {
       });
 
       if (currentItems.length > 0) {
-        await tx.storeVersionItem.createMany({
+        await db.storeVersionItem.createMany({
           data: currentItems.map(item => {
             let itemIds = getId('storeVersionItem');
 
@@ -367,7 +370,7 @@ class StoreVersionServiceImpl {
         });
       }
 
-      let shouldKeepDirty = await this.hasStoreLiveChangesSince(tx, {
+      let shouldKeepDirty = await this.hasStoreLiveChangesSince({
         storeOid: store.oid,
         since: snapshotStartedAt
       });
@@ -375,7 +378,7 @@ class StoreVersionServiceImpl {
       let didClearDirtyAt = false;
 
       if (!shouldKeepDirty) {
-        let cleared = await tx.store.updateMany({
+        let cleared = await db.store.updateMany({
           where: {
             oid: store.oid,
             dirtyAt: d.expectedDirtyAt
@@ -388,7 +391,7 @@ class StoreVersionServiceImpl {
         didClearDirtyAt = cleared.count > 0;
       }
 
-      let createdVersion = await tx.storeVersion.findUnique({
+      let createdVersion = await db.storeVersion.findUnique({
         where: {
           id: version.id
         },

--- a/src/systems/cargo/service/src/worker.ts
+++ b/src/systems/cargo/service/src/worker.ts
@@ -1,26 +1,14 @@
+import { runQueueProcessors } from '@lowerdeck/queue';
 import { createRequire } from 'module';
+import { documentCleanupProcessors } from './queues/documentCleanup';
+import { documentFlushProcessors } from './queues/documentFlush';
+import { documentVersionSyncProcessors } from './queues/documentVersionSync';
+import { storeCleanupProcessors } from './queues/storeCleanup';
 
 let require = createRequire(import.meta.url);
 (globalThis as any).require = require;
 
 async function main() {
-  await import('./init');
-  await import('./instrument');
-
-  let [
-    { runQueueProcessors },
-    { documentCleanupProcessors },
-    { documentFlushProcessors },
-    { documentVersionSyncProcessors },
-    { storeCleanupProcessors }
-  ] = await Promise.all([
-    import('@lowerdeck/queue'),
-    import('./queues/documentCleanup'),
-    import('./queues/documentFlush'),
-    import('./queues/documentVersionSync'),
-    import('./queues/storeCleanup')
-  ]);
-
   await runQueueProcessors([
     documentFlushProcessors,
     documentCleanupProcessors,

--- a/src/systems/cargo/service/src/worker.ts
+++ b/src/systems/cargo/service/src/worker.ts
@@ -10,18 +10,21 @@ async function main() {
   let [
     { runQueueProcessors },
     { documentCleanupProcessors },
-    { documentFlushProcessor },
+    { documentFlushProcessors },
+    { documentVersionSyncProcessors },
     { storeCleanupProcessors }
   ] = await Promise.all([
     import('@lowerdeck/queue'),
     import('./queues/documentCleanup'),
     import('./queues/documentFlush'),
+    import('./queues/documentVersionSync'),
     import('./queues/storeCleanup')
   ]);
 
   await runQueueProcessors([
-    documentFlushProcessor,
+    documentFlushProcessors,
     documentCleanupProcessors,
+    documentVersionSyncProcessors,
     storeCleanupProcessors
   ]);
 }

--- a/src/systems/cargo/service/src/worker.ts
+++ b/src/systems/cargo/service/src/worker.ts
@@ -4,6 +4,7 @@ import { documentCleanupProcessors } from './queues/documentCleanup';
 import { documentFlushProcessors } from './queues/documentFlush';
 import { documentVersionSyncProcessors } from './queues/documentVersionSync';
 import { storeCleanupProcessors } from './queues/storeCleanup';
+import { storeVersionProcessors } from './queues/storeVersion';
 
 let require = createRequire(import.meta.url);
 (globalThis as any).require = require;
@@ -13,7 +14,8 @@ async function main() {
     documentFlushProcessors,
     documentCleanupProcessors,
     documentVersionSyncProcessors,
-    storeCleanupProcessors
+    storeCleanupProcessors,
+    storeVersionProcessors
   ]);
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Adds new persistence models and background processors (store versioning, document version sync, dirty-draft flushing) plus a new live WebSocket path, touching core document/storage data flows and transactional behavior.
> 
> **Overview**
> Introduces **store version snapshots** by adding `StoreVersion`/`StoreVersionItem` models, tracking `Store.dirtyAt`, and a `storeVersionService` that snapshots store contents (including `documentVersionId`s) and clears `dirtyAt` only if no newer live changes occurred.
> 
> Adds **live document WebSocket support**: Cargo exposes `/document-live` with participant presence + live updates (including broadcasting parent edits to still-linked children), and the files API adds `/documents-live` as an authenticated WebSocket proxy to Cargo.
> 
> Reworks **document draft/clone/version propagation**: drafts are marked “dirty” in Redis and flushed via new queues/cron with revision backstops; new document version sync queues propagate newly created parent versions to follower children (skipping children with local drafts or diverged ownership). Also introduces “effective store” resolution so linked documents/files/items report the parent store until the first divergent write.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4cae21baf86a69240f4c530427a54dacfe33c78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->