### PR TITLE
Extend store access permissions

### DIFF
--- a/src/backend/apis/core/src/controllers/instance/store.ts
+++ b/src/backend/apis/core/src/controllers/instance/store.ts
@@ -8,6 +8,8 @@ import { checkAccess } from '../../middleware/checkAccess';
 import { instanceGroup, instancePath } from '../../middleware/instanceGroup';
 import { storeItemPresenter, storePresenter } from '../../presenters';
 
+let storeAccessSchema = v.enumOf(['private', 'public_read', 'public_write']);
+
 let assertStoreCrudAllowed = (ctx: Parameters<typeof hasInstanceConsumerAccess>[0]) => {
   if (hasInstanceConsumerAccess(ctx)) {
     throw new ServiceError(
@@ -73,7 +75,8 @@ export let storeController = Controller.create(
       .body(
         'default',
         v.object({
-          name: v.string()
+          name: v.string(),
+          access: v.optional(storeAccessSchema)
         })
       )
       .output(storePresenter)
@@ -87,7 +90,8 @@ export let storeController = Controller.create(
             organization: ctx.organization
           },
           input: {
-            name: ctx.body.name
+            name: ctx.body.name,
+            access: ctx.body.access
           }
         });
 
@@ -112,7 +116,8 @@ export let storeController = Controller.create(
       .body(
         'default',
         v.object({
-          name: v.optional(v.string())
+          name: v.optional(v.string()),
+          access: v.optional(storeAccessSchema)
         })
       )
       .output(storePresenter)
@@ -128,7 +133,8 @@ export let storeController = Controller.create(
           },
           ...getInstanceCargoAccess(ctx),
           input: {
-            name: ctx.body.name
+            name: ctx.body.name,
+            access: ctx.body.access
           }
         });
 

--- a/src/backend/apis/core/src/presenters/implementation/store.ts
+++ b/src/backend/apis/core/src/presenters/implementation/store.ts
@@ -7,6 +7,7 @@ export let v1StorePresenter = Presenter.create(storeType)
     object: 'store',
     id: store.id,
     name: store.name,
+    access: store.access,
     item_count: store.itemCount,
     created_at: store.createdAt,
     updated_at: store.updatedAt
@@ -18,6 +19,7 @@ export let v1StorePresenter = Presenter.create(storeType)
       }),
       id: v.string(),
       name: v.string(),
+      access: v.enumOf(['private', 'public_read', 'public_write']),
       item_count: v.number(),
       created_at: v.date(),
       updated_at: v.date()

--- a/src/backend/internal-clients/src/links/actor.ts
+++ b/src/backend/internal-clients/src/links/actor.ts
@@ -155,5 +155,20 @@ export let ensureSubspaceConsumerActor = async (
   if (actorId) return { id: actorId };
 
   let loadedConsumer = await loadConsumer(consumer);
-  throw new Error(`Subspace actors do not support consumer linking: ${loadedConsumer.id}`);
+  let actorIdentifier = getConsumerActorIdentifier(loadedConsumer);
+  let actor = await upsertSubspaceActor({
+    tenantId,
+    identifier: actorIdentifier,
+    name: loadedConsumer.name,
+    consumerId: loadedConsumer.id
+  });
+
+  await persistConsumerLink({
+    service: 'subspace',
+    consumer: loadedConsumer,
+    actorId: actor.id,
+    actorIdentifier
+  });
+
+  return actor;
 };

--- a/src/backend/internal-clients/src/links/upsert.ts
+++ b/src/backend/internal-clients/src/links/upsert.ts
@@ -107,12 +107,14 @@ export let upsertSubspaceActor = async (d: {
   tenantId: string;
   identifier: string;
   name: string;
-  organizationActorId: string;
+  organizationActorId?: string;
+  consumerId?: string;
 }): Promise<InternalActorLink> =>
   await subspace.actor.upsert({
     tenantId: d.tenantId,
     identifier: d.identifier,
     name: d.name,
     type: 'external',
-    organizationActorId: d.organizationActorId
+    organizationActorId: d.organizationActorId,
+    consumerId: d.consumerId
   });

--- a/src/systems/cargo/service/prisma/schema/skill.prisma
+++ b/src/systems/cargo/service/prisma/schema/skill.prisma
@@ -11,5 +11,9 @@ model Skill {
   storeOid BigInt @unique
   store    Store  @relation(fields: [storeOid], references: [oid], onDelete: Cascade)
 
+  parentSkillOid BigInt?
+  parentSkill    Skill?  @relation("SkillHierarchy", fields: [parentSkillOid], references: [oid], onDelete: Cascade)
+  childSkills    Skill[] @relation("SkillHierarchy")
+
   createdAt DateTime @default(now())
 }

