### PR TITLE
Enforce skill config during sync

### DIFF
--- a/src/systems/cargo/modules/skill/src/lib/combineConfigs.ts
+++ b/src/systems/cargo/modules/skill/src/lib/combineConfigs.ts
@@ -1,13 +1,13 @@
 import type { SkillConfiguration } from '@metorial-cargo/db';
 
-export let intersectStringArrays = (arrays: string[][]) => {
+export let intersectStringArrays = (arrays: string[][]): string[] => {
   if (arrays.length === 0) return [];
-  if (arrays.length === 1) return arrays[0];
+  if (arrays.length === 1) return arrays[0]!;
 
   let [first, ...rest] = arrays;
+  let restSets = rest.map(array => new Set(array));
 
-  let restSet = new Set(rest.flat());
-  return first!.filter(item => restSet.has(item));
+  return first!.filter(item => restSets.every(set => set.has(item)));
 };
 
 export let intersectBooleans = (values: boolean[]) => values.every(v => v);

--- a/src/systems/cargo/modules/skill/src/lib/combineConfigs.ts
+++ b/src/systems/cargo/modules/skill/src/lib/combineConfigs.ts
@@ -1,0 +1,40 @@
+import type { SkillConfiguration } from '@metorial-cargo/db';
+
+export let intersectStringArrays = (arrays: string[][]) => {
+  if (arrays.length === 0) return [];
+  if (arrays.length === 1) return arrays[0];
+
+  let [first, ...rest] = arrays;
+
+  let restSet = new Set(rest.flat());
+  return first!.filter(item => restSet.has(item));
+};
+
+export let intersectBooleans = (values: boolean[]) => values.every(v => v);
+
+export let combineConfigs = (
+  configs: (SkillConfiguration | undefined | null)[],
+  defaultConfig: SkillConfiguration | null | undefined
+) => {
+  let producedConfigs = configs.filter((c): c is SkillConfiguration => !!c);
+
+  if (!producedConfigs.length && defaultConfig) return defaultConfig;
+
+  if (!producedConfigs.length) {
+    return {
+      allowScripts: true,
+      allowedFileExtensions: [],
+      allowNonStandardDirectories: true
+    };
+  }
+
+  return {
+    allowScripts: intersectBooleans(producedConfigs.map(c => c.allowScripts)),
+    allowedFileExtensions: intersectStringArrays(
+      producedConfigs.map(c => c.allowedFileExtensions)
+    ),
+    allowNonStandardDirectories: intersectBooleans(
+      producedConfigs.map(c => c.allowNonStandardDirectories)
+    )
+  };
+};

--- a/src/systems/cargo/modules/skill/src/lib/files.ts
+++ b/src/systems/cargo/modules/skill/src/lib/files.ts
@@ -1,0 +1,47 @@
+export let skillStandardDirectories = ['scripts', 'references', 'assets'];
+
+export let skillStandardFiles = ['SKILL.md'];
+
+export let isAllowedSkillPath = (path: string) => {
+  let normalizedPath = path.replace(/^\/+/, '');
+  if (skillStandardFiles.includes(normalizedPath)) return true;
+  return skillStandardDirectories.some(dir => normalizedPath.startsWith(`${dir}/`));
+};
+
+export let safeNonScriptFileExtensions = [
+  'txt',
+  'md',
+  'markdown',
+  'csv',
+  'tsv',
+  'json',
+  'jsonl',
+  'xml',
+  'yaml',
+  'yml',
+  'toml',
+  'ini',
+  'log',
+  'pdf',
+  'docx',
+  'xlsx',
+  'pptx',
+  'odt',
+  'ods',
+  'odp',
+  'jpg',
+  'jpeg',
+  'png',
+  'gif',
+  'webp',
+  'svg',
+  'mp3',
+  'wav',
+  'mp4',
+  'mov',
+  'zip',
+  'tar',
+  'gz'
+];
+
+export let scriptsFolder = 'scripts';

--- a/src/systems/cargo/modules/skill/src/queues/sync/process.ts
+++ b/src/systems/cargo/modules/skill/src/queues/sync/process.ts
@@ -108,6 +108,12 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
       await fileProcessor.put({ path: resultPath, content });
     },
 
