### PR TITLE
Harden cell resource creation

### DIFF
--- a/src/backend/multi-region/src/sync/fromDeployment/consumerSurface.ts
+++ b/src/backend/multi-region/src/sync/fromDeployment/consumerSurface.ts
@@ -3,6 +3,7 @@ import { db } from '@metorial/db';
 import { createQueue } from '@metorial/queue';
 import { cell } from '../../cell';
 import { globalDB } from '../../db';
+import { upsertOrganization } from './organization';
 
 export let syncConsumerSurfacesCron = createCron(
   {
@@ -60,6 +61,8 @@ export let syncConsumerSurfaceSingleQueueProcessor = syncConsumerSurfaceSingleQu
       }
     });
     if (!surface) return;
+
+    await upsertOrganization(surface.organization.id);
 
     let inner = {
       status: surface.status,

--- a/src/backend/multi-region/src/sync/fromDeployment/oauth.ts
+++ b/src/backend/multi-region/src/sync/fromDeployment/oauth.ts
@@ -4,6 +4,7 @@ import { Fabric } from '@metorial/fabric';
 import { createQueue } from '@metorial/queue';
 import { cell } from '../../cell';
 import { globalDB } from '../../db';
+import { upsertOrganization } from './organization';
 
 let syncOAuthApp = async (_app: { id: string }) => {
   let app = await db.oAuthApplication.findUnique({
@@ -18,6 +19,8 @@ let syncOAuthApp = async (_app: { id: string }) => {
   // // Only sync apps that can be used in other deployments
   // if (app.type == 'server_side') return;
   // if (app.accessLevel == 'organization') return;
+
+  if (app.organization) await upsertOrganization(app.organization.id);
 
   let inner = {
     id: app.id,

--- a/src/backend/multi-region/src/sync/fromDeployment/organization.ts
+++ b/src/backend/multi-region/src/sync/fromDeployment/organization.ts
@@ -5,6 +5,29 @@ import { createQueue } from '@metorial/queue';
 import { cell } from '../../cell';
 import { globalDB } from '../../db';
 
+export let upsertOrganization = async (organizationId: string) => {
+  let organization = await db.organization.findUnique({
+    where: { id: organizationId }
+  });
+  if (!organization) return;
+
+  let inner = {
+    status: organization.status,
+    type: organization.type,
+    name: organization.name,
+    slug: organization.slug,
+    image: organization.image,
+    createdAt: organization.createdAt,
+    deletedAt: organization.deletedAt
+  };
+
+  await globalDB.organization.upsert({
+    where: { id: organization.id },
+    update: inner,
+    create: { id: organization.id, ...inner, ownerOid: (await cell).oid }
+  });
+};
+
 export let syncOrgsCron = createCron(
   {
     name: 'global/sync/from-deployment/org',
@@ -40,26 +63,7 @@ let syncOrgSingleQueue = createQueue<{ orgId: string }>({
 });
 
 export let syncOrgSingleQueueProcessor = syncOrgSingleQueue.process(async data => {
-  let organization = await db.organization.findUnique({
-    where: { id: data.orgId }
-  });
-  if (!organization) return;
-
-  let inner = {
-    status: organization.status,
-    type: organization.type,
-    name: organization.name,
-    slug: organization.slug,
-    image: organization.image,
-    createdAt: organization.createdAt,
-    deletedAt: organization.deletedAt
-  };
-
-  await globalDB.organization.upsert({
-    where: { id: organization.id },
-    update: inner,
-    create: { id: organization.id, ...inner, ownerOid: (await cell).oid }
-  });
+  await upsertOrganization(data.orgId);
 });
 
 Fabric.listen('organization.updated:after', async event => {

--- a/src/backend/multi-region/src/sync/fromDeployment/portal.ts
+++ b/src/backend/multi-region/src/sync/fromDeployment/portal.ts
@@ -4,6 +4,7 @@ import { Fabric } from '@metorial/fabric';
 import { createQueue } from '@metorial/queue';
 import { cell } from '../../cell';
 import { globalDB } from '../../db';
+import { upsertOrganization } from './organization';
 
 export let syncPortalsCron = createCron(
   {
@@ -56,6 +57,8 @@ export let syncPortalSingleQueueProcessor = syncPortalSingleQueue.process(async 
     }
   });
   if (!portal) return;
+
+  await upsertOrganization(portal.organization.id);
 
   let inner = {
     status: portal.status,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes cross-region replication order by ensuring organizations are upserted before related resources, which can affect data consistency and increase sync write load. Risk is moderate because it touches multi-region sync paths and introduces new dependency calls in several processors.
> 
> **Overview**
> Hardens multi-region sync by introducing a shared `upsertOrganization(organizationId)` helper and reusing it in the org sync queue processor.
> 
> Before upserting `portal`, `consumerSurface`, and `oAuthApplication` records into `globalDB`, the sync processors now first upsert the referenced organization to avoid creating/replicating dependent resources without their parent organization present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca439a558acc34705a6c91abc310384a1b743cfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->