### PR TITLE
Fix skills

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -623,6 +623,7 @@
         "@metorial/db": "^1.0.0",
         "@metorial/fabric": "^1.0.0",
         "@metorial/id": "^1.0.0",
+        "@metorial/internal-clients": "^1.0.0",
         "@metorial/module-email": "^1.0.0",
         "@metorial/module-file": "^1.0.0",
         "@metorial/queue": "^1.0.0",

--- a/src/backend/modules/file/src/cargo.ts
+++ b/src/backend/modules/file/src/cargo.ts
@@ -1,15 +1,15 @@
+import { db, type Instance, type Organization, type User } from '@metorial/db';
 import {
-  cargo as internalCargo,
   ensureInternalActor,
   ensureInternalScope,
+  cargo as internalCargo,
   type InternalScope,
   type InternalScopeOwner
 } from '@metorial/internal-clients';
-import { db, type Instance, type Organization, type User } from '@metorial/db';
 import { uploadFile as uploadCargoHttpFile } from '../../../../systems/_clients/cargo/src';
-import type { CargoAccessActor, CargoStorePermission } from './services/access';
 import { purposes, purposeSlugs } from './definitions';
 import { env } from './env';
+import type { CargoAccessActor, CargoStorePermission } from './services/access';
 
 export let cargo = internalCargo;
 

--- a/src/backend/modules/file/src/services/file.ts
+++ b/src/backend/modules/file/src/services/file.ts
@@ -45,7 +45,10 @@ class FileServiceImpl {
     }
   }
 
