### PR TITLE
Harden sync queues

### DIFF
--- a/src/systems/shuttle/service/src/queues/lifecycle/serverVersion.ts
+++ b/src/systems/shuttle/service/src/queues/lifecycle/serverVersion.ts
@@ -6,7 +6,14 @@ import { createChangeNotificationQueue } from '../changeNotification/create';
 
 export let serverVersionCreatedQueue = createQueue<{ serverVersionId: string }>({
   name: 'shut/l/serverVersion/created',
-  redisUrl: env.service.REDIS_URL
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: {
+    concurrency: 3,
+    limiter: {
+      max: 30,
+      duration: 1000
+    }
+  }
 });
 
 export let serverVersionCreatedQueueProcessor = serverVersionCreatedQueue.process(

--- a/src/systems/subspace/modules/custom-provider/src/queues/scm/cron.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/scm/cron.ts
@@ -1,6 +1,6 @@
 import { createCron } from '@lowerdeck/cron';
 import { env } from '../../env';
-import { scmSyncManyQueue } from './sync';
+import { enqueueScmSyncMany } from './sync';
 
 export let scmSyncManyCron = createCron(
   {
@@ -9,6 +9,6 @@ export let scmSyncManyCron = createCron(
     cron: '* * * * *'
   },
   async () => {
-    await scmSyncManyQueue.add({});
+    await enqueueScmSyncMany();
   }
 );

--- a/src/systems/subspace/modules/custom-provider/src/queues/scm/sync.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/scm/sync.ts
@@ -1,24 +1,22 @@
-import { createLock } from '@lowerdeck/lock';
 import { createQueue } from '@lowerdeck/queue';
 import { db, snowflake } from '@metorial-subspace/db';
 import { env } from '../../env';
 import { origin } from '../../origin';
 import { handlePushQueue } from './handlePush';
 
+let SCM_SYNC_MANY_JOB_ID = 'scm-sync-many';
+
 export let scmSyncManyQueue = createQueue<{}>({
   name: 'sub/cpr/scm/sync/many',
   redisUrl: env.service.REDIS_URL
 });
 
-let lock = createLock({
-  name: 'sub/cpr/scm/sync/many/lock',
-  redisUrl: env.service.REDIS_URL
-});
+export let enqueueScmSyncMany = () => scmSyncManyQueue.add({}, { id: SCM_SYNC_MANY_JOB_ID });
 
 let CURSOR_ID = 1;
 
-export let scmSyncManyQueueProcessor = scmSyncManyQueue.process(async data =>
-  lock.usingLock('1', async () => {
+export let scmSyncManyQueueProcessor = scmSyncManyQueue.process(async () => {
+  for (let i = 0; i < 50; i++) {
     let changeNotification = await db.originSyncChangeNotificationCursor.findFirst({
       where: { id: CURSOR_ID }
     });
@@ -88,7 +86,5 @@ export let scmSyncManyQueueProcessor = scmSyncManyQueue.process(async data =>
       create: { id: CURSOR_ID, cursor: lastItem.id },
       update: { cursor: lastItem.id }
     });
-
-    await scmSyncManyQueue.add({});
-  })
-);
+  }
+});

--- a/src/systems/subspace/provider-backends/provider-shuttle/src/queues/registry/syncServers.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/queues/registry/syncServers.ts
@@ -1,6 +1,5 @@
 import { createCron } from '@lowerdeck/cron';
 import { Hash } from '@lowerdeck/hash';
-import { createLock } from '@lowerdeck/lock';
 import { createQueue } from '@lowerdeck/queue';
 import { slugify } from '@lowerdeck/slugify';
 import {
@@ -19,11 +18,6 @@ let registryClient = env.service.REGISTRY_URL
     })
   : null;
 
