### PR TITLE
Add skill agents

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -922,6 +922,7 @@
       "dependencies": {
         "@metorial/code": "^1.0.0",
         "@metorial/data-hooks": "^1.0.0",
+        "@metorial/dynamic-component": "^1.0.0",
         "@metorial/frontend-config": "^1.0.0",
         "@metorial/state": "^1.0.0",
         "@metorial/ui": "^1.0.0",
@@ -949,6 +950,7 @@
       "dependencies": {
         "@metorial/code": "^1.0.0",
         "@metorial/data-hooks": "^1.0.0",
+        "@metorial/dynamic-component": "^1.0.0",
         "@metorial/frontend-config": "^1.0.0",
         "@metorial/state": "^1.0.0",
         "@metorial/ui": "^1.0.0",
@@ -1010,6 +1012,7 @@
       "dependencies": {
         "@metorial/code": "^1.0.0",
         "@metorial/data-hooks": "^1.0.0",
+        "@metorial/dynamic-component": "^1.0.0",
         "@metorial/frontend-config": "^1.0.0",
         "@metorial/layout": "^1.0.0",
         "@metorial/state": "^1.0.0",
@@ -1745,12 +1748,14 @@
       "name": "@metorial/cargo",
       "dependencies": {
         "@lowerdeck/api-mux": "^1.0.4",
+        "@lowerdeck/canonicalize": "^1.0.4",
         "@lowerdeck/cron": "^1.1.2",
         "@lowerdeck/delay": "^1.0.4",
         "@lowerdeck/env": "^1.0.6",
         "@lowerdeck/error": "^1.2.3",
         "@lowerdeck/execution-context": "^1.1.1",
         "@lowerdeck/forwarded-for": "^1.0.4",
+        "@lowerdeck/hash": "^1.0.4",
         "@lowerdeck/hono": "^1.0.10",
         "@lowerdeck/id": "^1.0.8",
         "@lowerdeck/pagination": "^1.0.8",
@@ -1760,6 +1765,7 @@
         "@lowerdeck/rpc-server": "^1.0.11",
         "@lowerdeck/sentry": "^1.0.2",
         "@lowerdeck/service": "^1.0.7",
+        "@lowerdeck/slugify": "^1.0.6",
         "@lowerdeck/snowflake": "^1.0.2",
         "@lowerdeck/tokens": "^1.0.5",
         "@lowerdeck/validation": "1.0.10",
@@ -8801,6 +8807,8 @@
 
     "@metorial/auth/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
+    "@metorial/cargo/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@metorial/cargo/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@metorial/cargo/vitest": ["vitest@4.0.17", "", { "dependencies": { "@vitest/expect": "4.0.17", "@vitest/mocker": "4.0.17", "@vitest/pretty-format": "4.0.17", "@vitest/runner": "4.0.17", "@vitest/snapshot": "4.0.17", "@vitest/spy": "4.0.17", "@vitest/utils": "4.0.17", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.17", "@vitest/browser-preview": "4.0.17", "@vitest/browser-webdriverio": "4.0.17", "@vitest/ui": "4.0.17", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg=="],
@@ -10358,6 +10366,8 @@
     "@metorial/ares/vitest/tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "@metorial/ares/vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
+    "@metorial/cargo/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@metorial/cargo/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/src/backend/apis/core/src/controllers/index.ts
+++ b/src/backend/apis/core/src/controllers/index.ts
@@ -112,6 +112,7 @@ import {
   sessionTemplateController,
   sessionTemplateProviderController,
   skillController,
+  skillAgentController,
   skillGroupController,
   skillGroupItemController,
   skillItemController,
@@ -383,6 +384,7 @@ export let magnetarController = Controller.create<any>(
     fileLinkController,
 
     skillController,
+    skillAgentController,
     skillGroupController,
     skillGroupItemController,
     skillItemController,
@@ -490,6 +492,7 @@ export let dashboardController = Controller.create<any>(
     fileLinkController,
 
     skillController,
+    skillAgentController,
     skillGroupController,
     skillGroupItemController,
     skillItemController,

--- a/src/backend/apis/core/src/controllers/instance/skills/index.ts
+++ b/src/backend/apis/core/src/controllers/instance/skills/index.ts
@@ -1,4 +1,5 @@
 export * from './skill';
+export * from './skillAgent';
 export * from './skillParticipant';
 export * from './skillGroup';
 export * from './skillGroupItem';

--- a/src/backend/apis/core/src/controllers/instance/skills/skillAgent.ts
+++ b/src/backend/apis/core/src/controllers/instance/skills/skillAgent.ts
@@ -1,0 +1,171 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import type { Instance, Organization } from '@metorial/db';
+import { skillAgentService } from '@metorial/module-file';
+import type { SubspaceSkill } from '@metorial/module-subspace';
+import { Controller } from '@metorial/rest';
+import { getInstanceCargoAccess } from '../../../lib/cargoAccess';
+import { checkAccess } from '../../../middleware/checkAccess';
+import { instancePath } from '../../../middleware/instanceGroup';
+import { requireConsumerTokenForPublishableKey } from '../../../middleware/requireConsumerTokenForPublishableKey';
+import { skillAgentPresenter } from '../../../presenters';
+import { skillGroup } from './skill';
+
+let skillReadScopes = ['instance.skill:read', 'consumer#instance.skill:read'] as const;
+let skillWriteScopes = ['instance.skill:write', 'consumer#instance.skill:write'] as const;
+
+type SkillAgentContext = Parameters<typeof getInstanceCargoAccess>[0] & {
+  instance: Instance;
+  organization: Organization;
+  skill: SubspaceSkill;
+};
+
+let getSkillAgentInput = (ctx: SkillAgentContext) => ({
+  owner: {
+    type: 'instance' as const,
+    instance: ctx.instance,
+    organization: ctx.organization
+  },
+  skillId: ctx.skill.id,
+  storeId: ctx.skill.storeId,
+  ...getInstanceCargoAccess(ctx)
+});
+
+export let skillAgentGroup = skillGroup.use(async ctx => {
+  if (!ctx.params.skillAgentId) {
+    throw new Error('skillAgentId is required');
+  }
+
+  let skillAgent = await skillAgentService.getSkillAgentById({
+    ...getSkillAgentInput(ctx),
+    skillAgentId: ctx.params.skillAgentId
+  });
+
+  if (skillAgent.skillId !== ctx.skill.id) {
+    throw new ServiceError(notFoundError('skill.agent', ctx.params.skillAgentId));
+  }
+
+  return { skillAgent };
+});
+
+export let skillAgentController = Controller.create(
+  {
+    name: 'Skill Agents',
+    description: 'Manage sub-agents attached to a skill.'
+  },
+  {
+    create: skillGroup
+      .post(instancePath('skills/:skillId/agents', 'skills.agents.create'), {
+        name: 'Create skill agent',
+        description: 'Creates a new agent document in the skill agents directory.'
+      })
+      .use(checkAccess({ possibleScopes: [...skillWriteScopes] }))
+      .use(requireConsumerTokenForPublishableKey())
+      .body(
+        'default',
+        v.object({
+          name: v.string(),
+          description: v.optional(v.nullable(v.string())),
+          content: v.optional(v.string())
+        })
+      )
+      .output(skillAgentPresenter)
+      .do(async ctx => {
+        let skillAgent = await skillAgentService.createSkillAgent({
+          ...getSkillAgentInput(ctx),
+          input: {
+            name: ctx.body.name,
+            description: ctx.body.description,
+            content: ctx.body.content
+          }
+        });
+
+        return skillAgentPresenter.present({ skillAgent });
+      }),
+
+    list: skillGroup
+      .get(instancePath('skills/:skillId/agents', 'skills.agents.list'), {
+        name: 'List skill agents',
+        description: 'Returns a paginated list of agents for a specific skill.'
+      })
+      .use(checkAccess({ possibleScopes: [...skillReadScopes] }))
+      .use(requireConsumerTokenForPublishableKey())
+      .outputList(skillAgentPresenter)
+      .query(
+        'default',
+        Paginator.validate(
+          v.object({
+            include_archived: v.optional(v.boolean())
+          })
+        )
+      )
+      .do(async ctx => {
+        let { include_archived, ...pagination } = ctx.query;
+        let paginator = await skillAgentService.listSkillAgents({
+          ...getSkillAgentInput(ctx),
+          includeArchived: include_archived
+        });
+        let list = await paginator.run(pagination);
+
+        return Paginator.present(list, skillAgent =>
+          skillAgentPresenter.present({ skillAgent })
+        );
+      }),
+
+    get: skillAgentGroup
+      .get(instancePath('skills/:skillId/agents/:skillAgentId', 'skills.agents.get'), {
+        name: 'Get skill agent by ID',
+        description: 'Retrieves a specific agent within a skill.'
+      })
+      .use(checkAccess({ possibleScopes: [...skillReadScopes] }))
+      .use(requireConsumerTokenForPublishableKey())
+      .output(skillAgentPresenter)
+      .do(async ctx => skillAgentPresenter.present({ skillAgent: ctx.skillAgent })),
+
+    update: skillAgentGroup
+      .patch(instancePath('skills/:skillId/agents/:skillAgentId', 'skills.agents.update'), {
+        name: 'Update skill agent',
+        description: 'Updates the name or description for a specific skill agent.'
+      })
+      .use(checkAccess({ possibleScopes: [...skillWriteScopes] }))
+      .use(requireConsumerTokenForPublishableKey())
+      .body(
+        'default',
+        v.object({
+          name: v.optional(v.string()),
+          description: v.optional(v.nullable(v.string()))
+        })
+      )
+      .output(skillAgentPresenter)
+      .do(async ctx => {
+        let skillAgent = await skillAgentService.updateSkillAgent({
+          ...getSkillAgentInput(ctx),
+          skillAgent: ctx.skillAgent,
+          input: {
+            name: ctx.body.name,
+            description: ctx.body.description
+          }
+        });
+
+        return skillAgentPresenter.present({ skillAgent });
+      }),
+
+    delete: skillAgentGroup
+      .delete(instancePath('skills/:skillId/agents/:skillAgentId', 'skills.agents.delete'), {
+        name: 'Delete skill agent',
+        description: 'Archives a specific skill agent and removes its linked store item.'
+      })
+      .use(checkAccess({ possibleScopes: [...skillWriteScopes] }))
+      .use(requireConsumerTokenForPublishableKey())
+      .output(skillAgentPresenter)
+      .do(async ctx => {
+        let skillAgent = await skillAgentService.deleteSkillAgent({
+          ...getSkillAgentInput(ctx),
+          skillAgent: ctx.skillAgent
+        });
+
+        return skillAgentPresenter.present({ skillAgent });
+      })
+  }
+);

--- a/src/backend/apis/core/src/presenters/implementation/skills/index.ts
+++ b/src/backend/apis/core/src/presenters/implementation/skills/index.ts
@@ -1,4 +1,5 @@
 export * from './skill';
+export * from './skillAgent';
 export * from './skillParticipant';
 export * from './skillGroup';
 export * from './skillGroupItem';

--- a/src/backend/apis/core/src/presenters/implementation/skills/skillAgent.ts
+++ b/src/backend/apis/core/src/presenters/implementation/skills/skillAgent.ts
@@ -1,0 +1,42 @@
+import { v } from '@lowerdeck/validation';
+import { Presenter } from '@metorial/presenter';
+import { skillAgentType } from '../../types';
+
+export let v1SkillAgentPresenter = Presenter.create(skillAgentType)
+  .presenter(async ({ skillAgent }) => ({
+    object: 'skill.agent' as const,
+    id: skillAgent.id,
+    skill_id: skillAgent.skillId,
+    name: skillAgent.name,
+    description: skillAgent.description,
+    slug: skillAgent.slug,
+    status: skillAgent.status,
+    store_id: skillAgent.storeId,
+    store_item_id: skillAgent.storeItemId ?? null,
+    path: skillAgent.path ?? null,
+    document_id: skillAgent.documentId,
+    archived_at: skillAgent.archivedAt,
+    created_at: skillAgent.createdAt,
+    updated_at: skillAgent.updatedAt
+  }))
+  .schema(
+    v.object({
+      object: v.literal('skill.agent', {
+        description: "String representing the object's type"
+      }),
+      id: v.string(),
+      skill_id: v.string(),
+      name: v.string(),
+      description: v.nullable(v.string()),
+      slug: v.string(),
+      status: v.enumOf(['active', 'archived']),
+      store_id: v.string(),
+      store_item_id: v.nullable(v.string()),
+      path: v.nullable(v.string()),
+      document_id: v.string(),
+      archived_at: v.nullable(v.date()),
+      created_at: v.date(),
+      updated_at: v.date()
+    })
+  )
+  .build();

--- a/src/backend/apis/core/src/presenters/index.ts
+++ b/src/backend/apis/core/src/presenters/index.ts
@@ -158,6 +158,7 @@ import {
   v1SkillGroupItemPresenter,
   v1SkillGroupPresenter,
   v1SkillItemPresenter,
+  v1SkillAgentPresenter,
   v1SkillParticipantPresenter,
   v1SkillPresenter,
   v1SkillTemplateItemPresenter,
@@ -321,6 +322,7 @@ import {
   skillGroupItemType,
   skillGroupType,
   skillItemType,
+  skillAgentType,
   skillParticipantType,
   skillTemplateItemType,
   skillTemplateType,
@@ -548,6 +550,11 @@ export let storeItemListPresenter = declarePresenter(storeItemListType, {
 export let storeParticipantPresenter = declarePresenter(storeParticipantType, {
   mt_2025_01_01_dashboard: v1StoreParticipantPresenter,
   mt_2026_01_01_magnetar: v1StoreParticipantPresenter
+});
+
+export let skillAgentPresenter = declarePresenter(skillAgentType, {
+  mt_2025_01_01_dashboard: v1SkillAgentPresenter,
+  mt_2026_01_01_magnetar: v1SkillAgentPresenter
 });
 
 export let skillParticipantPresenter = declarePresenter(skillParticipantType, {

--- a/src/backend/apis/core/src/presenters/types.ts
+++ b/src/backend/apis/core/src/presenters/types.ts
@@ -82,6 +82,7 @@ import type {
   CargoFileLink,
   CargoStore,
   CargoStorePermissions,
+  CargoSkillAgent,
   EnrichedCargoDocument,
   EnrichedCargoDocumentParticipant,
   EnrichedCargoDocumentVersion,
@@ -474,6 +475,10 @@ export let storeItemListType = PresentableType.create<{
 export let storeParticipantType = PresentableType.create<{
   storeParticipant: EnrichedCargoStoreParticipant;
 }>()('storeParticipant');
+
+export let skillAgentType = PresentableType.create<{
+  skillAgent: CargoSkillAgent;
+}>()('skillAgent');
 
 export let skillParticipantType = PresentableType.create<{
   skillParticipant: EnrichedCargoSkillParticipant;

--- a/src/backend/modules/file/src/cargo.ts
+++ b/src/backend/modules/file/src/cargo.ts
@@ -77,6 +77,8 @@ export type CargoSkillParticipant = Awaited<ReturnType<typeof cargo.skillPartici
 export type CargoSkillParticipantList = Awaited<
   ReturnType<typeof cargo.skillParticipant.list>
 >;
+export type CargoSkillAgent = Awaited<ReturnType<typeof cargo.skillAgent.get>>;
+export type CargoSkillAgentList = Awaited<ReturnType<typeof cargo.skillAgent.list>>;
 export type CargoSkillVersion = Awaited<ReturnType<typeof cargo.skillVersion.get>>;
 export type CargoSkillVersionList = Awaited<ReturnType<typeof cargo.skillVersion.list>>;
 export type CargoSkillVersionSnapshot = Awaited<

--- a/src/backend/modules/file/src/services/index.ts
+++ b/src/backend/modules/file/src/services/index.ts
@@ -11,16 +11,19 @@ export type {
   CargoFileLinkByKeyResult,
   CargoFileReference,
   CargoScope,
-  CargoStore,
-  CargoStoreItem,
-  CargoStorePermissions,
-  CargoStoreParticipant,
+  CargoSkillAgent,
   CargoSkillParticipant,
   CargoSkillVersion,
-  CargoSkillVersionSnapshot
+  CargoSkillVersionSnapshot,
+  CargoStore,
+  CargoStoreItem,
+  CargoStoreParticipant,
+  CargoStorePermissions
 } from '../cargo';
 export type { CargoAccessActor, CargoAccessInput, CargoStorePermission } from './access';
+
 export { uploadCargoFile } from '../cargo';
+
 export * from './access';
 export * from './document';
 export * from './documentParticipant';
@@ -28,6 +31,7 @@ export * from './documentVersion';
 export * from './file';
 export * from './fileLink';
 export * from './fileReference';
+export * from './skillAgent';
 export * from './skillParticipant';
 export * from './skillVersion';
 export * from './store';

--- a/src/backend/modules/file/src/services/skillAgent.ts
+++ b/src/backend/modules/file/src/services/skillAgent.ts
@@ -1,0 +1,161 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import { cargo, type CargoSkillAgent } from '../cargo';
+import {
+  resolveCargoAccess,
+  type CargoAccessActor,
+  type CargoStorePermission
+} from './access';
+import type { FileOwner } from './file';
+import { storeService } from './store';
+
+type SkillAgentAccessInput = {
+  owner: FileOwner;
+  skillId: string;
+  storeId: string;
+  accessActor?: CargoAccessActor;
+  defaultPermissions?: CargoStorePermission[];
+  overridePermissions?: boolean;
+};
+
+class SkillAgentServiceImpl {
+  private async assertStoreAccess(d: SkillAgentAccessInput) {
+    await storeService.getStoreById({
+      owner: d.owner,
+      storeId: d.storeId,
+      accessActor: d.accessActor,
+      defaultPermissions: d.defaultPermissions,
+      overridePermissions: d.overridePermissions
+    });
+  }
+
+  async createSkillAgent(
+    d: SkillAgentAccessInput & {
+      input: {
+        name: string;
+        description?: string | null;
+        content?: string;
+      };
+    }
+  ) {
+    await this.assertStoreAccess(d);
+
+    let { scope, actorId, defaultPermissions, overridePermissions } =
+      await resolveCargoAccess(d);
+
+    return await cargo.skillAgent.create({
+      tenantId: scope.tenantId,
+      environmentId: scope.environmentId,
+      skillId: d.skillId,
+      name: d.input.name,
+      description: d.input.description,
+      content: d.input.content,
+      actorId,
+      defaultPermissions,
+      overridePermissions
+    });
+  }
+
+  async listSkillAgents(
+    d: SkillAgentAccessInput & {
+      includeArchived?: boolean;
+    }
+  ) {
+    await this.assertStoreAccess(d);
+
+    let { scope } = await resolveCargoAccess(d);
+
+    return Paginator.create(() => async input => {
+      let result = await cargo.skillAgent.list({
+        tenantId: scope.tenantId,
+        environmentId: scope.environmentId,
+        skillId: d.skillId,
+        includeArchived: d.includeArchived,
+        ...input
+      });
+
+      return {
+        items: result.items,
+        pagination: {
+          hasNextPage: result.pagination.has_more_after,
+          hasPreviousPage: result.pagination.has_more_before
+        }
+      };
+    });
+  }
+
+  async getSkillAgentById(
+    d: SkillAgentAccessInput & {
+      skillAgentId: string;
+    }
+  ) {
+    await this.assertStoreAccess(d);
+
+    let { scope } = await resolveCargoAccess(d);
+    let skillAgent = await cargo.skillAgent.get({
+      tenantId: scope.tenantId,
+      environmentId: scope.environmentId,
+      skillAgentId: d.skillAgentId
+    });
+
+    if (skillAgent.skillId !== d.skillId) {
+      throw new ServiceError(notFoundError('skill.agent', d.skillAgentId));
+    }
+
+    return skillAgent;
+  }
+
+  async updateSkillAgent(
+    d: SkillAgentAccessInput & {
+      skillAgent: CargoSkillAgent;
+      input: {
+        name?: string;
+        description?: string | null;
+      };
+    }
+  ) {
+    await this.assertStoreAccess(d);
+
+    let { scope, actorId, defaultPermissions, overridePermissions } =
+      await resolveCargoAccess(d);
+
+    return await cargo.skillAgent.update({
+      tenantId: scope.tenantId,
+      environmentId: scope.environmentId,
+      skillAgentId: d.skillAgent.id,
+      name: d.input.name,
+      description: d.input.description,
+      actorId,
+      defaultPermissions,
+      overridePermissions
+    });
+  }
+
+  async deleteSkillAgent(
+    d: SkillAgentAccessInput & {
+      skillAgent: CargoSkillAgent;
+    }
+  ) {
+    await this.assertStoreAccess(d);
+
+    let { scope, actorId, defaultPermissions, overridePermissions } =
+      await resolveCargoAccess(d);
+
+    return await cargo.skillAgent.delete({
+      tenantId: scope.tenantId,
+      environmentId: scope.environmentId,
+      skillAgentId: d.skillAgent.id,
+      actorId,
+      defaultPermissions,
+      overridePermissions
+    });
+  }
+}
+
+export type { CargoSkillAgent };
+
+export let skillAgentService = Service.create(
+  'fileSkillAgent',
+  () => new SkillAgentServiceImpl()
+).build();

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill/index.tsx
@@ -1,5 +1,6 @@
 import { Paths } from '@metorial/frontend-config';
 import {
+  SkillAgentsScene,
   SkillGroupsForSkillScene,
   SkillLinkProvidersScene,
   StoreFileViewerScene
@@ -37,6 +38,7 @@ export let SkillPage = () => {
           Paths.instance(organization.data, project.data, instance.data, 'doc', documentId)
         }
       />
+      <SkillAgentsScene instanceId={instance.data?.id} skillId={skillId} />
       <SkillLinkProvidersScene instanceId={instance.data?.id} skillId={skillId} />
       <SkillGroupsForSkillScene
         instanceId={instance.data?.id}

--- a/src/frontend/scenes/skills/src/scenes/index.ts
+++ b/src/frontend/scenes/skills/src/scenes/index.ts
@@ -1,19 +1,32 @@
 import { dynamicComponent } from '@metorial/dynamic-component';
-import type { SkillGroupSkillsScene as _SkillGroupSkillsScene } from './skillGroups';
-import type { SkillGroupsForSkillScene as _SkillGroupsForSkillScene } from './skillGroups';
-import type { SkillLinkProvidersScene as _SkillLinkProvidersScene } from './skillLinkProviders';
-import type { SkillTemplateLinkProvidersScene as _SkillTemplateLinkProvidersScene } from './skillLinkProviders';
+import type { SkillAgentsScene as _SkillAgentsScene } from './skillAgents';
+import type {
+  SkillGroupsForSkillScene as _SkillGroupsForSkillScene,
+  SkillGroupSkillsScene as _SkillGroupSkillsScene
+} from './skillGroups';
+import type {
+  SkillLinkProvidersScene as _SkillLinkProvidersScene,
+  SkillTemplateLinkProvidersScene as _SkillTemplateLinkProvidersScene
+} from './skillLinkProviders';
 import type { SkillParticipantsScene as _SkillParticipantsScene } from './skillParticipants';
-import type { SkillGroupSettingsScene as _SkillGroupSettingsScene } from './skillSettings';
-import type { SkillSettingsScene as _SkillSettingsScene } from './skillSettings';
-import type { SkillTemplateSettingsScene as _SkillTemplateSettingsScene } from './skillSettings';
-import type { StoreFileViewerScene as _StoreFileViewerScene } from './skillStoreFileViewer';
-import type { SkillStoreFileViewerScene as _SkillStoreFileViewerScene } from './skillStoreFileViewer';
+import type {
+  SkillGroupSettingsScene as _SkillGroupSettingsScene,
+  SkillSettingsScene as _SkillSettingsScene,
+  SkillTemplateSettingsScene as _SkillTemplateSettingsScene
+} from './skillSettings';
+import type {
+  SkillStoreFileViewerScene as _SkillStoreFileViewerScene,
+  StoreFileViewerScene as _StoreFileViewerScene
+} from './skillStoreFileViewer';
 import type { SkillVersionsScene as _SkillVersionsScene } from './skillVersions';
 
 export let SkillLinkProvidersScene = dynamicComponent<
   Parameters<typeof _SkillLinkProvidersScene>
 >(() => import('./skillLinkProviders').then(m => m.SkillLinkProvidersScene));
+
+export let SkillAgentsScene = dynamicComponent<Parameters<typeof _SkillAgentsScene>>(() =>
+  import('./skillAgents').then(m => m.SkillAgentsScene)
+);
 
 export let SkillGroupSkillsScene = dynamicComponent<Parameters<typeof _SkillGroupSkillsScene>>(
   () => import('./skillGroups').then(m => m.SkillGroupSkillsScene)

--- a/src/frontend/scenes/skills/src/scenes/skillAgents.tsx
+++ b/src/frontend/scenes/skills/src/scenes/skillAgents.tsx
@@ -1,0 +1,293 @@
+import { renderWithPagination, useForm } from '@metorial/data-hooks';
+import {
+  type SkillAgent,
+  useCreateSkillAgent,
+  useDeleteSkillAgent,
+  useSkillAgents,
+  useUpdateSkillAgent
+} from '@metorial/state';
+import {
+  Badge,
+  Button,
+  Dialog,
+  Input,
+  Menu,
+  Spacer,
+  Text,
+  confirm,
+  showModal
+} from '@metorial/ui';
+import { Box, Table } from '@metorial/ui-product';
+import { RiAddLine, RiMore2Line } from '@remixicon/react';
+import styled from 'styled-components';
+
+let EmptyState = styled.div`
+  line-height: 1.6;
+  padding: 8px 0;
+`;
+
+let AgentName = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 5px 0;
+`;
+
+let Actions = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+`;
+
+let normalizeOptionalString = (value: string | undefined | null) => {
+  let trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+let showSkillAgentFormModal = (p: {
+  mode: 'create' | 'edit';
+  instanceId: string;
+  skillId: string;
+  agent?: SkillAgent;
+  onComplete: () => Promise<void> | void;
+}) =>
+  showModal(({ dialogProps, close }) => {
+    let createSkillAgent = useCreateSkillAgent();
+    let updateSkillAgent = useUpdateSkillAgent();
+
+    let isCreate = p.mode === 'create';
+    let form = useForm({
+      initialValues: {
+        name: p.agent?.name ?? '',
+        description: p.agent?.description ?? '',
+        content: ''
+      },
+      onSubmit: async values => {
+        if (isCreate) {
+          let [result] = await createSkillAgent.mutate({
+            instanceId: p.instanceId,
+            skillId: p.skillId,
+            name: values.name.trim(),
+            description: normalizeOptionalString(values.description),
+            content: normalizeOptionalString(values.content)
+          });
+
+          if (!result) return;
+        } else {
+          if (!p.agent) return;
+
+          let [result] = await updateSkillAgent.mutate({
+            instanceId: p.instanceId,
+            skillId: p.skillId,
+            skillAgentId: p.agent.id,
+            name: values.name.trim(),
+            description: normalizeOptionalString(values.description)
+          });
+
+          if (!result) return;
+        }
+
+        await p.onComplete();
+        close();
+      },
+      schema: yup =>
+        yup.object({
+          name: yup.string().trim().required('Enter a name'),
+          description: yup.string(),
+          content: yup.string()
+        }) as any
+    });
+
+    return (
+      <Dialog.Wrapper {...dialogProps} width={560}>
+        <Dialog.Title>{isCreate ? 'Create Skill Agent' : 'Edit Skill Agent'}</Dialog.Title>
+        <Dialog.Description>
+          Skill agents define sub-agent behavior and are stored with this skill.
+        </Dialog.Description>
+
+        <form onSubmit={form.handleSubmit}>
+          <Input label="Name" {...form.getFieldProps('name')} />
+          <form.RenderError field="name" />
+
+          <Spacer height={15} />
+
+          <Input label="Description" {...form.getFieldProps('description')} />
+          <form.RenderError field="description" />
+
+          {isCreate && (
+            <>
+              <Spacer height={15} />
+
+              <Input
+                label="Initial Content"
+                as="textarea"
+                minRows={5}
+                {...form.getFieldProps('content')}
+              />
+              <form.RenderError field="content" />
+            </>
+          )}
+
+          <Spacer height={20} />
+
+          <Dialog.Actions>
+            <Button variant="outline" type="button" onClick={close} size="2">
+              Cancel
+            </Button>
+            <Button
+              size="2"
+              type="submit"
+              loading={isCreate ? createSkillAgent.isLoading : updateSkillAgent.isLoading}
+              success={isCreate ? createSkillAgent.isSuccess : updateSkillAgent.isSuccess}
+            >
+              {isCreate ? 'Create Agent' : 'Save Agent'}
+            </Button>
+          </Dialog.Actions>
+
+          <createSkillAgent.RenderError />
+          <updateSkillAgent.RenderError />
+        </form>
+      </Dialog.Wrapper>
+    );
+  });
+
+let getSkillAgentTableRow = (p: {
+  agent: SkillAgent;
+  isDeleting: boolean;
+  onEdit: (agent: SkillAgent) => void;
+  onDelete: (agent: SkillAgent) => void;
+}) => [
+  <AgentName>
+    <Text size="2" weight="strong">
+      {p.agent.name}
+    </Text>
+    {p.agent.description && (
+      <Text color="gray600" size="1">
+        {p.agent.description}
+      </Text>
+    )}
+  </AgentName>,
+  <Badge color={p.agent.status === 'active' ? 'green' : 'gray'} size="1">
+    {p.agent.status}
+  </Badge>,
+  <Text color={p.agent.path ? 'gray800' : 'gray500'} size="2">
+    {p.agent.path ?? p.agent.documentId}
+  </Text>,
+  <Actions>
+    <Menu
+      items={[
+        { id: 'edit', label: 'Edit' },
+        { id: 'delete', label: 'Delete' }
+      ]}
+      onItemClick={item => {
+        if (item === 'edit') p.onEdit(p.agent);
+        if (item === 'delete') {
+          confirm({
+            title: `Delete ${p.agent.name}?`,
+            description: 'This will archive the skill agent and remove its linked store item.',
+            confirmText: 'Delete',
+            onConfirm: async () => p.onDelete(p.agent)
+          });
+        }
+      }}
+    >
+      <Button
+        size="1"
+        variant="outline"
+        iconRight={<RiMore2Line />}
+        loading={p.isDeleting}
+        title="Skill agent options"
+      />
+    </Menu>
+  </Actions>
+];
+
+export let SkillAgentsScene = (p: {
+  instanceId: string | null | undefined;
+  skillId: string | null | undefined;
+}) => {
+  let skillAgents = useSkillAgents(p.instanceId, p.skillId, { order: 'asc' });
+  let deleteSkillAgent = useDeleteSkillAgent();
+
+  let openCreateModal = () => {
+    if (!p.instanceId || !p.skillId) return;
+
+    showSkillAgentFormModal({
+      mode: 'create',
+      instanceId: p.instanceId,
+      skillId: p.skillId,
+      onComplete: () => skillAgents.refetch()
+    });
+  };
+
+  let openEditModal = (agent: SkillAgent) => {
+    if (!p.instanceId || !p.skillId) return;
+
+    showSkillAgentFormModal({
+      mode: 'edit',
+      instanceId: p.instanceId,
+      skillId: p.skillId,
+      agent,
+      onComplete: () => skillAgents.refetch()
+    });
+  };
+
+  let deleteAgent = async (agent: SkillAgent) => {
+    if (!p.instanceId || !p.skillId) return;
+
+    let [result] = await deleteSkillAgent.mutate({
+      instanceId: p.instanceId,
+      skillId: p.skillId,
+      skillAgentId: agent.id
+    });
+
+    if (!result) return;
+    await skillAgents.refetch();
+  };
+
+  return (
+    <Box
+      title="Skill Agents"
+      description="Create and manage sub-agents attached to this skill."
+      rightActions={
+        <Button
+          size="2"
+          variant="outline"
+          iconLeft={<RiAddLine />}
+          disabled={!p.instanceId || !p.skillId}
+          onClick={openCreateModal}
+        >
+          Create Agent
+        </Button>
+      }
+    >
+      {renderWithPagination(skillAgents)(skillAgents => (
+        <>
+          {skillAgents.data.items.length === 0 ? (
+            <EmptyState>
+              <Text color="gray600" size="2">
+                No skill agents have been created for this skill yet.
+              </Text>
+            </EmptyState>
+          ) : (
+            <Table
+              headers={['Name', 'Status', 'Document', '']}
+              data={skillAgents.data.items.map(agent =>
+                getSkillAgentTableRow({
+                  agent,
+                  isDeleting: deleteSkillAgent.isLoading,
+                  onEdit: openEditModal,
+                  onDelete: deleteAgent
+                })
+              )}
+            />
+          )}
+
+          <deleteSkillAgent.RenderError />
+        </>
+      ))}
+    </Box>
+  );
+};

--- a/src/frontend/scenes/skills/src/scenes/skillGroups.tsx
+++ b/src/frontend/scenes/skills/src/scenes/skillGroups.tsx
@@ -305,6 +305,7 @@ export let SkillGroupSkillsScene = (p: {
           iconLeft={<RiAddLine />}
           disabled={!p.instanceId || !p.skillGroupId}
           onClick={openPicker}
+          variant="outline"
         >
           Add Skill
         </Button>
@@ -436,6 +437,7 @@ export let SkillGroupsForSkillScene = (p: {
           iconLeft={<RiAddLine />}
           disabled={!p.instanceId || !p.skillId || !allSkillGroups.data}
           onClick={openPicker}
+          variant="outline"
         >
           Add to Group
         </Button>

--- a/src/frontend/scenes/skills/src/scenes/skillLinkProviders.tsx
+++ b/src/frontend/scenes/skills/src/scenes/skillLinkProviders.tsx
@@ -646,8 +646,8 @@ let AddSkillItemMenu = (p: {
       if (item === 'provider' || item === 'integration') p.onSelect(item);
     }}
   >
-    <Button size="2" iconLeft={<RiAddLine />} disabled={p.disabled}>
-      Add
+    <Button size="2" iconLeft={<RiAddLine />} disabled={p.disabled} variant="outline">
+      Add Provider
     </Button>
   </Menu>
 );

--- a/src/frontend/state/src/skills/loaders/skills.ts
+++ b/src/frontend/state/src/skills/loaders/skills.ts
@@ -1,4 +1,8 @@
 import type {
+  DashboardInstanceSkillsAgentsCreateBody,
+  DashboardInstanceSkillsAgentsGetOutput,
+  DashboardInstanceSkillsAgentsListQuery,
+  DashboardInstanceSkillsAgentsUpdateBody,
   DashboardInstanceSkillsCreateBody,
   DashboardInstanceSkillsDuplicateBody,
   DashboardInstanceSkillsForkBody,
@@ -20,6 +24,7 @@ import { usePaginator } from '../../lib/usePaginator';
 import { withAuth } from '../../user';
 
 export type Skill = DashboardInstanceSkillsGetOutput;
+export type SkillAgent = DashboardInstanceSkillsAgentsGetOutput;
 export type SkillItem = DashboardInstanceSkillsItemsGetOutput;
 export type SkillParticipant = DashboardInstanceSkillsParticipantsGetOutput;
 export type SkillVersion = DashboardInstanceSkillsVersionsGetOutput;
@@ -102,6 +107,91 @@ export let useSkill = (
   skillId: string | null | undefined
 ) => {
   let data = skillLoader.use(instanceId && skillId ? { instanceId, skillId } : null);
+
+  return {
+    ...data,
+    updateMutator: data.useMutator('update'),
+    deleteMutator: data.useMutator('delete')
+  };
+};
+
+export let skillAgentsLoader = createLoader({
+  name: 'skillAgents',
+  parents: [skillLoader],
+  fetch: (
+    i: { instanceId: string; skillId: string } & DashboardInstanceSkillsAgentsListQuery
+  ) => withAuth(sdk => sdk.skills.agents.list(i.instanceId, i.skillId, i)),
+  mutators: {}
+});
+
+export let useCreateSkillAgent = skillAgentsLoader.createExternalMutator(
+  (i: DashboardInstanceSkillsAgentsCreateBody & { instanceId: string; skillId: string }) =>
+    withAuth(sdk => sdk.skills.agents.create(i.instanceId, i.skillId, i))
+);
+
+export let useUpdateSkillAgent = skillAgentsLoader.createExternalMutator(
+  (
+    i: DashboardInstanceSkillsAgentsUpdateBody & {
+      instanceId: string;
+      skillId: string;
+      skillAgentId: string;
+    }
+  ) => withAuth(sdk => sdk.skills.agents.update(i.instanceId, i.skillId, i.skillAgentId, i))
+);
+
+export let useDeleteSkillAgent = skillAgentsLoader.createExternalMutator(
+  (i: { instanceId: string; skillId: string; skillAgentId: string }) =>
+    withAuth(sdk => sdk.skills.agents.delete(i.instanceId, i.skillId, i.skillAgentId))
+);
+
+export let useSkillAgents = (
+  instanceId: string | null | undefined,
+  skillId: string | null | undefined,
+  query?: DashboardInstanceSkillsAgentsListQuery | null
+) => {
+  return usePaginator(
+    pagination =>
+      skillAgentsLoader.use(
+        instanceId && skillId && query !== null
+          ? { instanceId, skillId, ...pagination, ...(query ?? {}) }
+          : null
+      ),
+    instanceId && skillId
+      ? `${instanceId}:${skillId}:agents:${JSON.stringify(query ?? {})}`
+      : null
+  );
+};
+
+export let skillAgentLoader = createLoader({
+  name: 'skillAgent',
+  parents: [skillAgentsLoader, skillLoader],
+  fetch: (i: { instanceId: string; skillId: string; skillAgentId: string }) =>
+    withAuth(sdk => sdk.skills.agents.get(i.instanceId, i.skillId, i.skillAgentId)),
+  mutators: {
+    update: (
+      i: DashboardInstanceSkillsAgentsUpdateBody,
+      {
+        input: { instanceId, skillId, skillAgentId }
+      }: { input: { instanceId: string; skillId: string; skillAgentId: string } }
+    ) => withAuth(sdk => sdk.skills.agents.update(instanceId, skillId, skillAgentId, i)),
+
+    delete: (
+      _: void,
+      {
+        input: { instanceId, skillId, skillAgentId }
+      }: { input: { instanceId: string; skillId: string; skillAgentId: string } }
+    ) => withAuth(sdk => sdk.skills.agents.delete(instanceId, skillId, skillAgentId))
+  }
+});
+
+export let useSkillAgent = (
+  instanceId: string | null | undefined,
+  skillId: string | null | undefined,
+  skillAgentId: string | null | undefined
+) => {
+  let data = skillAgentLoader.use(
+    instanceId && skillId && skillAgentId ? { instanceId, skillId, skillAgentId } : null
+  );
 
   return {
     ...data,

--- a/src/systems/cargo/service/package.json
+++ b/src/systems/cargo/service/package.json
@@ -57,6 +57,7 @@
     "@lowerdeck/rpc-server": "^1.0.11",
     "@lowerdeck/sentry": "^1.0.2",
     "@lowerdeck/service": "^1.0.7",
+    "@lowerdeck/slugify": "^1.0.6",
     "@lowerdeck/snowflake": "^1.0.2",
     "@lowerdeck/tokens": "^1.0.5",
     "@lowerdeck/validation": "1.0.10",

--- a/src/systems/cargo/service/prisma/schema/docs.prisma
+++ b/src/systems/cargo/service/prisma/schema/docs.prisma
@@ -48,6 +48,7 @@ model Document {
   documentVersions     DocumentVersion[]
   storeItems           StoreItem[]
   storeVersionItems    StoreVersionItem[]
+  skillAgents          SkillAgent[]
 
   @@index([tenantOid, environmentOid])
   @@index([tenantOid, environmentOid, isTemplateBacking])

--- a/src/systems/cargo/service/prisma/schema/skill.prisma
+++ b/src/systems/cargo/service/prisma/schema/skill.prisma
@@ -24,7 +24,37 @@ model Skill {
   createdAt DateTime @default(now())
 
   skillParticipants SkillParticipant[]
-  skillVersions      SkillVersion[]
+  skillVersions     SkillVersion[]
+  skillAgents       SkillAgent[]
+}
+
+enum SkillAgentStatus {
+  active
+  archived
+}
+
+model SkillAgent {
+  oid BigInt @id
+  id  String @unique
+
+  status SkillAgentStatus @default(active)
+
+  name String
+  slug String
+  description String?
+
+  skillOid BigInt
+  skill    Skill  @relation(fields: [skillOid], references: [oid], onDelete: Cascade)
+
+  storeItemOid BigInt?    @unique
+  storeItem    StoreItem? @relation(fields: [storeItemOid], references: [oid], onDelete: SetNull)
+
+  documentOid BigInt
+  document    Document @relation(fields: [documentOid], references: [oid], onDelete: Cascade)
+
+  archivedAt DateTime?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @default(now()) @updatedAt
 }
 
 model SkillVersion {

--- a/src/systems/cargo/service/prisma/schema/store.prisma
+++ b/src/systems/cargo/service/prisma/schema/store.prisma
@@ -187,6 +187,8 @@ model StoreItem {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
+  skillAgent SkillAgent?
+
   @@unique([storeOid, path])
   @@unique([directoryOid])
   @@index([parentDirectoryOid])

--- a/src/systems/cargo/service/src/controllers/index.ts
+++ b/src/systems/cargo/service/src/controllers/index.ts
@@ -10,6 +10,7 @@ import { fileLinkController } from './fileLink';
 import { filePurposeController } from './filePurpose';
 import { fileReferenceController } from './fileReference';
 import { reconcileController } from './reconcile';
+import { skillAgentController } from './skillAgent';
 import { skillController } from './skill';
 import { skillParticipantController } from './skillParticipant';
 import { skillTemplateController } from './skillTemplate';
@@ -29,6 +30,7 @@ export let rootController = app.controller({
   fileLink: fileLinkController,
   fileReference: fileReferenceController,
   skill: skillController,
+  skillAgent: skillAgentController,
   skillParticipant: skillParticipantController,
   skillTemplate: skillTemplateController,
   skillVersion: skillVersionController,

--- a/src/systems/cargo/service/src/controllers/skillAgent.ts
+++ b/src/systems/cargo/service/src/controllers/skillAgent.ts
@@ -1,0 +1,147 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import { skillAgentPresenter } from '../presenters';
+import { skillAgentService } from '../services';
+import { app } from './_app';
+import { storePermissionsSchema } from './document';
+import { skillApp } from './skill';
+import { tenantApp } from './tenant';
+
+export let skillAgentApp = tenantApp.use(async ctx => {
+  let skillAgentId = ctx.body.skillAgentId;
+  if (!skillAgentId) throw new Error('Skill agent ID is required');
+
+  let skillAgent = await skillAgentService.getSkillAgentById({
+    tenant: ctx.tenant,
+    environment: ctx.environment,
+    skillAgentId
+  });
+
+  return { skillAgent };
+});
+
+export let skillAgentController = app.controller({
+  create: skillApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        skillId: v.string(),
+        name: v.string(),
+        description: v.optional(v.nullable(v.string())),
+        content: v.optional(v.string()),
+        actorId: v.optional(v.string()),
+        defaultPermissions: v.optional(storePermissionsSchema),
+        overridePermissions: v.optional(v.boolean())
+      })
+    )
+    .do(async ctx =>
+      skillAgentPresenter(
+        await skillAgentService.createSkillAgent({
+          tenant: ctx.tenant,
+          environment: ctx.environment,
+          skill: ctx.skill,
+          input: {
+            name: ctx.input.name,
+            description: ctx.input.description,
+            content: ctx.input.content,
+            actorId: ctx.input.actorId,
+            defaultPermissions: ctx.input.defaultPermissions,
+            overridePermissions: ctx.input.overridePermissions
+          }
+        })
+      )
+    ),
+
+  list: tenantApp
+    .handler()
+    .input(
+      Paginator.validate(
+        v.object({
+          tenantId: v.string(),
+          environmentId: v.string(),
+          skillId: v.optional(v.string()),
+          includeArchived: v.optional(v.boolean())
+        })
+      )
+    )
+    .do(async ctx => {
+      let paginator = await skillAgentService.listSkillAgents({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        skillId: ctx.input.skillId,
+        includeArchived: ctx.input.includeArchived
+      });
+      let list = await paginator.run(ctx.input);
+
+      return Paginator.presentLight(list, skillAgentPresenter);
+    }),
+
+  get: skillAgentApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        skillAgentId: v.string()
+      })
+    )
+    .do(async ctx => skillAgentPresenter(ctx.skillAgent)),
+
+  update: skillAgentApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        skillAgentId: v.string(),
+        name: v.optional(v.string()),
+        description: v.optional(v.nullable(v.string())),
+        actorId: v.optional(v.string()),
+        defaultPermissions: v.optional(storePermissionsSchema),
+        overridePermissions: v.optional(v.boolean())
+      })
+    )
+    .do(async ctx =>
+      skillAgentPresenter(
+        await skillAgentService.updateSkillAgent({
+          tenant: ctx.tenant,
+          environment: ctx.environment,
+          skillAgent: ctx.skillAgent,
+          actorId: ctx.input.actorId,
+          defaultPermissions: ctx.input.defaultPermissions,
+          overridePermissions: ctx.input.overridePermissions,
+          input: {
+            name: ctx.input.name,
+            description: ctx.input.description
+          }
+        })
+      )
+    ),
+
+  delete: skillAgentApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        skillAgentId: v.string(),
+        actorId: v.optional(v.string()),
+        defaultPermissions: v.optional(storePermissionsSchema),
+        overridePermissions: v.optional(v.boolean())
+      })
+    )
+    .do(async ctx =>
+      skillAgentPresenter(
+        await skillAgentService.deleteSkillAgent({
+          tenant: ctx.tenant,
+          environment: ctx.environment,
+          skillAgent: ctx.skillAgent,
+          actorId: ctx.input.actorId,
+          defaultPermissions: ctx.input.defaultPermissions,
+          overridePermissions: ctx.input.overridePermissions
+        })
+      )
+    )
+});

--- a/src/systems/cargo/service/src/controllers/tests/skill.e2e.test.ts
+++ b/src/systems/cargo/service/src/controllers/tests/skill.e2e.test.ts
@@ -254,6 +254,304 @@ describe('cargo skill.e2e', () => {
     expect(deletedStore).toBeNull();
   });
 
+  it('manages skill agents from markdown documents in skill stores', async () => {
+    let { tenant, environment } = await createScope();
+    let skill = await cargoClient.skill.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      skillId: 'csk_agents',
+      name: 'Agent Skill'
+    });
+
+    let createdAgent = await cargoClient.skillAgent.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      skillId: skill.id,
+      name: 'Research Assistant',
+      description: 'Find useful information',
+      content: 'agent instructions'
+    });
+
+    expect(createdAgent).toMatchObject({
+      skillId: skill.id,
+      name: 'Research Assistant',
+      description: 'Find useful information',
+      slug: 'research-assistant',
+      status: 'active',
+      path: '/agents/research-assistant.md',
+      documentId: expect.any(String),
+      storeItemId: expect.any(String)
+    });
+
+    let updatedAgent = await cargoClient.skillAgent.update({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      skillAgentId: createdAgent.id,
+      name: 'Research Lead',
+      description: null
+    });
+
+    expect(updatedAgent).toMatchObject({
+      id: createdAgent.id,
+      name: 'Research Lead',
+      description: null,
+      slug: 'research-assistant',
+      path: '/agents/research-assistant.md'
+    });
+
+    await expect(
+      cargoClient.document.delete({
+        tenantId: tenant.id,
+        environmentId: environment.id,
+        documentId: createdAgent.documentId
+      })
+    ).rejects.toThrow('Cannot delete document: it is linked to an active skill agent');
+
+    let createdDocument = await cargoClient.document.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: createdAgent.documentId
+    });
+
+    await expect(
+      cargoClient.file.delete({
+        tenantId: tenant.id,
+        environmentId: environment.id,
+        fileId: createdDocument.fileId
+      })
+    ).rejects.toThrow('Cannot delete file: it is linked to an active skill agent');
+
+    let manualDocument = await cargoClient.document.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      title: 'Manual Agent',
+      content: 'manual instructions',
+      store: {
+        id: skill.storeId,
+        path: '/agents/manual.md'
+      }
+    });
+
+    let listedAfterManual = await cargoClient.skillAgent.list({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      skillId: skill.id,
+      limit: 10
+    });
+    let manualAgent = listedAfterManual.items.find(item => item.documentId === manualDocument.id)!;
+
+    expect(manualAgent).toMatchObject({
+      name: 'Manual Agent',
+      slug: 'manual',
+      path: '/agents/manual.md',
+      status: 'active'
+    });
+
+    await cargoClient.store.modifyItems({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: skill.storeId,
+      operations: [
+        {
+          type: 'modify',
+          itemId: manualAgent.storeItemId,
+          path: '/agents/manual-renamed.md'
+        }
+      ]
+    });
+
+    let renamedAgent = await cargoClient.skillAgent.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      skillAgentId: manualAgent.id
+    });
+
+    expect(renamedAgent).toMatchObject({
+      name: 'manual-renamed',
+      slug: 'manual-renamed',
+      path: '/agents/manual-renamed.md',
+      status: 'active'
+    });
+
+    await cargoClient.store.modifyItems({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      storeId: skill.storeId,
+      operations: [
+        {
+          type: 'modify',
+          itemId: renamedAgent.storeItemId,
+          path: '/docs/manual-renamed.md'
+        }
+      ]
+    });
+
+    let archivedAfterMove = await cargoClient.skillAgent.list({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      skillId: skill.id,
+      includeArchived: true,
+      limit: 10
+    });
+    let movedAgent = archivedAfterMove.items.find(item => item.id === manualAgent.id)!;
+
+    expect(movedAgent).toMatchObject({
+      status: 'archived',
+      storeItemId: undefined,
+      archivedAt: expect.any(Date)
+    });
+
+    let deletedAgent = await cargoClient.skillAgent.delete({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      skillAgentId: createdAgent.id
+    });
+    let removedStoreItem = await db.storeItem.findFirst({
+      where: {
+        id: createdAgent.storeItemId
+      }
+    });
+    let deletedDocument = await cargoClient.document.delete({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      documentId: createdAgent.documentId
+    });
+
+    expect(deletedAgent.status).toBe('archived');
+    expect(deletedAgent.storeItemId).toBeUndefined();
+    expect(removedStoreItem).toBeNull();
+    expect(deletedDocument.status).toBe('deleted');
+
+    let purpose = await cargoClient.filePurpose.upsert({
+      slug: 'skill_agent_restricted_file',
+      name: 'Skill Agent Restricted File',
+      ownerType: 'organization',
+      canHaveLinks: true
+    });
+
+    await expect(
+      cargoClient.file.create({
+        tenantId: tenant.id,
+        environmentId: environment.id,
+        purpose: purpose.id,
+        storeId: 'skill-agent-restricted-file',
+        name: 'bad.md',
+        mimeType: 'text/markdown',
+        size: 10,
+        store: {
+          id: skill.storeId,
+          path: '/agents/bad.md'
+        }
+      })
+    ).rejects.toThrow('Only markdown documents can be added to the agents directory');
+
+    await expect(
+      cargoClient.document.create({
+        tenantId: tenant.id,
+        environmentId: environment.id,
+        title: 'Bad Agent',
+        content: 'bad',
+        store: {
+          id: skill.storeId,
+          path: '/agents/bad.txt'
+        }
+      })
+    ).rejects.toThrow('Only markdown documents can be added to the agents directory');
+
+    await expect(
+      cargoClient.store.modifyItems({
+        tenantId: tenant.id,
+        environmentId: environment.id,
+        storeId: skill.storeId,
+        operations: [
+          {
+            type: 'add',
+            path: '/agents/folder/'
+          }
+        ]
+      })
+    ).rejects.toThrow('Only markdown documents can be added to the agents directory');
+
+    let skillDocument = await cargoClient.document.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      title: 'Skill Root',
+      content: 'root instructions',
+      store: {
+        id: skill.storeId,
+        path: '/SKILL.md'
+      }
+    });
+    let skillDocumentItem = (
+      await cargoClient.storeItem.list({
+        tenantId: tenant.id,
+        environmentId: environment.id,
+        storeId: skill.storeId,
+        documentId: skillDocument.id,
+        limit: 10
+      })
+    ).items[0]!;
+
+    await expect(
+      cargoClient.store.modifyItems({
+        tenantId: tenant.id,
+        environmentId: environment.id,
+        storeId: skill.storeId,
+        operations: [
+          {
+            type: 'remove',
+            itemId: skillDocumentItem.id
+          }
+        ]
+      })
+    ).rejects.toThrow('SKILL.md cannot be removed from a skill store');
+
+    await expect(
+      cargoClient.store.modifyItems({
+        tenantId: tenant.id,
+        environmentId: environment.id,
+        storeId: skill.storeId,
+        operations: [
+          {
+            type: 'modify',
+            itemId: skillDocumentItem.id,
+            path: '/docs/SKILL.md'
+          }
+        ]
+      })
+    ).rejects.toThrow('SKILL.md cannot be moved in a skill store');
+
+    await expect(
+      cargoClient.file.create({
+        tenantId: tenant.id,
+        environmentId: environment.id,
+        purpose: purpose.id,
+        storeId: 'skill-root-file',
+        name: 'SKILL.md',
+        mimeType: 'text/markdown',
+        size: 10,
+        store: {
+          id: skill.storeId,
+          path: '/SKILL.md'
+        }
+      })
+    ).rejects.toThrow('SKILL.md is reserved for documents in skill stores');
+
+    await expect(
+      cargoClient.store.modifyItems({
+        tenantId: tenant.id,
+        environmentId: environment.id,
+        storeId: skill.storeId,
+        operations: [
+          {
+            type: 'add',
+            path: '/docs/SKILL.md/'
+          }
+        ]
+      })
+    ).rejects.toThrow('SKILL.md is reserved for documents in skill stores');
+  });
+
   it('creates skill versions for store snapshots and resolves document version content', async () => {
     let { tenant, environment } = await createScope();
     let skill = await cargoClient.skill.create({

--- a/src/systems/cargo/service/src/id.ts
+++ b/src/systems/cargo/service/src/id.ts
@@ -21,6 +21,7 @@ export let ID = createIdGenerator({
   storeVersion: idType.sorted('stv_'),
   storeVersionItem: idType.sorted('stvi_'),
   storeParticipant: idType.sorted('stp_'),
+  skillAgent: idType.sorted('ska_'),
   skillVersion: idType.sorted('skv_'),
   skillParticipant: idType.sorted('skp_'),
 

--- a/src/systems/cargo/service/src/presenters/index.ts
+++ b/src/systems/cargo/service/src/presenters/index.ts
@@ -9,6 +9,7 @@ export * from './filePurpose';
 export * from './fileReference';
 export * from './permissions';
 export * from './skill';
+export * from './skillAgent';
 export * from './skillParticipant';
 export * from './skillTemplate';
 export * from './skillVersion';

--- a/src/systems/cargo/service/src/presenters/skillAgent.ts
+++ b/src/systems/cargo/service/src/presenters/skillAgent.ts
@@ -1,0 +1,18 @@
+import type { SkillAgentRecord } from '../services/skillAgent';
+
+export let skillAgentPresenter = (skillAgent: SkillAgentRecord) => ({
+  object: 'cargo#skillAgent',
+  id: skillAgent.id,
+  skillId: skillAgent.skill.id,
+  name: skillAgent.name,
+  description: skillAgent.description,
+  slug: skillAgent.slug,
+  status: skillAgent.status,
+  storeId: skillAgent.skill.store.id,
+  storeItemId: skillAgent.storeItem?.id,
+  path: skillAgent.storeItem?.path,
+  documentId: skillAgent.document.id,
+  archivedAt: skillAgent.archivedAt,
+  createdAt: skillAgent.createdAt,
+  updatedAt: skillAgent.updatedAt
+});

--- a/src/systems/cargo/service/src/services/document.ts
+++ b/src/systems/cargo/service/src/services/document.ts
@@ -123,7 +123,9 @@ class DocumentServiceImpl {
       return document.draftVersionExpiresAt.getTime() <= now.getTime();
     }
 
-    return now.getTime() - document.currentVersion.createdAt.getTime() >= activeVersionWindowMs;
+    return (
+      now.getTime() - document.currentVersion.createdAt.getTime() >= activeVersionWindowMs
+    );
   }
 
   private async getDocumentRecord(
@@ -166,7 +168,9 @@ class DocumentServiceImpl {
     });
   }
 
-  private async withEffectiveFileStore<T extends DocumentRecord | ResolvedDocumentRecord>(document: T) {
+  private async withEffectiveFileStore<T extends DocumentRecord | ResolvedDocumentRecord>(
+    document: T
+  ) {
     let effectiveStoreSource = await getEffectiveDocumentStoreSource(document);
     if (effectiveStoreSource.file.storeId === document.file.storeId) {
       return document as DocumentWithEffectiveStoreId<T>;
@@ -181,7 +185,9 @@ class DocumentServiceImpl {
     } satisfies DocumentWithEffectiveStoreId<T>;
   }
 
-  private async getParentLiveContent(document: Pick<DocumentRecord, 'isContentOwner' | 'parentDocumentOid'>) {
+  private async getParentLiveContent(
+    document: Pick<DocumentRecord, 'isContentOwner' | 'parentDocumentOid'>
+  ) {
     return await withTransaction(
       async db => {
         if (!document.parentDocumentOid) {
@@ -245,16 +251,14 @@ class DocumentServiceImpl {
     }
   }
 
-  private async upsertParticipant(
-    d: {
-      document: { oid: bigint };
-      actor: { oid: bigint };
-      mode: 'view' | 'edit';
-    }
-  ) {
-    return await withTransaction(async tx => {
+  private async upsertParticipant(d: {
+    document: { oid: bigint };
+    actor: { oid: bigint };
+    mode: 'view' | 'edit';
+  }) {
+    return await withTransaction(async db => {
       let now = new Date();
-      let existing = await tx.documentParticipant.findFirst({
+      let existing = await db.documentParticipant.findFirst({
         where: {
           documentOid: d.document.oid,
           tenantActorOid: d.actor.oid
@@ -265,7 +269,7 @@ class DocumentServiceImpl {
         d.mode === 'edit' || existing?.role === 'editor' ? 'editor' : 'viewer';
 
       if (existing) {
-        return await tx.documentParticipant.update({
+        return await db.documentParticipant.update({
           where: {
             id: existing.id
           },
@@ -281,12 +285,11 @@ class DocumentServiceImpl {
         });
       }
 
-      let generated = getId('documentParticipant');
+      let id = getId('documentParticipant');
 
-      return await tx.documentParticipant.create({
+      return await db.documentParticipant.create({
         data: {
-          oid: generated.oid,
-          id: generated.id,
+          ...id,
           role,
           documentOid: d.document.oid,
           tenantActorOid: d.actor.oid,
@@ -309,9 +312,7 @@ class DocumentServiceImpl {
     return await this.upsertParticipant(d);
   }
 
-  async materializeDocumentParticipantsFromStores(d: {
-    document: Document;
-  }) {
+  async materializeDocumentParticipantsFromStores(d: { document: Document }) {
     return await withTransaction(async client => {
       let storeActors = await storeAccessService.listStoreParticipantActorsForDocument({
         document: d.document
@@ -360,15 +361,13 @@ class DocumentServiceImpl {
     });
   }
 
-  private async ensureVersionEditor(
-    d: {
-      version: { oid: bigint };
-      document: { oid: bigint };
-      actor: { oid: bigint };
-    }
-  ) {
-    return await withTransaction(async tx => {
-      let existing = await tx.documentVersionEditors.findFirst({
+  private async ensureVersionEditor(d: {
+    version: { oid: bigint };
+    document: { oid: bigint };
+    actor: { oid: bigint };
+  }) {
+    return await withTransaction(async db => {
+      let existing = await db.documentVersionEditors.findFirst({
         where: {
           documentVersionOid: d.version.oid,
           tenantActorOid: d.actor.oid
@@ -379,7 +378,7 @@ class DocumentServiceImpl {
 
       let generated = getId('documentVersionEditor');
 
-      await tx.documentParticipant.updateMany({
+      await db.documentParticipant.updateMany({
         where: {
           documentOid: d.document.oid,
           tenantActorOid: d.actor.oid
@@ -391,10 +390,9 @@ class DocumentServiceImpl {
         }
       });
 
-      return await tx.documentVersionEditors.create({
+      return await db.documentVersionEditors.create({
         data: {
-          oid: generated.oid,
-          id: generated.id,
+          ...generated,
           documentVersionOid: d.version.oid,
           tenantActorOid: d.actor.oid
         }
@@ -411,13 +409,12 @@ class DocumentServiceImpl {
       listEditedAt?: Date;
     }
   ) {
-    return await withTransaction(async tx => {
+    return await withTransaction(async db => {
       let generated = getId('documentVersion');
 
-      return await tx.documentVersion.create({
+      return await db.documentVersion.create({
         data: {
-          oid: generated.oid,
-          id: generated.id,
+          ...generated,
           tenantOid: d.tenant.oid,
           environmentOid: d.environment.oid,
           documentOid: d.document.oid,
@@ -440,7 +437,7 @@ class DocumentServiceImpl {
       listEditedAt?: Date;
     }
   ) {
-    return await withTransaction(async tx => {
+    return await withTransaction(async db => {
       let now = new Date();
       let shouldCreateNewVersion = this.shouldCreateNewVersionForWrite(d.document, now);
 
@@ -453,7 +450,7 @@ class DocumentServiceImpl {
         nextContent: d.nextContent
       });
       let hasLinkedChildContentConsumers = d.document.isContentOwner
-        ? (await tx.document.count({
+        ? (await db.document.count({
             where: {
               parentDocumentOid: d.document.oid,
               isContentOwner: false,
@@ -473,14 +470,14 @@ class DocumentServiceImpl {
         if (d.document.currentVersion) {
           let retiredContentIds = getId('documentContent');
 
-          await tx.documentContent.create({
+          await db.documentContent.create({
             data: {
               oid: retiredContentIds.oid,
               content: d.document.content.content
             }
           });
 
-          await tx.documentVersion.update({
+          await db.documentVersion.update({
             where: {
               id: d.document.currentVersion.id
             },
@@ -494,7 +491,7 @@ class DocumentServiceImpl {
           if (shouldDetachOwnedContent) {
             let liveContentIds = getId('documentContent');
 
-            await tx.documentContent.create({
+            await db.documentContent.create({
               data: {
                 oid: liveContentIds.oid,
                 content: d.nextContent
@@ -503,7 +500,7 @@ class DocumentServiceImpl {
 
             liveContentOid = liveContentIds.oid;
           } else {
-            await tx.documentContent.update({
+            await db.documentContent.update({
               where: {
                 oid: d.document.contentOid
               },
@@ -517,7 +514,7 @@ class DocumentServiceImpl {
         } else {
           let liveContentIds = getId('documentContent');
 
-          await tx.documentContent.create({
+          await db.documentContent.create({
             data: {
               oid: liveContentIds.oid,
               content: d.nextContent
@@ -543,7 +540,7 @@ class DocumentServiceImpl {
         if (shouldDetachOwnedContent) {
           let liveContentIds = getId('documentContent');
 
-          await tx.documentContent.create({
+          await db.documentContent.create({
             data: {
               oid: liveContentIds.oid,
               content: d.nextContent
@@ -565,7 +562,7 @@ class DocumentServiceImpl {
             nextVersionNumber += 1;
             didCreateVersion = true;
           } else {
-            activeVersion = await tx.documentVersion.update({
+            activeVersion = await db.documentVersion.update({
               where: {
                 id: d.document.currentVersion.id
               },
@@ -579,7 +576,7 @@ class DocumentServiceImpl {
             });
           }
         } else {
-          await tx.documentContent.update({
+          await db.documentContent.update({
             where: {
               oid: d.document.contentOid
             },
@@ -604,7 +601,7 @@ class DocumentServiceImpl {
           nextVersionNumber += 1;
           didCreateVersion = true;
         } else {
-          activeVersion = await tx.documentVersion.update({
+          activeVersion = await db.documentVersion.update({
             where: {
               id: d.document.currentVersion.id
             },
@@ -620,7 +617,7 @@ class DocumentServiceImpl {
       } else {
         let liveContentIds = getId('documentContent');
 
-        await tx.documentContent.create({
+        await db.documentContent.create({
           data: {
             oid: liveContentIds.oid,
             content: d.nextContent
@@ -642,7 +639,7 @@ class DocumentServiceImpl {
           nextVersionNumber += 1;
           didCreateVersion = true;
         } else {
-          activeVersion = await tx.documentVersion.update({
+          activeVersion = await db.documentVersion.update({
             where: {
               id: d.document.currentVersion.id
             },
@@ -675,7 +672,7 @@ class DocumentServiceImpl {
       actors: TenantActor[];
     }
   ) {
-    return await withTransaction(async tx => {
+    return await withTransaction(async db => {
       let nextTitle = d.draft.title;
       let nextContent = d.draft.content;
       let hasContentChange = nextContent !== d.document.content.content;
@@ -711,11 +708,13 @@ class DocumentServiceImpl {
         liveContentOid = writeResult.liveContentOid;
         maxVersionNumber = writeResult.nextVersionNumber;
         isContentOwner = writeResult.isContentOwner;
-        createdVersionId = writeResult.didCreateVersion ? (writeResult.activeVersion?.id ?? null) : null;
+        createdVersionId = writeResult.didCreateVersion
+          ? (writeResult.activeVersion?.id ?? null)
+          : null;
         draftVersionExpiresAt = writeResult.draftVersionExpiresAt;
       }
 
-      await tx.file.update({
+      await db.file.update({
         where: {
           id: d.document.file.id
         },
@@ -730,7 +729,7 @@ class DocumentServiceImpl {
         }
       });
 
-      let updatedDocument = await tx.document.update({
+      let updatedDocument = await db.document.update({
         where: {
           id: d.document.id
         },
@@ -798,7 +797,7 @@ class DocumentServiceImpl {
         })
       : undefined;
 
-    return await withTransaction(async tx => {
+    return await withTransaction(async db => {
       let documentIds = d.input.id
         ? { oid: getId('document').oid, id: d.input.id }
         : getId('document');
@@ -820,14 +819,14 @@ class DocumentServiceImpl {
         }
       });
 
-      await tx.documentContent.create({
+      await db.documentContent.create({
         data: {
           oid: contentIds.oid,
           content: d.input.content
         }
       });
 
-      let document = await tx.document.create({
+      let document = await db.document.create({
         data: {
           oid: documentIds.oid,
           id: documentIds.id,
@@ -868,7 +867,7 @@ class DocumentServiceImpl {
         });
       }
 
-      let createdDocument = await tx.document.update({
+      let createdDocument = await db.document.update({
         where: {
           id: document.id
         },
@@ -1123,7 +1122,8 @@ class DocumentServiceImpl {
 
     let resolved = await documentDraftService.withDocumentLock(d.document.id, async () => {
       let currentDraft = await documentDraftService.getDraftByDocumentId(d.document.id);
-      let currentContent = currentDraft?.content ?? d.document.resolvedContent ?? d.document.content.content;
+      let currentContent =
+        currentDraft?.content ?? d.document.resolvedContent ?? d.document.content.content;
       let nextDraft: DocumentDraft = {
         documentId: d.document.id,
         title:
@@ -1198,7 +1198,11 @@ class DocumentServiceImpl {
     return await this.withEffectiveFileStore(resolved);
   }
 
-  async flushDocumentDraft(d: { documentId: string; force?: boolean; queuedRevision?: number }) {
+  async flushDocumentDraft(d: {
+    documentId: string;
+    force?: boolean;
+    queuedRevision?: number;
+  }) {
     return await documentDraftService.withDocumentLock(d.documentId, async () => {
       let draft = await documentDraftService.getDraftByDocumentId(d.documentId);
       if (!draft) {
@@ -1218,8 +1222,8 @@ class DocumentServiceImpl {
         return null;
       }
 
-      let result = await withTransaction(async tx => {
-        let currentDocument = await tx.document.findFirst({
+      let result = await withTransaction(async db => {
+        let currentDocument = await db.document.findFirst({
           where: {
             id: d.documentId
           },
@@ -1237,7 +1241,7 @@ class DocumentServiceImpl {
 
         let actors =
           draft.actorIds.length > 0
-            ? await tx.tenantActor.findMany({
+            ? await db.tenantActor.findMany({
                 where: {
                   tenantOid: currentDocument.tenantOid,
                   id: {
@@ -1257,7 +1261,10 @@ class DocumentServiceImpl {
       });
 
       await documentDraftService.deleteDraft(d.documentId);
-      await documentDraftService.clearDocumentMarkersUpToRevision(d.documentId, draft.revision);
+      await documentDraftService.clearDocumentMarkersUpToRevision(
+        d.documentId,
+        draft.revision
+      );
       if (result.didPersistChange) {
         await storeVersionService.touchStoresLastEditedAtForDocument({
           documentOid: result.document.oid
@@ -1315,7 +1322,10 @@ class DocumentServiceImpl {
           documentId: document.id,
           draftVersionExpiresAt: document.draftVersionExpiresAt!
         })),
-      nextCursorOid: documents.length === d.limit ? documents[documents.length - 1]!.oid.toString() : undefined
+      nextCursorOid:
+        documents.length === d.limit
+          ? documents[documents.length - 1]!.oid.toString()
+          : undefined
     };
   }
 
@@ -1327,9 +1337,9 @@ class DocumentServiceImpl {
       let draft = await documentDraftService.getDraftByDocumentId(d.documentId);
       if (draft) return null;
 
-      return await withTransaction(async tx => {
+      return await withTransaction(async db => {
         let now = new Date();
-        let document = await tx.document.findFirst({
+        let document = await db.document.findFirst({
           where: {
             id: d.documentId,
             file: {
@@ -1352,14 +1362,14 @@ class DocumentServiceImpl {
         if (draftVersionExpiresAt.getTime() > now.getTime()) return null;
 
         let retiredContentIds = getId('documentContent');
-        await tx.documentContent.create({
+        await db.documentContent.create({
           data: {
             oid: retiredContentIds.oid,
             content: document.content.content
           }
         });
 
-        await tx.documentVersion.update({
+        await db.documentVersion.update({
           where: {
             id: document.currentVersion.id
           },
@@ -1379,7 +1389,7 @@ class DocumentServiceImpl {
           listEditedAt: now
         });
 
-        let updatedDocument = await tx.document.update({
+        let updatedDocument = await db.document.update({
           where: {
             id: document.id
           },
@@ -1465,7 +1475,9 @@ class DocumentServiceImpl {
     );
 
     return {
-      childDocumentIds: childDrafts.filter(child => child.draft === null).map(child => child.childId),
+      childDocumentIds: childDrafts
+        .filter(child => child.draft === null)
+        .map(child => child.childId),
       nextCursor: children.length === d.limit ? children[children.length - 1]!.id : undefined
     };
   }
@@ -1504,9 +1516,7 @@ class DocumentServiceImpl {
       }))
     );
 
-    return childDrafts
-      .filter(child => child.draft === null)
-      .map(child => child.child);
+    return childDrafts.filter(child => child.draft === null).map(child => child.child);
   }
 
   async syncChildDocumentVersionFromParentVersion(d: {
@@ -1517,8 +1527,8 @@ class DocumentServiceImpl {
       let draft = await documentDraftService.getDraftByDocumentId(d.childDocumentId);
       if (draft) return null;
 
-      return await withTransaction(async tx => {
-        let parentVersion = await tx.documentVersion.findFirst({
+      return await withTransaction(async db => {
+        let parentVersion = await db.documentVersion.findFirst({
           where: {
             id: d.parentDocumentVersionId,
             document: {
@@ -1533,7 +1543,7 @@ class DocumentServiceImpl {
         });
         if (!parentVersion) return null;
 
-        let childDocument = await tx.document.findFirst({
+        let childDocument = await db.document.findFirst({
           where: {
             id: d.childDocumentId,
             tenantOid: parentVersion.tenantOid,
@@ -1577,7 +1587,7 @@ class DocumentServiceImpl {
           listEditedAt: parentVersion.listEditedAt ?? new Date()
         });
 
-        await tx.file.update({
+        await db.file.update({
           where: {
             id: childDocument.file.id
           },
@@ -1586,7 +1596,7 @@ class DocumentServiceImpl {
           }
         });
 
-        let syncedDocument = await tx.document.update({
+        let syncedDocument = await db.document.update({
           where: {
             id: childDocument.id
           },
@@ -1654,7 +1664,7 @@ class DocumentServiceImpl {
     let purpose = await filePurposeService.ensureDocumentFilePurpose();
     let cloneType = d.input.cloneType ?? 'sync_until_change';
 
-    let clonedDocument = await withTransaction(async tx => {
+    let clonedDocument = await withTransaction(async db => {
       let documentIds = d.input.id
         ? { oid: getId('document').oid, id: d.input.id }
         : getId('document');
@@ -1679,7 +1689,7 @@ class DocumentServiceImpl {
       });
 
       if (cloneType === 'duplicate') {
-        await tx.documentContent.create({
+        await db.documentContent.create({
           data: {
             oid: contentIds.oid,
             content: sourceContent
@@ -1687,7 +1697,7 @@ class DocumentServiceImpl {
         });
       }
 
-      let document = await tx.document.create({
+      let document = await db.document.create({
         data: {
           oid: documentIds.oid,
           id: documentIds.id,
@@ -1713,7 +1723,7 @@ class DocumentServiceImpl {
         listEditedAt: new Date()
       });
 
-      let nextDocument = await tx.document.update({
+      let nextDocument = await db.document.update({
         where: {
           id: document.id
         },
@@ -1764,7 +1774,22 @@ class DocumentServiceImpl {
     this.ensureDocumentActive(d.document);
     this.assertDocumentWritable(d.document);
 
-    let deletedDocument = await withTransaction(async tx => {
+    let activeSkillAgentCount = await db.skillAgent.count({
+      where: {
+        documentOid: d.document.oid,
+        status: 'active'
+      }
+    });
+
+    if (activeSkillAgentCount > 0) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Cannot delete document: it is linked to an active skill agent'
+        })
+      );
+    }
+
+    let deletedDocument = await withTransaction(async db => {
       await fileService.deleteFile({
         file: d.document.file
       });

--- a/src/systems/cargo/service/src/services/documentCleanup.ts
+++ b/src/systems/cargo/service/src/services/documentCleanup.ts
@@ -31,10 +31,7 @@ class DocumentCleanupServiceImpl {
     }
   }
 
-  async listStaleDocumentVersions(d?: {
-    cursor?: string;
-    limit?: number;
-  }) {
+  async listStaleDocumentVersions(d?: { cursor?: string; limit?: number }) {
     return await db.documentVersion.findMany({
       where: {
         id: d?.cursor ? { gt: d.cursor } : undefined,
@@ -55,9 +52,7 @@ class DocumentCleanupServiceImpl {
     });
   }
 
-  async cleanupDocumentVersion(d: {
-    documentVersionId: string;
-  }) {
+  async cleanupDocumentVersion(d: { documentVersionId: string }) {
     let version = await db.documentVersion.findUnique({
       where: {
         id: d.documentVersionId
@@ -74,8 +69,8 @@ class DocumentCleanupServiceImpl {
 
     let contentOid = version.contentOid;
 
-    await withTransaction(async tx => {
-      await tx.documentVersion.updateMany({
+    await withTransaction(async db => {
+      await db.documentVersion.updateMany({
         where: {
           previousVersionOid: version.oid
         },
@@ -84,7 +79,7 @@ class DocumentCleanupServiceImpl {
         }
       });
 
-      await tx.documentVersion.delete({
+      await db.documentVersion.delete({
         where: {
           id: version.id
         }

--- a/src/systems/cargo/service/src/services/file.ts
+++ b/src/systems/cargo/service/src/services/file.ts
@@ -336,6 +336,23 @@ class FileServiceImpl {
   async deleteFile(d: { file: File }) {
     await this.ensureFileActive(d.file);
     this.assertFileWritable(d.file);
+    let activeSkillAgentCount = await db.skillAgent.count({
+      where: {
+        status: 'active',
+        document: {
+          fileOid: d.file.oid
+        }
+      }
+    });
+
+    if (activeSkillAgentCount > 0) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Cannot delete file: it is linked to an active skill agent'
+        })
+      );
+    }
+
     let hasRefs = await fileReferenceService.hasReferencesForFile({
       file: d.file
     });

--- a/src/systems/cargo/service/src/services/index.ts
+++ b/src/systems/cargo/service/src/services/index.ts
@@ -13,6 +13,7 @@ export * from './filePurpose';
 export * from './fileReference';
 export * from './reconcile';
 export * from './skill';
+export * from './skillAgent';
 export * from './skillParticipant';
 export * from './skillTemplate';
 export * from './skillVersion';

--- a/src/systems/cargo/service/src/services/skillAgent.ts
+++ b/src/systems/cargo/service/src/services/skillAgent.ts
@@ -1,0 +1,310 @@
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import { slugify } from '@lowerdeck/slugify';
+import type { Prisma, StoreParticipantPermissions } from '../../prisma/generated/client';
+import { db, withTransaction } from '../db';
+import { actorService } from './actor';
+import { documentService } from './document';
+import type { CargoTenantEnvironment } from './filePurpose';
+import type { SkillRecord } from './skill';
+import { storeService } from './store';
+import { storeAccessService, storeWritePermission } from './storeAccess';
+
+export let skillAgentInclude = {
+  skill: {
+    include: {
+      store: true
+    }
+  },
+  storeItem: {
+    select: {
+      id: true,
+      path: true
+    }
+  },
+  document: {
+    select: {
+      id: true
+    }
+  }
+} satisfies Prisma.SkillAgentInclude;
+
+export type SkillAgentRecord = Prisma.SkillAgentGetPayload<{
+  include: typeof skillAgentInclude;
+}>;
+
+class SkillAgentServiceImpl {
+  private normalizeCreateName(name: string) {
+    let normalizedName = name.trim();
+    if (!normalizedName) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Skill agent name cannot be empty'
+        })
+      );
+    }
+
+    let slugInput = normalizedName.toLowerCase().endsWith('.md')
+      ? normalizedName.slice(0, -3)
+      : normalizedName;
+    let slug = slugify(slugInput);
+    if (!slug) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Skill agent name must include at least one slug character'
+        })
+      );
+    }
+
+    return {
+      name: normalizedName,
+      slug,
+      path: `/agents/${slug}.md`
+    };
+  }
+
+  private async getSkillAgentRecord(
+    d: CargoTenantEnvironment & {
+      skillAgentId: string;
+      includeArchived?: boolean;
+    }
+  ) {
+    return await withTransaction(
+      async db => {
+        let skillAgent = await db.skillAgent.findFirst({
+          where: {
+            id: d.skillAgentId,
+            status: d.includeArchived ? undefined : 'active',
+            skill: {
+              tenantOid: d.tenant.oid,
+              environmentOid: d.environment.oid
+            }
+          },
+          include: skillAgentInclude
+        });
+
+        if (!skillAgent) throw new ServiceError(notFoundError('skillAgent', d.skillAgentId));
+
+        return skillAgent;
+      },
+      { ifExists: true }
+    );
+  }
+
+  async createSkillAgent(
+    d: CargoTenantEnvironment & {
+      skill: SkillRecord;
+      input: {
+        name: string;
+        description?: string | null;
+        content?: string;
+        actorId?: string;
+        defaultPermissions?: StoreParticipantPermissions[];
+        overridePermissions?: boolean;
+      };
+    }
+  ) {
+    if (!d.input.content?.trim()) {
+      d.input.content = [
+        `# ${d.input.name}`,
+        d.input.description?.trim().length ? `> ${d.input.description}` : undefined,
+        `Describe your agent here. It has access to all resources and tools of the associated skill. Describe the personality, behavior, and capabilities of the agent; use examples and concrete details to help it use the skill effectively.`
+      ]
+        .filter(Boolean)
+        .join('\n\n');
+    }
+
+    let input = this.normalizeCreateName(d.input.name);
+    let document = await documentService.createDocument({
+      tenant: d.tenant,
+      environment: d.environment,
+      input: {
+        title: input.name,
+        content: d.input.content ?? '',
+        actorId: d.input.actorId,
+        store: {
+          id: d.skill.store.id,
+          path: input.path
+        },
+        defaultPermissions: d.input.defaultPermissions,
+        overridePermissions: d.input.overridePermissions
+      }
+    });
+
+    let skillAgent = await db.skillAgent.findFirst({
+      where: {
+        skillOid: d.skill.oid,
+        documentOid: document.oid,
+        status: 'active'
+      },
+      include: skillAgentInclude
+    });
+
+    if (!skillAgent) {
+      throw new ServiceError(notFoundError('skillAgent', document.id));
+    }
+
+    if (d.input.description !== undefined) {
+      await db.skillAgent.update({
+        where: {
+          id: skillAgent.id
+        },
+        data: {
+          description: d.input.description
+        }
+      });
+    }
+
+    return await this.getSkillAgentRecord({
+      tenant: d.tenant,
+      environment: d.environment,
+      skillAgentId: skillAgent.id
+    });
+  }
+
+  async listSkillAgents(
+    d: CargoTenantEnvironment & {
+      skillId?: string;
+      includeArchived?: boolean;
+    }
+  ) {
+    return Paginator.create(({ prisma }) =>
+      prisma(
+        async opts =>
+          await db.skillAgent.findMany({
+            ...opts,
+            where: {
+              status: d.includeArchived ? undefined : 'active',
+              skill: {
+                tenantOid: d.tenant.oid,
+                environmentOid: d.environment.oid,
+                id: d.skillId
+              }
+            },
+            include: skillAgentInclude
+          })
+      )
+    );
+  }
+
+  async getSkillAgentById(
+    d: CargoTenantEnvironment & {
+      skillAgentId: string;
+      includeArchived?: boolean;
+    }
+  ) {
+    return await this.getSkillAgentRecord(d);
+  }
+
+  async updateSkillAgent(
+    d: CargoTenantEnvironment & {
+      skillAgent: SkillAgentRecord;
+      actorId?: string;
+      defaultPermissions?: StoreParticipantPermissions[];
+      overridePermissions?: boolean;
+      input: {
+        name?: string;
+        description?: string | null;
+      };
+    }
+  ) {
+    if (d.input.name === undefined && d.input.description === undefined) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'At least one skill agent field must be updated'
+        })
+      );
+    }
+
+    let name = d.input.name?.trim();
+    if (d.input.name !== undefined && !name) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Skill agent name cannot be empty'
+        })
+      );
+    }
+
+    await storeAccessService.assertStoreAccessForStore({
+      tenant: d.tenant,
+      environment: d.environment,
+      store: d.skillAgent.skill.store,
+      actorId: d.actorId,
+      defaultPermissions: d.defaultPermissions,
+      overridePermissions: d.overridePermissions,
+      requiredPermission: storeWritePermission
+    });
+
+    await db.skillAgent.update({
+      where: {
+        id: d.skillAgent.id
+      },
+      data: {
+        name,
+        description: d.input.description
+      }
+    });
+
+    return await this.getSkillAgentRecord({
+      tenant: d.tenant,
+      environment: d.environment,
+      skillAgentId: d.skillAgent.id
+    });
+  }
+
+  async deleteSkillAgent(
+    d: CargoTenantEnvironment & {
+      skillAgent: SkillAgentRecord;
+      actorId?: string;
+      defaultPermissions?: StoreParticipantPermissions[];
+      overridePermissions?: boolean;
+    }
+  ) {
+    let actor = d.actorId
+      ? await actorService.getActorById({
+          tenant: d.tenant,
+          actorId: d.actorId
+        })
+      : undefined;
+
+    if (d.skillAgent.storeItem) {
+      await storeService.modifyStoreItems({
+        tenant: d.tenant,
+        environment: d.environment,
+        store: d.skillAgent.skill.store,
+        operations: [
+          {
+            type: 'remove',
+            itemId: d.skillAgent.storeItem.id
+          }
+        ],
+        actor,
+        defaultPermissions: d.defaultPermissions,
+        overridePermissions: d.overridePermissions
+      });
+    } else {
+      await db.skillAgent.update({
+        where: {
+          id: d.skillAgent.id
+        },
+        data: {
+          status: 'archived',
+          archivedAt: new Date()
+        }
+      });
+    }
+
+    return await this.getSkillAgentRecord({
+      tenant: d.tenant,
+      environment: d.environment,
+      skillAgentId: d.skillAgent.id,
+      includeArchived: true
+    });
+  }
+}
+
+export let skillAgentService = Service.create(
+  'cargoSkillAgentService',
+  () => new SkillAgentServiceImpl()
+).build();

--- a/src/systems/cargo/service/src/services/skillParticipant.ts
+++ b/src/systems/cargo/service/src/services/skillParticipant.ts
@@ -24,13 +24,7 @@ export type SkillParticipantRecord = Prisma.SkillParticipantGetPayload<{
 
 let explicitRoles: SkillParticipantRole[] = ['creator', 'user', 'forker'];
 let storeBackedRoles: SkillParticipantRole[] = ['editor', 'viewer'];
-let roleOrder: SkillParticipantRole[] = [
-  'creator',
-  'editor',
-  'viewer',
-  'user',
-  'forker'
-];
+let roleOrder: SkillParticipantRole[] = ['creator', 'editor', 'viewer', 'user', 'forker'];
 
 let sortRoles = (roles: SkillParticipantRole[]) =>
   [...new Set(roles)].sort((a, b) => roleOrder.indexOf(a) - roleOrder.indexOf(b));
@@ -62,8 +56,8 @@ class SkillParticipantServiceImpl {
     actor: Pick<TenantActor, 'oid'>;
     roles: SkillParticipantRole[];
   }) {
-    return await withTransaction(async tx => {
-      let existing = await tx.skillParticipant.findUnique({
+    return await withTransaction(async db => {
+      let existing = await db.skillParticipant.findUnique({
         where: {
           skillOid_tenantActorOid: {
             skillOid: d.skill.oid,
@@ -75,7 +69,7 @@ class SkillParticipantServiceImpl {
 
       if (existing) {
         if (sameRoles(existing.roles, nextRoles)) {
-          return (await tx.skillParticipant.findUnique({
+          return (await db.skillParticipant.findUnique({
             where: {
               skillOid_tenantActorOid: {
                 skillOid: d.skill.oid,
@@ -86,7 +80,7 @@ class SkillParticipantServiceImpl {
           }))!;
         }
 
-        return await tx.skillParticipant.update({
+        return await db.skillParticipant.update({
           where: {
             id: existing.id
           },
@@ -99,7 +93,7 @@ class SkillParticipantServiceImpl {
 
       let generated = getId('skillParticipant');
 
-      return await tx.skillParticipant.create({
+      return await db.skillParticipant.create({
         data: {
           oid: generated.oid,
           id: generated.id,
@@ -124,11 +118,9 @@ class SkillParticipantServiceImpl {
     });
   }
 
-  async syncSkillParticipantsFromStore(d: {
-    skill: Pick<Skill, 'oid' | 'storeOid'>;
-  }) {
-    return await withTransaction(async tx => {
-      let storeParticipants = await tx.storeParticipant.findMany({
+  async syncSkillParticipantsFromStore(d: { skill: Pick<Skill, 'oid' | 'storeOid'> }) {
+    return await withTransaction(async db => {
+      let storeParticipants = await db.storeParticipant.findMany({
         where: {
           storeOid: d.skill.storeOid
         },
@@ -136,7 +128,7 @@ class SkillParticipantServiceImpl {
           tenantActor: true
         }
       });
-      let existingParticipants = await tx.skillParticipant.findMany({
+      let existingParticipants = await db.skillParticipant.findMany({
         where: {
           skillOid: d.skill.oid
         },
@@ -158,7 +150,10 @@ class SkillParticipantServiceImpl {
         syncedActorOids.add(storeParticipant.tenantActorOid.toString());
 
         let existing = existingByActorOid.get(storeParticipant.tenantActorOid.toString());
-        let nextRoles = sortRoles([...withoutStoreBackedRoles(existing?.roles ?? []), storeRole]);
+        let nextRoles = sortRoles([
+          ...withoutStoreBackedRoles(existing?.roles ?? []),
+          storeRole
+        ]);
 
         if (existing) {
           if (sameRoles(existing.roles, nextRoles)) {
@@ -167,7 +162,7 @@ class SkillParticipantServiceImpl {
           }
 
           syncedParticipants.push(
-            await tx.skillParticipant.update({
+            await db.skillParticipant.update({
               where: {
                 id: existing.id
               },
@@ -183,7 +178,7 @@ class SkillParticipantServiceImpl {
         let generated = getId('skillParticipant');
 
         syncedParticipants.push(
-          await tx.skillParticipant.create({
+          await db.skillParticipant.create({
             data: {
               oid: generated.oid,
               id: generated.id,
@@ -203,7 +198,7 @@ class SkillParticipantServiceImpl {
         let nextRoles = withoutStoreBackedRoles(participant.roles);
 
         if (nextRoles.length === 0) {
-          await tx.skillParticipant.delete({
+          await db.skillParticipant.delete({
             where: {
               id: participant.id
             }
@@ -214,7 +209,7 @@ class SkillParticipantServiceImpl {
         if (sameRoles(participant.roles, nextRoles)) continue;
 
         syncedParticipants.push(
-          await tx.skillParticipant.update({
+          await db.skillParticipant.update({
             where: {
               id: participant.id
             },
@@ -232,8 +227,8 @@ class SkillParticipantServiceImpl {
 
   async syncAllSkillParticipantsFromStores(d: CargoTenantEnvironment) {
     let skills = await withTransaction(
-      async tx =>
-        await tx.skill.findMany({
+      async db =>
+        await db.skill.findMany({
           where: {
             tenantOid: d.tenant.oid,
             environmentOid: d.environment.oid

--- a/src/systems/cargo/service/src/services/storeItemMutation.ts
+++ b/src/systems/cargo/service/src/services/storeItemMutation.ts
@@ -1,6 +1,7 @@
 import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Service } from '@lowerdeck/service';
 import type {
+  Skill,
   Store,
   StoreDirectory,
   StoreItemKind,
@@ -74,9 +75,16 @@ type NormalizedStoreItemOperation =
 
 let modifyOperationLimit = 500;
 let maxStoreItems = 1000;
+let reservedSkillDocumentName = 'SKILL.md';
+let agentsDirectoryPath = '/agents/';
+
+type SkillStoreRecord = Pick<Skill, 'oid' | 'id'>;
 
 class StoreItemMutationServiceImpl {
-  private assertStoreWritable(d: { store: Pick<Store, 'id'> & { isReadOnly?: boolean }; allowReadOnly?: boolean }) {
+  private assertStoreWritable(d: {
+    store: Pick<Store, 'id'> & { isReadOnly?: boolean };
+    allowReadOnly?: boolean;
+  }) {
     if (!d.allowReadOnly && d.store.isReadOnly) {
       throw new ServiceError(
         badRequestError({
@@ -88,6 +96,230 @@ class StoreItemMutationServiceImpl {
 
   private getContentItemKind(target: ResolvedStoreItemTarget): StoreItemKind {
     return target.document ? 'document' : 'file';
+  }
+
+  private async getSkillForStore(store: Pick<Store, 'oid'>) {
+    return await withTransaction(
+      async db =>
+        await db.skill.findFirst({
+          where: {
+            storeOid: store.oid
+          },
+          select: {
+            oid: true,
+            id: true
+          }
+        }),
+      { ifExists: true }
+    );
+  }
+
+  private getAgentSlug(path: NormalizedStorePath) {
+    return path.name!.replace(/\.md$/i, '');
+  }
+
+  private isAgentPath(path: NormalizedStorePath) {
+    return path.parentPath === agentsDirectoryPath && path.name?.toLowerCase().endsWith('.md');
+  }
+
+  private getAgentNameFromItem(
+    item: StoreItemRecord,
+    path: NormalizedStorePath,
+    preferPathName?: boolean
+  ) {
+    let slug = this.getAgentSlug(path);
+    if (preferPathName) return slug;
+
+    return item.document?.title?.trim() || slug;
+  }
+
+  private assertSkillStoreItemAllowed(d: { path: NormalizedStorePath; kind: StoreItemKind }) {
+    if (d.path.name === reservedSkillDocumentName && d.kind !== 'document') {
+      throw new ServiceError(
+        badRequestError({
+          message: 'SKILL.md is reserved for documents in skill stores'
+        })
+      );
+    }
+
+    if (d.path.parentPath === agentsDirectoryPath) {
+      if (d.kind !== 'document' || !d.path.name?.toLowerCase().endsWith('.md')) {
+        throw new ServiceError(
+          badRequestError({
+            message:
+              'Only markdown documents can be added to the agents directory of a skill store'
+          })
+        );
+      }
+    }
+  }
+
+  private assertSkillStoreRemoveAllowed(item: StoreItemRecord) {
+    let path = this.normalizeExistingItemPath(item);
+
+    if (path.path === `/${reservedSkillDocumentName}`) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'SKILL.md cannot be removed from a skill store'
+        })
+      );
+    }
+  }
+
+  private assertSkillStoreModifyAllowed(d: {
+    item: StoreItemRecord;
+    nextPath: NormalizedStorePath;
+    nextKind: StoreItemKind;
+  }) {
+    let currentPath = this.normalizeExistingItemPath(d.item);
+
+    if (
+      currentPath.path === `/${reservedSkillDocumentName}` &&
+      d.nextPath.path !== currentPath.path
+    ) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'SKILL.md cannot be moved in a skill store'
+        })
+      );
+    }
+
+    this.assertSkillStoreItemAllowed({
+      path: d.nextPath,
+      kind: d.nextKind
+    });
+  }
+
+  private async archiveActiveSkillAgentsForStoreItem(d: {
+    skill: SkillStoreRecord;
+    item: Pick<StoreItemRecord, 'oid'>;
+  }) {
+    await withTransaction(
+      async db => {
+        await db.skillAgent.updateMany({
+          where: {
+            skillOid: d.skill.oid,
+            storeItemOid: d.item.oid,
+            status: 'active'
+          },
+          data: {
+            status: 'archived',
+            storeItemOid: null,
+            archivedAt: new Date()
+          }
+        });
+      },
+      { ifExists: true }
+    );
+  }
+
+  private async upsertSkillAgentForStoreItem(d: {
+    skill: SkillStoreRecord;
+    item: StoreItemRecord;
+    path: NormalizedStorePath;
+    preferPathName?: boolean;
+  }) {
+    if (d.item.kind !== 'document' || !d.item.documentOid || !d.item.document) return;
+
+    await withTransaction(
+      async db => {
+        let slug = this.getAgentSlug(d.path);
+        let name = this.getAgentNameFromItem(d.item, d.path, d.preferPathName);
+        let documentOid = d.item.documentOid!;
+        let existingActive = await db.skillAgent.findFirst({
+          where: {
+            skillOid: d.skill.oid,
+            storeItemOid: d.item.oid,
+            status: 'active'
+          }
+        });
+
+        if (existingActive) {
+          await db.skillAgent.update({
+            where: {
+              id: existingActive.id
+            },
+            data: {
+              name,
+              slug,
+              documentOid
+            }
+          });
+          return;
+        }
+
+        let archivedAgent = await db.skillAgent.findFirst({
+          where: {
+            skillOid: d.skill.oid,
+            documentOid,
+            status: 'archived'
+          },
+          orderBy: {
+            updatedAt: 'desc'
+          }
+        });
+
+        if (archivedAgent) {
+          await db.skillAgent.update({
+            where: {
+              id: archivedAgent.id
+            },
+            data: {
+              name,
+              slug,
+              status: 'active',
+              storeItemOid: d.item.oid,
+              archivedAt: null
+            }
+          });
+          return;
+        }
+
+        let ids = getId('skillAgent');
+        await db.skillAgent.create({
+          data: {
+            ...ids,
+            name,
+            slug,
+            skillOid: d.skill.oid,
+            storeItemOid: d.item.oid,
+            documentOid
+          }
+        });
+      },
+      { ifExists: true }
+    );
+  }
+
+  private async syncSkillAgentForStoreItemTransition(d: {
+    skill: SkillStoreRecord | null;
+    previousItem?: StoreItemRecord | null;
+    nextItem?: StoreItemRecord | null;
+  }) {
+    if (!d.skill) return;
+
+    let previousPath = d.previousItem ? this.normalizeExistingItemPath(d.previousItem) : null;
+    let nextPath = d.nextItem ? this.normalizeExistingItemPath(d.nextItem) : null;
+    let wasAgent =
+      !!previousPath && this.isAgentPath(previousPath) && d.previousItem?.kind === 'document';
+    let isAgent = !!nextPath && this.isAgentPath(nextPath) && d.nextItem?.kind === 'document';
+
+    if (wasAgent && !isAgent) {
+      await this.archiveActiveSkillAgentsForStoreItem({
+        skill: d.skill,
+        item: d.previousItem!
+      });
+      return;
+    }
+
+    if (!isAgent) return;
+
+    await this.upsertSkillAgentForStoreItem({
+      skill: d.skill,
+      item: d.nextItem!,
+      path: nextPath!,
+      preferPathName: !!previousPath && previousPath.path !== nextPath!.path
+    });
   }
 
   private normalizeExistingItemPath(item: Pick<StoreItemRecord, 'path' | 'kind'>) {
@@ -107,12 +339,7 @@ class StoreItemMutationServiceImpl {
     }
   }
 
-  private async getStoreItemRecord(
-    d: {
-      store: Pick<Store, 'oid'>;
-      itemId: string;
-    }
-  ) {
+  private async getStoreItemRecord(d: { store: Pick<Store, 'oid'>; itemId: string }) {
     return await withTransaction(
       async client => {
         let item = await client.storeItem.findFirst({
@@ -131,12 +358,7 @@ class StoreItemMutationServiceImpl {
     );
   }
 
-  private async getStoreItemByPath(
-    d: {
-      store: Pick<Store, 'oid'>;
-      path: string;
-    }
-  ) {
+  private async getStoreItemByPath(d: { store: Pick<Store, 'oid'>; path: string }) {
     return await withTransaction(
       async client =>
         await client.storeItem.findFirst({
@@ -150,12 +372,7 @@ class StoreItemMutationServiceImpl {
     );
   }
 
-  private async getStoreDirectoryByPath(
-    d: {
-      store: Pick<Store, 'oid'>;
-      path: string;
-    }
-  ) {
+  private async getStoreDirectoryByPath(d: { store: Pick<Store, 'oid'>; path: string }) {
     return await withTransaction(
       async client =>
         await client.storeDirectory.findFirst({
@@ -351,13 +568,11 @@ class StoreItemMutationServiceImpl {
     });
   }
 
-  private async ensureDirectoryRecord(
-    d: {
-      store: Pick<Store, 'oid'>;
-      path: string;
-      isAutoCreated: boolean;
-    }
-  ) {
+  private async ensureDirectoryRecord(d: {
+    store: Pick<Store, 'oid'>;
+    path: string;
+    isAutoCreated: boolean;
+  }) {
     return await withTransaction(async client => {
       let normalizedPath = normalizeStorePath({
         path: d.path,
@@ -378,7 +593,7 @@ class StoreItemMutationServiceImpl {
               isAutoCreated: false
             }
           });
-      }
+        }
 
         return existingDirectory;
       }
@@ -526,12 +741,10 @@ class StoreItemMutationServiceImpl {
     });
   }
 
-  private async pruneImplicitDirectories(
-    d: {
-      store: Store;
-      startPath: string | null | undefined;
-    }
-  ) {
+  private async pruneImplicitDirectories(d: {
+    store: Store;
+    startPath: string | null | undefined;
+  }) {
     return await withTransaction(async client => {
       let removedItemCount = 0;
       let currentPath = d.startPath;
@@ -608,9 +821,7 @@ class StoreItemMutationServiceImpl {
     });
   }
 
-  private async cleanupFileReference(
-    fileReference: StoreItemRecord['reference']
-  ) {
+  private async cleanupFileReference(fileReference: StoreItemRecord['reference']) {
     return await withTransaction(
       async () => {
         if (!fileReference) return;
@@ -853,12 +1064,7 @@ class StoreItemMutationServiceImpl {
     });
   }
 
-  private async assertDirectoryIsEmpty(
-    d: {
-      store: Store;
-      directory: StoreDirectory;
-    }
-  ) {
+  private async assertDirectoryIsEmpty(d: { store: Store; directory: StoreDirectory }) {
     return await withTransaction(
       async client => {
         let childItemCount = await client.storeItem.count({
@@ -880,12 +1086,7 @@ class StoreItemMutationServiceImpl {
     );
   }
 
-  private async removeStoreItem(
-    d: {
-      store: Store;
-      item: StoreItemRecord;
-    }
-  ) {
+  private async removeStoreItem(d: { store: Store; item: StoreItemRecord }) {
     return await withTransaction(async client => {
       if (d.item.kind === 'directory') {
         let normalizedPath = this.normalizeExistingItemPath(d.item);
@@ -1104,10 +1305,18 @@ class StoreItemMutationServiceImpl {
       }))!;
       let root = await this.ensureStoreRootDirectoryInTransaction(d);
       let itemCountDelta = root.createdItemCount;
+      let skill = await this.getSkillForStore(d.store);
       let normalizedPath = normalizeStorePath({
         path: d.path,
         kind: 'file'
       });
+      if (skill) {
+        this.assertSkillStoreItemAllowed({
+          path: normalizedPath,
+          kind: this.getContentItemKind(d.target)
+        });
+      }
+
       let hierarchy = await this.ensureDirectoryHierarchy({
         tenant: d.tenant,
         environment: d.environment,
@@ -1154,6 +1363,12 @@ class StoreItemMutationServiceImpl {
 
       await storeVersionService.markStoreDirtyIfNeeded({
         storeOid: d.store.oid
+      });
+
+      await this.syncSkillAgentForStoreItemTransition({
+        skill,
+        previousItem: null,
+        nextItem: result.item
       });
 
       return result.item;
@@ -1227,6 +1442,7 @@ class StoreItemMutationServiceImpl {
       }))!;
       let root = await this.ensureStoreRootDirectoryInTransaction(d);
       let itemCount = currentStore.itemCount + root.createdItemCount;
+      let skill = await this.getSkillForStore(d.store);
 
       if (itemCount > maxStoreItems) {
         throw new ServiceError(
@@ -1238,6 +1454,13 @@ class StoreItemMutationServiceImpl {
 
       for (let operation of operations) {
         if (operation.type === 'add') {
+          if (skill) {
+            this.assertSkillStoreItemAllowed({
+              path: operation.path,
+              kind: operation.kind
+            });
+          }
+
           if (operation.kind === 'directory') {
             let hierarchy = await this.ensureDirectoryHierarchy({
               tenant: d.tenant,
@@ -1299,6 +1522,11 @@ class StoreItemMutationServiceImpl {
             type: 'add',
             item: result.item
           });
+          await this.syncSkillAgentForStoreItemTransition({
+            skill,
+            previousItem: null,
+            nextItem: result.item
+          });
 
           continue;
         }
@@ -1309,6 +1537,15 @@ class StoreItemMutationServiceImpl {
         });
 
         if (operation.type === 'remove') {
+          if (skill) {
+            this.assertSkillStoreRemoveAllowed(item);
+            await this.syncSkillAgentForStoreItemTransition({
+              skill,
+              previousItem: item,
+              nextItem: null
+            });
+          }
+
           let removedItem = await this.removeStoreItem({
             store: d.store,
             item
@@ -1358,6 +1595,14 @@ class StoreItemMutationServiceImpl {
             path: operation.path,
             kind: 'directory'
           });
+          if (skill) {
+            this.assertSkillStoreModifyAllowed({
+              item,
+              nextPath,
+              nextKind: 'directory'
+            });
+          }
+
           let hierarchy = await this.ensureDirectoryHierarchy({
             tenant: d.tenant,
             environment: d.environment,
@@ -1400,6 +1645,17 @@ class StoreItemMutationServiceImpl {
           path: operation.path ?? item.path,
           kind: 'file'
         });
+        let nextKind = operation.target
+          ? this.getContentItemKind(operation.target)
+          : item.kind;
+        if (skill) {
+          this.assertSkillStoreModifyAllowed({
+            item,
+            nextPath,
+            nextKind
+          });
+        }
+
         let previousParentPath = item.parentDirectory?.path
           ? normalizeStorePath({
               path: item.parentDirectory.path,
@@ -1415,18 +1671,26 @@ class StoreItemMutationServiceImpl {
         });
         itemCount += hierarchy.createdItemCount;
 
+        let updatedItem = await this.updateContentStoreItem({
+          tenant: d.tenant,
+          environment: d.environment,
+          store: d.store,
+          item,
+          path: nextPath,
+          target: operation.target,
+          actor: d.actor
+        });
+
         results.push({
           type: 'modify',
-          item: await this.updateContentStoreItem({
-            tenant: d.tenant,
-            environment: d.environment,
-            store: d.store,
-            item,
-            path: nextPath,
-            target: operation.target,
-            actor: d.actor
-          })
+          item: updatedItem
         });
+        await this.syncSkillAgentForStoreItemTransition({
+          skill,
+          previousItem: item,
+          nextItem: updatedItem
+        });
+
         itemCount -= await this.pruneImplicitDirectories({
           store: d.store,
           startPath: previousParentPath

--- a/src/systems/cargo/service/src/services/storeTemplateSync.ts
+++ b/src/systems/cargo/service/src/services/storeTemplateSync.ts
@@ -2,7 +2,12 @@ import { canonicalize } from '@lowerdeck/canonicalize';
 import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Hash } from '@lowerdeck/hash';
 import { Service } from '@lowerdeck/service';
-import type { Prisma, Store, StoreItemKind, StoreTemplateItem } from '../../prisma/generated/client';
+import type {
+  Prisma,
+  Store,
+  StoreItemKind,
+  StoreTemplateItem
+} from '../../prisma/generated/client';
 import { db, withTransaction } from '../db';
 import { getId } from '../id';
 import { getCargoFilesBucketName, getStorage } from '../storage';
@@ -36,7 +41,9 @@ type StoreTemplateSyncRecord = Prisma.StoreTemplateGetPayload<{
 
 type StoreTemplateSyncItem = StoreTemplateSyncRecord['items'][number];
 
-let decodeStoreTemplateItemContent = (item: Pick<StoreTemplateItem, 'id' | 'kind' | 'content' | 'encoding'>) => {
+let decodeStoreTemplateItemContent = (
+  item: Pick<StoreTemplateItem, 'id' | 'kind' | 'content' | 'encoding'>
+) => {
   if (item.kind === 'directory') return null;
 
   if (item.content === null || item.encoding === null) {
@@ -93,7 +100,9 @@ class StoreTemplateSyncServiceImpl {
     return storeTemplate;
   }
 
-  private assertStandaloneTemplate(storeTemplate: Pick<StoreTemplateSyncRecord, 'id' | 'type'>) {
+  private assertStandaloneTemplate(
+    storeTemplate: Pick<StoreTemplateSyncRecord, 'id' | 'type'>
+  ) {
     if (storeTemplate.type !== 'standalone') {
       throw new ServiceError(
         badRequestError({
@@ -107,7 +116,11 @@ class StoreTemplateSyncServiceImpl {
     let content = decodeStoreTemplateItemContent(d.item);
     let contentHash = content ? await Hash.sha256(content.toString('base64')) : null;
     let fileStoreId =
-      content && d.item.kind === 'file' ? `template_${contentHash}` : content ? `template_doc_${contentHash}` : null;
+      content && d.item.kind === 'file'
+        ? `template_${contentHash}`
+        : content
+          ? `template_doc_${contentHash}`
+          : null;
     let contentByteSize = content?.length ?? null;
     let hash = await Hash.sha256(
       canonicalize({
@@ -289,7 +302,9 @@ class StoreTemplateSyncServiceImpl {
         environment
       })),
       nextCursorOid:
-        environments.length === limit ? environments[environments.length - 1]!.oid.toString() : undefined
+        environments.length === limit
+          ? environments[environments.length - 1]!.oid.toString()
+          : undefined
     };
   }
 
@@ -298,8 +313,8 @@ class StoreTemplateSyncServiceImpl {
     tenant: { oid: bigint; id: string };
     environment: { oid: bigint; id: string };
   }) {
-    return await withTransaction(async tx => {
-      let existing = await tx.storeTemplateBacking.findFirst({
+    return await withTransaction(async db => {
+      let existing = await db.storeTemplateBacking.findFirst({
         where: {
           storeTemplateOid: d.storeTemplate.oid,
           tenantOid: d.tenant.oid,
@@ -319,7 +334,7 @@ class StoreTemplateSyncServiceImpl {
           !store.isTemplateBacking ||
           store.parentStoreTemplateOid !== d.storeTemplate.oid
         ) {
-          store = await tx.store.update({
+          store = await db.store.update({
             where: {
               id: store.id
             },
@@ -341,7 +356,7 @@ class StoreTemplateSyncServiceImpl {
 
       let storeIds = getId('store');
       let backingIds = getId('storeTemplateBacking');
-      let store = await tx.store.create({
+      let store = await db.store.create({
         data: {
           oid: storeIds.oid,
           id: storeIds.id,
@@ -356,7 +371,7 @@ class StoreTemplateSyncServiceImpl {
         }
       });
 
-      let backing = await tx.storeTemplateBacking.create({
+      let backing = await db.storeTemplateBacking.create({
         data: {
           oid: backingIds.oid,
           id: backingIds.id,
@@ -487,14 +502,15 @@ class StoreTemplateSyncServiceImpl {
     let title = getDocumentTitle(d.item, content);
 
     if (d.existingItem?.kind === 'document' && d.existingItem.document) {
-      let document = await withTransaction(async tx => {
-        let currentDocument = await tx.document.findFirst({
+      let document = await withTransaction(async db => {
+        let currentDocument = await db.document.findFirst({
           where: {
             id: d.existingItem!.document!.id
           },
           include: documentInclude
         });
-        if (!currentDocument) throw new ServiceError(notFoundError('document', d.existingItem!.document!.id));
+        if (!currentDocument)
+          throw new ServiceError(notFoundError('document', d.existingItem!.document!.id));
 
         let hasContentChange = currentDocument.content.content !== content;
         let hasTitleChange = currentDocument.title !== title;
@@ -503,7 +519,7 @@ class StoreTemplateSyncServiceImpl {
 
         let contentIds = hasContentChange ? getId('documentContent') : null;
         if (contentIds) {
-          await tx.documentContent.create({
+          await db.documentContent.create({
             data: {
               oid: contentIds.oid,
               content
@@ -525,7 +541,7 @@ class StoreTemplateSyncServiceImpl {
             })
           : null;
 
-        await tx.file.update({
+        await db.file.update({
           where: {
             id: currentDocument.file.id
           },
@@ -540,7 +556,7 @@ class StoreTemplateSyncServiceImpl {
           }
         });
 
-        return await tx.document.update({
+        return await db.document.update({
           where: {
             id: currentDocument.id
           },
@@ -666,7 +682,8 @@ class StoreTemplateSyncServiceImpl {
     if (!environment) throw new ServiceError(notFoundError('environment', d.environmentId));
 
     if (storeTemplate.tenantOid && storeTemplate.tenantOid !== tenant.oid) return null;
-    if (storeTemplate.environmentOid && storeTemplate.environmentOid !== environment.oid) return null;
+    if (storeTemplate.environmentOid && storeTemplate.environmentOid !== environment.oid)
+      return null;
 
     let { backing, store } = await this.ensureBackingStore({
       storeTemplate,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new persisted `SkillAgent` model plus store-mutation side effects and new deletion constraints for files/documents, which can affect skill store workflows and data integrity if edge cases are missed.
> 
> **Overview**
> Adds first-class **Skill Agents** to skills: a new `SkillAgent` entity persisted in Cargo (Prisma model + IDs), with new Cargo RPC/controller endpoints and Core API routes under `skills/:skillId/agents` for create/list/get/update/delete.
> 
> Skill agents are **backed by markdown documents in the skill store** (`/agents/<slug>.md`): store item mutations now enforce skill-store rules (only markdown docs in `/agents/`, reserve `SKILL.md` from moves/removals), and automatically upsert/archive `SkillAgent` records when agent documents are added/moved/removed.
> 
> Adds frontend state loaders/mutators and a new dashboard scene to manage agents (create/edit/delete + pagination), and adds guards preventing deletion of a document/file while it’s linked to an active skill agent; includes new Cargo e2e coverage for the end-to-end agent/store behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc3d9cf104a39dde41b20040949b4d866428e746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->