### PR TITLE
Harden shuttle server sync

### DIFF
--- a/src/systems/shuttle/service/prisma/schema/server.prisma
+++ b/src/systems/shuttle/service/prisma/schema/server.prisma
@@ -114,4 +114,5 @@ model ServerVersion {
   changeNotifications ChangeNotification[]
 
   @@unique([serverOid, identifier])
+  @@index([serverOid, isCurrent])
 }

--- a/src/systems/shuttle/service/src/queues/lifecycle/serverVersion.ts
+++ b/src/systems/shuttle/service/src/queues/lifecycle/serverVersion.ts
@@ -21,6 +21,7 @@ export let serverVersionCreatedQueueProcessor = serverVersionCreatedQueue.proces
       await db.serverVersion.updateMany({
         where: {
           serverOid: serverVersion.serverOid,
+          isCurrent: true,
           oid: { not: serverVersion.oid }
         },
         data: {
@@ -28,7 +29,7 @@ export let serverVersionCreatedQueueProcessor = serverVersionCreatedQueue.proces
         }
       });
 
-      await db.serverVersion.updateMany({
+      await db.serverVersion.update({
         where: { oid: serverVersion.oid },
         data: {
           isCurrent: true,

--- a/src/systems/subspace/provider-backends/provider-shuttle/src/queues/sync/changeNotifications.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/queues/sync/changeNotifications.ts
@@ -1,4 +1,3 @@
-import { createLock } from '@lowerdeck/lock';
 import { createQueue, QueueRetryError } from '@lowerdeck/queue';
 import { db } from '@metorial-subspace/db';
 import { backend as shuttleBackend } from '../../backend';
@@ -18,82 +17,47 @@ export let syncChangeNotificationsQueue = createQueue<{}>({
   }
 });
 
-let lock = createLock({
-  name: 'sub/shut/cnhnotif/lock',
-  redisUrl: env.service.REDIS_URL
-});
-
 let isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value == 'object' && value !== null;
 
-let isLockContentionError = (error: unknown) => {
-  if (!isRecord(error)) return false;
-  if (error.name !== 'ExecutionError') return false;
-
-  let attempts = error.attempts;
-  if (!Array.isArray(attempts)) return false;
-
-  let voteErrors = attempts.flatMap(attempt => {
-    if (!isRecord(attempt)) return [];
-
-    let votesAgainst = attempt.votesAgainst;
-    if (votesAgainst instanceof Map) return [...votesAgainst.values()];
-    if (Array.isArray(votesAgainst)) return votesAgainst;
-
-    return [];
-  });
-
-  return (
-    voteErrors.length > 0 &&
-    voteErrors.every(error => isRecord(error) && error.name === 'ResourceLockedError')
-  );
-};
-
 export let syncChangeNotificationsQueueProcessor = syncChangeNotificationsQueue.process(
   async () => {
-    try {
-      await lock.usingLock(shuttleBackend.id, async () => {
-        let backend = await db.backend.findFirst({
-          where: { id: shuttleBackend.id },
-          include: { shuttleSyncChangeNotificationCursor: true }
-        });
-        if (!backend) throw new QueueRetryError();
+    let backend = await db.backend.findFirst({
+      where: { id: shuttleBackend.id },
+      include: { shuttleSyncChangeNotificationCursor: true }
+    });
+    if (!backend) throw new QueueRetryError();
 
-        let changeNotifications = await shuttle.changeNotification.list({
-          limit: 100,
-          after: backend.shuttleSyncChangeNotificationCursor?.cursor,
-          order: 'asc'
-        });
-        if (!changeNotifications.items.length) return;
+    let changeNotifications = await shuttle.changeNotification.list({
+      limit: 100,
+      after: backend.shuttleSyncChangeNotificationCursor?.cursor,
+      order: 'asc'
+    });
+    if (!changeNotifications.items.length) return;
 
-        await syncShuttleVersionQueue.addManyWithOps(
-          changeNotifications.items
-            .map(item => ({
-              serverId: item.serverId!,
-              serverVersionId: item.serverVersionId!,
-              tenantId: item.tenantId
-            }))
-            .filter(item => item.serverId && item.serverVersionId)
-            .map(data => ({
-              data,
-              opts: { id: data.serverVersionId }
-            }))
-        );
+    await syncShuttleVersionQueue.addManyWithOps(
+      changeNotifications.items
+        .map(item => ({
+          serverId: item.serverId!,
+          serverVersionId: item.serverVersionId!,
+          tenantId: item.tenantId
+        }))
+        .filter(item => item.serverId && item.serverVersionId)
+        .map(data => ({
+          data,
+          opts: { id: data.serverVersionId }
+        }))
+    );
 
-        let lastItem = changeNotifications.items[changeNotifications.items.length - 1];
-        if (!lastItem) return;
+    let lastItem = changeNotifications.items[changeNotifications.items.length - 1];
+    if (!lastItem) return;
 
-        await db.shuttleSyncChangeNotificationCursor.upsert({
-          where: { backendOid: backend.oid },
-          create: { backendOid: backend.oid, cursor: lastItem.id },
-          update: { cursor: lastItem.id }
-        });
+    await db.shuttleSyncChangeNotificationCursor.upsert({
+      where: { backendOid: backend.oid },
+      create: { backendOid: backend.oid, cursor: lastItem.id },
+      update: { cursor: lastItem.id }
+    });
 
-        await syncChangeNotificationsQueue.add({});
-      });
-    } catch (error) {
-      if (isLockContentionError(error)) return;
-      throw error;
-    }
+    await syncChangeNotificationsQueue.add({}, { id: backend.id });
   }
 );

--- a/src/systems/subspace/provider-backends/provider-shuttle/src/queues/sync/cron.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/queues/sync/cron.ts
@@ -1,4 +1,5 @@
 import { createCron } from '@lowerdeck/cron';
+import { backend as shuttleBackend } from '../../backend';
 import { env } from '../../env';
 import { syncAuthConfigEventsQueue } from './authConfigEvents';
 import { syncChangeNotificationsQueue } from './changeNotifications';
@@ -11,7 +12,7 @@ export let syncChangeNotificationsCron = createCron(
     cron: '* * * * *'
   },
   async () => {
-    await syncChangeNotificationsQueue.add({}, { id: 'poll' });
+    await syncChangeNotificationsQueue.add({}, { id: shuttleBackend.id });
   }
 );
 

--- a/src/systems/subspace/provider-backends/provider-slates/src/queues/sync/changeNotifications.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/queues/sync/changeNotifications.ts
@@ -1,4 +1,3 @@
-import { createLock } from '@lowerdeck/lock';
 import { createQueue, QueueRetryError } from '@lowerdeck/queue';
 import { db } from '@metorial-subspace/db';
 import { backend as slatesBackend } from '../../backend';
@@ -8,51 +7,54 @@ import { syncSlateVersionQueue } from './syncSlateVersion';
 
 export let syncChangeNotificationsQueue = createQueue<{}>({
   name: 'sub/slt/cnhnotif',
-  redisUrl: env.service.REDIS_URL
-});
-
-let lock = createLock({
-  name: 'sub/slt/cnhnotif/lock',
-  redisUrl: env.service.REDIS_URL
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: {
+    limiter: {
+      max: 1,
+      duration: 10_000
+    },
+    concurrency: 1
+  }
 });
 
 export let syncChangeNotificationsQueueProcessor = syncChangeNotificationsQueue.process(
-  async data =>
-    lock.usingLock(slatesBackend.id, async () => {
-      let backend = await db.backend.findFirst({
-        where: { id: slatesBackend.id },
-        include: { slatesSyncChangeNotificationCursor: true }
-      });
-      if (!backend) throw new QueueRetryError();
+  async data => {
+    let backend = await db.backend.findFirst({
+      where: { id: slatesBackend.id },
+      include: { slatesSyncChangeNotificationCursor: true }
+    });
+    if (!backend) throw new QueueRetryError();
 
-      let changeNotifications = await slates.changeNotification.list({
-        limit: 100,
-        after: backend.slatesSyncChangeNotificationCursor?.cursor,
-        order: 'asc'
-      });
-      if (!changeNotifications.items.length) return;
+    let changeNotifications = await slates.changeNotification.list({
+      limit: 100,
+      after: backend.slatesSyncChangeNotificationCursor?.cursor,
+      order: 'asc'
+    });
+    if (!changeNotifications.items.length) return;
 
-      await syncSlateVersionQueue.addManyWithOps(
-        changeNotifications.items
-          .map(item => ({
-            data: {
-              slateId: item.slateId,
-              slateVersionId: item.slateVersionId!
-            },
-            opts: {
-              id: item.slateVersionId!
-            }
-          }))
-          .filter(item => item.data.slateVersionId)
-      );
+    await syncSlateVersionQueue.addManyWithOps(
+      changeNotifications.items
+        .map(item => ({
+          data: {
+            slateId: item.slateId,
+            slateVersionId: item.slateVersionId!
+          },
+          opts: {
+            id: item.slateVersionId!
+          }
+        }))
+        .filter(item => item.data.slateVersionId)
+    );
 
-      let lastItem = changeNotifications.items[changeNotifications.items.length - 1];
-      if (!lastItem) return;
+    let lastItem = changeNotifications.items[changeNotifications.items.length - 1];
+    if (!lastItem) return;
 
-      await db.slatesSyncChangeNotificationCursor.upsert({
-        where: { backendOid: backend.oid },
-        create: { backendOid: backend.oid, cursor: lastItem.id },
-        update: { cursor: lastItem.id }
-      });
-    })
+    await db.slatesSyncChangeNotificationCursor.upsert({
+      where: { backendOid: backend.oid },
+      create: { backendOid: backend.oid, cursor: lastItem.id },
+      update: { cursor: lastItem.id }
+    });
+
+    await syncChangeNotificationsQueue.add({}, { id: backend.id });
+  }
 );

--- a/src/systems/subspace/provider-backends/provider-slates/src/queues/sync/cron.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/queues/sync/cron.ts
@@ -1,6 +1,7 @@
 import { createCron } from '@lowerdeck/cron';
-import { syncAuthConfigEventsQueue } from './authConfigEvents';
+import { backend } from '../../backend';
 import { env } from '../../env';
+import { syncAuthConfigEventsQueue } from './authConfigEvents';
 import { syncChangeNotificationsQueue } from './changeNotifications';
 import { syncOAuthSetupsQueue } from './oauthSetups';
 import { syncSlatesQueue } from './syncSlates';
@@ -12,7 +13,7 @@ export let syncChangeNotificationsCron = createCron(
     cron: '* * * * *'
   },
   async () => {
-    await syncChangeNotificationsQueue.add({});
+    await syncChangeNotificationsQueue.add({}, { id: backend.id });
   }
 );
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches version "current" selection and sync queue scheduling; mistakes could cause incorrect current-version flags or missed/duplicated sync processing under concurrency.
> 
> **Overview**
> Hardens server version lifecycle updates by indexing `ServerVersion` on `(serverOid, isCurrent)` and ensuring only previously-current versions for a server are cleared before marking the new version current.
> 
> Simplifies Shuttle/Slates change-notification syncing by removing the distributed lock and instead enforcing single-worker execution via queue `concurrency`/rate limiting, and by using stable job IDs (backend ID) for both cron-triggered polling and self-rescheduling to reduce duplicate poll jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7208a16d198466979a98b2b05f0d852c57361bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->