-let lock = createLock({
-  name: 'sub/sht/sync/server/cnhnotif/lock',
-  redisUrl: env.service.REDIS_URL
-});
-
 export let syncServersCron = createCron(
   {
     name: 'sub/sht/sync/server/cron',
@@ -38,7 +32,8 @@ export let syncServersCron = createCron(
 
     await syncServersReg.addMany(
       serverRegistries.map(r => ({
-        registryUrl: r.from.url
+        registryUrl: r.from.url,
+        registryId: r.id
       }))
     );
   }
@@ -46,63 +41,67 @@ export let syncServersCron = createCron(
 
 let syncServersReg = createQueue<{
   registryUrl: string;
+  registryId?: string;
 }>({
   name: 'sub/sht/sync/server/reg',
   redisUrl: env.service.REDIS_URL
 });
 
 export let syncServersRegProcessor = syncServersReg.process(async data => {
-  await syncServersMany.add({
-    registryUrl: data.registryUrl
-  });
+  await syncServersMany.add({ registryUrl: data.registryUrl }, { id: data.registryId });
 });
 
 let syncServersMany = createQueue<{
   registryUrl: string;
 }>({
   name: 'sub/sht/sync/server/many',
-  redisUrl: env.service.REDIS_URL
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: {
+    concurrency: 1,
+    limiter: {
+      max: 1,
+      duration: 5_000
+    }
+  }
 });
 
-export let syncServersManyProcessor = syncServersMany.process(data =>
-  lock.usingLock(data.registryUrl, async () => {
-    let client = createMcpRegistryClient({
-      endpoint: data.registryUrl
-    });
+export let syncServersManyProcessor = syncServersMany.process(async data => {
+  let client = createMcpRegistryClient({
+    endpoint: data.registryUrl
+  });
 
-    let cursor = await db.shuttleSyncMcpServerRegistryCursor.findUnique({
-      where: { registryUrl: data.registryUrl }
-    });
+  let cursor = await db.shuttleSyncMcpServerRegistryCursor.findUnique({
+    where: { registryUrl: data.registryUrl }
+  });
 
-    let servers = await client.server.list({
-      after: cursor?.cursor,
-      limit: 100
-    });
-    if (!servers.items.length) return;
+  let servers = await client.server.list({
+    after: cursor?.cursor,
+    limit: 100
+  });
+  if (!servers.items.length) return;
 
-    await syncServersSingle.addManyWithOps(
-      servers.items.map(s => ({
-        data: { id: s.id, registryUrl: data.registryUrl },
-        opts: { id: s.id }
-      }))
-    );
+  await syncServersSingle.addManyWithOps(
+    servers.items.map(s => ({
+      data: { id: s.id, registryUrl: data.registryUrl },
+      opts: { id: s.id }
+    }))
+  );
 
-    await db.shuttleSyncMcpServerRegistryCursor.upsert({
-      where: { registryUrl: data.registryUrl },
-      create: {
-        registryUrl: data.registryUrl,
-        cursor: servers.items[servers.items.length - 1]!.id as string
-      },
-      update: {
-        cursor: servers.items[servers.items.length - 1]!.id as string
-      }
-    });
+  await db.shuttleSyncMcpServerRegistryCursor.upsert({
+    where: { registryUrl: data.registryUrl },
+    create: {
+      registryUrl: data.registryUrl,
+      cursor: servers.items[servers.items.length - 1]!.id as string
+    },
+    update: {
+      cursor: servers.items[servers.items.length - 1]!.id as string
+    }
+  });
 
-    await syncServersMany.add({
-      registryUrl: data.registryUrl
-    });
-  })
-);
+  await syncServersMany.add({
+    registryUrl: data.registryUrl
+  });
+});
 
 let syncServersSingle = createQueue<{
   registryUrl: string;

--- a/src/systems/subspace/provider-backends/provider-shuttle/src/queues/sync/syncShuttleVersion.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/queues/sync/syncShuttleVersion.ts
@@ -1,4 +1,3 @@
-import { createLock } from '@lowerdeck/lock';
 import { createQueue } from '@lowerdeck/queue';
 import { db, snowflake } from '@metorial-subspace/db';
 import { syncVersionToCustomProvider } from '@metorial-subspace/module-custom-provider';
@@ -20,11 +19,6 @@ export let syncShuttleVersionQueue = createQueue<{
       duration: 1000
     }
   }
-});
-
-let shuttleServerVersionUpsertLock = createLock({
-  name: 'sub/shut/serverVersion/upsert/lock',
-  redisUrl: env.service.REDIS_URL
 });
 
 export let syncShuttleVersionQueueProcessor = syncShuttleVersionQueue.process(async data => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes queue scheduling/deduplication and removes distributed locks in favor of rate limiting and fixed job IDs, which could alter throughput and re-entrancy behavior for sync pipelines.
> 
> **Overview**
> Adds explicit `workerOpts` concurrency/rate limiting to high-traffic queues (e.g. `serverVersionCreatedQueue`, `syncServersMany`) to control throughput.
> 
> Reworks sync job orchestration to avoid lock-based recursion: `scmSyncMany` is now enqueued via `enqueueScmSyncMany()` with a fixed job id and processes multiple pages in a bounded loop, and shuttle registry server syncing drops the Redis lock in favor of queue-level throttling and stable per-registry job ids while continuing to re-enqueue for pagination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f61f4c0c005e77bd0d70f75c49426f65f93905d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->