### PR TITLE
Add subspace skill core

### DIFF
--- a/src/systems/subspace/apps/controller/package.json
+++ b/src/systems/subspace/apps/controller/package.json
@@ -58,6 +58,7 @@
     "@metorial-subspace/module-deployment": "^1.0.0",
     "@metorial-subspace/module-identity": "^1.0.0",
     "@metorial-subspace/module-integration": "^1.0.0",
+    "@metorial-subspace/module-skills": "^1.0.0",
     "@metorial-subspace/module-session": "^1.0.0",
     "@metorial-subspace/module-tenant": "^1.0.0",
     "@metorial-subspace/presenters": "^1.0.0",

--- a/src/systems/subspace/apps/controller/src/controllers/index.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/index.ts
@@ -84,6 +84,8 @@ import { sessionProviderController } from './sessionProvider';
 import { sessionTemplateController } from './sessionTemplate';
 import { sessionTemplateProviderController } from './sessionTemplateProvider';
 import { sessionUsageRecordController } from './sessionUsageRecord';
+import { skillController } from './skill';
+import { skillItemController } from './skillItem';
 import { solutionController } from './solution';
 import { tenantController } from './tenant';
 import { toolCallController } from './toolCall';
@@ -183,6 +185,11 @@ let sessionControllers = {
   providerRunUsageRecord: providerRunUsageRecordController
 };
 
+let skillControllers = {
+  skill: skillController,
+  skillItem: skillItemController
+};
+
 let extensionControllers = {
   customProvider: customProviderController,
   customProviderCommit: customProviderCommitController,
@@ -205,6 +212,7 @@ type SystemControllers = typeof systemControllers;
 type CallbackControllers = typeof callbackControllers;
 type ProviderControllers = typeof providerControllers;
 type SessionControllers = typeof sessionControllers;
+type SkillControllers = typeof skillControllers;
 type ExtensionControllers = typeof extensionControllers;
 type AgentControllers = typeof agentControllers;
 type IdentityControllers = typeof identityControllers;
@@ -215,6 +223,7 @@ type RootController = SystemControllers &
   CallbackControllers &
   ProviderControllers &
   SessionControllers &
+  SkillControllers &
   ExtensionControllers &
   AgentControllers &
   IdentityControllers &
@@ -227,6 +236,7 @@ let createRootController = (): RootController =>
     ...callbackControllers,
     ...providerControllers,
     ...sessionControllers,
+    ...skillControllers,
     ...extensionControllers,
     ...agentControllers,
     ...identityControllers,

--- a/src/systems/subspace/apps/controller/src/controllers/skill.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/skill.ts
@@ -83,7 +83,6 @@ export let skillController = app.controller({
       v.object({
         tenantId: v.string(),
         environmentId: v.string(),
-        skillGroupId: v.string(),
         name: v.string(),
         description: v.optional(v.string()),
         metadata: v.optional(v.record(v.any())),
@@ -96,7 +95,6 @@ export let skillController = app.controller({
         environment: ctx.environment,
         solution: ctx.solution,
         input: {
-          skillGroupId: ctx.input.skillGroupId,
           name: ctx.input.name,
           description: ctx.input.description,
           metadata: ctx.input.metadata,
@@ -116,7 +114,6 @@ export let skillController = app.controller({
         skillId: v.string(),
         allowDeleted: v.optional(v.boolean()),
 
-        skillGroupId: v.optional(v.string()),
         name: v.optional(v.string()),
         description: v.optional(v.nullable(v.string())),
         metadata: v.optional(v.nullable(v.record(v.any()))),
@@ -130,7 +127,6 @@ export let skillController = app.controller({
         solution: ctx.solution,
         skill: ctx.skill,
         input: {
-          skillGroupId: ctx.input.skillGroupId,
           name: ctx.input.name,
           description: ctx.input.description,
           metadata: ctx.input.metadata,
@@ -170,7 +166,6 @@ export let skillController = app.controller({
         environmentId: v.string(),
         skillId: v.string(),
         allowDeleted: v.optional(v.boolean()),
-        skillGroupId: v.optional(v.string()),
         name: v.string(),
         description: v.optional(v.string()),
         metadata: v.optional(v.record(v.any())),
@@ -184,7 +179,6 @@ export let skillController = app.controller({
         solution: ctx.solution,
         skill: ctx.skill,
         input: {
-          skillGroupId: ctx.input.skillGroupId,
           name: ctx.input.name,
           description: ctx.input.description,
           metadata: ctx.input.metadata,

--- a/src/systems/subspace/apps/controller/src/controllers/skill.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/skill.ts
@@ -1,0 +1,197 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import { skillService } from '@metorial-subspace/module-skills';
+import { skillPresenter } from '@metorial-subspace/presenters';
+import { app } from './_app';
+import { createdAtValidator, updatedAtValidator } from './_dateFilter';
+import { tenantApp } from './tenant';
+
+export let skillApp = tenantApp.use(async ctx => {
+  let skillId = ctx.body.skillId;
+  if (!skillId) throw new Error('Skill ID is required');
+
+  let skill = await skillService.getSkillById({
+    skillId,
+    tenant: ctx.tenant,
+    environment: ctx.environment,
+    solution: ctx.solution,
+    allowDeleted: ctx.body.allowDeleted
+  });
+
+  return { skill };
+});
+
+export let skillController = app.controller({
+  list: tenantApp
+    .handler()
+    .input(
+      Paginator.validate(
+        v.object({
+          tenantId: v.string(),
+          environmentId: v.string(),
+
+          search: v.optional(v.string()),
+
+          status: v.optional(v.array(v.enumOf(['active', 'archived', 'deleted']))),
+          allowDeleted: v.optional(v.boolean()),
+
+          ids: v.optional(v.array(v.string())),
+          skillGroupIds: v.optional(v.array(v.string())),
+          integrationIds: v.optional(v.array(v.string())),
+          providerIds: v.optional(v.array(v.string())),
+
+          createdAt: createdAtValidator,
+          updatedAt: updatedAtValidator
+        })
+      )
+    )
+    .do(async ctx => {
+      let paginator = await skillService.listSkills({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+        search: ctx.input.search,
+        status: ctx.input.status,
+        allowDeleted: ctx.input.allowDeleted,
+        ids: ctx.input.ids,
+        skillGroupIds: ctx.input.skillGroupIds,
+        integrationIds: ctx.input.integrationIds,
+        providerIds: ctx.input.providerIds,
+        createdAt: ctx.input.createdAt,
+        updatedAt: ctx.input.updatedAt
+      });
+
+      let list = await paginator.run(ctx.input);
+      return Paginator.presentLight(list, skillPresenter);
+    }),
+
+  get: skillApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        skillId: v.string(),
+        allowDeleted: v.optional(v.boolean())
+      })
+    )
+    .do(async ctx => skillPresenter(ctx.skill)),
+
+  create: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        skillGroupId: v.string(),
+        name: v.string(),
+        description: v.optional(v.string()),
+        metadata: v.optional(v.record(v.any())),
+        privateMetadata: v.optional(v.record(v.any()))
+      })
+    )
+    .do(async ctx => {
+      let skill = await skillService.createSkill({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+        input: {
+          skillGroupId: ctx.input.skillGroupId,
+          name: ctx.input.name,
+          description: ctx.input.description,
+          metadata: ctx.input.metadata,
+          privateMetadata: ctx.input.privateMetadata
+        }
+      });
+
+      return skillPresenter(skill);
+    }),
+
+  update: skillApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        skillId: v.string(),
+        allowDeleted: v.optional(v.boolean()),
+
+        skillGroupId: v.optional(v.string()),
+        name: v.optional(v.string()),
+        description: v.optional(v.nullable(v.string())),
+        metadata: v.optional(v.nullable(v.record(v.any()))),
+        privateMetadata: v.optional(v.nullable(v.record(v.any())))
+      })
+    )
+    .do(async ctx => {
+      let skill = await skillService.updateSkill({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+        skill: ctx.skill,
+        input: {
+          skillGroupId: ctx.input.skillGroupId,
+          name: ctx.input.name,
+          description: ctx.input.description,
+          metadata: ctx.input.metadata,
+          privateMetadata: ctx.input.privateMetadata
+        }
+      });
+
+      return skillPresenter(skill);
+    }),
+
+  delete: skillApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        skillId: v.string(),
+        allowDeleted: v.optional(v.boolean())
+      })
+    )
+    .do(async ctx => {
+      let skill = await skillService.archiveSkill({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+        skill: ctx.skill
+      });
+
+      return skillPresenter(skill);
+    }),
+
+  fork: skillApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        skillId: v.string(),
+        allowDeleted: v.optional(v.boolean()),
+        skillGroupId: v.optional(v.string()),
+        name: v.string(),
+        description: v.optional(v.string()),
+        metadata: v.optional(v.record(v.any())),
+        privateMetadata: v.optional(v.record(v.any()))
+      })
+    )
+    .do(async ctx => {
+      let skill = await skillService.forkSkill({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+        skill: ctx.skill,
+        input: {
+          skillGroupId: ctx.input.skillGroupId,
+          name: ctx.input.name,
+          description: ctx.input.description,
+          metadata: ctx.input.metadata,
+          privateMetadata: ctx.input.privateMetadata
+        }
+      });
+
+      return skillPresenter(skill);
+    })
+});

--- a/src/systems/subspace/apps/controller/src/controllers/skillItem.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/skillItem.ts
@@ -1,0 +1,128 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import { skillItemService } from '@metorial-subspace/module-skills';
+import { skillItemPresenter } from '@metorial-subspace/presenters';
+import { app } from './_app';
+import { createdAtValidator } from './_dateFilter';
+import { tenantApp } from './tenant';
+
+let createSkillItemValidator = v.union([
+  v.object({
+    tenantId: v.string(),
+    environmentId: v.string(),
+    skillId: v.string(),
+    type: v.literal('integration'),
+    integrationId: v.string()
+  }),
+  v.object({
+    tenantId: v.string(),
+    environmentId: v.string(),
+    skillId: v.string(),
+    type: v.literal('provider'),
+    providerId: v.string()
+  })
+]);
+
+export let skillItemApp = tenantApp.use(async ctx => {
+  let skillItemId = ctx.body.skillItemId;
+  if (!skillItemId) throw new Error('SkillItem ID is required');
+
+  let skillItem = await skillItemService.getSkillItemById({
+    skillItemId,
+    tenant: ctx.tenant,
+    environment: ctx.environment,
+    solution: ctx.solution,
+    allowDeleted: ctx.body.allowDeleted
+  });
+
+  return { skillItem };
+});
+
+export let skillItemController = app.controller({
+  list: tenantApp
+    .handler()
+    .input(
+      Paginator.validate(
+        v.object({
+          tenantId: v.string(),
+          environmentId: v.string(),
+
+          status: v.optional(v.array(v.enumOf(['active', 'archived', 'deleted']))),
+          allowDeleted: v.optional(v.boolean()),
+
+          ids: v.optional(v.array(v.string())),
+          skillIds: v.optional(v.array(v.string())),
+          type: v.optional(v.array(v.enumOf(['integration', 'provider']))),
+          integrationIds: v.optional(v.array(v.string())),
+          providerIds: v.optional(v.array(v.string())),
+
+          createdAt: createdAtValidator
+        })
+      )
+    )
+    .do(async ctx => {
+      let paginator = await skillItemService.listSkillItems({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+        status: ctx.input.status,
+        allowDeleted: ctx.input.allowDeleted,
+        ids: ctx.input.ids,
+        skillIds: ctx.input.skillIds,
+        type: ctx.input.type,
+        integrationIds: ctx.input.integrationIds,
+        providerIds: ctx.input.providerIds,
+        createdAt: ctx.input.createdAt
+      });
+
+      let list = await paginator.run(ctx.input);
+      return Paginator.presentLight(list, skillItemPresenter);
+    }),
+
+  get: skillItemApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        skillItemId: v.string(),
+        allowDeleted: v.optional(v.boolean())
+      })
+    )
+    .do(async ctx => skillItemPresenter(ctx.skillItem)),
+
+  create: tenantApp
+    .handler()
+    .input(createSkillItemValidator)
+    .do(async ctx => {
+      let skillItem = await skillItemService.createSkillItem({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+        input: ctx.input
+      });
+
+      return skillItemPresenter(skillItem);
+    }),
+
+  delete: skillItemApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        skillItemId: v.string(),
+        allowDeleted: v.optional(v.boolean())
+      })
+    )
+    .do(async ctx => {
+      let skillItem = await skillItemService.archiveSkillItem({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+        skillItem: ctx.skillItem
+      });
+
+      return skillItemPresenter(skillItem);
+    })
+});