-  async enrichFiles(d: { owner: FileOwner; files: CargoFile[] }): Promise<EnrichedCargoFile[]> {
+  async enrichFiles(d: {
+    owner: FileOwner;
+    files: CargoFile[];
+  }): Promise<EnrichedCargoFile[]> {
     let creators = d.files
       .map(file => file.createdBy)
       .filter((creator): creator is CargoActor => !!creator);

--- a/src/backend/modules/file/src/services/skillExport.ts
+++ b/src/backend/modules/file/src/services/skillExport.ts
@@ -6,12 +6,12 @@ import {
   type CargoAccessActor,
   type CargoStorePermission
 } from './access';
-import type { FileOwner } from './file';
-import { fileService, type EnrichedCargoFile } from './file';
 import {
   documentParticipantService,
   type EnrichedCargoDocumentActor
 } from './documentParticipant';
+import type { FileOwner } from './file';
+import { fileService, type EnrichedCargoFile } from './file';
 
 type SkillExportAccessInput = {
   owner: FileOwner;

--- a/src/backend/modules/file/src/services/skillMarketplace.ts
+++ b/src/backend/modules/file/src/services/skillMarketplace.ts
@@ -31,7 +31,6 @@ type SkillMarketplaceAccessInput = {
 type SkillMarketplaceInput = {
   name?: string;
   description?: string | null;
-  slug?: string;
   providerOverrides?: Record<string, any> | null;
   imageFileId?: string | null;
   skillConfigurationId?: string | null;
@@ -332,7 +331,6 @@ class SkillMarketplaceServiceImpl {
       environmentId: scope.environmentId,
       name: d.input.name,
       description: d.input.description,
-      slug: d.input.slug,
       providerOverrides: d.input.providerOverrides,
       imageFileId: d.input.imageFileId,
       skillConfigurationId: d.input.skillConfigurationId
@@ -354,7 +352,6 @@ class SkillMarketplaceServiceImpl {
       skillMarketplaceId: d.skillMarketplace.backing.id,
       name: d.input.name,
       description: d.input.description,
-      slug: d.input.slug,
       providerOverrides: d.input.providerOverrides,
       imageFileId: d.input.imageFileId,
       skillConfigurationId: d.input.skillConfigurationId

--- a/src/backend/modules/file/src/services/skillParticipant.ts
+++ b/src/backend/modules/file/src/services/skillParticipant.ts
@@ -2,11 +2,11 @@ import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import { cargo, type CargoSkillParticipant } from '../cargo';
 import { resolveCargoAccess, type CargoAccessActor } from './access';
-import type { FileOwner } from './file';
 import {
   documentParticipantService,
   type EnrichedCargoDocumentActor
 } from './documentParticipant';
+import type { FileOwner } from './file';
 
 export type EnrichedCargoSkillParticipant = Omit<CargoSkillParticipant, 'actor'> & {
   actor: EnrichedCargoDocumentActor;

--- a/src/backend/modules/file/src/services/skillPlugin.ts
+++ b/src/backend/modules/file/src/services/skillPlugin.ts
@@ -28,7 +28,6 @@ type SkillPluginInput = {
   description?: string | null;
   longDescription?: string | null;
   category?: string | null;
-  slug?: string;
   providerOverrides?: Record<string, any> | null;
   imageFileId?: string | null;
   skillConfigurationId?: string | null;
@@ -297,7 +296,6 @@ class SkillPluginServiceImpl {
       description: d.input.description,
       longDescription: d.input.longDescription,
       category: d.input.category,
-      slug: d.input.slug,
       providerOverrides: d.input.providerOverrides,
       imageFileId: d.input.imageFileId,
       skillConfigurationId: d.input.skillConfigurationId
@@ -321,7 +319,6 @@ class SkillPluginServiceImpl {
       description: d.input.description,
       longDescription: d.input.longDescription,
       category: d.input.category,
-      slug: d.input.slug,
       providerOverrides: d.input.providerOverrides,
       imageFileId: d.input.imageFileId,
       skillConfigurationId: d.input.skillConfigurationId

--- a/src/backend/modules/file/src/services/store.ts
+++ b/src/backend/modules/file/src/services/store.ts
@@ -1,13 +1,13 @@
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import { cargo, type CargoStore } from '../cargo';
-import type { FileOwner } from './file';
 import {
   resolveCargoAccess,
   type CargoAccessActor,
   type CargoStoreAccess,
   type CargoStorePermission
 } from './access';
+import type { FileOwner } from './file';
 import { storeItemService } from './storeItem';
 
 export type CargoStoreItemOperation = {
@@ -55,7 +55,8 @@ class StoreServiceImpl {
     defaultPermissions?: CargoStorePermission[];
     overridePermissions?: boolean;
   }) {
-    let { scope, actorId, defaultPermissions, overridePermissions } = await resolveCargoAccess(d);
+    let { scope, actorId, defaultPermissions, overridePermissions } =
+      await resolveCargoAccess(d);
 
     return Paginator.create(() => async input => {
       let result = await cargo.store.list({
@@ -87,7 +88,8 @@ class StoreServiceImpl {
     defaultPermissions?: CargoStorePermission[];
     overridePermissions?: boolean;
   }) {
-    let { scope, actorId, defaultPermissions, overridePermissions } = await resolveCargoAccess(d);
+    let { scope, actorId, defaultPermissions, overridePermissions } =
+      await resolveCargoAccess(d);
 
     return await cargo.store.get({
       tenantId: scope.tenantId,
@@ -106,7 +108,8 @@ class StoreServiceImpl {
     defaultPermissions?: CargoStorePermission[];
     overridePermissions?: boolean;
   }) {
-    let { scope, actorId, defaultPermissions, overridePermissions } = await resolveCargoAccess(d);
+    let { scope, actorId, defaultPermissions, overridePermissions } =
+      await resolveCargoAccess(d);
 
     return await cargo.store.getPermissions({
       tenantId: scope.tenantId,
@@ -129,7 +132,8 @@ class StoreServiceImpl {
       access?: CargoStoreAccess;
     };
   }) {
-    let { scope, actorId, defaultPermissions, overridePermissions } = await resolveCargoAccess(d);
+    let { scope, actorId, defaultPermissions, overridePermissions } =
+      await resolveCargoAccess(d);
 
     return await cargo.store.update({
       tenantId: scope.tenantId,
@@ -150,7 +154,8 @@ class StoreServiceImpl {
     defaultPermissions?: CargoStorePermission[];
     overridePermissions?: boolean;
   }) {
-    let { scope, actorId, defaultPermissions, overridePermissions } = await resolveCargoAccess(d);
+    let { scope, actorId, defaultPermissions, overridePermissions } =
+      await resolveCargoAccess(d);
 
     return await cargo.store.delete({
       tenantId: scope.tenantId,
@@ -170,7 +175,8 @@ class StoreServiceImpl {
     overridePermissions?: boolean;
     operations: CargoStoreItemOperation[];
   }) {
-    let { scope, actorId, defaultPermissions, overridePermissions } = await resolveCargoAccess(d);
+    let { scope, actorId, defaultPermissions, overridePermissions } =
+      await resolveCargoAccess(d);
 
     let items = await cargo.store.modifyItems({
       tenantId: scope.tenantId,

--- a/src/backend/modules/file/src/services/storeItem.ts
+++ b/src/backend/modules/file/src/services/storeItem.ts
@@ -1,8 +1,12 @@
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import { cargo, type CargoStoreItem } from '../cargo';
 import type { CargoStoreItemType } from '../cargo';
-import { resolveCargoAccess, type CargoAccessActor, type CargoStorePermission } from './access';
+import { cargo, type CargoStoreItem } from '../cargo';
+import {
+  resolveCargoAccess,
+  type CargoAccessActor,
+  type CargoStorePermission
+} from './access';
 import { documentService, type EnrichedCargoDocument } from './document';
 import { fileService, type EnrichedCargoFile, type FileOwner } from './file';
 
@@ -36,9 +40,7 @@ class StoreItemServiceImpl {
     return d.storeItems.map(storeItem => ({
       ...storeItem,
       file: storeItem.file ? (enrichedFiles[nextFileIndex++] ?? null) : null,
-      document: storeItem.document
-        ? (enrichedDocuments[nextDocumentIndex++] ?? null)
-        : null
+      document: storeItem.document ? (enrichedDocuments[nextDocumentIndex++] ?? null) : null
     }));
   }
 
@@ -61,7 +63,8 @@ class StoreItemServiceImpl {
     defaultPermissions?: CargoStorePermission[];
     overridePermissions?: boolean;
   }) {
-    let { scope, actorId, defaultPermissions, overridePermissions } = await resolveCargoAccess(d);
+    let { scope, actorId, defaultPermissions, overridePermissions } =
+      await resolveCargoAccess(d);
 
     let storeItem = await cargo.storeItem.get({
       tenantId: scope.tenantId,
@@ -88,7 +91,8 @@ class StoreItemServiceImpl {
     defaultPermissions?: CargoStorePermission[];
     overridePermissions?: boolean;
   }) {
-    let { scope, actorId, defaultPermissions, overridePermissions } = await resolveCargoAccess(d);
+    let { scope, actorId, defaultPermissions, overridePermissions } =
+      await resolveCargoAccess(d);
 
     return Paginator.create(() => async input => {
       let result = await cargo.storeItem.list({

--- a/src/backend/modules/file/src/services/storeParticipant.ts
+++ b/src/backend/modules/file/src/services/storeParticipant.ts
@@ -2,11 +2,11 @@ import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import { cargo, type CargoStoreParticipant } from '../cargo';
 import { resolveCargoAccess, type CargoAccessActor } from './access';
-import type { FileOwner } from './file';
 import {
   documentParticipantService,
   type EnrichedCargoDocumentActor
 } from './documentParticipant';
+import type { FileOwner } from './file';
 
 export type EnrichedCargoStoreParticipant = Omit<CargoStoreParticipant, 'actor'> & {
   actor: EnrichedCargoDocumentActor;

--- a/src/backend/modules/organization/package.json
+++ b/src/backend/modules/organization/package.json
@@ -15,6 +15,7 @@
     "@lowerdeck/error": "^1.2.3",
     "@metorial/fabric": "^1.0.0",
     "@metorial/id": "^1.0.0",
+    "@metorial/internal-clients": "^1.0.0",
     "@metorial/module-file": "^1.0.0",
     "@metorial/module-email": "^1.0.0",
     "@lowerdeck/pagination": "^1.0.8",

--- a/src/backend/modules/organization/src/queues/syncSubspaceTenant.ts
+++ b/src/backend/modules/organization/src/queues/syncSubspaceTenant.ts
@@ -1,7 +1,12 @@
-import { syncSubspaceTenantForProject } from '@metorial/module-subspace';
-
 import { db } from '@metorial/db';
+import {
+  ensureInternalProjectTenant,
+  ensureInternalScope,
+  type InternalService
+} from '@metorial/internal-clients';
 import { createQueue, QueueRetryError } from '@metorial/queue';
+
+let internalTenantServices: InternalService[] = ['cargo', 'synthesis', 'subspace'];
 
 export let syncSubspaceTenantQueue = createQueue<{ projectId: string }>({
   name: 'org/sync/subspaceTenant'
@@ -13,7 +18,26 @@ export let syncSubspaceTenantQueueProcessor = syncSubspaceTenantQueue.process(as
   });
   if (!project) throw new QueueRetryError();
 
-  await syncSubspaceTenantForProject(project, {
-    await: true
+  let instances = await db.instance.findMany({
+    where: {
+      projectOid: project.oid
+    },
+    select: {
+      id: true
+    }
   });
+
+  for (let service of internalTenantServices) {
+    await ensureInternalProjectTenant({ service, project });
+
+    for (let instance of instances) {
+      await ensureInternalScope({
+        service,
+        owner: {
+          type: 'instance',
+          instance
+        }
+      });
+    }
+  }
 });

--- a/src/systems/cargo/db/prisma/schema/skill.prisma
+++ b/src/systems/cargo/db/prisma/schema/skill.prisma
@@ -14,6 +14,7 @@ model Skill {
   image Json?
 
   name        String?
+  slug        String? @unique
   description String?
   metadata    Json?
 

--- a/src/systems/cargo/modules/skill/src/services/managedSkillPlugin.ts
+++ b/src/systems/cargo/modules/skill/src/services/managedSkillPlugin.ts
@@ -196,8 +196,7 @@ class ManagedSkillPluginServiceImpl {
     let skillPluginChanged =
       managedSkillPlugin.skillPlugin.status !== 'active' ||
       managedSkillPlugin.skillPlugin.name !== values.name ||
-      managedSkillPlugin.skillPlugin.description !== values.description ||
-      managedSkillPlugin.skillPlugin.slug !== values.slug;
+      managedSkillPlugin.skillPlugin.description !== values.description;
 
     let managedConfigChanged = managedSkillPlugin.configHash !== values.configHash;
 
@@ -210,8 +209,7 @@ class ManagedSkillPluginServiceImpl {
           data: {
             status: 'active',
             name: values.name,
-            description: values.description,
-            slug: values.slug
+            description: values.description
           },
           include: skillPluginInclude
         });

--- a/src/systems/cargo/modules/skill/src/services/skill.ts
+++ b/src/systems/cargo/modules/skill/src/services/skill.ts
@@ -71,7 +71,7 @@ class SkillServiceImpl {
       parentSkillCloneType?: 'fork' | 'duplicate';
       input: {
         id: string;
-        slug: string;
+        slug?: string | null;
         actorId?: string;
         name: string;
         description?: string | null;
@@ -150,7 +150,7 @@ class SkillServiceImpl {
           id: d.input.id,
           status: 'active',
           name: d.input.name,
-          slug: d.input.slug,
+          slug: d.input.slug ?? null,
           description: d.input.description,
           metadata: d.input.metadata as any,
 

--- a/src/systems/cargo/modules/skill/src/services/skill.ts
+++ b/src/systems/cargo/modules/skill/src/services/skill.ts
@@ -14,7 +14,11 @@ import {
 } from '@metorial-cargo/list-utils';
 import type { CargoTenantEnvironment } from '@metorial-cargo/module-file';
 import { actorService } from '@metorial-cargo/module-file';
-import { storeAccessService, storeService } from '@metorial-cargo/module-store';
+import {
+  storeAccessService,
+  storeReadPermission,
+  storeService
+} from '@metorial-cargo/module-store';
 import { internalImageService } from '../internal/image';
 import { enqueueSkillLifecycle } from '../queues/lifecycle';
 import { skillParticipantService } from './skillParticipant';
@@ -67,6 +71,7 @@ class SkillServiceImpl {
       parentSkillCloneType?: 'fork' | 'duplicate';
       input: {
         id: string;
+        slug: string;
         actorId?: string;
         name: string;
         description?: string | null;
@@ -112,24 +117,32 @@ class SkillServiceImpl {
               templateId: d.parentSkillTemplate.storeTemplate.id,
               name: d.input.name,
               actor,
-              access: 'public_read'
+              access: 'private'
             }
           })
-        : await storeService.createStore({
-            tenant: d.tenant,
-            environment: d.environment,
-            input: {
-              name: d.input.name,
+        : d.parentSkill
+          ? await storeService.cloneStore({
+              tenant: d.tenant,
+              environment: d.environment,
+              store: d.parentSkill.store,
               actor,
-              access: 'public_read',
-              parentStore: d.parentSkill?.store,
-              cloneType: !d.parentSkill
-                ? undefined
-                : d.parentSkillCloneType === 'duplicate'
-                  ? 'duplicate'
-                  : 'sync_until_change'
-            }
-          });
+              defaultPermissions: [storeReadPermission],
+              input: {
+                name: d.input.name,
+                access: 'private',
+                cloneType:
+                  d.parentSkillCloneType === 'duplicate' ? 'duplicate' : 'sync_until_change'
+              }
+            })
+          : await storeService.createStore({
+              tenant: d.tenant,
+              environment: d.environment,
+              input: {
+                name: d.input.name,
+                actor,
+                access: 'private'
+              }
+            });
 
       let skill = await db.skill.create({
         data: {
@@ -137,6 +150,7 @@ class SkillServiceImpl {
           id: d.input.id,
           status: 'active',
           name: d.input.name,
+          slug: d.input.slug,
           description: d.input.description,
           metadata: d.input.metadata as any,
 

--- a/src/systems/cargo/modules/skill/src/services/skillMarketplace.ts
+++ b/src/systems/cargo/modules/skill/src/services/skillMarketplace.ts
@@ -76,7 +76,6 @@ type SkillMarketplaceInput = {
   providerOverrides?: Prisma.InputJsonValue | null;
   name?: string;
   description?: string | null;
-  slug?: string;
   skillConfigurationId?: string | null;
 };
 
@@ -98,7 +97,6 @@ class SkillMarketplaceServiceImpl {
       input.providerOverrides !== undefined ||
       input.name !== undefined ||
       input.description !== undefined ||
-      input.slug !== undefined ||
       input.skillConfigurationId !== undefined
     );
   }
@@ -241,7 +239,7 @@ class SkillMarketplaceServiceImpl {
           providerOverrides: d.input.providerOverrides as any,
           name: d.input.name,
           description: d.input.description,
-          slug: `${slugify((d.input.slug ?? d.input.name).replaceAll('_', '-'))}-${generatePlainId(6)}`,
+          slug: `${slugify((d.input.slug ?? d.input.name).replaceAll('_', '-'))}-${generatePlainId(6)}`.toLowerCase(),
           tenantOid: d.tenant.oid,
           environmentOid: d.environment.oid,
           skillConfigurationOid,

--- a/src/systems/cargo/modules/skill/src/services/skillPlugin.ts
+++ b/src/systems/cargo/modules/skill/src/services/skillPlugin.ts
@@ -104,7 +104,6 @@ type SkillPluginInput = {
   description?: string | null;
   longDescription?: string | null;
   category?: string | null;
-  slug?: string;
   skillConfigurationId?: string | null;
 };
 
@@ -128,7 +127,6 @@ class SkillPluginServiceImpl {
       input.description !== undefined ||
       input.longDescription !== undefined ||
       input.category !== undefined ||
-      input.slug !== undefined ||
       input.skillConfigurationId !== undefined
     );
   }
@@ -192,7 +190,6 @@ class SkillPluginServiceImpl {
       statuses?: SkillPluginStatusFilter[];
       search?: string;
       category?: string;
-      slug?: string;
       createdAt?: DateFilter;
       updatedAt?: DateFilter;
     }
@@ -249,7 +246,6 @@ class SkillPluginServiceImpl {
                   : undefined!,
                 { status: { in: statuses } },
                 d.category ? { category: d.category } : undefined!,
-                d.slug ? { slug: d.slug } : undefined!,
                 search ? { id: { in: search.map(r => r.documentId) } } : undefined!,
                 d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
                 d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
@@ -303,7 +299,7 @@ class SkillPluginServiceImpl {
           description: d.input.description,
           longDescription: d.input.longDescription,
           category: d.input.category,
-          slug: `${slugify((d.input.slug ?? d.input.name).replaceAll('_', '-'))}-${generatePlainId(6)}`,
+          slug: `${slugify((d.input.slug ?? d.input.name).replaceAll('_', '-'))}-${generatePlainId(6)}`.toLowerCase(),
           tenantOid: d.tenant.oid,
           environmentOid: d.environment.oid,
           skillConfigurationOid,

--- a/src/systems/cargo/service/src/controllers/skill.ts
+++ b/src/systems/cargo/service/src/controllers/skill.ts
@@ -39,7 +39,7 @@ export let skillController = app.controller({
         tenantId: v.string(),
         environmentId: v.string(),
         skillId: v.string(),
-        slug: v.string(),
+        slug: v.optional(v.string()),
         actorId: v.optional(v.string()),
         parentSkill: v.optional(
           v.object({

--- a/src/systems/cargo/service/src/controllers/skill.ts
+++ b/src/systems/cargo/service/src/controllers/skill.ts
@@ -1,7 +1,7 @@
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
-import { skillParticipantPresenter, skillPresenter } from '../presenters';
 import { skillService, skillTemplateService } from '@metorial-cargo/module-skill';
+import { skillParticipantPresenter, skillPresenter } from '../presenters';
 import { app } from './_app';
 import { dateFilterSchema } from './_dateFilter';
 import { storePermissionsSchema } from './document';
@@ -39,6 +39,7 @@ export let skillController = app.controller({
         tenantId: v.string(),
         environmentId: v.string(),
         skillId: v.string(),
+        slug: v.string(),
         actorId: v.optional(v.string()),
         parentSkill: v.optional(
           v.object({
@@ -79,6 +80,7 @@ export let skillController = app.controller({
           id: ctx.input.skillId,
           actorId: ctx.input.actorId,
           name: ctx.input.name,
+          slug: ctx.input.slug,
           description: ctx.input.description,
           metadata: ctx.input.metadata,
           clientName: ctx.input.clientName,

--- a/src/systems/cargo/service/src/controllers/skillMarketplace.ts
+++ b/src/systems/cargo/service/src/controllers/skillMarketplace.ts
@@ -24,7 +24,6 @@ let statusFilterSchema = v.optional(v.array(v.enumOf(['active', 'archived', 'del
 let skillMarketplaceInput = {
   name: v.optional(v.string()),
   description: v.optional(v.nullable(v.string())),
-  slug: v.optional(v.string()),
   providerOverrides: metadataSchema,
   imageFileId: v.optional(v.nullable(v.string())),
   skillConfigurationId: v.optional(v.nullable(v.string()))
@@ -49,7 +48,6 @@ export let skillMarketplaceController = app.controller({
           input: {
             name: ctx.input.name,
             description: ctx.input.description,
-            slug: ctx.input.slug,
             providerOverrides: ctx.input.providerOverrides,
             imageFileId: ctx.input.imageFileId,
             skillConfigurationId: ctx.input.skillConfigurationId
@@ -69,7 +67,6 @@ export let skillMarketplaceController = app.controller({
           skillConfigurationIds: v.optional(v.array(v.string())),
           statuses: statusFilterSchema,
           search: v.optional(v.string()),
-          slug: v.optional(v.string()),
           createdAt: dateFilterSchema,
           updatedAt: dateFilterSchema
         })
@@ -83,7 +80,6 @@ export let skillMarketplaceController = app.controller({
         skillConfigurationIds: ctx.input.skillConfigurationIds,
         statuses: ctx.input.statuses,
         search: ctx.input.search,
-        slug: ctx.input.slug,
         createdAt: ctx.input.createdAt,
         updatedAt: ctx.input.updatedAt
       });
@@ -142,7 +138,6 @@ export let skillMarketplaceController = app.controller({
           input: {
             name: ctx.input.name,
             description: ctx.input.description,
-            slug: ctx.input.slug,
             providerOverrides: ctx.input.providerOverrides,
             imageFileId: ctx.input.imageFileId,
             skillConfigurationId: ctx.input.skillConfigurationId

--- a/src/systems/cargo/service/src/controllers/skillPlugin.ts
+++ b/src/systems/cargo/service/src/controllers/skillPlugin.ts
@@ -26,7 +26,6 @@ let skillPluginInput = {
   description: v.optional(v.nullable(v.string())),
   longDescription: v.optional(v.nullable(v.string())),
   category: v.optional(v.nullable(v.string())),
-  slug: v.optional(v.string()),
   providerOverrides: metadataSchema,
   imageFileId: v.optional(v.nullable(v.string())),
   skillConfigurationId: v.optional(v.nullable(v.string()))
@@ -53,7 +52,6 @@ export let skillPluginController = app.controller({
             description: ctx.input.description,
             longDescription: ctx.input.longDescription,
             category: ctx.input.category,
-            slug: ctx.input.slug,
             providerOverrides: ctx.input.providerOverrides,
             imageFileId: ctx.input.imageFileId,
             skillConfigurationId: ctx.input.skillConfigurationId
@@ -76,7 +74,6 @@ export let skillPluginController = app.controller({
           statuses: statusFilterSchema,
           search: v.optional(v.string()),
           category: v.optional(v.string()),
-          slug: v.optional(v.string()),
           createdAt: dateFilterSchema,
           updatedAt: dateFilterSchema
         })
@@ -93,7 +90,6 @@ export let skillPluginController = app.controller({
         statuses: ctx.input.statuses,
         search: ctx.input.search,
         category: ctx.input.category,
-        slug: ctx.input.slug,
         createdAt: ctx.input.createdAt,
         updatedAt: ctx.input.updatedAt
       });
@@ -154,7 +150,6 @@ export let skillPluginController = app.controller({
             description: ctx.input.description,
             longDescription: ctx.input.longDescription,
             category: ctx.input.category,
-            slug: ctx.input.slug,
             providerOverrides: ctx.input.providerOverrides,
             imageFileId: ctx.input.imageFileId,
             skillConfigurationId: ctx.input.skillConfigurationId

--- a/src/systems/subspace/modules/skills/src/services/skill.ts
+++ b/src/systems/subspace/modules/skills/src/services/skill.ts
@@ -455,6 +455,7 @@ class skillServiceImpl {
       ...cargoScope,
       skillId: skillData.id,
       name: skillData.name,
+      slug: skillData.slug,
       imageFileId: d.input.imageFileId,
       actorId: cargoActor?.id,
       parentSkill: parentSkill
@@ -483,7 +484,9 @@ class skillServiceImpl {
             environmentOid: d.environment.oid,
             name: skillData.name,
             description: skillData.description,
-            image: (d.input.image ?? (cargoSkill.image as EntityImage | null) ?? undefined) as any,
+            image: (d.input.image ??
+              (cargoSkill.image as EntityImage | null) ??
+              undefined) as any,
             slug: skillData.slug
           }
         });
@@ -492,7 +495,9 @@ class skillServiceImpl {
       let skill = await db.skill.create({
         data: {
           ...skillData,
-          image: (d.input.image ?? (cargoSkill.image as EntityImage | null) ?? undefined) as any,
+          image: (d.input.image ??
+            (cargoSkill.image as EntityImage | null) ??
+            undefined) as any,
           ownerTenantActorOid: d._operation.tenantActor?.oid,
           storeId: cargoSkill.storeId,
           skillEntityOid: skillEntity.oid


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Schema and API behavior changes around skills (new unique `Skill.slug`, new create parameter, and store cloning/access defaults) plus tenant provisioning logic updates may affect existing data/migrations and skill creation flows.
> 
> **Overview**
> **Skills now have first-class slugs in Cargo.** Adds a nullable, *unique* `Skill.slug` column, wires `slug` through `POST /skill.create` into `skillService.createSkill`, and propagates slug creation from Subspace when creating skills in Cargo.
> 
> **Skill plugin/marketplace slug handling is tightened.** Removes `slug` as a user-provided/filterable field in the Cargo service controllers and backend file module wrappers, while ensuring generated slugs are normalized to lowercase.
> 
> **Skill/store provisioning and tenant sync are adjusted.** Skill creation now defaults stores to `private` access and changes parent-skill store handling to use `cloneStore` with `storeReadPermission`; org `syncSubspaceTenant` queue now provisions internal project tenants and per-instance scopes across `cargo`, `synthesis`, and `subspace` via `@metorial/internal-clients`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18a7c985467f440dfdb3a23aac428c42a3c7ad9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->