### PR TITLE
Harden skills

### DIFF
--- a/src/systems/cargo/modules/skill/src/services/managedSkillPlugin.ts
+++ b/src/systems/cargo/modules/skill/src/services/managedSkillPlugin.ts
@@ -1,5 +1,6 @@
 import { notFoundError, ServiceError } from '@lowerdeck/error';
 import { Hash } from '@lowerdeck/hash';
+import { generatePlainId } from '@lowerdeck/id';
 import { Service } from '@lowerdeck/service';
 import { slugify } from '@lowerdeck/slugify';
 import type { Prisma, SkillPluginSkillStatus, SkillPluginStatus } from '@metorial-cargo/db';
@@ -47,7 +48,7 @@ class ManagedSkillPluginServiceImpl {
       name,
       description,
       slug: slugify(
-        `managed-${(skill.clientName ?? skill.name ?? skill.id).replaceAll('_', '-')}`
+        `managed-${(skill.clientName ?? skill.name ?? skill.id).replaceAll('_', '-')}-${generatePlainId(12)}`.toLowerCase()
       ),
       configHash: await Hash.sha256(
         JSON.stringify({

--- a/src/systems/cargo/modules/skill/src/services/skillMarketplace.ts
+++ b/src/systems/cargo/modules/skill/src/services/skillMarketplace.ts
@@ -1,5 +1,6 @@
 import { canonicalize } from '@lowerdeck/canonicalize';
 import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { generatePlainId } from '@lowerdeck/id';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import { slugify } from '@lowerdeck/slugify';
@@ -80,19 +81,6 @@ type SkillMarketplaceInput = {
 };
 
 class SkillMarketplaceServiceImpl {
-  private normalizeSlug(d: { slug?: string; name: string }) {
-    let normalized = slugify(d.slug ?? d.name);
-    if (!normalized) {
-      throw new ServiceError(
-        badRequestError({
-          message: 'Skill marketplace slug must include at least one slug character'
-        })
-      );
-    }
-
-    return normalized;
-  }
-
   private assertName(name: string) {
     if (name.trim()) return;
 
@@ -172,7 +160,6 @@ class SkillMarketplaceServiceImpl {
       skillConfigurationIds?: string[];
       statuses?: SkillMarketplaceStatusFilter[];
       search?: string;
-      slug?: string;
       createdAt?: DateFilter;
       updatedAt?: DateFilter;
     }
@@ -206,7 +193,6 @@ class SkillMarketplaceServiceImpl {
                   ? { skillConfigurationOid: skillConfigurations.in }
                   : undefined!,
                 { status: { in: statuses } },
-                d.slug ? { slug: d.slug } : undefined!,
                 search ? { id: { in: search.map(r => r.documentId) } } : undefined!,
                 d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
                 d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
@@ -245,7 +231,6 @@ class SkillMarketplaceServiceImpl {
       environment: d.environment,
       skillConfigurationId: d.input.skillConfigurationId
     });
-    let slug = this.normalizeSlug({ slug: d.input.slug, name: d.input.name });
 
     return await withTransaction(async db => {
       let destination = await createSkillDestination({ tenant: d.tenant });
@@ -256,7 +241,7 @@ class SkillMarketplaceServiceImpl {
           providerOverrides: d.input.providerOverrides as any,
           name: d.input.name,
           description: d.input.description,
-          slug,
+          slug: `${slugify((d.input.slug ?? d.input.name).replaceAll('_', '-'))}-${generatePlainId(6)}`,
           tenantOid: d.tenant.oid,
           environmentOid: d.environment.oid,
           skillConfigurationOid,
@@ -335,13 +320,6 @@ class SkillMarketplaceServiceImpl {
         providerOverrides: d.input.providerOverrides as any,
         name: d.input.name,
         description: d.input.description,
-        slug:
-          d.input.slug !== undefined
-            ? this.normalizeSlug({
-                slug: d.input.slug,
-                name: d.input.name ?? d.skillMarketplace.name
-              })
-            : undefined,
         skillConfigurationOid
       }
     });

--- a/src/systems/cargo/modules/skill/src/services/skillPlugin.ts
+++ b/src/systems/cargo/modules/skill/src/services/skillPlugin.ts
@@ -1,5 +1,6 @@
 import { canonicalize } from '@lowerdeck/canonicalize';
 import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { generatePlainId } from '@lowerdeck/id';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import { slugify } from '@lowerdeck/slugify';
@@ -108,19 +109,6 @@ type SkillPluginInput = {
 };
 
 class SkillPluginServiceImpl {
-  private normalizeSlug(d: { slug?: string; name: string }) {
-    let normalized = slugify(d.slug ?? d.name);
-    if (!normalized) {
-      throw new ServiceError(
-        badRequestError({
-          message: 'Skill plugin slug must include at least one slug character'
-        })
-      );
-    }
-
-    return normalized;
-  }
-
   private assertName(name: string) {
     if (name.trim()) return;
 
@@ -302,7 +290,6 @@ class SkillPluginServiceImpl {
       environment: d.environment,
       skillConfigurationId: d.input.skillConfigurationId
     });
-    let slug = this.normalizeSlug({ slug: d.input.slug, name: d.input.name });
 
     return await withTransaction(async db => {
       let destination = await createSkillDestination({ tenant: d.tenant });
@@ -316,7 +303,7 @@ class SkillPluginServiceImpl {
           description: d.input.description,
           longDescription: d.input.longDescription,
           category: d.input.category,
-          slug,
+          slug: `${slugify((d.input.slug ?? d.input.name).replaceAll('_', '-'))}-${generatePlainId(6)}`,
           tenantOid: d.tenant.oid,
           environmentOid: d.environment.oid,
           skillConfigurationOid,
@@ -396,13 +383,6 @@ class SkillPluginServiceImpl {
         description: d.input.description,
         longDescription: d.input.longDescription,
         category: d.input.category,
-        slug:
-          d.input.slug !== undefined
-            ? this.normalizeSlug({
-                slug: d.input.slug,
-                name: d.input.name ?? d.skillPlugin.name
-              })
-            : undefined,
         skillConfigurationOid
       }
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how `slug` values are generated and removes some slug filtering/updating paths, which can affect lookups, uniqueness expectations, and downstream references to slugs.
> 
> **Overview**
> **Hardens slug generation** by appending a random `generatePlainId` suffix when creating `skillPlugin`, `skillMarketplace`, and managed skill plugin records, reducing slug collisions.
> 
> **Tightens slug handling** by removing `normalizeSlug` validation/helpers, dropping `slug` as a filter in `listSkillMarketplaces`, and no longer updating `slug` during `updateSkillPlugin`/`updateSkillMarketplace`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e7adba332e5d641ece80cb0f5d828ea88b7783a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->