### PR TITLE
Add integration tool filter editing

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
@@ -83,7 +83,7 @@ let getToolFilters = (values: ToolFilterFormValues) =>
         type: 'tool_keys' as const,
         keys: values.selectedToolKeys
       }
-    : undefined;
+    : null;
 
 let useProviderSetupVisibility = (p: {
   instanceId: string | null | undefined;
@@ -92,6 +92,7 @@ let useProviderSetupVisibility = (p: {
   existingConfigId?: string | null;
   allowAuthConfig?: boolean;
   respectIntegrationCustomConfigPolicy?: boolean;
+  respectIntegrationToolFilterPolicy?: boolean;
   isUpdate?: boolean;
 }) => {
   let provider = useProvider(p.instanceId, p.providerId);
@@ -110,6 +111,7 @@ let useProviderSetupVisibility = (p: {
       ? true
       : (p.integration?.configuration?.canAttachCustomProviderConfig ?? true);
   let allowToolFilters = p.integration?.configuration?.canOverrideToolFilters ?? true;
+  if (p.respectIntegrationToolFilterPolicy === false) allowToolFilters = true;
   let providerSupportsAuth = provider.data?.type.auth.status === 'enabled';
   let hasConfigInputs = configCapabilities.hasSchemaFields;
   // Auto-creating an empty config silently is only desirable on initial
@@ -485,6 +487,7 @@ let IntegrationProviderSetupStep = (p: {
     integration: p.integration ?? null,
     existingConfigId: p.integrationProvider?.config?.id,
     respectIntegrationCustomConfigPolicy: false,
+    respectIntegrationToolFilterPolicy: false,
     isUpdate
   });
   let authMethods = useProviderAuthMethods(

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
@@ -1124,7 +1124,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
       <ConfigureSectionCard
         key="tools"
         title="Tool Filters"
-        description="Limit which tools sessions from this template are allowed to use."
+        description="Limit which tools this provider setup is allowed to use."
         requirement="optional"
         completed={isToolsCompleted}
       >


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the integration provider panel to always expose tool filter controls and alters the submitted `toolFilters` value from `undefined` to `null`, which could affect API payload handling.
> 
> **Overview**
> Integration provider configuration now supports editing *tool filters* by adding a `respectIntegrationToolFilterPolicy` override in `useProviderSetupVisibility` and disabling the integration-level restriction in the provider panel flow.
> 
> Submission behavior for tool filters is adjusted so non-selected mode sends `toolFilters: null` (instead of omitting/`undefined`). The tool filter section copy in the session template provider panel is updated to better reflect provider-setup scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 179350be489a13347f5f2c9e8e0609a47574b453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->