### PR TITLE
Harden shuttle version sync

### DIFF
--- a/src/systems/subspace/provider-backends/provider-shuttle/src/queues/sync/changeNotifications.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/queues/sync/changeNotifications.ts
@@ -26,16 +26,26 @@ let lock = createLock({
 let isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value == 'object' && value !== null;
 
-let isLockContentionError = (error: unknown) => {
+let isLockContentionError = async (error: unknown) => {
   if (!isRecord(error)) return false;
   if (error.name !== 'ExecutionError') return false;
 
   let attempts = error.attempts;
   if (!Array.isArray(attempts)) return false;
 
-  let voteErrors = attempts.flatMap(attempt => {
-    if (!isRecord(attempt)) return [];
+  let attemptStats = await Promise.all(
+    attempts.map(async attempt => {
+      try {
+        return await attempt;
+      } catch {
+        return null;
+      }
+    })
+  );
 
+  if (!attemptStats.length || !attemptStats.every(isRecord)) return false;
+
+  let voteErrors = attemptStats.flatMap(attempt => {
     let votesAgainst = attempt.votesAgainst;
     if (votesAgainst instanceof Map) return [...votesAgainst.values()];
     if (Array.isArray(votesAgainst)) return votesAgainst;
@@ -92,7 +102,7 @@ export let syncChangeNotificationsQueueProcessor = syncChangeNotificationsQueue.
         await syncChangeNotificationsQueue.add({});
       });
     } catch (error) {
-      if (isLockContentionError(error)) return;
+      if (await isLockContentionError(error)) return;
       throw error;
     }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes error-handling around distributed lock contention in the change-notification sync queue; misclassification could cause real failures to be silently ignored or extra retries to occur.
> 
> **Overview**
> Improves the `syncChangeNotificationsQueue` lock-contention handling by making `isLockContentionError` async and resolving/guarding `error.attempts` entries before inspecting `votesAgainst`.
> 
> The processor now `await`s this check in the catch block, reducing failures when lock attempt details are promises/reject and ensuring only true `ResourceLockedError` cases are swallowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7083add4f4424d2eaf32fac509037bfb459f9e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->