### PR TITLE
Order explorer items by name

### DIFF
--- a/src/frontend/apps/explorer/src/app.tsx
+++ b/src/frontend/apps/explorer/src/app.tsx
@@ -268,6 +268,36 @@ let getErrorMessage = (error: unknown) => {
   return typeof error === 'string' ? error : 'Unknown error';
 };
 
+let readOperationNamePrefixes = [
+  'list',
+  'get',
+  'read',
+  'fetch',
+  'search',
+  'find',
+  'lookup',
+  'retrieve',
+  'query',
+  'describe',
+  'inspect',
+  'view',
+  'show'
+];
+
+let isReadOperationToolName = (name: string) => {
+  let normalizedName = name.trim().toLowerCase();
+  return readOperationNamePrefixes.some(prefix => normalizedName.startsWith(prefix));
+};
+
+let prioritizeReadOperationTools = (tools: Tool[]) =>
+  [...tools].sort((a, b) => {
+    let aIsReadOperation = isReadOperationToolName(a.name);
+    let bIsReadOperation = isReadOperationToolName(b.name);
+
+    if (aIsReadOperation === bIsReadOperation) return 0;
+    return aIsReadOperation ? -1 : 1;
+  });
+
 let ExpandableCard = ({
   title,
   description,
@@ -639,7 +669,12 @@ export let ExplorerApp = () => {
         }
 
         startTransition(() => {
-          setCollections({ tools, resources, resourceTemplates, prompts });
+          setCollections({
+            tools: { ...tools, items: prioritizeReadOperationTools(tools.items) },
+            resources,
+            resourceTemplates,
+            prompts
+          });
           setServerCapabilities(client.getServerCapabilities() ?? null);
           setServerVersion(client.getServerVersion()?.version ?? null);
           setStatus('connected');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that reorders tool display based on name prefixes; no changes to tool execution, auth, or data handling.
> 
> **Overview**
> The explorer now **prioritizes likely read-only tools** in the Tools tab by sorting the loaded tool list so names starting with common read prefixes (e.g., `list`, `get`, `fetch`, `search`) appear first.
> 
> This adds a small name-normalization heuristic (`prioritizeReadOperationTools`) and applies it when setting the initial `tools` collection after connecting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34f05c8be4c664cf75290884751fd6686faac3d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->