### PR TITLE
Fix internal client system

### DIFF
--- a/src/backend/db/prisma/schema/organization/instance.prisma
+++ b/src/backend/db/prisma/schema/organization/instance.prisma
@@ -26,8 +26,8 @@ model Instance {
   organizationOid BigInt
   organization    Organization @relation(fields: [organizationOid], references: [oid], onDelete: Cascade)
 
-  internalTenantIdentifier      String?
-  internalEnvironmentIdentifier String?
+  internalTenantIdentifier      String? @map("subspaceTenantIdentifier")
+  internalEnvironmentIdentifier String? @map("subspaceEnvironmentIdentifier")
 
   subspaceTenantId  String?
   cargoTenantId     String?

--- a/src/backend/db/prisma/schema/organization/organization.prisma
+++ b/src/backend/db/prisma/schema/organization/organization.prisma
@@ -37,11 +37,9 @@ model Organization {
 
   internalTenantIdentifier String?
 
-  subspaceTenantIds      String[]
-  cargoTenantId          String?
-  cargoEnvironmentId     String?
-  synthesisTenantId      String?
-  synthesisEnvironmentId String?
+  subspaceTenantIds  String[]
+  cargoTenantId      String?
+  cargoEnvironmentId String?
 
   deletedAt DateTime?
   createdAt DateTime  @default(now())

--- a/src/backend/db/prisma/schema/organization/project.prisma
+++ b/src/backend/db/prisma/schema/organization/project.prisma
@@ -18,7 +18,7 @@ model Project {
   organizationOid BigInt
   organization    Organization @relation(fields: [organizationOid], references: [oid], onDelete: Cascade)
 
-  internalTenantIdentifier String?
+  internalTenantIdentifier String? @map("subspaceTenantIdentifier")
 
   subspaceTenantId  String?
   cargoTenantId     String?

--- a/src/backend/internal-clients/src/links/organization.ts
+++ b/src/backend/internal-clients/src/links/organization.ts
@@ -7,13 +7,8 @@ import {
   persistOrganizationScope,
   toScope
 } from './shared';
-import {
-  upsertCargoEnvironment,
-  upsertCargoTenant,
-  upsertSynthesisEnvironment,
-  upsertSynthesisTenant
-} from './upsert';
 import type { InternalScope } from './types';
+import { upsertCargoEnvironment, upsertCargoTenant } from './upsert';
 
 export let ensureCargoOrganizationScope = async (
   organization: Organization
@@ -56,64 +51,6 @@ export let ensureCargoOrganizationScope = async (
 
   await persistOrganizationScope({
     service: 'cargo',
-    organization,
-    tenantId,
-    tenantIdentifier,
-    environmentId
-  });
-
-  return toScope({
-    tenantId,
-    environmentId,
-    tenantIdentifier,
-    environmentIdentifier: defaultInternalEnvironmentIdentifier,
-    tenantName: organization.name,
-    environmentName: 'Default',
-    environmentType: 'production'
-  });
-};
-
-export let ensureSynthesisOrganizationScope = async (
-  organization: Organization
-): Promise<InternalScope> => {
-  let tenantId = getOrganizationServiceTenantId('synthesis', organization);
-  let environmentId = getOrganizationServiceEnvironmentId('synthesis', organization);
-  let tenantIdentifier = getOrganizationTenantIdentifier(organization);
-
-  if (tenantId && environmentId) {
-    return toScope({
-      tenantId,
-      environmentId,
-      tenantIdentifier,
-      environmentIdentifier: defaultInternalEnvironmentIdentifier,
-      tenantName: organization.name,
-      environmentName: 'Default',
-      environmentType: 'production'
-    });
-  }
-
-  if (!tenantId) {
-    tenantId = (
-      await upsertSynthesisTenant({
-        identifier: tenantIdentifier,
-        name: organization.name
-      })
-    ).id;
-  }
-
-  if (!environmentId) {
-    environmentId = (
-      await upsertSynthesisEnvironment({
-        tenantId,
-        identifier: defaultInternalEnvironmentIdentifier,
-        name: 'Default',
-        type: 'production'
-      })
-    ).id;
-  }
-
-  await persistOrganizationScope({
-    service: 'synthesis',
     organization,
     tenantId,
     tenantIdentifier,

--- a/src/backend/internal-clients/src/links/project.ts
+++ b/src/backend/internal-clients/src/links/project.ts
@@ -5,8 +5,8 @@ import {
   loadProjectWithInstances,
   persistProjectTenantLink
 } from './shared';
-import { upsertCargoTenant, upsertSubspaceTenant, upsertSynthesisTenant } from './upsert';
 import type { InternalProject, InternalService } from './types';
+import { upsertCargoTenant, upsertSubspaceTenant, upsertSynthesisTenant } from './upsert';
 
 let ensureProjectTenant = async (d: {
   service: InternalService;

--- a/src/backend/internal-clients/src/links/scope.ts
+++ b/src/backend/internal-clients/src/links/scope.ts
@@ -11,10 +11,7 @@ import {
   ensureSubspaceInstanceScope,
   ensureSynthesisInstanceScope
 } from './instance';
-import {
-  ensureCargoOrganizationScope,
-  ensureSynthesisOrganizationScope
-} from './organization';
+import { ensureCargoOrganizationScope } from './organization';
 import {
   ensureCargoProjectTenant,
   ensureInternalProjectTenant,
@@ -24,7 +21,7 @@ import {
 import type { InternalActorRef, InternalScopeOwner, InternalService } from './types';
 import { ensureCargoUserScope, ensureSynthesisUserScope } from './user';
 
-let unsupportedInternalService = (service: never): never => {
+let unsupportedInternalService = (service: never | string): never => {
   throw new Error(`unsupported internal service: ${service}`);
 };
 
@@ -46,17 +43,15 @@ export let ensureInternalScope = async (d: {
       return unsupportedInternalService(d.service);
 
     case 'organization':
-      if (d.service == 'subspace') {
-        throw new Error('subspace organization scopes are not supported');
+      if (d.service == 'cargo') {
+        return await ensureCargoOrganizationScope(d.owner.organization);
       }
 
-      return d.service == 'cargo'
-        ? await ensureCargoOrganizationScope(d.owner.organization)
-        : await ensureSynthesisOrganizationScope(d.owner.organization);
+      return unsupportedInternalService(d.service);
 
     case 'user':
       if (d.service == 'subspace') {
-        throw new Error('subspace user scopes are not supported');
+        return unsupportedInternalService(d.service);
       }
 
       return d.service == 'cargo'

--- a/src/backend/internal-clients/src/links/shared.ts
+++ b/src/backend/internal-clients/src/links/shared.ts
@@ -75,16 +75,13 @@ export let getInstanceServiceEnvironmentId = (
   }
 };
 
-export let getOrganizationServiceTenantId = (
-  service: 'cargo' | 'synthesis',
-  organization: Organization
-) => (service == 'cargo' ? organization.cargoTenantId : organization.synthesisTenantId);
+export let getOrganizationServiceTenantId = (service: 'cargo', organization: Organization) =>
+  organization.cargoTenantId;
 
 export let getOrganizationServiceEnvironmentId = (
-  service: 'cargo' | 'synthesis',
+  service: 'cargo',
   organization: Organization
-) =>
-  service == 'cargo' ? organization.cargoEnvironmentId : organization.synthesisEnvironmentId;
+) => organization.cargoEnvironmentId;
 
 export let getUserServiceTenantId = (service: 'cargo' | 'synthesis', user: User) =>
   service == 'cargo' ? user.cargoTenantId : user.synthesisTenantId;
@@ -252,7 +249,7 @@ export let persistProjectTenantLink = async (d: {
 };
 
 export let persistOrganizationScope = async (d: {
-  service: 'cargo' | 'synthesis';
+  service: 'cargo';
   organization: Organization;
   tenantId: string;
   tenantIdentifier: string;
@@ -267,12 +264,6 @@ export let persistOrganizationScope = async (d: {
       : {}),
     ...(d.service == 'cargo' && !d.organization.cargoEnvironmentId
       ? { cargoEnvironmentId: d.environmentId }
-      : {}),
-    ...(d.service == 'synthesis' && !d.organization.synthesisTenantId
-      ? { synthesisTenantId: d.tenantId }
-      : {}),
-    ...(d.service == 'synthesis' && !d.organization.synthesisEnvironmentId
-      ? { synthesisEnvironmentId: d.environmentId }
       : {})
   };
 

--- a/src/backend/internal-clients/src/links/user.ts
+++ b/src/backend/internal-clients/src/links/user.ts
@@ -7,13 +7,13 @@ import {
   persistUserScope,
   toScope
 } from './shared';
+import type { InternalScope } from './types';
 import {
   upsertCargoEnvironment,
   upsertCargoTenant,
   upsertSynthesisEnvironment,
   upsertSynthesisTenant
 } from './upsert';
-import type { InternalScope } from './types';
 
 export let ensureCargoUserScope = async (user: User): Promise<InternalScope> => {
   let tenantId = getUserServiceTenantId('cargo', user);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Prisma schema mappings/fields and narrows internal-scope logic, which could break existing DB migrations or any code paths that relied on organization-level synthesis scopes.
> 
> **Overview**
> This PR updates Prisma models to **remap `internalTenantIdentifier`/`internalEnvironmentIdentifier` to the existing `subspace*Identifier` DB columns** for `Instance` and `Project`, and removes the organization-level `synthesis*` tenant/environment fields.
> 
> In the internal client linking layer, it **drops organization-level synthesis scope creation/persistence**, restricting `getOrganizationService*` helpers and `persistOrganizationScope` to `cargo` only, and updates `ensureInternalScope` to treat non-`cargo` organization scopes (and subspace user scopes) as unsupported errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39ca4ce9c1a2d819bcb07802476af8876d855653. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->