+    async deletePath(inPath: string) {
+      await fileProcessor.flush();
+      let resultPath = basePathRef.current ? path.join(basePathRef.current, inPath) : inPath;
+      await deleteBucketPath(resultPath);
+    },
+
     setBasePath(path: string | undefined) {
       basePathRef.current = path ?? '';
     },

--- a/src/systems/cargo/modules/skill/src/serializers/_lib/types.ts
+++ b/src/systems/cargo/modules/skill/src/serializers/_lib/types.ts
@@ -46,6 +46,7 @@ export interface MarketplaceSerializerInput {
 
 export interface SerializerContext {
   setFile: (path: string, content: string | Buffer | ArrayBuffer) => Promise<void>;
+  deletePath: (path: string) => Promise<void>;
   hashIsEqual: (hash: string) => boolean;
   setBasePath: (path: string | undefined) => void;
 }

--- a/src/systems/cargo/modules/skill/src/serializers/skill/index.ts
+++ b/src/systems/cargo/modules/skill/src/serializers/skill/index.ts
@@ -5,6 +5,12 @@ import { db } from '@metorial-cargo/db';
 import { fileService } from '@metorial-cargo/module-file';
 import PQueue from 'p-queue';
 import { parse, stringify } from 'yaml';
+import { combineConfigs } from '../../lib/combineConfigs';
+import {
+  isAllowedSkillPath,
+  safeNonScriptFileExtensions,
+  scriptsFolder
+} from '../../lib/files';
 import { createApplicator } from '../_lib/apply';
 import type { SkillSerializerInput } from '../_lib/types';
 import { getPluginPath } from '../plugin';
@@ -30,6 +36,74 @@ let storeItemInclude = {
 let frontmatterRegex = /^---[ \t]*\r?\n([\s\S]*?)^---[ \t]*(?:\r?\n|$)/m;
 
 let isRootSkillDocument = (path: string) => path.replace(/^\/+/, '') === 'SKILL.md';
+
+type SkillConfigurationPolicy = {
+  allowScripts: boolean;
+  allowedFileExtensions?: string[] | null;
+  allowNonStandardDirectories: boolean;
+};
+
+let normalizeSkillPath = (path: string) => path.replace(/^\/+/, '');
+
+let normalizeFileExtension = (extension: string) => {
+  let normalized = extension.trim().toLowerCase();
+  if (!normalized) return null;
+  return normalized.startsWith('.') ? normalized : `.${normalized}`;
+};
+
+let getFileExtension = (path: string) => {
+  let fileName = normalizeSkillPath(path).split('/').at(-1) ?? '';
+  let dotIndex = fileName.lastIndexOf('.');
+  if (dotIndex <= 0 || dotIndex === fileName.length - 1) return null;
+  return normalizeFileExtension(fileName.slice(dotIndex));
+};
+
+let isScriptsPath = (path: string) => {
+  let normalizedPath = normalizeSkillPath(path);
+  return normalizedPath === scriptsFolder || normalizedPath.startsWith(`${scriptsFolder}/`);
+};
+
+let getEffectiveAllowedFileExtensions = (config: SkillConfigurationPolicy) => {
+  let allowedExtensions = (config.allowedFileExtensions ?? [])
+    .map(normalizeFileExtension)
+    .filter((extension): extension is string => !!extension);
+
+  if (config.allowScripts) {
+    return {
+      shouldFilter: allowedExtensions.length > 0,
+      extensions: allowedExtensions
+    };
+  }
+
+  let safeExtensions = new Set(
+    safeNonScriptFileExtensions
+      .map(normalizeFileExtension)
+      .filter((extension): extension is string => !!extension)
+  );
+
+  return {
+    shouldFilter: true,
+    extensions: allowedExtensions.length
+      ? allowedExtensions.filter(extension => safeExtensions.has(extension))
+      : [...safeExtensions]
+  };
+};
+
+let isAllowedBySkillConfig = (path: string, config: SkillConfigurationPolicy) => {
+  let normalizedPath = normalizeSkillPath(path);
+
+  if (!config.allowNonStandardDirectories && !isAllowedSkillPath(normalizedPath)) {
+    return false;
+  }
+
+  if (!config.allowScripts && isScriptsPath(normalizedPath)) return false;
+
+  let allowedExtensions = getEffectiveAllowedFileExtensions(config);
+  if (!allowedExtensions.shouldFilter) return true;
+
+  let extension = getFileExtension(normalizedPath);
+  return !!extension && allowedExtensions.extensions.includes(extension);
+};
 
 let isRecord = (value: unknown): value is Record<string, unknown> =>
   !!value && typeof value === 'object' && !Array.isArray(value);
@@ -83,18 +157,45 @@ export let applySkill = createApplicator('skill', async (input, context) => {
     where: { oid: input.skill.storeOid }
   });
 
+  let defaultConfig = await db.skillConfiguration.findFirst({
+    where: {
+      tenantOid: input.skill.tenantOid,
+      environmentOid: input.skill.environmentOid,
+      isDefault: true
+    }
+  });
+
+  let config = combineConfigs(
+    [
+      input.skillPlugin.skillConfiguration,
+      input.skillPluginSkill.skillConfiguration,
+      input.skillMarketplacePlugin?.skillConfiguration,
+      input.skillMarketplace?.skillConfiguration
+    ],
+    defaultConfig
+  );
+
+  let effectiveAllowedFileExtensions = getEffectiveAllowedFileExtensions(config);
   let hash = await Hash.sha256(
     [
-      1,
+      2,
       input.skill.oid,
       input.skillPlugin.oid,
       input.skill.updatedAt.getTime(),
-      skillStore.lastEditedAt.getTime()
+      skillStore.lastEditedAt.getTime(),
+      config.allowScripts,
+      config.allowNonStandardDirectories,
+      effectiveAllowedFileExtensions.shouldFilter,
+      [...effectiveAllowedFileExtensions.extensions].sort().join(',')
     ].join(':')
   );
   if (context.hashIsEqual(hash)) return;
 
   context.setBasePath(getSkillPath(input));
+
+  if (!config.allowScripts) {
+    await context.deletePath(scriptsFolder);
+  }
 
   let q = new PQueue({ concurrency: 10 });
   let cursor: string | null = null;
@@ -116,6 +217,7 @@ export let applySkill = createApplicator('skill', async (input, context) => {
 
     for (let item of items) {
       if (item.path.startsWith('/agents/') || item.path.startsWith('/agents/')) continue;
+      if (!isAllowedBySkillConfig(item.path, config)) continue;
 
       if (item.kind === 'document' && item.document) {
         let content = isRootSkillDocument(item.path)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes which files are synced (and may delete existing `scripts/` content) based on combined configuration, which can affect downstream consumers if policies are misconfigured.
> 
> **Overview**
> Skill sync now enforces `SkillConfiguration` when exporting a skill: it combines plugin/skill/marketplace policies (with a tenant/environment default fallback) and uses that to filter which store items are written to the destination.
> 
> The sync serializer adds path/extension policy checks (standard directories vs non-standard, script-folder blocking, safe extension allowlist when scripts are disabled) and includes policy state in the content hash so config changes trigger resync.
> 
> `SerializerContext` gains `deletePath`, implemented in the sync processor, and `applySkill` uses it to remove the `scripts/` folder from the destination when scripts are disallowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 346dc72487410d83215afa6d5fb06515968c5796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->