--- a/src/systems/subspace/apps/controller/src/controllers/tests/skill.e2e.test.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/tests/skill.e2e.test.ts
@@ -46,22 +46,6 @@ let createTenantContext = async () => {
   };
 };
 
-let createSkillGroup = async (d: {
-  tenantOid: bigint;
-  environmentOid: bigint;
-  solutionOid: number;
-}) =>
-  await testDb.skillGroup.create({
-    data: {
-      ...getId('skillGroup'),
-      slug: 'test-skill-group',
-      name: 'Test Skill Group',
-      tenantOid: d.tenantOid,
-      environmentOid: d.environmentOid,
-      solutionOid: d.solutionOid
-    }
-  });
-
 let createIntegration = async (d: {
   tenantOid: bigint;
   environmentOid: bigint;
@@ -210,24 +194,29 @@ describe('skill.e2e', () => {
   it('creates, updates, and archives a skill through the controller', async () => {
     let { client, tenant, tenantRecord, environmentRecord, solutionRecord } =
       await createTenantContext();
-    let skillGroup = await createSkillGroup({
-      tenantOid: tenantRecord.oid,
-      environmentOid: environmentRecord.oid,
-      solutionOid: solutionRecord.oid
-    });
 
     let created = await client.skill.create({
       tenantId: tenant.id,
       environmentId: environmentRecord.id,
-      skillGroupId: skillGroup.id,
       name: 'Draft Skill',
       description: 'Initial description'
     });
 
+    let createdSkillRecord = await testDb.skill.findUniqueOrThrow({
+      where: { id: created.id }
+    });
+    let createdSkillGroupRecord = await testDb.skillGroup.findUniqueOrThrow({
+      where: { id: created.skillGroupId }
+    });
+
     expect(created.name).toBe('Draft Skill');
-    expect(created.skillGroupId).toBe(skillGroup.id);
+    expect(created.skillGroupId).toBe(createdSkillGroupRecord.id);
     expect(created.integrations).toEqual([]);
     expect(created.providers).toEqual([]);
+    expect(createdSkillGroupRecord.ownerSkillOid).toBe(createdSkillRecord.oid);
+    expect(createdSkillGroupRecord.slug).toBe(created.slug);
+    expect(createdSkillGroupRecord.name).toBe(created.name);
+    expect(createdSkillGroupRecord.description).toBe(created.description);
 
     let updated = await client.skill.update({
       tenantId: tenant.id,
@@ -239,6 +228,14 @@ describe('skill.e2e', () => {
 
     expect(updated.name).toBe('Updated Skill');
     expect(updated.description).toBe('Updated description');
+
+    let updatedSkillGroupRecord = await testDb.skillGroup.findUniqueOrThrow({
+      where: { id: created.skillGroupId }
+    });
+
+    expect(updatedSkillGroupRecord.slug).toBe(updated.slug);
+    expect(updatedSkillGroupRecord.name).toBe(updated.name);
+    expect(updatedSkillGroupRecord.description).toBe(updated.description);
 
     let archived = await client.skill.delete({
       tenantId: tenant.id,
@@ -257,11 +254,6 @@ describe('skill.e2e', () => {
   it('resurrects an archived integration skill item when it is added again', async () => {
     let { client, tenant, tenantRecord, environmentRecord, solutionRecord } =
       await createTenantContext();
-    let skillGroup = await createSkillGroup({
-      tenantOid: tenantRecord.oid,
-      environmentOid: environmentRecord.oid,
-      solutionOid: solutionRecord.oid
-    });
     let integration = await createIntegration({
       tenantOid: tenantRecord.oid,
       environmentOid: environmentRecord.oid,
@@ -271,7 +263,6 @@ describe('skill.e2e', () => {
     let skill = await client.skill.create({
       tenantId: tenant.id,
       environmentId: environmentRecord.id,
-      skillGroupId: skillGroup.id,
       name: 'Resurrection Skill'
     });
 
@@ -319,19 +310,13 @@ describe('skill.e2e', () => {
     expect(skillIntegrationRecord.status).toBe('active');
   });
 
-  it('forks a skill through the controller without exposing parentSkillId in the write api', async () => {
+  it('passes the owner skill group through fork chains', async () => {
     let { client, tenant, tenantRecord, environmentRecord, solutionRecord } =
       await createTenantContext();
-    let skillGroup = await createSkillGroup({
-      tenantOid: tenantRecord.oid,
-      environmentOid: environmentRecord.oid,
-      solutionOid: solutionRecord.oid
-    });
 
     let original = await client.skill.create({
       tenantId: tenant.id,
       environmentId: environmentRecord.id,
-      skillGroupId: skillGroup.id,
       name: 'Original Skill'
     });
 
@@ -341,27 +326,63 @@ describe('skill.e2e', () => {
       skillId: original.id,
       name: 'Forked Skill'
     });
+    let transientFork = await client.skill.fork({
+      tenantId: tenant.id,
+      environmentId: environmentRecord.id,
+      skillId: fork.id,
+      name: 'Transient Fork'
+    });
 
     expect(fork.name).toBe('Forked Skill');
     expect(fork.forkedFromId).toBe(original.id);
+    expect(fork.skillGroupId).toBe(original.skillGroupId);
+    expect(transientFork.forkedFromId).toBe(fork.id);
+    expect(transientFork.skillGroupId).toBe(original.skillGroupId);
 
-    let forkRecord = await testDb.skill.findUniqueOrThrow({
-      where: { id: fork.id },
-      include: { forkedFrom: true }
-    });
+    let [originalRecord, forkRecord, transientForkRecord, skillGroupRecord] = await Promise.all([
+      testDb.skill.findUniqueOrThrow({
+        where: { id: original.id }
+      }),
+      testDb.skill.findUniqueOrThrow({
+        where: { id: fork.id },
+        include: { forkedFrom: true }
+      }),
+      testDb.skill.findUniqueOrThrow({
+        where: { id: transientFork.id },
+        include: { forkedFrom: true }
+      }),
+      testDb.skillGroup.findUniqueOrThrow({
+        where: { id: original.skillGroupId }
+      })
+    ]);
 
+    expect(skillGroupRecord.ownerSkillOid).toBe(originalRecord.oid);
+    expect(forkRecord.skillGroupOid).toBe(originalRecord.skillGroupOid);
+    expect(transientForkRecord.skillGroupOid).toBe(originalRecord.skillGroupOid);
     expect(forkRecord.parentSkillOid).toBeTruthy();
     expect(forkRecord.forkedFrom?.parentSkillOid).toBeTruthy();
+    expect(transientForkRecord.parentSkillOid).toBeTruthy();
+    expect(transientForkRecord.forkedFrom?.parentSkillOid).toBeTruthy();
+
+    let updatedOriginal = await client.skill.update({
+      tenantId: tenant.id,
+      environmentId: environmentRecord.id,
+      skillId: original.id,
+      name: 'Updated Original Skill',
+      description: 'Updated original description'
+    });
+    let updatedSkillGroupRecord = await testDb.skillGroup.findUniqueOrThrow({
+      where: { id: original.skillGroupId }
+    });
+
+    expect(updatedSkillGroupRecord.slug).toBe(updatedOriginal.slug);
+    expect(updatedSkillGroupRecord.name).toBe(updatedOriginal.name);
+    expect(updatedSkillGroupRecord.description).toBe(updatedOriginal.description);
   });
 
   it('reconciles provider links and indexes integrations/providers into the skill document', async () => {
     let { client, tenant, tenantRecord, environmentRecord, solutionRecord } =
       await createTenantContext();
-    let skillGroup = await createSkillGroup({
-      tenantOid: tenantRecord.oid,
-      environmentOid: environmentRecord.oid,
-      solutionOid: solutionRecord.oid
-    });
     let integration = await createIntegration({
       tenantOid: tenantRecord.oid,
       environmentOid: environmentRecord.oid,
@@ -383,7 +404,6 @@ describe('skill.e2e', () => {
     let skill = await client.skill.create({
       tenantId: tenant.id,
       environmentId: environmentRecord.id,
-      skillGroupId: skillGroup.id,
       name: 'Indexed Skill'
     });
 

--- a/src/systems/subspace/apps/controller/src/controllers/tests/skill.e2e.test.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/tests/skill.e2e.test.ts
@@ -1,0 +1,417 @@
+import { ID, get4ByteIntId, getId } from '@metorial-subspace/db';
+import { indexSkillRecord, reconcileSkillProviderLinks } from '@metorial-subspace/module-skills';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createSubspaceControllerRootTestClient } from '../../test/client';
+import { getVoyagerStubCalls } from '../../test/helpers/voyagerStub';
+import { cleanDatabase, testDb } from '../../test/setup';
+
+let createTenantContext = async () => {
+  let anonymousClient = createSubspaceControllerRootTestClient();
+  let solution = await anonymousClient.solution.upsert({
+    name: 'Test Solution',
+    identifier: 'test-skill-solution'
+  });
+
+  let client = createSubspaceControllerRootTestClient({
+    headers: {
+      'Subspace-Solution-Id': solution.id
+    }
+  });
+
+  let tenant = await client.tenant.upsert({
+    name: 'Test Tenant',
+    identifier: 'test-skill-tenant',
+    environments: [
+      {
+        name: 'Development',
+        identifier: 'test-skill-tenant-dev',
+        type: 'development'
+      }
+    ]
+  });
+
+  let [tenantRecord, environmentRecord, solutionRecord] = await Promise.all([
+    testDb.tenant.findUniqueOrThrow({ where: { id: tenant.id } }),
+    testDb.environment.findUniqueOrThrow({ where: { identifier: 'test-skill-tenant-dev' } }),
+    testDb.solution.findUniqueOrThrow({ where: { id: solution.id } })
+  ]);
+
+  return {
+    client,
+    solution,
+    tenant,
+    tenantRecord,
+    environmentRecord,
+    solutionRecord
+  };
+};
+
+let createSkillGroup = async (d: {
+  tenantOid: bigint;
+  environmentOid: bigint;
+  solutionOid: number;
+}) =>
+  await testDb.skillGroup.create({
+    data: {
+      ...getId('skillGroup'),
+      slug: 'test-skill-group',
+      name: 'Test Skill Group',
+      tenantOid: d.tenantOid,
+      environmentOid: d.environmentOid,
+      solutionOid: d.solutionOid
+    }
+  });
+
+let createIntegration = async (d: {
+  tenantOid: bigint;
+  environmentOid: bigint;
+  solutionOid: number;
+}) =>
+  await testDb.integration.create({
+    data: {
+      ...getId('integration'),
+      status: 'active',
+      slug: 'test-skill-integration',
+      name: 'Test Skill Integration',
+      description: 'Integration used by skill tests',
+      canAttachCustomToolFilters: true,
+      canAttachCustomProviderConfig: false,
+      canOverrideToolFilters: false,
+      currentVersionIndex: 0,
+      tenantOid: d.tenantOid,
+      environmentOid: d.environmentOid,
+      solutionOid: d.solutionOid
+    }
+  });
+
+let createProvider = async (d: {
+  tenantOid: bigint;
+  environmentOid: bigint;
+  solutionOid: number;
+}) => {
+  let publisherTag = await testDb.providerTag.create({
+    data: {
+      ...getId('providerTag'),
+      tag: 'pub-test-skill-provider'
+    }
+  });
+  let providerTag = await testDb.providerTag.create({
+    data: {
+      ...getId('providerTag'),
+      tag: 'pro-test-skill-provider'
+    }
+  });
+
+  let providerType = await testDb.providerType.create({
+    data: {
+      oid: get4ByteIntId(),
+      id: ID.generateIdSync('providerType'),
+      shortKey: 'tsk',
+      identifier: 'test-skill-provider-type',
+      name: 'Test Skill Provider Type',
+      attributes: {
+        provider: 'metorial-native',
+        backend: 'native',
+        triggers: { status: 'disabled' },
+        auth: { status: 'disabled' },
+        config: { status: 'disabled' }
+      }
+    }
+  });
+
+  let publisher = await testDb.publisher.create({
+    data: {
+      ...getId('publisher'),
+      type: 'tenant',
+      identifier: 'test-skill-publisher',
+      name: 'Test Skill Publisher',
+      description: 'Publisher for skill tests',
+      tag: publisherTag.tag,
+      tenantOid: d.tenantOid
+    }
+  });
+
+  let providerEntry = await testDb.providerEntry.create({
+    data: {
+      ...getId('providerEntry'),
+      identifier: 'test-skill-provider-entry',
+      name: 'Test Skill Provider Entry',
+      description: 'Entry for skill tests',
+      publisherOid: publisher.oid
+    }
+  });
+
+  let provider = await testDb.provider.create({
+    data: {
+      ...getId('provider'),
+      access: 'public',
+      status: 'active',
+      identifier: 'test-skill-provider',
+      slug: 'test-skill-provider',
+      name: 'Test Skill Provider',
+      description: 'Provider for skill tests',
+      tag: providerTag.tag,
+      entryOid: providerEntry.oid,
+      publisherOid: publisher.oid,
+      typeOid: providerType.oid
+    }
+  });
+
+  await testDb.providerListing.create({
+    data: {
+      ...getId('providerListing'),
+      status: 'active',
+      isPublic: true,
+      isCustomized: false,
+      isMetorial: false,
+      isVerified: false,
+      isOfficial: false,
+      name: 'Test Skill Provider Listing',
+      slug: 'test-skill-provider-listing',
+      description: 'Listing for skill tests',
+      skills: [],
+      publisherOid: publisher.oid,
+      providerOid: provider.oid,
+      typeOid: providerType.oid
+    }
+  });
+
+  return provider;
+};
+
+let createIntegrationProvider = async (d: {
+  integrationOid: bigint;
+  providerOid: bigint;
+  tenantOid: bigint;
+  environmentOid: bigint;
+  solutionOid: number;
+}) =>
+  await testDb.integrationProvider.create({
+    data: {
+      ...getId('integrationProvider'),
+      status: 'active',
+      name: 'Test Skill Integration Provider',
+      description: 'Link between integration and provider',
+      toolFilter: { type: 'v1.allow_all' },
+      currentVersionIndex: 0,
+      integrationOid: d.integrationOid,
+      providerOid: d.providerOid,
+      tenantOid: d.tenantOid,
+      environmentOid: d.environmentOid,
+      solutionOid: d.solutionOid
+    }
+  });
+
+describe('skill.e2e', () => {
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  it('creates, updates, and archives a skill through the controller', async () => {
+    let { client, tenant, tenantRecord, environmentRecord, solutionRecord } =
+      await createTenantContext();
+    let skillGroup = await createSkillGroup({
+      tenantOid: tenantRecord.oid,
+      environmentOid: environmentRecord.oid,
+      solutionOid: solutionRecord.oid
+    });
+
+    let created = await client.skill.create({
+      tenantId: tenant.id,
+      environmentId: environmentRecord.id,
+      skillGroupId: skillGroup.id,
+      name: 'Draft Skill',
+      description: 'Initial description'
+    });
+
+    expect(created.name).toBe('Draft Skill');
+    expect(created.skillGroupId).toBe(skillGroup.id);
+    expect(created.integrations).toEqual([]);
+    expect(created.providers).toEqual([]);
+
+    let updated = await client.skill.update({
+      tenantId: tenant.id,
+      environmentId: environmentRecord.id,
+      skillId: created.id,
+      name: 'Updated Skill',
+      description: 'Updated description'
+    });
+
+    expect(updated.name).toBe('Updated Skill');
+    expect(updated.description).toBe('Updated description');
+
+    let archived = await client.skill.delete({
+      tenantId: tenant.id,
+      environmentId: environmentRecord.id,
+      skillId: created.id
+    });
+
+    expect(archived.status).toBe('archived');
+
+    let skillRecord = await testDb.skill.findUniqueOrThrow({
+      where: { id: created.id }
+    });
+    expect(skillRecord.status).toBe('archived');
+  });
+
+  it('resurrects an archived integration skill item when it is added again', async () => {
+    let { client, tenant, tenantRecord, environmentRecord, solutionRecord } =
+      await createTenantContext();
+    let skillGroup = await createSkillGroup({
+      tenantOid: tenantRecord.oid,
+      environmentOid: environmentRecord.oid,
+      solutionOid: solutionRecord.oid
+    });
+    let integration = await createIntegration({
+      tenantOid: tenantRecord.oid,
+      environmentOid: environmentRecord.oid,
+      solutionOid: solutionRecord.oid
+    });
+
+    let skill = await client.skill.create({
+      tenantId: tenant.id,
+      environmentId: environmentRecord.id,
+      skillGroupId: skillGroup.id,
+      name: 'Resurrection Skill'
+    });
+
+    let created = await client.skillItem.create({
+      tenantId: tenant.id,
+      environmentId: environmentRecord.id,
+      skillId: skill.id,
+      type: 'integration',
+      integrationId: integration.id
+    });
+
+    expect(created.type).toBe('integration');
+    expect(created.integration?.id).toBe(integration.id);
+
+    let archived = await client.skillItem.delete({
+      tenantId: tenant.id,
+      environmentId: environmentRecord.id,
+      skillItemId: created.id
+    });
+
+    expect(archived.status).toBe('archived');
+
+    let resurrected = await client.skillItem.create({
+      tenantId: tenant.id,
+      environmentId: environmentRecord.id,
+      skillId: skill.id,
+      type: 'integration',
+      integrationId: integration.id
+    });
+
+    expect(resurrected.id).toBe(created.id);
+    expect(resurrected.status).toBe('active');
+
+    let [skillItemRecord, skillIntegrationRecord] = await Promise.all([
+      testDb.skillItem.findUniqueOrThrow({ where: { id: created.id } }),
+      testDb.skillIntegration.findFirstOrThrow({
+        where: {
+          skill: { id: skill.id },
+          integration: { id: integration.id }
+        }
+      })
+    ]);
+
+    expect(skillItemRecord.status).toBe('active');
+    expect(skillIntegrationRecord.status).toBe('active');
+  });
+
+  it('forks a skill through the controller without exposing parentSkillId in the write api', async () => {
+    let { client, tenant, tenantRecord, environmentRecord, solutionRecord } =
+      await createTenantContext();
+    let skillGroup = await createSkillGroup({
+      tenantOid: tenantRecord.oid,
+      environmentOid: environmentRecord.oid,
+      solutionOid: solutionRecord.oid
+    });
+
+    let original = await client.skill.create({
+      tenantId: tenant.id,
+      environmentId: environmentRecord.id,
+      skillGroupId: skillGroup.id,
+      name: 'Original Skill'
+    });
+
+    let fork = await client.skill.fork({
+      tenantId: tenant.id,
+      environmentId: environmentRecord.id,
+      skillId: original.id,
+      name: 'Forked Skill'
+    });
+
+    expect(fork.name).toBe('Forked Skill');
+    expect(fork.forkedFromId).toBe(original.id);
+
+    let forkRecord = await testDb.skill.findUniqueOrThrow({
+      where: { id: fork.id },
+      include: { forkedFrom: true }
+    });
+
+    expect(forkRecord.parentSkillOid).toBeTruthy();
+    expect(forkRecord.forkedFrom?.parentSkillOid).toBeTruthy();
+  });
+
+  it('reconciles provider links and indexes integrations/providers into the skill document', async () => {
+    let { client, tenant, tenantRecord, environmentRecord, solutionRecord } =
+      await createTenantContext();
+    let skillGroup = await createSkillGroup({
+      tenantOid: tenantRecord.oid,
+      environmentOid: environmentRecord.oid,
+      solutionOid: solutionRecord.oid
+    });
+    let integration = await createIntegration({
+      tenantOid: tenantRecord.oid,
+      environmentOid: environmentRecord.oid,
+      solutionOid: solutionRecord.oid
+    });
+    let provider = await createProvider({
+      tenantOid: tenantRecord.oid,
+      environmentOid: environmentRecord.oid,
+      solutionOid: solutionRecord.oid
+    });
+    await createIntegrationProvider({
+      integrationOid: integration.oid,
+      providerOid: provider.oid,
+      tenantOid: tenantRecord.oid,
+      environmentOid: environmentRecord.oid,
+      solutionOid: solutionRecord.oid
+    });
+
+    let skill = await client.skill.create({
+      tenantId: tenant.id,
+      environmentId: environmentRecord.id,
+      skillGroupId: skillGroup.id,
+      name: 'Indexed Skill'
+    });
+
+    await client.skillItem.create({
+      tenantId: tenant.id,
+      environmentId: environmentRecord.id,
+      skillId: skill.id,
+      type: 'integration',
+      integrationId: integration.id
+    });
+
+    await reconcileSkillProviderLinks({ skillId: skill.id });
+
+    let links = await testDb.skillProviderLink.findMany({
+      where: { skill: { id: skill.id } },
+      include: { provider: true }
+    });
+
+    expect(links).toHaveLength(1);
+    expect(links[0]?.provider.id).toBe(provider.id);
+
+    await indexSkillRecord({ skillId: skill.id });
+
+    let indexCalls = getVoyagerStubCalls('record:index');
+    let latestIndexCall = indexCalls[indexCalls.length - 1];
+
+    expect(latestIndexCall?.payload.documentId).toBe(skill.id);
+    expect(latestIndexCall?.payload.body.integrationNames).toContain(integration.name);
+    expect(latestIndexCall?.payload.body.providerNames).toContain(provider.name);
+  });
+});

--- a/src/systems/subspace/apps/controller/src/test/helpers/voyagerStub.ts
+++ b/src/systems/subspace/apps/controller/src/test/helpers/voyagerStub.ts
@@ -3,9 +3,11 @@ import { serialize } from '@lowerdeck/serialize';
 
 type StubState = { counter: number };
 type RpcCall = { id: string; name: string; payload: any };
+type RecordedCall = { name: string; payload: any };
 
 let stubState: StubState | null = null;
 let fetchRouter: ReturnType<typeof createFetchRouter> | null = null;
+let recordedCalls: RecordedCall[] = [];
 
 let rpcHandlers: Record<string, (payload: any, state: StubState) => any> = {
   'source:upsert': (p, s) => ({
@@ -67,6 +69,8 @@ export function setupVoyagerStub() {
     let results: Array<{ __typename: string; id: string; name: string; status: number; result: any }> = [];
 
     for (let call of body.calls ?? []) {
+      recordedCalls.push({ name: call.name, payload: call.payload });
+
       let handler = rpcHandlers[call.name];
       if (!handler) {
         return new Response(
@@ -93,4 +97,9 @@ export function setupVoyagerStub() {
 
 export function resetVoyagerStub() {
   if (stubState) stubState.counter = 0;
+  recordedCalls = [];
+}
+
+export function getVoyagerStubCalls(name?: string) {
+  return name ? recordedCalls.filter(call => call.name === name) : recordedCalls;
 }

--- a/src/systems/subspace/apps/worker/package.json
+++ b/src/systems/subspace/apps/worker/package.json
@@ -25,6 +25,7 @@
     "@metorial-subspace/module-deployment": "^1.0.0",
     "@metorial-subspace/module-integration": "^1.0.0",
     "@metorial-subspace/module-provider-internal": "^1.0.0",
+    "@metorial-subspace/module-skills": "^1.0.0",
     "@lowerdeck/telemetry": "^1.1.1",
     "@metorial-subspace/module-tenant": "^1.0.0",
     "@metorial-subspace/provider-native": "^1.0.0",

--- a/src/systems/subspace/apps/worker/src/worker.ts
+++ b/src/systems/subspace/apps/worker/src/worker.ts
@@ -13,6 +13,7 @@ import { identityQueueProcessor } from '@metorial-subspace/module-identity';
 import { integrationQueueProcessor } from '@metorial-subspace/module-integration';
 import { providerInternalQueueProcessor } from '@metorial-subspace/module-provider-internal';
 import { sessionQueueProcessor } from '@metorial-subspace/module-session';
+import { skillsQueueProcessor } from '@metorial-subspace/module-skills';
 import { tenantQueueProcessors } from '@metorial-subspace/module-tenant';
 import { nativeProviderQueues } from '@metorial-subspace/provider-native';
 import { shuttleProviderQueues } from '@metorial-subspace/provider-shuttle';
@@ -33,6 +34,7 @@ runQueueProcessors([
   callbackQueueProcessor,
   identityQueueProcessor,
   integrationQueueProcessor,
+  skillsQueueProcessor,
   agentQueueProcessor
 ]);
 

--- a/src/systems/subspace/db/prisma/schema/intergration/integration.prisma
+++ b/src/systems/subspace/db/prisma/schema/intergration/integration.prisma
@@ -49,6 +49,7 @@ model Integration {
   providerTemplateBacking           ProviderTemplateBacking?
   ownerMagicMcpServerBackings       MagicMcpServerBacking[]            @relation("MagicMcpServerOwnerIntegration")
   magicMcpServerBacking             MagicMcpServerBacking?             @relation("MagicMcpServerBackingIntegration")
+  skillIntegrations                 SkillIntegration[]
 
   @@index([createdAt])
   @@index([updatedAt])

--- a/src/systems/subspace/db/prisma/schema/provider/provider.prisma
+++ b/src/systems/subspace/db/prisma/schema/provider/provider.prisma
@@ -103,6 +103,8 @@ model Provider {
   identityCredentials            IdentityCredential[]
   managedProviderAuthCredentials ManagedProviderAuthCredentials[]
   integrationProviders           IntegrationProvider[]
+  skillProviders                 SkillProvider[]
+  skillProviderLinks             SkillProviderLink[]
 
   @@index([status])
   @@index([access])

--- a/src/systems/subspace/db/prisma/schema/skills/skill.prisma
+++ b/src/systems/subspace/db/prisma/schema/skills/skill.prisma
@@ -1,0 +1,178 @@
+model SkillGroup {
+  oid BigInt @id
+  id  String @unique
+
+  slug        String  @unique
+  name        String
+  description String?
+
+  ownerSkillOid BigInt? @unique
+  ownerSkill    Skill?  @relation("SkillGroupOwner", fields: [ownerSkillOid], references: [oid], onDelete: SetNull)
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  environmentOid BigInt
+  environment    Environment @relation(fields: [environmentOid], references: [oid], onDelete: Cascade)
+
+  solutionOid Int
+  solution    Solution @relation(fields: [solutionOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  skills Skill[]
+}
+
+enum SkillStatus {
+  active
+  archived
+  deleted
+}
+
+model Skill {
+  oid BigInt @id
+  id  String @unique
+
+  status SkillStatus
+
+  slug            String  @unique
+  name            String
+  description     String?
+  metadata        Json?
+  privateMetadata Json?
+
+  skillGroupOid BigInt
+  skillGroup    SkillGroup @relation(fields: [skillGroupOid], references: [oid], onDelete: Cascade)
+
+  parentSkillOid BigInt?
+  parentSkill    Skill?  @relation("SkillParentChild", fields: [parentSkillOid], references: [oid], onDelete: SetNull)
+  childSkills    Skill[] @relation("SkillParentChild")
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  environmentOid BigInt
+  environment    Environment @relation(fields: [environmentOid], references: [oid], onDelete: Cascade)
+
+  solutionOid Int
+  solution    Solution @relation(fields: [solutionOid], references: [oid], onDelete: Cascade)
+
+  owningSkillGroup SkillGroup? @relation("SkillGroupOwner")
+  forks            SkillFork[] @relation("SkillForkParent")
+  forkedFrom       SkillFork?  @relation("SkillForkChild")
+
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @default(now()) @updatedAt
+  skillIntegrations  SkillIntegration[]
+  skillProviders     SkillProvider[]
+  skillItems         SkillItem[]
+  skillProviderLinks SkillProviderLink[]
+}
+
+model SkillFork {
+  oid BigInt @id
+  id  String @unique
+
+  parentSkillOid BigInt
+  parentSkill    Skill  @relation("SkillForkParent", fields: [parentSkillOid], references: [oid], onDelete: Cascade)
+
+  childSkillOid BigInt @unique
+  childSkill    Skill  @relation("SkillForkChild", fields: [childSkillOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+}
+
+enum SkillIntegrationStatus {
+  active
+  archived
+  deleted
+}
+
+model SkillIntegration {
+  oid BigInt @id
+  id  String @unique
+
+  status SkillIntegrationStatus
+
+  skillOid BigInt
+  skill    Skill  @relation(fields: [skillOid], references: [oid], onDelete: Cascade)
+
+  integrationOid BigInt
+  integration    Integration @relation(fields: [integrationOid], references: [oid], onDelete: Cascade)
+
+  itemOid BigInt    @unique
+  item    SkillItem @relation(fields: [itemOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@unique([skillOid, integrationOid])
+}
+
+enum SkillProviderStatus {
+  active
+  archived
+  deleted
+}
+
+model SkillProvider {
+  oid BigInt @id
+  id  String @unique
+
+  status SkillProviderStatus
+
+  skillOid BigInt
+  skill    Skill  @relation(fields: [skillOid], references: [oid], onDelete: Cascade)
+
+  providerOid BigInt
+  provider    Provider @relation(fields: [providerOid], references: [oid], onDelete: Cascade)
+
+  itemOid BigInt    @unique
+  item    SkillItem @relation(fields: [itemOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@unique([skillOid, providerOid])
+}
+
+model SkillProviderLink {
+  oid BigInt @id
+  id  String @unique
+
+  skillOid BigInt
+  skill    Skill  @relation(fields: [skillOid], references: [oid], onDelete: Cascade)
+
+  providerOid BigInt
+  provider    Provider @relation(fields: [providerOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@unique([skillOid, providerOid])
+}
+
+enum SkillItemType {
+  integration
+  provider
+}
+
+enum SkillItemStatus {
+  active
+  archived
+  deleted
+}
+
+model SkillItem {
+  oid BigInt @id
+  id  String @unique
+
+  status SkillItemStatus
+  type   SkillItemType
+
+  skillOid BigInt
+  skill    Skill  @relation(fields: [skillOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  integration SkillIntegration?
+  provider    SkillProvider?
+}

--- a/src/systems/subspace/db/prisma/schema/solution.prisma
+++ b/src/systems/subspace/db/prisma/schema/solution.prisma
@@ -65,4 +65,6 @@ model Solution {
   integrationInstanceGroups                IntegrationInstanceGroup[]
   integrationInstanceGroupSources          IntegrationInstanceGroupSource[]
   integrationInstanceGroupProviders        IntegrationInstanceGroupProvider[]
+  skillGroups                              SkillGroup[]
+  skills                                   Skill[]
 }

--- a/src/systems/subspace/db/prisma/schema/tenant.prisma
+++ b/src/systems/subspace/db/prisma/schema/tenant.prisma
@@ -97,6 +97,8 @@ model Tenant {
   integrationInstanceGroups                IntegrationInstanceGroup[]
   integrationInstanceGroupSources          IntegrationInstanceGroupSource[]
   integrationInstanceGroupProviders        IntegrationInstanceGroupProvider[]
+  skillGroups                              SkillGroup[]
+  skills                                   Skill[]
 }
 
 enum EnvironmentType {
@@ -167,6 +169,8 @@ model Environment {
   integrationInstanceGroups                IntegrationInstanceGroup[]
   integrationInstanceGroupSources          IntegrationInstanceGroupSource[]
   integrationInstanceGroupProviders        IntegrationInstanceGroupProvider[]
+  skillGroups                              SkillGroup[]
+  skills                                   Skill[]
 }
 
 enum TenantActorType {
@@ -185,6 +189,7 @@ model TenantActor {
   identifier          String
   name                String
   organizationActorId String?
+  consumerId          String?
 
   tenantOid BigInt
   tenant    Tenant @relation(fields: [tenantOid], references: [oid], onDelete: Cascade)

--- a/src/systems/subspace/db/src/id.ts
+++ b/src/systems/subspace/db/src/id.ts
@@ -147,7 +147,15 @@ export let ID = createIdGenerator({
   integrationSetupSession_clientSecret: idType.key('iss_secret'),
   integrationSetupSessionProvider: idType.sorted('isp'),
   integrationSetupSessionStep: idType.sorted('isst'),
-  integrationSetupSessionEvent: idType.sorted('ise')
+  integrationSetupSessionEvent: idType.sorted('ise'),
+
+  skillGroup: idType.sorted('skg'),
+  skill: idType.sorted('skl'),
+  skillFork: idType.sorted('skf'),
+  skillItem: idType.sorted('ski'),
+  skillIntegration: idType.sorted('skn'),
+  skillProvider: idType.sorted('skp'),
+  skillProviderLink: idType.sorted('skpl')
 });
 
 let workerIdBits = 12;

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationProvider.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationProvider.ts
@@ -3,6 +3,7 @@ import { db } from '@metorial-subspace/db';
 import { identityInternalService } from '@metorial-subspace/module-identity';
 import { syncIntegrationInstanceGroupSessionTemplatesQueue } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
 import { syncIntegrationInstanceSessionTemplatesQueue } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate';
+import { reconcileSkillProviderLinksForIntegrationProviderQueue } from '@metorial-subspace/module-skills';
 import { env } from '../../env';
 import { indexIntegrationQueue } from '../search/integration';
 import { indexIntegrationInstanceQueue } from '../search/integrationInstance';
@@ -39,6 +40,9 @@ export let integrationProviderCreatedQueueProcessor = integrationProviderCreated
     if (!integrationProvider) throw new QueueRetryError();
 
     await indexParentIntegration(data.integrationProviderId);
+    await reconcileSkillProviderLinksForIntegrationProviderQueue.add({
+      integrationProviderId: data.integrationProviderId
+    });
 
     await db.integrationInstanceProvider.updateMany({
       where: { integrationProviderOid: integrationProvider.oid },
@@ -55,6 +59,9 @@ export let integrationProviderUpdatedQueue = createQueue<{ integrationProviderId
 export let integrationProviderUpdatedQueueProcessor = integrationProviderUpdatedQueue.process(
   async data => {
     await indexParentIntegration(data.integrationProviderId);
+    await reconcileSkillProviderLinksForIntegrationProviderQueue.add({
+      integrationProviderId: data.integrationProviderId
+    });
   }
 );
 
@@ -78,6 +85,9 @@ export let integrationProviderArchivedQueueProcessor =
       integrationProviderId: data.integrationProviderId
     });
     await indexParentIntegration(data.integrationProviderId);
+    await reconcileSkillProviderLinksForIntegrationProviderQueue.add({
+      integrationProviderId: data.integrationProviderId
+    });
   });
 
 export let integrationProviderArchiveInstanceProvidersManyQueue = createQueue<{

--- a/src/systems/subspace/modules/search/src/index.ts
+++ b/src/systems/subspace/modules/search/src/index.ts
@@ -89,6 +89,12 @@ export let voyagerIndex = {
     name: 'Integrations'
   }),
 
+  skill: await voyager.index.upsert({
+    sourceId: (await voyagerSource).id,
+    identifier: getIndexName('skill'),
+    name: 'Skills'
+  }),
+
   integrationInstance: await voyager.index.upsert({
     sourceId: (await voyagerSource).id,
     identifier: getIndexName('integration_instance'),

--- a/src/systems/subspace/modules/skills/package.json
+++ b/src/systems/subspace/modules/skills/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@metorial-subspace/module-integration",
+  "name": "@metorial-subspace/module-skills",
   "version": "1.0.0",
   "author": "Tobias Herber",
   "license": "FSL-1.1",
@@ -9,8 +9,6 @@
     "lint": "prettier src/**/*.ts --check"
   },
   "dependencies": {
-    "@lowerdeck/cron": "^1.1.1",
-    "@lowerdeck/canonicalize": "^1.0.4",
     "@lowerdeck/env": "^1.0.6",
     "@lowerdeck/error": "^1.2.3",
     "@lowerdeck/id": "^1.0.8",
@@ -18,19 +16,13 @@
     "@lowerdeck/queue": "^1.0.9",
     "@lowerdeck/service": "^1.0.7",
     "@lowerdeck/slugify": "^1.0.6",
-    "@lowerdeck/validation": "^1.0.10",
     "@metorial-subspace/db": "^1.0.0",
     "@metorial-subspace/list-utils": "^1.0.0",
-    "@metorial-subspace/module-auth": "^1.0.0",
     "@metorial-subspace/module-catalog": "^1.0.0",
-    "@metorial-subspace/module-deployment": "^1.0.0",
-    "@metorial-subspace/module-identity": "^1.0.0",
-    "@metorial-subspace/module-session": "^1.0.0",
-    "@metorial-subspace/module-provider-internal": "^1.0.0",
+    "@metorial-subspace/module-integration": "^1.0.0",
     "@metorial-subspace/module-search": "^1.0.0",
-    "@metorial-subspace/module-skills": "^1.0.0",
     "@metorial-subspace/module-tenant": "^1.0.0",
-    "date-fns": "^4.1.0"
+    "@lowerdeck/validation": "^1.0.10"
   },
   "devDependencies": {
     "@metorial-subspace/tsconfig": "^1.0.0",

--- a/src/systems/subspace/modules/skills/src/env.ts
+++ b/src/systems/subspace/modules/skills/src/env.ts
@@ -1,0 +1,8 @@
+import { createValidatedEnv } from '@lowerdeck/env';
+import { v } from '@lowerdeck/validation';
+
+export let env = createValidatedEnv({
+  service: {
+    REDIS_URL: v.string()
+  }
+});

--- a/src/systems/subspace/modules/skills/src/index.ts
+++ b/src/systems/subspace/modules/skills/src/index.ts
@@ -1,0 +1,14 @@
+import { combineQueueProcessors } from '@lowerdeck/queue';
+import { lifecycleQueues } from './queues/lifecycle';
+import { reconcilerQueues } from './queues/reconciler';
+import { searchQueues } from './queues/search';
+
+export * from './queues/reconciler/reconcileSkillProviderLink';
+export * from './queues/search/skill';
+export * from './services';
+
+export let skillsQueueProcessor = combineQueueProcessors([
+  lifecycleQueues,
+  searchQueues,
+  reconcilerQueues
+]);

--- a/src/systems/subspace/modules/skills/src/queues/lifecycle/index.ts
+++ b/src/systems/subspace/modules/skills/src/queues/lifecycle/index.ts
@@ -1,0 +1,15 @@
+import { combineQueueProcessors } from '@lowerdeck/queue';
+import {
+  skillArchivedQueueProcessor,
+  skillCreatedQueueProcessor,
+  skillUpdatedQueueProcessor
+} from './skill';
+import { skillItemArchivedQueueProcessor, skillItemCreatedQueueProcessor } from './skillItem';
+
+export let lifecycleQueues = combineQueueProcessors([
+  skillCreatedQueueProcessor,
+  skillUpdatedQueueProcessor,
+  skillArchivedQueueProcessor,
+  skillItemCreatedQueueProcessor,
+  skillItemArchivedQueueProcessor
+]);

--- a/src/systems/subspace/modules/skills/src/queues/lifecycle/skill.ts
+++ b/src/systems/subspace/modules/skills/src/queues/lifecycle/skill.ts
@@ -1,0 +1,46 @@
+import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { db } from '@metorial-subspace/db';
+import { env } from '../../env';
+import { reconcileSkillProviderLinksQueue } from '../reconciler/reconcileSkillProviderLink';
+
+export let skillCreatedQueue = createQueue<{ skillId: string }>({
+  name: 'sub/sk/lc/skill/created',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let skillCreatedQueueProcessor = skillCreatedQueue.process(async data => {
+  let skill = await db.skill.findUnique({
+    where: { id: data.skillId }
+  });
+  if (!skill) throw new QueueRetryError();
+
+  await reconcileSkillProviderLinksQueue.add({ skillId: skill.id });
+});
+
+export let skillUpdatedQueue = createQueue<{ skillId: string }>({
+  name: 'sub/sk/lc/skill/updated',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let skillUpdatedQueueProcessor = skillUpdatedQueue.process(async data => {
+  let skill = await db.skill.findUnique({
+    where: { id: data.skillId }
+  });
+  if (!skill) throw new QueueRetryError();
+
+  await reconcileSkillProviderLinksQueue.add({ skillId: skill.id });
+});
+
+export let skillArchivedQueue = createQueue<{ skillId: string }>({
+  name: 'sub/sk/lc/skill/archived',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let skillArchivedQueueProcessor = skillArchivedQueue.process(async data => {
+  let skill = await db.skill.findUnique({
+    where: { id: data.skillId }
+  });
+  if (!skill) return;
+
+  await reconcileSkillProviderLinksQueue.add({ skillId: skill.id });
+});

--- a/src/systems/subspace/modules/skills/src/queues/lifecycle/skillItem.ts
+++ b/src/systems/subspace/modules/skills/src/queues/lifecycle/skillItem.ts
@@ -1,0 +1,34 @@
+import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { db } from '@metorial-subspace/db';
+import { env } from '../../env';
+import { reconcileSkillProviderLinksQueue } from '../reconciler/reconcileSkillProviderLink';
+
+export let skillItemCreatedQueue = createQueue<{ skillItemId: string }>({
+  name: 'sub/sk/lc/skillItem/created',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let skillItemCreatedQueueProcessor = skillItemCreatedQueue.process(async data => {
+  let skillItem = await db.skillItem.findUnique({
+    where: { id: data.skillItemId },
+    include: { skill: true }
+  });
+  if (!skillItem) throw new QueueRetryError();
+
+  await reconcileSkillProviderLinksQueue.add({ skillId: skillItem.skill.id });
+});
+
+export let skillItemArchivedQueue = createQueue<{ skillItemId: string }>({
+  name: 'sub/sk/lc/skillItem/archived',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let skillItemArchivedQueueProcessor = skillItemArchivedQueue.process(async data => {
+  let skillItem = await db.skillItem.findUnique({
+    where: { id: data.skillItemId },
+    include: { skill: true }
+  });
+  if (!skillItem) return;
+
+  await reconcileSkillProviderLinksQueue.add({ skillId: skillItem.skill.id });
+});

--- a/src/systems/subspace/modules/skills/src/queues/reconciler/index.ts
+++ b/src/systems/subspace/modules/skills/src/queues/reconciler/index.ts
@@ -1,0 +1,10 @@
+import { combineQueueProcessors } from '@lowerdeck/queue';
+import {
+  reconcileSkillProviderLinksForIntegrationProviderQueueProcessor,
+  reconcileSkillProviderLinksQueueProcessor
+} from './reconcileSkillProviderLink';
+
+export let reconcilerQueues = combineQueueProcessors([
+  reconcileSkillProviderLinksQueueProcessor,
+  reconcileSkillProviderLinksForIntegrationProviderQueueProcessor
+]);

--- a/src/systems/subspace/modules/skills/src/queues/reconciler/reconcileSkillProviderLink.ts
+++ b/src/systems/subspace/modules/skills/src/queues/reconciler/reconcileSkillProviderLink.ts
@@ -1,0 +1,112 @@
+import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { db, getId, withTransaction } from '@metorial-subspace/db';
+import { env } from '../../env';
+import { indexSkillQueue } from '../search/skill';
+
+export let reconcileSkillProviderLinksQueue = createQueue<{ skillId: string }>({
+  name: 'sub/sk/lc/reconcileSkillProviderLinks',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let reconcileSkillProviderLinks = async (d: { skillId: string }) => {
+  let skill = await db.skill.findUnique({
+    where: { id: d.skillId },
+    include: {
+      skillProviders: {
+        where: { status: 'active' as const }
+      },
+      skillIntegrations: {
+        where: { status: 'active' as const },
+        include: {
+          integration: {
+            include: {
+              providers: {
+                where: { status: 'active' as const }
+              }
+            }
+          }
+        }
+      },
+      skillProviderLinks: true
+    }
+  });
+  if (!skill) throw new QueueRetryError();
+
+  let desiredProviderOids = new Set<bigint>(
+    skill.skillProviders.map(provider => provider.providerOid)
+  );
+
+  for (let skillIntegration of skill.skillIntegrations) {
+    for (let integrationProvider of skillIntegration.integration.providers) {
+      desiredProviderOids.add(integrationProvider.providerOid);
+    }
+  }
+
+  let existingProviderOids = new Set(skill.skillProviderLinks.map(link => link.providerOid));
+  let providerOidsToCreate = Array.from(desiredProviderOids).filter(
+    providerOid => !existingProviderOids.has(providerOid)
+  );
+  let linkOidsToDelete = skill.skillProviderLinks
+    .filter(link => !desiredProviderOids.has(link.providerOid) || skill.status !== 'active')
+    .map(link => link.oid);
+
+  await withTransaction(async db => {
+    if (linkOidsToDelete.length) {
+      await db.skillProviderLink.deleteMany({
+        where: {
+          oid: { in: linkOidsToDelete }
+        }
+      });
+    }
+
+    for (let providerOid of skill.status === 'active' ? providerOidsToCreate : []) {
+      await db.skillProviderLink.create({
+        data: {
+          ...getId('skillProviderLink'),
+          skillOid: skill.oid,
+          providerOid
+        }
+      });
+    }
+  });
+
+  await indexSkillQueue.add({ skillId: d.skillId });
+};
+
+export let reconcileSkillProviderLinksQueueProcessor =
+  reconcileSkillProviderLinksQueue.process(async data => {
+    await reconcileSkillProviderLinks(data);
+  });
+
+export let reconcileSkillProviderLinksForIntegrationProviderQueue = createQueue<{
+  integrationProviderId: string;
+}>({
+  name: 'sub/sk/lc/reconcileSkillProviderLinksForIntegrationProvider',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let reconcileSkillProviderLinksForIntegrationProviderQueueProcessor =
+  reconcileSkillProviderLinksForIntegrationProviderQueue.process(async data => {
+    let integrationProvider = await db.integrationProvider.findUnique({
+      where: { id: data.integrationProviderId }
+    });
+    if (!integrationProvider) throw new QueueRetryError();
+
+    let skills = await db.skill.findMany({
+      where: {
+        status: 'active' as const,
+        skillIntegrations: {
+          some: {
+            status: 'active' as const,
+            integrationOid: integrationProvider.integrationOid
+          }
+        }
+      },
+      select: { id: true }
+    });
+    if (!skills.length) return;
+
+    await reconcileSkillProviderLinksQueue.addMany(
+      skills.map(skill => ({ skillId: skill.id }))
+    );
+  });

--- a/src/systems/subspace/modules/skills/src/queues/search/index.ts
+++ b/src/systems/subspace/modules/skills/src/queues/search/index.ts
@@ -1,0 +1,4 @@
+import { combineQueueProcessors } from '@lowerdeck/queue';
+import { indexSkillQueueProcessor } from './skill';
+
+export let searchQueues = combineQueueProcessors([indexSkillQueueProcessor]);

--- a/src/systems/subspace/modules/skills/src/queues/search/skill.ts
+++ b/src/systems/subspace/modules/skills/src/queues/search/skill.ts
@@ -1,0 +1,63 @@
+import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { db } from '@metorial-subspace/db';
+import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
+import { env } from '../../env';
+
+export let indexSkillQueue = createQueue<{ skillId: string }>({
+  name: 'sub/sk/sidx/skill',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let indexSkillRecord = async (d: { skillId: string }) => {
+  let skill = await db.skill.findUnique({
+    where: { id: d.skillId },
+    include: {
+      tenant: true,
+      skillGroup: true,
+      skillIntegrations: {
+        where: { status: 'active' },
+        include: {
+          integration: true
+        }
+      },
+      skillProviderLinks: {
+        include: {
+          provider: true
+        }
+      }
+    }
+  });
+  if (!skill) throw new QueueRetryError();
+
+  if (skill.status !== 'active' || (!skill.name && !skill.description)) {
+    await voyager.record.delete({
+      sourceId: (await voyagerSource).id,
+      indexId: voyagerIndex.skill.id,
+      documentIds: [skill.id]
+    });
+    return;
+  }
+
+  await voyager.record.index({
+    sourceId: (await voyagerSource).id,
+    indexId: voyagerIndex.skill.id,
+    documentId: skill.id,
+    tenantIds: [skill.tenant.id],
+    fields: {
+      skillId: skill.id,
+      skillGroupId: skill.skillGroup.id,
+      integrationIds: skill.skillIntegrations.map(item => item.integration.id),
+      providerIds: skill.skillProviderLinks.map(link => link.provider.id)
+    },
+    body: {
+      name: skill.name,
+      description: skill.description,
+      integrationNames: skill.skillIntegrations.map(item => item.integration.name),
+      providerNames: skill.skillProviderLinks.map(link => link.provider.name)
+    }
+  });
+};
+
+export let indexSkillQueueProcessor = indexSkillQueue.process(async data => {
+  await indexSkillRecord(data);
+});

--- a/src/systems/subspace/modules/skills/src/services/index.ts
+++ b/src/systems/subspace/modules/skills/src/services/index.ts
@@ -1,0 +1,2 @@
+export * from './skill';
+export * from './skillItem';

--- a/src/systems/subspace/modules/skills/src/services/skill.ts
+++ b/src/systems/subspace/modules/skills/src/services/skill.ts
@@ -9,7 +9,6 @@ import {
   type Environment,
   getId,
   type Skill,
-  type SkillGroup,
   type SkillStatus,
   type Solution,
   type Tenant,
@@ -59,8 +58,6 @@ let getSlug = (input: { name: string }) =>
   `${slugify(input.name)}-${generatePlainId(7).toLowerCase()}`.toLowerCase();
 
 type SkillWriteInput = {
-  skillGroupId?: string;
-  parentSkillId?: string | null;
   name?: string;
   description?: string | null;
   metadata?: Record<string, any> | null;
@@ -68,25 +65,6 @@ type SkillWriteInput = {
 };
 
 class skillServiceImpl {
-  private async resolveSkillGroup(d: {
-    tenant: Tenant;
-    solution: Solution;
-    environment: Environment;
-    skillGroupId: string;
-  }) {
-    let skillGroup = await db.skillGroup.findFirst({
-      where: {
-        id: d.skillGroupId,
-        tenantOid: d.tenant.oid,
-        solutionOid: d.solution.oid,
-        environmentOid: d.environment.oid
-      }
-    });
-    if (!skillGroup) throw new ServiceError(notFoundError('skillGroup', d.skillGroupId));
-
-    return skillGroup;
-  }
-
   private async resolveParentSkill(d: {
     tenant: Tenant;
     solution: Solution;
@@ -100,7 +78,8 @@ class skillServiceImpl {
         solutionOid: d.solution.oid,
         environmentOid: d.environment.oid,
         ...normalizeStatusForGet({ allowDeleted: false }).noParent
-      }
+      },
+      include: { skillGroup: true }
     });
     if (!parentSkill) throw new ServiceError(notFoundError('skill', d.parentSkillId));
 
@@ -113,7 +92,6 @@ class skillServiceImpl {
     tenant: Tenant;
     solution: Solution;
     environment: Environment;
-    skillGroup: SkillGroup;
     parentSkill: Skill | null;
     input: Required<Pick<SkillWriteInput, 'name'>> &
       Omit<SkillWriteInput, 'name' | 'skillGroupId' | 'parentSkillId'>;
@@ -126,7 +104,6 @@ class skillServiceImpl {
       description: d.input.description?.trim() || null,
       metadata: d.input.metadata,
       privateMetadata: d.input.privateMetadata,
-      skillGroupOid: d.skillGroup.oid,
       parentSkillOid: d.parentSkill?.oid ?? null,
       tenantOid: d.tenant.oid,
       solutionOid: d.solution.oid,
@@ -134,12 +111,7 @@ class skillServiceImpl {
     };
   }
 
-  private skillUpdateData(d: {
-    current: Skill;
-    skillGroup: SkillGroup;
-    parentSkill: Skill | null;
-    input: SkillWriteInput;
-  }) {
+  private skillUpdateData(d: { current: Skill; input: SkillWriteInput }) {
     return {
       status: 'active' as const,
       name: d.input.name?.trim() || d.current.name,
@@ -151,10 +123,7 @@ class skillServiceImpl {
       privateMetadata:
         d.input.privateMetadata === undefined
           ? d.current.privateMetadata
-          : d.input.privateMetadata,
-      skillGroupOid: d.skillGroup.oid,
-      parentSkillOid:
-        d.input.parentSkillId === undefined ? d.current.parentSkillOid : d.parentSkill?.oid ?? null
+          : d.input.privateMetadata
     };
   }
 
@@ -198,7 +167,9 @@ class skillServiceImpl {
               AND: [
                 d.ids ? { id: { in: d.ids } } : undefined!,
                 d.skillGroupIds ? { skillGroup: { id: { in: d.skillGroupIds } } } : undefined!,
-                d.parentSkillIds ? { parentSkill: { id: { in: d.parentSkillIds } } } : undefined!,
+                d.parentSkillIds
+                  ? { parentSkill: { id: { in: d.parentSkillIds } } }
+                  : undefined!,
                 d.integrationIds
                   ? {
                       skillIntegrations: {
@@ -254,13 +225,12 @@ class skillServiceImpl {
     solution: Solution;
     environment: Environment;
     input: {
-      skillGroupId: string;
-      parentSkillId?: string | null;
       name: string;
       description?: string | null;
       metadata?: Record<string, any> | null;
       privateMetadata?: Record<string, any> | null;
     };
+    _parentSkillId?: string | null;
   }) {
     let name = d.input.name.trim();
     if (!name.length) {
@@ -272,40 +242,60 @@ class skillServiceImpl {
       );
     }
 
-    let [skillGroup, parentSkill] = await Promise.all([
-      this.resolveSkillGroup({
-        tenant: d.tenant,
-        solution: d.solution,
-        environment: d.environment,
-        skillGroupId: d.input.skillGroupId
-      }),
-      d.input.parentSkillId
-        ? this.resolveParentSkill({
-            tenant: d.tenant,
-            solution: d.solution,
-            environment: d.environment,
-            parentSkillId: d.input.parentSkillId
-          })
-        : null
-    ]);
-
-    return await withTransaction(async db => {
-      let skill = await db.skill.create({
-        data: this.skillCreateData({
+    let parentSkill = d._parentSkillId
+      ? await this.resolveParentSkill({
           tenant: d.tenant,
           solution: d.solution,
           environment: d.environment,
-          skillGroup,
-          parentSkill,
-          input: {
-            name,
-            description: d.input.description,
-            metadata: d.input.metadata,
-            privateMetadata: d.input.privateMetadata
+          parentSkillId: d._parentSkillId
+        })
+      : null;
+
+    return await withTransaction(async db => {
+      let skillData = this.skillCreateData({
+        tenant: d.tenant,
+        solution: d.solution,
+        environment: d.environment,
+        parentSkill,
+        input: {
+          name,
+          description: d.input.description,
+          metadata: d.input.metadata,
+          privateMetadata: d.input.privateMetadata
+        }
+      });
+
+      let skillGroup = parentSkill?.skillGroup;
+      let isNewSkillGroup = !skillGroup;
+
+      if (!skillGroup) {
+        skillGroup = await db.skillGroup.create({
+          data: {
+            ...getId('skillGroup'),
+            tenantOid: d.tenant.oid,
+            solutionOid: d.solution.oid,
+            environmentOid: d.environment.oid,
+            name: skillData.name,
+            description: skillData.description,
+            slug: skillData.slug
           }
-        }),
+        });
+      }
+
+      let skill = await db.skill.create({
+        data: {
+          ...skillData,
+          skillGroupOid: skillGroup.oid
+        },
         include: skillInclude
       });
+
+      if (!isNewSkillGroup) {
+        skillGroup = await db.skillGroup.update({
+          where: { oid: skillGroup.oid },
+          data: { ownerSkillOid: skill.oid }
+        });
+      }
 
       await addAfterTransactionHook(async () => skillCreatedQueue.add({ skillId: skill.id }));
 
@@ -319,7 +309,6 @@ class skillServiceImpl {
     environment: Environment;
     skill: Skill;
     input: {
-      skillGroupId?: string;
       name: string;
       description?: string | null;
       metadata?: Record<string, any> | null;
@@ -329,52 +318,17 @@ class skillServiceImpl {
     checkTenant(d, d.skill);
     checkDeletedRelation(d.skill);
 
-    let skillGroup = d.input.skillGroupId
-      ? await this.resolveSkillGroup({
-          tenant: d.tenant,
-          solution: d.solution,
-          environment: d.environment,
-          skillGroupId: d.input.skillGroupId
-        })
-      : await db.skillGroup.findUniqueOrThrow({
-          where: { oid: d.skill.skillGroupOid }
-        });
-
-    let createdSkill = await this.createSkill({
+    return await this.createSkill({
       tenant: d.tenant,
       solution: d.solution,
       environment: d.environment,
       input: {
-        skillGroupId: skillGroup.id,
-        parentSkillId: d.skill.id,
         name: d.input.name,
         description: d.input.description,
         metadata: d.input.metadata,
         privateMetadata: d.input.privateMetadata
-      }
-    });
-
-    await withTransaction(async db => {
-      let existingFork = await db.skillFork.findFirst({
-        where: {
-          parentSkillOid: d.skill.oid,
-          childSkillOid: createdSkill.oid
-        }
-      });
-      if (existingFork) return;
-
-      await db.skillFork.create({
-        data: {
-          ...getId('skillFork'),
-          parentSkillOid: d.skill.oid,
-          childSkillOid: createdSkill.oid
-        }
-      });
-    });
-
-    return await db.skill.findUniqueOrThrow({
-      where: { oid: createdSkill.oid },
-      include: skillInclude
+      },
+      _parentSkillId: d.skill.id
     });
   }
 
@@ -392,40 +346,6 @@ class skillServiceImpl {
       where: { oid: d.skill.oid }
     });
 
-    let [skillGroup, parentSkill] = await Promise.all([
-      d.input.skillGroupId
-        ? this.resolveSkillGroup({
-            tenant: d.tenant,
-            solution: d.solution,
-            environment: d.environment,
-            skillGroupId: d.input.skillGroupId
-          })
-        : db.skillGroup.findUniqueOrThrow({
-            where: { oid: current.skillGroupOid }
-          }),
-      d.input.parentSkillId
-        ? this.resolveParentSkill({
-            tenant: d.tenant,
-            solution: d.solution,
-            environment: d.environment,
-            parentSkillId: d.input.parentSkillId
-          })
-        : d.input.parentSkillId === null
-          ? null
-          : current.parentSkillOid
-            ? await db.skill.findUnique({ where: { oid: current.parentSkillOid } })
-            : null
-    ]);
-
-    if (parentSkill?.oid === current.oid) {
-      throw new ServiceError(
-        badRequestError({
-          message: 'Skill cannot be its own parent.',
-          code: 'skill_parent_self'
-        })
-      );
-    }
-
     return await withTransaction(async db => {
       let skill = await db.skill.update({
         where: {
@@ -436,12 +356,21 @@ class skillServiceImpl {
         },
         data: this.skillUpdateData({
           current,
-          skillGroup,
-          parentSkill,
           input: d.input
         }),
         include: skillInclude
       });
+
+      if (skill.skillGroup.ownerSkillOid === skill.oid) {
+        await db.skillGroup.update({
+          where: { oid: skill.skillGroup.oid },
+          data: {
+            name: skill.name,
+            description: skill.description,
+            slug: skill.slug
+          }
+        });
+      }
 
       await addAfterTransactionHook(async () => skillUpdatedQueue.add({ skillId: skill.id }));
 

--- a/src/systems/subspace/modules/skills/src/services/skill.ts
+++ b/src/systems/subspace/modules/skills/src/services/skill.ts
@@ -1,0 +1,510 @@
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { generatePlainId } from '@lowerdeck/id';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import { slugify } from '@lowerdeck/slugify';
+import {
+  addAfterTransactionHook,
+  db,
+  type Environment,
+  getId,
+  type Skill,
+  type SkillGroup,
+  type SkillStatus,
+  type Solution,
+  type Tenant,
+  withTransaction
+} from '@metorial-subspace/db';
+import {
+  checkDeletedEdit,
+  checkDeletedRelation,
+  type DateFilter,
+  normalizeDateFilter,
+  normalizeStatusForGet,
+  normalizeStatusForList
+} from '@metorial-subspace/list-utils';
+import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
+import { checkTenant } from '@metorial-subspace/module-tenant';
+import {
+  skillArchivedQueue,
+  skillCreatedQueue,
+  skillUpdatedQueue
+} from '../queues/lifecycle/skill';
+
+export let skillInclude = {
+  skillGroup: true,
+  parentSkill: true,
+  forkedFrom: {
+    include: {
+      parentSkill: true
+    }
+  },
+  childSkills: {
+    where: { status: 'active' as const }
+  },
+  skillIntegrations: {
+    where: { status: 'active' as const },
+    include: { integration: true }
+  },
+  skillProviderLinks: {
+    include: {
+      provider: {
+        include: { listing: true }
+      }
+    }
+  }
+};
+
+let getSlug = (input: { name: string }) =>
+  `${slugify(input.name)}-${generatePlainId(7).toLowerCase()}`.toLowerCase();
+
+type SkillWriteInput = {
+  skillGroupId?: string;
+  parentSkillId?: string | null;
+  name?: string;
+  description?: string | null;
+  metadata?: Record<string, any> | null;
+  privateMetadata?: Record<string, any> | null;
+};
+
+class skillServiceImpl {
+  private async resolveSkillGroup(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    skillGroupId: string;
+  }) {
+    let skillGroup = await db.skillGroup.findFirst({
+      where: {
+        id: d.skillGroupId,
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid
+      }
+    });
+    if (!skillGroup) throw new ServiceError(notFoundError('skillGroup', d.skillGroupId));
+
+    return skillGroup;
+  }
+
+  private async resolveParentSkill(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    parentSkillId: string;
+  }) {
+    let parentSkill = await db.skill.findFirst({
+      where: {
+        id: d.parentSkillId,
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid,
+        ...normalizeStatusForGet({ allowDeleted: false }).noParent
+      }
+    });
+    if (!parentSkill) throw new ServiceError(notFoundError('skill', d.parentSkillId));
+
+    checkDeletedRelation(parentSkill);
+
+    return parentSkill;
+  }
+
+  private skillCreateData(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    skillGroup: SkillGroup;
+    parentSkill: Skill | null;
+    input: Required<Pick<SkillWriteInput, 'name'>> &
+      Omit<SkillWriteInput, 'name' | 'skillGroupId' | 'parentSkillId'>;
+  }) {
+    return {
+      ...getId('skill'),
+      status: 'active' as const,
+      slug: getSlug({ name: d.input.name }),
+      name: d.input.name.trim(),
+      description: d.input.description?.trim() || null,
+      metadata: d.input.metadata,
+      privateMetadata: d.input.privateMetadata,
+      skillGroupOid: d.skillGroup.oid,
+      parentSkillOid: d.parentSkill?.oid ?? null,
+      tenantOid: d.tenant.oid,
+      solutionOid: d.solution.oid,
+      environmentOid: d.environment.oid
+    };
+  }
+
+  private skillUpdateData(d: {
+    current: Skill;
+    skillGroup: SkillGroup;
+    parentSkill: Skill | null;
+    input: SkillWriteInput;
+  }) {
+    return {
+      status: 'active' as const,
+      name: d.input.name?.trim() || d.current.name,
+      description:
+        d.input.description === undefined
+          ? d.current.description
+          : d.input.description?.trim() || null,
+      metadata: d.input.metadata === undefined ? d.current.metadata : d.input.metadata,
+      privateMetadata:
+        d.input.privateMetadata === undefined
+          ? d.current.privateMetadata
+          : d.input.privateMetadata,
+      skillGroupOid: d.skillGroup.oid,
+      parentSkillOid:
+        d.input.parentSkillId === undefined ? d.current.parentSkillOid : d.parentSkill?.oid ?? null
+    };
+  }
+
+  async listSkills(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    search?: string;
+    status?: SkillStatus[];
+    allowDeleted?: boolean;
+    ids?: string[];
+    skillGroupIds?: string[];
+    parentSkillIds?: string[];
+    integrationIds?: string[];
+    providerIds?: string[];
+    createdAt?: DateFilter;
+    updatedAt?: DateFilter;
+  }) {
+    d.search = d.search?.trim();
+    if (!d.search?.length) d.search = undefined;
+
+    let search = d.search
+      ? await voyager.record.search({
+          tenantId: d.tenant.id,
+          sourceId: (await voyagerSource).id,
+          indexId: voyagerIndex.skill.id,
+          query: d.search
+        })
+      : null;
+
+    return Paginator.create(({ prisma }) =>
+      prisma(
+        async opts =>
+          await db.skill.findMany({
+            ...opts,
+            where: {
+              tenantOid: d.tenant.oid,
+              solutionOid: d.solution.oid,
+              environmentOid: d.environment.oid,
+              ...normalizeStatusForList(d).noParent,
+              AND: [
+                d.ids ? { id: { in: d.ids } } : undefined!,
+                d.skillGroupIds ? { skillGroup: { id: { in: d.skillGroupIds } } } : undefined!,
+                d.parentSkillIds ? { parentSkill: { id: { in: d.parentSkillIds } } } : undefined!,
+                d.integrationIds
+                  ? {
+                      skillIntegrations: {
+                        some: {
+                          status: 'active' as const,
+                          integration: { id: { in: d.integrationIds } }
+                        }
+                      }
+                    }
+                  : undefined!,
+                d.providerIds
+                  ? {
+                      skillProviderLinks: {
+                        some: { provider: { id: { in: d.providerIds } } }
+                      }
+                    }
+                  : undefined!,
+                search ? { id: { in: search.map(r => r.documentId) } } : undefined!,
+                d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+                d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
+              ].filter(Boolean)
+            },
+            include: skillInclude
+          })
+      )
+    );
+  }
+
+  async getSkillById(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    skillId: string;
+    allowDeleted?: boolean;
+  }) {
+    let skill = await db.skill.findFirst({
+      where: {
+        id: d.skillId,
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid,
+        ...normalizeStatusForGet(d).noParent
+      },
+      include: skillInclude
+    });
+    if (!skill) throw new ServiceError(notFoundError('skill', d.skillId));
+
+    return skill;
+  }
+
+  async createSkill(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    input: {
+      skillGroupId: string;
+      parentSkillId?: string | null;
+      name: string;
+      description?: string | null;
+      metadata?: Record<string, any> | null;
+      privateMetadata?: Record<string, any> | null;
+    };
+  }) {
+    let name = d.input.name.trim();
+    if (!name.length) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Skill name is required.',
+          code: 'skill_name_required'
+        })
+      );
+    }
+
+    let [skillGroup, parentSkill] = await Promise.all([
+      this.resolveSkillGroup({
+        tenant: d.tenant,
+        solution: d.solution,
+        environment: d.environment,
+        skillGroupId: d.input.skillGroupId
+      }),
+      d.input.parentSkillId
+        ? this.resolveParentSkill({
+            tenant: d.tenant,
+            solution: d.solution,
+            environment: d.environment,
+            parentSkillId: d.input.parentSkillId
+          })
+        : null
+    ]);
+
+    return await withTransaction(async db => {
+      let skill = await db.skill.create({
+        data: this.skillCreateData({
+          tenant: d.tenant,
+          solution: d.solution,
+          environment: d.environment,
+          skillGroup,
+          parentSkill,
+          input: {
+            name,
+            description: d.input.description,
+            metadata: d.input.metadata,
+            privateMetadata: d.input.privateMetadata
+          }
+        }),
+        include: skillInclude
+      });
+
+      await addAfterTransactionHook(async () => skillCreatedQueue.add({ skillId: skill.id }));
+
+      return skill;
+    });
+  }
+
+  async forkSkill(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    skill: Skill;
+    input: {
+      skillGroupId?: string;
+      name: string;
+      description?: string | null;
+      metadata?: Record<string, any> | null;
+      privateMetadata?: Record<string, any> | null;
+    };
+  }) {
+    checkTenant(d, d.skill);
+    checkDeletedRelation(d.skill);
+
+    let skillGroup = d.input.skillGroupId
+      ? await this.resolveSkillGroup({
+          tenant: d.tenant,
+          solution: d.solution,
+          environment: d.environment,
+          skillGroupId: d.input.skillGroupId
+        })
+      : await db.skillGroup.findUniqueOrThrow({
+          where: { oid: d.skill.skillGroupOid }
+        });
+
+    let createdSkill = await this.createSkill({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      input: {
+        skillGroupId: skillGroup.id,
+        parentSkillId: d.skill.id,
+        name: d.input.name,
+        description: d.input.description,
+        metadata: d.input.metadata,
+        privateMetadata: d.input.privateMetadata
+      }
+    });
+
+    await withTransaction(async db => {
+      let existingFork = await db.skillFork.findFirst({
+        where: {
+          parentSkillOid: d.skill.oid,
+          childSkillOid: createdSkill.oid
+        }
+      });
+      if (existingFork) return;
+
+      await db.skillFork.create({
+        data: {
+          ...getId('skillFork'),
+          parentSkillOid: d.skill.oid,
+          childSkillOid: createdSkill.oid
+        }
+      });
+    });
+
+    return await db.skill.findUniqueOrThrow({
+      where: { oid: createdSkill.oid },
+      include: skillInclude
+    });
+  }
+
+  async updateSkill(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    skill: Skill;
+    input: SkillWriteInput;
+  }) {
+    checkTenant(d, d.skill);
+    checkDeletedEdit(d.skill, 'update');
+
+    let current = await db.skill.findUniqueOrThrow({
+      where: { oid: d.skill.oid }
+    });
+
+    let [skillGroup, parentSkill] = await Promise.all([
+      d.input.skillGroupId
+        ? this.resolveSkillGroup({
+            tenant: d.tenant,
+            solution: d.solution,
+            environment: d.environment,
+            skillGroupId: d.input.skillGroupId
+          })
+        : db.skillGroup.findUniqueOrThrow({
+            where: { oid: current.skillGroupOid }
+          }),
+      d.input.parentSkillId
+        ? this.resolveParentSkill({
+            tenant: d.tenant,
+            solution: d.solution,
+            environment: d.environment,
+            parentSkillId: d.input.parentSkillId
+          })
+        : d.input.parentSkillId === null
+          ? null
+          : current.parentSkillOid
+            ? await db.skill.findUnique({ where: { oid: current.parentSkillOid } })
+            : null
+    ]);
+
+    if (parentSkill?.oid === current.oid) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Skill cannot be its own parent.',
+          code: 'skill_parent_self'
+        })
+      );
+    }
+
+    return await withTransaction(async db => {
+      let skill = await db.skill.update({
+        where: {
+          oid: d.skill.oid,
+          tenantOid: d.tenant.oid,
+          solutionOid: d.solution.oid,
+          environmentOid: d.environment.oid
+        },
+        data: this.skillUpdateData({
+          current,
+          skillGroup,
+          parentSkill,
+          input: d.input
+        }),
+        include: skillInclude
+      });
+
+      await addAfterTransactionHook(async () => skillUpdatedQueue.add({ skillId: skill.id }));
+
+      return skill;
+    });
+  }
+
+  async archiveSkill(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    skill: Skill;
+  }) {
+    checkTenant(d, d.skill);
+    checkDeletedEdit(d.skill, 'archive');
+
+    return await withTransaction(async db => {
+      let skill = await db.skill.update({
+        where: {
+          oid: d.skill.oid,
+          tenantOid: d.tenant.oid,
+          solutionOid: d.solution.oid,
+          environmentOid: d.environment.oid
+        },
+        data: { status: 'archived' },
+        include: skillInclude
+      });
+
+      await Promise.all([
+        db.skillItem.updateMany({
+          where: { skillOid: skill.oid, status: 'active' },
+          data: { status: 'archived' }
+        }),
+        db.skillIntegration.updateMany({
+          where: { skillOid: skill.oid, status: 'active' },
+          data: { status: 'archived' }
+        }),
+        db.skillProvider.updateMany({
+          where: { skillOid: skill.oid, status: 'active' },
+          data: { status: 'archived' }
+        }),
+        db.skillProviderLink.deleteMany({
+          where: { skillOid: skill.oid }
+        })
+      ]);
+
+      await addAfterTransactionHook(async () => skillArchivedQueue.add({ skillId: skill.id }));
+
+      return skill;
+    });
+  }
+
+  async getActiveSkillById(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    skillId: string;
+  }) {
+    let skill = await this.getSkillById({ ...d, allowDeleted: false });
+    checkDeletedRelation(skill);
+
+    return skill;
+  }
+}
+
+export let skillService = Service.create('skillService', () => new skillServiceImpl()).build();

--- a/src/systems/subspace/modules/skills/src/services/skillItem.ts
+++ b/src/systems/subspace/modules/skills/src/services/skillItem.ts
@@ -1,0 +1,369 @@
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import {
+  addAfterTransactionHook,
+  db,
+  type Environment,
+  getId,
+  type SkillItem,
+  type SkillItemStatus,
+  type SkillItemType,
+  type Solution,
+  type Tenant,
+  withTransaction
+} from '@metorial-subspace/db';
+import {
+  checkDeletedEdit,
+  checkDeletedRelation,
+  type DateFilter,
+  normalizeDateFilter,
+  normalizeStatusForGet,
+  normalizeStatusForList
+} from '@metorial-subspace/list-utils';
+import { providerService } from '@metorial-subspace/module-catalog';
+import { integrationService } from '@metorial-subspace/module-integration';
+import { skillItemArchivedQueue, skillItemCreatedQueue } from '../queues/lifecycle/skillItem';
+import { skillService } from './skill';
+
+export let skillItemInclude = {
+  skill: true,
+  integration: {
+    include: {
+      integration: true
+    }
+  },
+  provider: {
+    include: {
+      provider: {
+        include: { listing: true }
+      }
+    }
+  }
+};
+
+let getParentSkillStatusFilter = (allowDeleted?: boolean) =>
+  allowDeleted ? undefined : { notIn: ['deleted' as const, 'archived' as const] };
+
+class skillItemServiceImpl {
+  async listSkillItems(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    status?: SkillItemStatus[];
+    allowDeleted?: boolean;
+    ids?: string[];
+    skillIds?: string[];
+    type?: SkillItemType[];
+    integrationIds?: string[];
+    providerIds?: string[];
+    createdAt?: DateFilter;
+  }) {
+    return Paginator.create(({ prisma }) =>
+      prisma(
+        async opts =>
+          await db.skillItem.findMany({
+            ...opts,
+            where: {
+              ...normalizeStatusForList(d).noParent,
+              skill: {
+                tenantOid: d.tenant.oid,
+                solutionOid: d.solution.oid,
+                environmentOid: d.environment.oid,
+                status: getParentSkillStatusFilter(d.allowDeleted)
+              },
+              AND: [
+                d.ids ? { id: { in: d.ids } } : undefined!,
+                d.skillIds ? { skill: { id: { in: d.skillIds } } } : undefined!,
+                d.type?.length ? { type: { in: d.type } } : undefined!,
+                d.integrationIds
+                  ? {
+                      integration: {
+                        is: {
+                          integration: { id: { in: d.integrationIds } }
+                        }
+                      }
+                    }
+                  : undefined!,
+                d.providerIds
+                  ? {
+                      provider: {
+                        is: {
+                          provider: { id: { in: d.providerIds } }
+                        }
+                      }
+                    }
+                  : undefined!,
+                d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!
+              ].filter(Boolean)
+            },
+            include: skillItemInclude
+          })
+      )
+    );
+  }
+
+  async getSkillItemById(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    skillItemId: string;
+    allowDeleted?: boolean;
+  }) {
+    let skillItem = await db.skillItem.findFirst({
+      where: {
+        id: d.skillItemId,
+        ...normalizeStatusForGet(d).noParent,
+        skill: {
+          tenantOid: d.tenant.oid,
+          solutionOid: d.solution.oid,
+          environmentOid: d.environment.oid,
+          status: getParentSkillStatusFilter(d.allowDeleted)
+        }
+      },
+      include: skillItemInclude
+    });
+    if (!skillItem) throw new ServiceError(notFoundError('skillItem', d.skillItemId));
+
+    return skillItem;
+  }
+
+  async createSkillItem(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    input:
+      | {
+          skillId: string;
+          type: 'integration';
+          integrationId: string;
+        }
+      | {
+          skillId: string;
+          type: 'provider';
+          providerId: string;
+        };
+  }) {
+    let skill = await skillService.getActiveSkillById({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      skillId: d.input.skillId
+    });
+
+    if (d.input.type === 'integration') {
+      let integration = await integrationService.getIntegrationById({
+        tenant: d.tenant,
+        solution: d.solution,
+        environment: d.environment,
+        integrationId: d.input.integrationId,
+        allowDeleted: false
+      });
+
+      checkDeletedRelation(integration);
+
+      let existing = await db.skillIntegration.findFirst({
+        where: {
+          skillOid: skill.oid,
+          integrationOid: integration.oid
+        },
+        include: {
+          item: {
+            include: skillItemInclude
+          }
+        }
+      });
+
+      if (existing?.status === 'active' && existing.item.status === 'active') {
+        throw new ServiceError(
+          badRequestError({
+            message: 'Integration already exists on skill.',
+            code: 'skill_item_exists'
+          })
+        );
+      }
+
+      return await withTransaction(async db => {
+        let itemId = existing?.item.id;
+
+        if (existing) {
+          await db.skillItem.update({
+            where: { oid: existing.itemOid },
+            data: { status: 'active' }
+          });
+
+          await db.skillIntegration.update({
+            where: { oid: existing.oid },
+            data: { status: 'active' }
+          });
+        } else {
+          let item = await db.skillItem.create({
+            data: {
+              ...getId('skillItem'),
+              status: 'active',
+              type: 'integration',
+              skillOid: skill.oid
+            }
+          });
+
+          itemId = item.id;
+
+          await db.skillIntegration.create({
+            data: {
+              ...getId('skillIntegration'),
+              status: 'active',
+              skillOid: skill.oid,
+              integrationOid: integration.oid,
+              itemOid: item.oid
+            }
+          });
+        }
+
+        let skillItem = await db.skillItem.findFirstOrThrow({
+          where: { id: itemId! },
+          include: skillItemInclude
+        });
+
+        await addAfterTransactionHook(async () =>
+          skillItemCreatedQueue.add({ skillItemId: skillItem.id })
+        );
+
+        return skillItem;
+      });
+    }
+
+    let provider = await providerService.getProviderById({
+      solution: d.solution,
+      tenant: d.tenant,
+      environment: d.environment,
+      providerId: d.input.providerId,
+      includeDeprecated: true
+    });
+
+    checkDeletedRelation(provider);
+
+    let existing = await db.skillProvider.findFirst({
+      where: {
+        skillOid: skill.oid,
+        providerOid: provider.oid
+      },
+      include: {
+        item: {
+          include: skillItemInclude
+        }
+      }
+    });
+
+    if (existing?.status === 'active' && existing.item.status === 'active') {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Provider already exists on skill.',
+          code: 'skill_item_exists'
+        })
+      );
+    }
+
+    return await withTransaction(async db => {
+      let itemId = existing?.item.id;
+
+      if (existing) {
+        await db.skillItem.update({
+          where: { oid: existing.itemOid },
+          data: { status: 'active' }
+        });
+
+        await db.skillProvider.update({
+          where: { oid: existing.oid },
+          data: { status: 'active' }
+        });
+      } else {
+        let item = await db.skillItem.create({
+          data: {
+            ...getId('skillItem'),
+            status: 'active',
+            type: 'provider',
+            skillOid: skill.oid
+          }
+        });
+
+        itemId = item.id;
+
+        await db.skillProvider.create({
+          data: {
+            ...getId('skillProvider'),
+            status: 'active',
+            skillOid: skill.oid,
+            providerOid: provider.oid,
+            itemOid: item.oid
+          }
+        });
+      }
+
+      let skillItem = await db.skillItem.findFirstOrThrow({
+        where: { id: itemId! },
+        include: skillItemInclude
+      });
+
+      await addAfterTransactionHook(async () =>
+        skillItemCreatedQueue.add({ skillItemId: skillItem.id })
+      );
+
+      return skillItem;
+    });
+  }
+
+  async archiveSkillItem(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    skillItem: SkillItem;
+  }) {
+    checkDeletedEdit(d.skillItem, 'archive');
+
+    let current = await db.skillItem.findFirst({
+      where: {
+        oid: d.skillItem.oid,
+        skill: {
+          tenantOid: d.tenant.oid,
+          solutionOid: d.solution.oid,
+          environmentOid: d.environment.oid
+        }
+      },
+      include: skillItemInclude
+    });
+    if (!current) throw new ServiceError(notFoundError('skillItem', d.skillItem.id));
+
+    return await withTransaction(async db => {
+      let skillItem = await db.skillItem.update({
+        where: { oid: current.oid },
+        data: { status: 'archived' },
+        include: skillItemInclude
+      });
+
+      if (current.integration) {
+        await db.skillIntegration.update({
+          where: { oid: current.integration.oid },
+          data: { status: 'archived' }
+        });
+      }
+
+      if (current.provider) {
+        await db.skillProvider.update({
+          where: { oid: current.provider.oid },
+          data: { status: 'archived' }
+        });
+      }
+
+      await addAfterTransactionHook(async () =>
+        skillItemArchivedQueue.add({ skillItemId: skillItem.id })
+      );
+
+      return skillItem;
+    });
+  }
+}
+
+export let skillItemService = Service.create(
+  'skillItemService',
+  () => new skillItemServiceImpl()
+).build();

--- a/src/systems/subspace/modules/skills/tsconfig.json
+++ b/src/systems/subspace/modules/skills/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@metorial-subspace/tsconfig/base.json",
+  "exclude": ["dist"],
+  "compilerOptions": {
+    "jsx": "react",
+    "outDir": "dist"
+  }
+}

--- a/src/systems/subspace/packages/presenters/src/index.ts
+++ b/src/systems/subspace/packages/presenters/src/index.ts
@@ -72,6 +72,7 @@ export * from './sessionTemplate';
 export * from './sessionTemplateProvider';
 export * from './sessionUsageRecord';
 export * from './setupSession';
+export * from './skill';
 export * from './solution';
 export * from './tenant';
 export * from './toolCall';

--- a/src/systems/subspace/packages/presenters/src/integration.ts
+++ b/src/systems/subspace/packages/presenters/src/integration.ts
@@ -14,7 +14,6 @@ import type {
   ProviderTemplateBacking
 } from '@metorial-subspace/db';
 import { integrationProviderPresenter } from './integrationProvider';
-import { integrationVersionPresenter } from './integrationVersion';
 
 export let integrationPresenter = (
   integration: Integration & {
@@ -80,6 +79,27 @@ export let integrationPresenter = (
       integration
     })
   ),
+
+  createdAt: integration.createdAt,
+  updatedAt: integration.updatedAt,
+  archivedAt: integration.archivedAt
+});
+
+export let integrationPreviewPresenter = (integration: Integration) => ({
+  object: 'integration',
+
+  id: integration.id,
+  status: integration.status,
+
+  slug: integration.slug,
+  name: integration.name,
+  description: integration.description,
+  metadata: integration.metadata,
+  privateMetadata: integration.privateMetadata,
+
+  canAttachCustomToolFilters: integration.canAttachCustomToolFilters,
+  canAttachCustomProviderConfig: integration.canAttachCustomProviderConfig,
+  canOverrideToolFilters: integration.canOverrideToolFilters,
 
   createdAt: integration.createdAt,
   updatedAt: integration.updatedAt,

--- a/src/systems/subspace/packages/presenters/src/provider.ts
+++ b/src/systems/subspace/packages/presenters/src/provider.ts
@@ -1,7 +1,6 @@
 import type {
   Provider,
   ProviderEntry,
-  ProviderListing,
   ProviderSpecification,
   ProviderType,
   ProviderVariant,
@@ -9,13 +8,13 @@ import type {
   Publisher,
   Tenant
 } from '@metorial-subspace/db';
+import { getImageUrl } from './brand';
 import { providerEntryPresenter } from './providerEntry';
 import { providerTypePresenter } from './providerType';
 import { providerVariantPresenter } from './providerVariant';
 import { providerVersionPresenter } from './providerVersion';
 import { publisherPresenter } from './publisher';
 import { tenantPresenter } from './tenant';
-import { getImageUrl } from './brand';
 
 export let providerPresenter = (
   provider: Provider & {
@@ -99,7 +98,7 @@ export let providerPresenter = (
 };
 
 export let providerPreviewPresenter = (
-  provider: Provider & { listing?: ProviderListing | null }
+  provider: Provider & { listing?: { id: string; image: string } | null }
 ) => ({
   object: 'provider',
 

--- a/src/systems/subspace/packages/presenters/src/skill.ts
+++ b/src/systems/subspace/packages/presenters/src/skill.ts
@@ -1,0 +1,84 @@
+import type {
+  Integration,
+  Provider,
+  ProviderListing,
+  Skill,
+  SkillFork,
+  SkillGroup,
+  SkillIntegration,
+  SkillItem,
+  SkillProvider,
+  SkillProviderLink
+} from '@metorial-subspace/db';
+import { integrationPreviewPresenter } from './integration';
+import { providerPreviewPresenter } from './provider';
+
+export let skillPreviewPresenter = (skill: Skill) => ({
+  object: 'skill',
+
+  id: skill.id,
+  status: skill.status,
+
+  slug: skill.slug,
+  name: skill.name,
+  description: skill.description,
+  metadata: skill.metadata,
+  privateMetadata: skill.privateMetadata,
+
+  createdAt: skill.createdAt,
+  updatedAt: skill.updatedAt
+});
+
+export let skillPresenter = (
+  skill: Skill & {
+    skillGroup: SkillGroup;
+    forkedFrom:
+      | (SkillFork & {
+          parentSkill: Skill;
+        })
+      | null;
+    skillIntegrations: (SkillIntegration & {
+      integration: Integration;
+    })[];
+    skillProviderLinks: (SkillProviderLink & {
+      provider: Provider & { listing?: ProviderListing | null };
+    })[];
+  }
+) => ({
+  ...skillPreviewPresenter(skill),
+
+  skillGroupId: skill.skillGroup.id,
+  forkedFromId: skill.forkedFrom?.parentSkill.id ?? null,
+
+  integrations: skill.skillIntegrations.map(item =>
+    integrationPreviewPresenter(item.integration)
+  ),
+  providers: skill.skillProviderLinks.map(link => providerPreviewPresenter(link.provider))
+});
+
+export let skillItemPresenter = (
+  skillItem: SkillItem & {
+    skill: Skill;
+    integration: (SkillIntegration & { integration: Integration }) | null;
+    provider:
+      | (SkillProvider & {
+          provider: Provider & { listing?: ProviderListing | null };
+        })
+      | null;
+  }
+) => ({
+  object: 'skillItem',
+
+  id: skillItem.id,
+  status: skillItem.status,
+  type: skillItem.type,
+
+  skillId: skillItem.skill.id,
+
+  integration: skillItem.integration
+    ? integrationPreviewPresenter(skillItem.integration.integration)
+    : null,
+  provider: skillItem.provider ? providerPreviewPresenter(skillItem.provider.provider) : null,
+
+  createdAt: skillItem.createdAt
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new persisted domain (`Skill*` models) with new controller endpoints, background queues, and search indexing; regressions could impact DB migrations, queue processing, and provider/integration linkage consistency.
> 
> **Overview**
> Introduces **Skills** as a first-class domain: adds new Prisma models (`Skill`, `SkillGroup`, `SkillItem`, `SkillIntegration`, `SkillProvider`, `SkillProviderLink`, `SkillFork`) plus ID types and relations from `Tenant`/`Environment`/`Solution`, `Integration`, and `Provider`.
> 
> Adds new controller APIs `skill` and `skillItem` (list/get/create/update/archive/fork + item create/archive) backed by a new `@metorial-subspace/module-skills` service layer, with e2e coverage.
> 
> Wires skills into the async system: registers `skillsQueueProcessor` in the worker, adds reconciliation queues to keep `SkillProviderLink` in sync (including hooks on `integrationProvider` lifecycle), and adds a Voyager `skill` index with skill record indexing/deletion based on status/content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c46d2ee64beb8f620ead374390971bb453ad6613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->