--- a/src/systems/cargo/service/prisma/schema/store.prisma
+++ b/src/systems/cargo/service/prisma/schema/store.prisma
@@ -3,12 +3,19 @@ enum StoreStatus {
   archived
 }
 
+enum StoreAccess {
+  private
+  public_read
+  public_write
+}
+
 model Store {
   oid BigInt @id
   id  String @unique
 
   name      String
-  itemCount Int    @default(0)
+  access    StoreAccess @default(private)
+  itemCount Int       @default(0)
   dirtyAt   DateTime?
 
   tenantOid BigInt
@@ -28,6 +35,7 @@ model Store {
   versions          StoreVersion[]
   storeParticipants StoreParticipant[]
   skill             Skill?
+  storeDirectories  StoreDirectory[]
 
   @@index([tenantOid, environmentOid, dirtyAt])
 }
@@ -41,14 +49,17 @@ model StoreItem {
   storeOid BigInt
   store    Store  @relation(fields: [storeOid], references: [oid], onDelete: Cascade)
 
-  fileOid BigInt
-  file    File   @relation(fields: [fileOid], references: [oid], onDelete: Cascade)
+  fileOid BigInt?
+  file    File?   @relation(fields: [fileOid], references: [oid], onDelete: Cascade)
 
-  referenceOid BigInt
-  reference    FileReference @relation(fields: [referenceOid], references: [oid], onDelete: Cascade)
+  referenceOid BigInt?
+  reference    FileReference? @relation(fields: [referenceOid], references: [oid], onDelete: Cascade)
 
   documentOid BigInt?
   document    Document? @relation(fields: [documentOid], references: [oid], onDelete: Cascade)
+
+  directoryOid BigInt?
+  directory    StoreDirectory? @relation(fields: [directoryOid], references: [oid], onDelete: Cascade)
 
   lastModifiedByTenantActorOid BigInt?
   lastModifiedByTenantActor    TenantActor? @relation(fields: [lastModifiedByTenantActorOid], references: [oid], onDelete: Cascade)
@@ -68,7 +79,7 @@ model StoreVersion {
   sourceDirtyAt DateTime
 
   storeOid BigInt
-  store    Store   @relation(fields: [storeOid], references: [oid], onDelete: Cascade)
+  store    Store  @relation(fields: [storeOid], references: [oid], onDelete: Cascade)
 
   createdAt DateTime @default(now())
 
@@ -125,4 +136,25 @@ model StoreParticipant {
   createdAt DateTime @default(now())
 
   @@unique([storeOid, tenantActorOid])
+}
+
+model StoreDirectory {
+  oid BigInt @id
+  id  String @unique
+
+  isAutoCreated Boolean
+
+  path String
+
+  storeOid BigInt
+  store    Store  @relation(fields: [storeOid], references: [oid], onDelete: Cascade)
+
+  parentDirectoryOid BigInt?
+  parentDirectory    StoreDirectory?  @relation("StoreDirectoryHierarchy", fields: [parentDirectoryOid], references: [oid], onDelete: Cascade)
+  childDirectories   StoreDirectory[] @relation("StoreDirectoryHierarchy")
+
+  createdAt  DateTime    @default(now())
+  storeItems StoreItem[]
+
+  @@unique([storeOid, path])
 }

--- a/src/systems/cargo/service/src/controllers/skill.ts
+++ b/src/systems/cargo/service/src/controllers/skill.ts
@@ -27,13 +27,23 @@ export let skillController = app.controller({
         environmentId: v.string(),
         skillId: v.optional(v.string()),
         storeId: v.optional(v.string()),
+        parentSkillId: v.optional(v.string()),
         name: v.string()
       })
     )
     .do(async ctx => {
+      let parentSkill = ctx.input.parentSkillId
+        ? await skillService.getSkillById({
+            tenant: ctx.tenant,
+            environment: ctx.environment,
+            skillId: ctx.input.parentSkillId
+          })
+        : undefined;
+
       let skill = await skillService.createSkill({
         tenant: ctx.tenant,
         environment: ctx.environment,
+        parentSkill,
         input: {
           id: ctx.input.skillId,
           storeId: ctx.input.storeId,

--- a/src/systems/cargo/service/src/controllers/store.ts
+++ b/src/systems/cargo/service/src/controllers/store.ts
@@ -6,6 +6,8 @@ import { app } from './_app';
 import { storePermissionsSchema } from './document';
 import { tenantApp } from './tenant';
 
+export let storeAccessSchema = v.enumOf(['private', 'public_read', 'public_write']);
+
 export let storeApp = tenantApp.use(async ctx => {
   let storeId = ctx.body.storeId;
   if (!storeId) throw new Error('Store ID is required');
@@ -35,7 +37,8 @@ export let storeController = app.controller({
         tenantId: v.string(),
         environmentId: v.string(),
         storeId: v.optional(v.string()),
-        name: v.string()
+        name: v.string(),
+        access: v.optional(storeAccessSchema)
       })
     )
     .do(async ctx => {
@@ -44,7 +47,8 @@ export let storeController = app.controller({
         environment: ctx.environment,
         input: {
           id: ctx.input.storeId,
-          name: ctx.input.name
+          name: ctx.input.name,
+          access: ctx.input.access
         }
       });
 
@@ -110,6 +114,7 @@ export let storeController = app.controller({
         environmentId: v.string(),
         storeId: v.string(),
         name: v.optional(v.string()),
+        access: v.optional(storeAccessSchema),
         actorId: v.optional(v.string()),
         defaultPermissions: v.optional(storePermissionsSchema),
         overridePermissions: v.optional(v.boolean())
@@ -124,7 +129,8 @@ export let storeController = app.controller({
         defaultPermissions: ctx.input.defaultPermissions,
         overridePermissions: ctx.input.overridePermissions,
         input: {
-          name: ctx.input.name
+          name: ctx.input.name,
+          access: ctx.input.access
         }
       });
 
@@ -140,6 +146,7 @@ export let storeController = app.controller({
         storeId: v.string(),
         targetStoreId: v.optional(v.string()),
         name: v.optional(v.string()),
+        access: v.optional(storeAccessSchema),
         actorId: v.optional(v.string()),
         defaultPermissions: v.optional(storePermissionsSchema),
         overridePermissions: v.optional(v.boolean())
@@ -155,7 +162,8 @@ export let storeController = app.controller({
         overridePermissions: ctx.input.overridePermissions,
         input: {
           id: ctx.input.targetStoreId,
-          name: ctx.input.name
+          name: ctx.input.name,
+          access: ctx.input.access
         }
       });
 

--- a/src/systems/cargo/service/src/controllers/tests/store.e2e.test.ts
+++ b/src/systems/cargo/service/src/controllers/tests/store.e2e.test.ts
@@ -107,7 +107,8 @@ describe('cargo store.e2e', () => {
       tenantId: tenant.id,
       environmentId: environment.id,
       storeId: created.id,
-      name: 'Brand Assets'
+      name: 'Brand Assets',
+      access: 'public_read'
     });
 
     let deleted = await cargoClient.store.delete({
@@ -125,12 +126,15 @@ describe('cargo store.e2e', () => {
     expect(created).toMatchObject({
       id: expect.any(String),
       name: 'Assets',
+      access: 'private',
       itemCount: 0
     });
     expect(listed.items).toHaveLength(1);
     expect(fetched.id).toBe(created.id);
     expect(fetched.itemCount).toBe(0);
+    expect(fetched.access).toBe('private');
     expect(updated.name).toBe('Brand Assets');
+    expect(updated.access).toBe('public_read');
     expect(deleted.id).toBe(created.id);
     expect(listedAfterDelete.items).toHaveLength(0);
   });
@@ -542,7 +546,7 @@ describe('cargo store.e2e', () => {
     ).rejects.toThrow('Store cannot contain more than 1000 items');
   });
 
-  it('enforces actor-scoped store read and write access', async () => {
+  it('keeps private stores actor-scoped unless permissions are granted explicitly', async () => {
     let { tenant, environment } = await createScope();
     let viewer = await createActor(tenant.id, {
       identifier: 'store-viewer',
@@ -551,7 +555,8 @@ describe('cargo store.e2e', () => {
     let store = await cargoClient.store.create({
       tenantId: tenant.id,
       environmentId: environment.id,
-      name: 'Secured Store'
+      name: 'Secured Store',
+      access: 'private'
     });
 
     let readable = await cargoClient.store.get({
@@ -585,6 +590,153 @@ describe('cargo store.e2e', () => {
     });
 
     expect(updated.name).toBe('Writable Store');
+  });
+
+  it('allows actor-backed reads for public_read stores and creates participants', async () => {
+    let { tenant, environment } = await createScope();
+    let actor = await createActor(tenant.id, {
+      identifier: 'public-store-reader',
+      name: 'Public Store Reader'
+    });
+    let store = await cargoClient.store.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      name: 'Readable Store',
+      access: 'public_read'
+    });
+
+    let fetched = await cargoClient.store.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: store.id,
+      actorId: actor.id
+    });
+    let participant = await db.storeParticipant.findFirst({
+      where: {
+        store: {
+          id: store.id
+        },
+        tenantActor: {
+          id: actor.id
+        }
+      }
+    });
+
+    await expect(
+      cargoClient.store.update({
+        tenantId: tenant.id,
+        environmentId: environment.id,
+        storeId: store.id,
+        actorId: actor.id,
+        name: 'Should Fail'
+      })
+    ).rejects.toThrow('Missing content_write access');
+
+    expect(fetched).toMatchObject({
+      id: store.id,
+      access: 'public_read'
+    });
+    expect(participant?.permissions).toEqual(['content_read']);
+  });
+
+  it('allows actor-backed writes for public_write stores and creates writable participants', async () => {
+    let { tenant, environment } = await createScope();
+    let purpose = await createPurpose();
+    let actor = await createActor(tenant.id, {
+      identifier: 'public-store-writer',
+      name: 'Public Store Writer'
+    });
+    let file = await createFile({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      purposeId: purpose.id,
+      storeId: 'public-store-file',
+      name: 'public-write.png'
+    });
+    let store = await cargoClient.store.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      name: 'Writable By Anyone',
+      access: 'public_write'
+    });
+
+    let updated = await cargoClient.store.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: store.id,
+      actorId: actor.id,
+      name: 'Still Writable'
+    });
+    let added = await cargoClient.store.modifyItems({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: store.id,
+      actorId: actor.id,
+      operations: [
+        {
+          fileId: file.id,
+          path: '/public-write.png'
+        }
+      ]
+    });
+    let participant = await db.storeParticipant.findFirst({
+      where: {
+        store: {
+          id: store.id
+        },
+        tenantActor: {
+          id: actor.id
+        }
+      }
+    });
+
+    expect(updated).toMatchObject({
+      id: store.id,
+      name: 'Still Writable',
+      access: 'public_write'
+    });
+    expect(added[0]!.item.path).toBe('/public-write.png');
+    expect(participant?.permissions).toEqual(['content_read', 'content_write']);
+  });
+
+  it('keeps no-actor requests unrestricted regardless of store access mode', async () => {
+    let { tenant, environment } = await createScope();
+    let privateStore = await cargoClient.store.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      name: 'No Actor Private',
+      access: 'private'
+    });
+    let publicStore = await cargoClient.store.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      name: 'No Actor Public',
+      access: 'public_write'
+    });
+
+    let privateUpdated = await cargoClient.store.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: privateStore.id,
+      name: 'No Actor Private Updated'
+    });
+    let publicUpdated = await cargoClient.store.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: publicStore.id,
+      name: 'No Actor Public Updated'
+    });
+    let listed = await cargoClient.store.list({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      limit: 10
+    });
+
+    expect(privateUpdated.name).toBe('No Actor Private Updated');
+    expect(publicUpdated.name).toBe('No Actor Public Updated');
+    expect(listed.items.map(store => store.id).sort()).toEqual(
+      [privateStore.id, publicStore.id].sort()
+    );
   });
 
   it('enforces actor-scoped store item mutations', async () => {

--- a/src/systems/cargo/service/src/presenters/store.ts
+++ b/src/systems/cargo/service/src/presenters/store.ts
@@ -4,6 +4,7 @@ export let storePresenter = (store: Store) => ({
   object: 'cargo#store',
   id: store.id,
   name: store.name,
+  access: store.access,
   itemCount: store.itemCount,
   createdAt: store.createdAt,
   updatedAt: store.updatedAt

--- a/src/systems/cargo/service/src/services/skill.ts
+++ b/src/systems/cargo/service/src/services/skill.ts
@@ -38,6 +38,7 @@ class SkillServiceImpl {
 
   async createSkill(
     d: CargoTenantEnvironment & {
+      parentSkill?: SkillRecord;
       input: {
         id?: string;
         storeId?: string;
@@ -60,7 +61,9 @@ class SkillServiceImpl {
         environment: d.environment,
         input: {
           id: d.input.storeId,
-          name: d.input.name
+          name: d.input.name,
+          access: 'public_read',
+          parentStore: d.parentSkill?.store
         }
       });
 
@@ -70,7 +73,8 @@ class SkillServiceImpl {
           id: skillIds.id,
           tenantOid: d.tenant.oid,
           environmentOid: d.environment.oid,
-          storeOid: store.oid
+          storeOid: store.oid,
+          parentSkillOid: d.parentSkill?.oid
         },
         include: skillInclude
       });

--- a/src/systems/cargo/service/src/services/store.ts
+++ b/src/systems/cargo/service/src/services/store.ts
@@ -1,7 +1,7 @@
 import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import type { Store } from '../../prisma/generated/client';
+import type { Store, StoreAccess } from '../../prisma/generated/client';
 import { db, withTransaction } from '../db';
 import { getId } from '../id';
 import { storeCleanupManyQueue } from '../queues/storeCleanup';
@@ -43,6 +43,7 @@ class StoreServiceImpl {
       input: {
         id?: string;
         name: string;
+        access?: StoreAccess;
         parentStore?: Store;
       };
     }
@@ -55,6 +56,7 @@ class StoreServiceImpl {
           oid: storeIds.oid,
           id: storeIds.id,
           name: d.input.name,
+          access: d.input.access ?? 'private',
           itemCount: 0,
           tenantOid: d.tenant.oid,
           environmentOid: d.environment.oid,
@@ -122,10 +124,11 @@ class StoreServiceImpl {
         store: Store;
         input: {
           name?: string;
+          access?: StoreAccess;
         };
       }
   ) {
-    if (d.input.name === undefined) {
+    if (d.input.name === undefined && d.input.access === undefined) {
       throw new ServiceError(
         badRequestError({
           message: 'At least one store field must be updated'
@@ -148,7 +151,8 @@ class StoreServiceImpl {
         id: d.store.id
       },
       data: {
-        name: d.input.name
+        name: d.input.name,
+        access: d.input.access
       }
     });
   }
@@ -160,6 +164,7 @@ class StoreServiceImpl {
         input: {
           id?: string;
           name?: string;
+          access?: StoreAccess;
         };
       }
   ) {
@@ -180,6 +185,7 @@ class StoreServiceImpl {
         input: {
           id: d.input.id,
           name: d.input.name ?? d.store.name,
+          access: d.input.access ?? d.store.access,
           parentStore: d.store
         }
       });

--- a/src/systems/cargo/service/src/services/storeAccess.ts
+++ b/src/systems/cargo/service/src/services/storeAccess.ts
@@ -2,6 +2,7 @@ import { forbiddenError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Service } from '@lowerdeck/service';
 import type {
   Prisma,
+  StoreAccess,
   Store,
   StoreParticipant,
   StoreParticipantPermissions,
@@ -29,12 +30,31 @@ let storeReadPermission: StoreParticipantPermissions = 'content_read';
 let storeWritePermission: StoreParticipantPermissions = 'content_write';
 
 let uniqueBigInts = (values: bigint[]) => [...new Set(values.map(value => value.toString()))].map(BigInt);
+let uniquePermissions = (values: StoreParticipantPermissions[]) => [...new Set(values)];
 
 let samePermissions = (
   left: StoreParticipantPermissions[] | undefined,
   right: StoreParticipantPermissions[] | undefined
 ) =>
   JSON.stringify([...(left ?? [])].sort()) === JSON.stringify([...(right ?? [])].sort());
+
+let mergePermissions = (
+  left: StoreParticipantPermissions[] | undefined,
+  right: StoreParticipantPermissions[] | undefined
+) => uniquePermissions([...(left ?? []), ...(right ?? [])]);
+
+let getPublicStorePermissions = (d: {
+  access: StoreAccess;
+  requiredPermission: StoreParticipantPermissions;
+}) => {
+  if (d.access === 'private') return undefined;
+
+  if (d.access === 'public_read') {
+    return d.requiredPermission === storeReadPermission ? [storeReadPermission] : undefined;
+  }
+
+  return [storeReadPermission, storeWritePermission];
+};
 
 class StoreAccessServiceImpl {
   async getActorForAccess(d: Pick<CargoTenantEnvironment, 'tenant'> & StoreAccessInput) {
@@ -273,6 +293,70 @@ class StoreAccessServiceImpl {
       .map(participant => participant.storeOid);
   }
 
+  private async ensureStoreParticipantsHavePermissions(d: {
+    actor: TenantActor;
+    items: Array<{
+      storeOid: bigint;
+      permissions: StoreParticipantPermissions[];
+    }>;
+  }) {
+    return await withTransaction(
+      async client => {
+        if (d.items.length === 0) return [] as StoreParticipant[];
+
+        let existingParticipants = await client.storeParticipant.findMany({
+          where: {
+            storeOid: {
+              in: d.items.map(item => item.storeOid)
+            },
+            tenantActorOid: d.actor.oid
+          }
+        });
+
+        let byStoreOid = new Map(
+          existingParticipants.map(participant => [participant.storeOid.toString(), participant])
+        );
+        let participants: StoreParticipant[] = [];
+
+        for (let item of d.items) {
+          let existing = byStoreOid.get(item.storeOid.toString());
+          if (existing) {
+            let nextPermissions = mergePermissions(existing.permissions, item.permissions);
+            if (!samePermissions(existing.permissions, nextPermissions)) {
+              existing = await client.storeParticipant.update({
+                where: {
+                  id: existing.id
+                },
+                data: {
+                  permissions: nextPermissions
+                }
+              });
+            }
+
+            participants.push(existing);
+            continue;
+          }
+
+          let ids = getId('storeParticipant');
+          let participant = await client.storeParticipant.create({
+            data: {
+              oid: ids.oid,
+              id: ids.id,
+              storeOid: item.storeOid,
+              tenantActorOid: d.actor.oid,
+              permissions: item.permissions
+            }
+          });
+          byStoreOid.set(item.storeOid.toString(), participant);
+          participants.push(participant);
+        }
+
+        return participants;
+      },
+      { ifExists: true }
+    );
+  }
+
   async resolveAccessibleStoreOids(
     d: CargoTenantEnvironment &
       StoreAccessInput & {
@@ -292,6 +376,19 @@ class StoreAccessServiceImpl {
         }
 
         let actor = await this.getActorForAccess(d);
+        let stores = await db.store.findMany({
+          where: {
+            tenantOid: d.tenant.oid,
+            environmentOid: d.environment.oid,
+            oid: {
+              in: relevantStoreOids
+            }
+          },
+          select: {
+            oid: true,
+            access: true
+          }
+        });
         let participants = actor
           ? await this.upsertStoreParticipants({
               storeOids: relevantStoreOids,
@@ -300,11 +397,35 @@ class StoreAccessServiceImpl {
               overridePermissions: d.overridePermissions
             })
           : [];
+        let publicStoreParticipants = actor
+          ? await this.ensureStoreParticipantsHavePermissions({
+              actor,
+              items: stores
+                .map(store => ({
+                  storeOid: store.oid,
+                  permissions: getPublicStorePermissions({
+                    access: store.access,
+                    requiredPermission: d.requiredPermission
+                  })
+                }))
+                .filter(
+                  (
+                    item
+                  ): item is {
+                    storeOid: bigint;
+                    permissions: StoreParticipantPermissions[];
+                  } => item.permissions !== undefined
+                )
+            })
+          : [];
 
         return {
           actor,
           relevantStoreOids,
-          accessibleStoreOids: this.getAccessibleStoreOids(participants, d.requiredPermission)
+          accessibleStoreOids: uniqueBigInts([
+            ...this.getAccessibleStoreOids(participants, d.requiredPermission),
+            ...this.getAccessibleStoreOids(publicStoreParticipants, d.requiredPermission)
+          ])
         };
       },
       { ifExists: true }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes store access-control behavior and persistence (new `Store.access` field) and auto-creates/updates participants for public stores, which could unintentionally broaden read/write access if misconfigured. Includes Prisma schema changes that require migrations and careful rollout/backfill validation.
> 
> **Overview**
> Introduces a persisted `Store.access` mode (`private`, `public_read`, `public_write`) and threads it through store create/update/clone APIs and presenters (both Cargo service and core instance API), defaulting new stores to `private`.
> 
> Updates Cargo access resolution so actor-scoped requests can read/write *public* stores without explicit grants by auto-creating/updating `StoreParticipant` records with the minimum implied permissions, while keeping `no actorId` requests unchanged.
> 
> Extends Cargo data model with store/skill hierarchy support (`Skill.parentSkill*` plus skill-created stores inheriting parent store and defaulting to `public_read`), adds `StoreDirectory` and optionalizes `StoreItem.file`/`reference` to support directory and non-file-backed items. Also enables Subspace consumer actor linking by upserting/persisting a Subspace actor instead of throwing, and expands e2e tests to cover the new access modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cca8ffd9e48d7b8aba35f49d8da14a146cff5a41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->