### PR TITLE
Fix magic mcp integration provider creation for new deployments

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/magicMcpForm.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/magicMcpForm.tsx
@@ -2,8 +2,8 @@ import { DashboardInstanceMagicMcpServersGetOutput } from '@metorial/dashboard-s
 import { renderWithLoader, useForm } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import {
-  useCreateMagicMcpServerProvider,
   useCreateMagicMcpServer,
+  useCreateMagicMcpServerProvider,
   useCurrentInstance,
   useMagicMcpServer,
   useUpdateMagicMcpServerProvider
@@ -59,7 +59,6 @@ export let MagicMcpServerForm = (
           description: values.description || undefined
         });
         if (res) {
-          toast.success('Magic MCP server updated');
           p.close?.();
         }
         return;

--- a/src/systems/subspace/modules/auth/src/services/providerAuthConfig.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthConfig.ts
@@ -172,21 +172,25 @@ class providerAuthConfigServiceImpl {
     providerAuthConfigId: string;
     allowDeleted?: boolean;
   }) {
-    let providerAuthConfig = await db.providerAuthConfig.findFirst({
-      where: {
-        tenantOid: d.tenant.oid,
-        solutionOid: d.solution.oid,
-        environmentOid: d.environment.oid,
+    let providerAuthConfig = await withTransaction(
+      async db =>
+        await db.providerAuthConfig.findFirst({
+          where: {
+            tenantOid: d.tenant.oid,
+            solutionOid: d.solution.oid,
+            environmentOid: d.environment.oid,
 
-        OR: [
-          { id: d.providerAuthConfigId },
-          { providerSetupSession: { id: d.providerAuthConfigId } }
-        ],
+            OR: [
+              { id: d.providerAuthConfigId },
+              { providerSetupSession: { id: d.providerAuthConfigId } }
+            ],
 
-        ...normalizeStatusForGet(d).hasParent
-      },
-      include
-    });
+            ...normalizeStatusForGet(d).hasParent
+          },
+          include
+        }),
+      { ifExists: true }
+    );
     if (!providerAuthConfig)
       throw new ServiceError(notFoundError('provider.auth_config', d.providerAuthConfigId));
 

--- a/src/systems/subspace/modules/auth/src/services/providerAuthCredentials.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthCredentials.ts
@@ -286,14 +286,18 @@ class providerAuthCredentialsServiceImpl {
     providerAuthCredentialsId: string;
     allowDeleted?: boolean;
   }) {
-    let providerAuthCredentials = await db.providerAuthCredentials.findFirst({
-      where: {
-        id: d.providerAuthCredentialsId,
-        ...normalizeStatusForGet(d).noParent,
-        OR: [getTenantOwnedWhere(d), getManagedBackingWhere(d)]
-      },
-      include
-    });
+    let providerAuthCredentials = await withTransaction(
+      async db =>
+        await db.providerAuthCredentials.findFirst({
+          where: {
+            id: d.providerAuthCredentialsId,
+            ...normalizeStatusForGet(d).noParent,
+            OR: [getTenantOwnedWhere(d), getManagedBackingWhere(d)]
+          },
+          include
+        }),
+      { ifExists: true }
+    );
     if (!providerAuthCredentials) {
       throw new ServiceError(
         notFoundError('provider.auth_credentials', d.providerAuthCredentialsId)

--- a/src/systems/subspace/modules/catalog/src/services/providerAuthMethod.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerAuthMethod.ts
@@ -7,7 +7,8 @@ import {
   type ProviderSpecification,
   type ProviderVersion,
   type Solution,
-  type Tenant
+  type Tenant,
+  withTransaction
 } from '@metorial-subspace/db';
 import { getProviderTenantFilter } from './provider';
 
@@ -96,20 +97,24 @@ class providerAuthMethodServiceImpl {
     providerAuthMethodId: string;
     includeDeprecated?: boolean;
   }) {
-    let providerAuthMethod = await db.providerAuthMethod.findFirst({
-      where: {
-        provider: getProviderTenantFilter({
-          ...d,
-          includeDeprecated: true
+    let providerAuthMethod = await withTransaction(
+      async db =>
+        await db.providerAuthMethod.findFirst({
+          where: {
+            provider: getProviderTenantFilter({
+              ...d,
+              includeDeprecated: true
+            }),
+            id: d.providerAuthMethodId
+          },
+          include: {
+            global: true,
+            provider: true,
+            specification: { omit: { value: true } }
+          }
         }),
-        id: d.providerAuthMethodId
-      },
-      include: {
-        global: true,
-        provider: true,
-        specification: { omit: { value: true } }
-      }
-    });
+      { ifExists: true }
+    );
     if (!providerAuthMethod) {
       throw new ServiceError(notFoundError('provider_tool', d.providerAuthMethodId));
     }

--- a/src/systems/subspace/modules/deployment/src/services/providerConfig.ts
+++ b/src/systems/subspace/modules/deployment/src/services/providerConfig.ts
@@ -187,17 +187,21 @@ class providerConfigServiceImpl {
     providerConfigId: string;
     allowDeleted?: boolean;
   }) {
-    let providerConfig = await db.providerConfig.findFirst({
-      where: {
-        id: d.providerConfigId,
-        tenantOid: d.tenant.oid,
-        solutionOid: d.solution.oid,
-        environmentOid: d.environment.oid,
-        isForVault: false,
-        ...normalizeStatusForGet(d).noParent
-      },
-      include
-    });
+    let providerConfig = await withTransaction(
+      async db =>
+        await db.providerConfig.findFirst({
+          where: {
+            id: d.providerConfigId,
+            tenantOid: d.tenant.oid,
+            solutionOid: d.solution.oid,
+            environmentOid: d.environment.oid,
+            isForVault: false,
+            ...normalizeStatusForGet(d).noParent
+          },
+          include
+        }),
+      { ifExists: true }
+    );
     if (!providerConfig)
       throw new ServiceError(notFoundError('provider.config', d.providerConfigId));
 

--- a/src/systems/subspace/modules/deployment/src/services/providerDeployment.ts
+++ b/src/systems/subspace/modules/deployment/src/services/providerDeployment.ts
@@ -149,17 +149,21 @@ class providerDeploymentServiceImpl {
     providerDeploymentId: string;
     allowDeleted?: boolean;
   }) {
-    let providerDeployment = await db.providerDeployment.findFirst({
-      where: {
-        id: d.providerDeploymentId,
-        tenantOid: d.tenant.oid,
-        solutionOid: d.solution.oid,
-        environmentOid: d.environment.oid,
+    let providerDeployment = await withTransaction(
+      async db =>
+        await db.providerDeployment.findFirst({
+          where: {
+            id: d.providerDeploymentId,
+            tenantOid: d.tenant.oid,
+            solutionOid: d.solution.oid,
+            environmentOid: d.environment.oid,
 
-        ...normalizeStatusForGet(d).noParent
-      },
-      include
-    });
+            ...normalizeStatusForGet(d).noParent
+          },
+          include
+        }),
+      { ifExists: true }
+    );
     if (!providerDeployment)
       throw new ServiceError(notFoundError('provider.deployment', d.providerDeploymentId));
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk: changes backend read paths to use `withTransaction({ ifExists: true })`, which can affect how queries participate in existing transactions and error/locking behavior. Frontend changes are minor UX tweaks around Magic MCP server update/create flow.
> 
> **Overview**
> Fixes the Magic MCP server form flow by correcting hook import ordering and removing the success toast on server updates (closing the panel on success remains), aligning the UI with the provider-configuration side panel flow used for new servers.
> 
> On the backend, wraps multiple provider-related `get*ById` service reads (`providerAuthConfig`, `providerAuthCredentials`, `providerAuthMethod`, `providerConfig`, `providerDeployment`) in `withTransaction(..., { ifExists: true })` so these lookups participate in an existing transaction when present, while still behaving as normal when called outside a transaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b383522d0ad921ebc6ffa80030579e1193db6fda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->