### PR TITLE
Add skill sync logs

### DIFF
--- a/src/systems/cargo/db/prisma/schema/marketplace.prisma
+++ b/src/systems/cargo/db/prisma/schema/marketplace.prisma
@@ -301,6 +301,9 @@ model SkillDestinationSync {
   prDescription String?
   commitMessage String?
 
+  /// [SyncLogEntry]
+  logs Json[] @default([])
+
   repositoryPropagations SkillDestinationSyncRepositoryPropagation[]
 }
 

--- a/src/systems/cargo/db/src/db.ts
+++ b/src/systems/cargo/db/src/db.ts
@@ -39,6 +39,12 @@ export let db = baseClient;
 
 export type TransactionDB = Parameters<Parameters<typeof db.$transaction>[0]>[0];
 
+declare global {
+  namespace PrismaJson {
+    type SyncLogEntry = [number, string];
+  }
+}
+
 let tdbStorage = new AsyncLocalStorage<{
   tdb: TransactionDB;
   afterHooks: Array<() => Promise<void | any>>;
@@ -101,12 +107,8 @@ export let addAfterTransactionHook = (hook: () => any) =>
     } else if (process.env.NODE_ENV === 'test') {
       enqueueAfterHook(hook, ctx);
     } else {
-      setTimeout(
-        () => {
-          enqueueAfterHook(hook, ctx);
-        },
-        5000
-      );
+      setTimeout(() => {
+        enqueueAfterHook(hook, ctx);
+      }, 5000);
     }
   });
-

--- a/src/systems/cargo/modules/skill/src/queues/sync/_lib/logs.ts
+++ b/src/systems/cargo/modules/skill/src/queues/sync/_lib/logs.ts
@@ -1,0 +1,45 @@
+import { db } from '@metorial-cargo/db';
+
+export type SkillDestinationSyncLogEntry = [number, string];
+
+let logKey = (entry: SkillDestinationSyncLogEntry) => `${entry[0]}:${entry[1]}`;
+
+export let appendSkillDestinationSyncLog = async (
+  skillDestinationSyncId: string,
+  message: string
+) => {
+  await db.skillDestinationSync.updateMany({
+    where: { id: skillDestinationSyncId },
+    data: {
+      logs: {
+        push: [Date.now(), message] satisfies SkillDestinationSyncLogEntry
+      }
+    }
+  });
+};
+
+export let appendSkillDestinationSyncLogs = async (d: {
+  skillDestinationSyncId: string;
+  logs: SkillDestinationSyncLogEntry[];
+}) => {
+  if (d.logs.length === 0) return;
+
+  let sync = await db.skillDestinationSync.findUnique({
+    where: { id: d.skillDestinationSyncId },
+    select: { logs: true }
+  });
+  if (!sync) return;
+
+  let existingKeys = new Set(sync.logs.map(logKey));
+  let newLogs = d.logs.filter(log => !existingKeys.has(logKey(log)));
+  if (newLogs.length === 0) return;
+
+  await db.skillDestinationSync.update({
+    where: { id: d.skillDestinationSyncId },
+    data: {
+      logs: {
+        set: [...sync.logs, ...newLogs]
+      }
+    }
+  });
+};

--- a/src/systems/cargo/modules/skill/src/queues/sync/collect.ts
+++ b/src/systems/cargo/modules/skill/src/queues/sync/collect.ts
@@ -1,5 +1,6 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db, env } from '@metorial-cargo/db';
+import { appendSkillDestinationSyncLog } from './_lib/logs';
 import { createTaskManager, type SyncTask } from './_lib/task';
 import { syncFinishQueue } from './finish';
 import { syncProcessQueue } from './process';
@@ -124,6 +125,11 @@ export let syncCollectQueueProcessor = syncCollectQueue.process(async data => {
   });
   if (!sync || sync.status !== 'processing') return;
 
+  await appendSkillDestinationSyncLog(
+    data.skillDestinationSyncId,
+    'Preparing content updates.'
+  );
+
   let currentItems = await db.skillDestinationItem.findMany({
     where: { destinationOid: sync.destination.oid },
     include: { skill: true, skillPlugin: true, skillMarketplace: true }
@@ -229,11 +235,20 @@ export let syncCollectQueueProcessor = syncCollectQueue.process(async data => {
   });
 
   if (tasks.length === 0) {
+    await appendSkillDestinationSyncLog(
+      data.skillDestinationSyncId,
+      'No content updates were needed.'
+    );
     await syncFinishQueue.add({
       skillDestinationSyncId: data.skillDestinationSyncId
     });
     return;
   }
+
+  await appendSkillDestinationSyncLog(
+    data.skillDestinationSyncId,
+    `Prepared ${tasks.length} content ${tasks.length === 1 ? 'update' : 'updates'}.`
+  );
 
   await syncProcessQueue.add({
     skillDestinationSyncId: data.skillDestinationSyncId,

--- a/src/systems/cargo/modules/skill/src/queues/sync/finish.ts
+++ b/src/systems/cargo/modules/skill/src/queues/sync/finish.ts
@@ -1,5 +1,6 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db, env } from '@metorial-cargo/db';
+import { appendSkillDestinationSyncLog } from './_lib/logs';
 
 export let syncFinishQueue = createQueue<{
   skillDestinationSyncId: string;
@@ -21,4 +22,5 @@ export let syncFinishQueueProcessor = syncFinishQueue.process(async data => {
     where: { id: data.skillDestinationSyncId },
     data: { status: 'completed', completedAt: new Date() }
   });
+  await appendSkillDestinationSyncLog(data.skillDestinationSyncId, 'Sync completed.');
 });

--- a/src/systems/cargo/modules/skill/src/queues/sync/process.ts
+++ b/src/systems/cargo/modules/skill/src/queues/sync/process.ts
@@ -7,6 +7,7 @@ import type { SerializerContext } from '../../serializers/_lib/types';
 import { applyMarketplace } from '../../serializers/marketplace';
 import { applyPlugin, getPluginPath } from '../../serializers/plugin';
 import { applySkill, getSkillPath } from '../../serializers/skill';
+import { appendSkillDestinationSyncLog } from './_lib/logs';
 import { type SyncTask } from './_lib/task';
 import { syncPropagateStartQueue } from './propagate';
 
@@ -61,6 +62,10 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
 
   let task = data.tasks[0];
   if (!task) {
+    await appendSkillDestinationSyncLog(
+      data.skillDestinationSyncId,
+      'Content updates are ready.'
+    );
     await syncPropagateStartQueue.add({
       skillDestinationSyncId: data.skillDestinationSyncId
     });
@@ -88,6 +93,13 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
 
   let basePathRef = { current: '' };
   let hashRef = { current: null as string | null };
+
+  let deleteBucketPath = async (prefix: string | undefined) => {
+    await codeBucketClient.deleteBucketPath({
+      bucketId: sync.destination.codeBucketId,
+      path: normalizeBucketPath(prefix ?? '')
+    });
+  };
 
   let fileProcessor = new BatchProcessor<{
     path: string;
@@ -178,13 +190,6 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
     };
   };
 
-  let deleteBucketPath = async (prefix: string | undefined) => {
-    await codeBucketClient.deleteBucketPath({
-      bucketId: sync.destination.codeBucketId,
-      path: normalizeBucketPath(prefix ?? '')
-    });
-  };
-
   let setDestinationItemHash = async (d: {
     hash: string;
     skillMarketplaceOid?: bigint;
@@ -225,6 +230,10 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
     });
 
     if (task.action === 'delete') {
+      await appendSkillDestinationSyncLog(
+        data.skillDestinationSyncId,
+        `Removing skill ${skillPluginSkill.skill.name ?? 'Untitled skill'}.`
+      );
       await deleteBucketPath(
         getSkillPath({
           skill: skillPluginSkill.skill,
@@ -242,6 +251,10 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
         }
       });
     } else {
+      await appendSkillDestinationSyncLog(
+        data.skillDestinationSyncId,
+        `Updating skill ${skillPluginSkill.skill.name ?? 'Untitled skill'}.`
+      );
       await applySkill.apply(
         {
           skill: skillPluginSkill.skill,
@@ -272,6 +285,10 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
     });
 
     if (task.action === 'delete') {
+      await appendSkillDestinationSyncLog(
+        data.skillDestinationSyncId,
+        `Removing plugin ${skillPlugin.name}.`
+      );
       await deleteBucketPath(
         getPluginPath({
           skillPlugin,
@@ -286,6 +303,10 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
         }
       });
     } else {
+      await appendSkillDestinationSyncLog(
+        data.skillDestinationSyncId,
+        `Updating plugin ${skillPlugin.name}.`
+      );
       await applyPlugin.apply(
         {
           skillPlugin,
@@ -306,6 +327,10 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
     }
   } else if (task?.type === 'marketplace') {
     let skillMarketplace = await loadMarketplace(task.skillMarketplaceId);
+    await appendSkillDestinationSyncLog(
+      data.skillDestinationSyncId,
+      `Updating marketplace ${skillMarketplace.name}.`
+    );
     await applyMarketplace.apply({ skillMarketplace }, context);
     await fileProcessor.flush();
 
@@ -325,6 +350,10 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
       tasks
     });
   } else {
+    await appendSkillDestinationSyncLog(
+      data.skillDestinationSyncId,
+      'Content updates are ready.'
+    );
     await syncPropagateStartQueue.add({
       skillDestinationSyncId: data.skillDestinationSyncId
     });

--- a/src/systems/cargo/modules/skill/src/queues/sync/propagate.ts
+++ b/src/systems/cargo/modules/skill/src/queues/sync/propagate.ts
@@ -1,6 +1,11 @@
 import { createQueue, QueueRetryError } from '@lowerdeck/queue';
 import { db, env, getId, withTransaction } from '@metorial-cargo/db';
 import { getOriginTenant, origin } from '../../internal/skillDestination';
+import {
+  appendSkillDestinationSyncLog,
+  appendSkillDestinationSyncLogs,
+  type SkillDestinationSyncLogEntry
+} from './_lib/logs';
 import { syncFinishQueue } from './finish';
 
 let failSync = async (d: { skillDestinationSyncId: string; error: unknown }) => {
@@ -16,8 +21,30 @@ let failSync = async (d: { skillDestinationSyncId: string; error: unknown }) => 
       completedAt: new Date()
     }
   });
+  await appendSkillDestinationSyncLog(d.skillDestinationSyncId, 'Sync failed.');
 
   return errorMessage;
+};
+
+let formatRepositoryName = (
+  repository?: { externalOwner: string; externalName: string } | null
+) => (repository ? `${repository.externalOwner}/${repository.externalName}` : 'repository');
+
+let normalizeOriginLogs = (logs: unknown, prefix: string): SkillDestinationSyncLogEntry[] => {
+  if (!Array.isArray(logs)) return [];
+
+  return logs.flatMap(log => {
+    if (
+      Array.isArray(log) &&
+      typeof log[0] === 'number' &&
+      Number.isFinite(log[0]) &&
+      typeof log[1] === 'string'
+    ) {
+      return [[log[0], `${prefix}: ${log[1]}`] satisfies SkillDestinationSyncLogEntry];
+    }
+
+    return [];
+  });
 };
 
 export let syncPropagateStartQueue = createQueue<{
@@ -69,8 +96,16 @@ export let syncPropagateStartQueueProcessor = syncPropagateStartQueue.process(as
     where: { oid: sync.oid },
     data: { isAtRepoSyncStage: true }
   });
+  await appendSkillDestinationSyncLog(
+    data.skillDestinationSyncId,
+    'Preparing repository updates.'
+  );
 
   if (repositoryLinks.length === 0) {
+    await appendSkillDestinationSyncLog(
+      data.skillDestinationSyncId,
+      'No repository updates are configured.'
+    );
     await syncFinishQueue.add({
       skillDestinationSyncId: data.skillDestinationSyncId
     });
@@ -169,6 +204,16 @@ export let syncPropagatePerformQueueProcessor = syncPropagatePerformQueue.proces
           oid: propagation.skillRepository.tenantOid,
           id: sync.destination.id
         });
+        let originRepositories = await origin.scmRepository.getMany({
+          tenantId: originTenant.id,
+          scmRepositoryIds: [propagation.skillRepository.repoId]
+        });
+        let repositoryName = formatRepositoryName(originRepositories.repositories[0]);
+
+        await appendSkillDestinationSyncLog(
+          data.skillDestinationSyncId,
+          `Starting update for ${repositoryName}.`
+        );
 
         let originSync = await origin.scmRepository.syncCodeBucketToBranch({
           tenantId: originTenant.id,
@@ -285,8 +330,16 @@ export let syncPropagateWaitQueueProcessor = syncPropagateWaitQueue.process(asyn
   let originSyncById = new Map(
     originSyncs.syncs.map(originSync => [originSync.id, originSync])
   );
+  let originRepositories = await origin.scmRepository.getMany({
+    tenantId: originTenant.id,
+    scmRepositoryIds: propagations.map(propagation => propagation.skillRepository.repoId)
+  });
+  let originRepositoryById = new Map(
+    originRepositories.repositories.map(repository => [repository.id, repository])
+  );
 
   let pendingPropagationIds: string[] = [];
+  let copiedLogs: SkillDestinationSyncLogEntry[] = [];
   let failed = false;
 
   for (let propagation of propagations) {
@@ -301,6 +354,11 @@ export let syncPropagateWaitQueueProcessor = syncPropagateWaitQueue.process(asyn
       continue;
     }
 
+    let repositoryName = formatRepositoryName(
+      originRepositoryById.get(propagation.skillRepository.repoId)
+    );
+    copiedLogs.push(...normalizeOriginLogs(originSync.logs, repositoryName));
+
     if (
       originSync.status === 'merged' ||
       originSync.status === 'complete_unmerged' ||
@@ -313,6 +371,10 @@ export let syncPropagateWaitQueueProcessor = syncPropagateWaitQueue.process(asyn
           completedAt: new Date()
         }
       });
+      await appendSkillDestinationSyncLog(
+        data.skillDestinationSyncId,
+        `Repository update completed for ${repositoryName}.`
+      );
       continue;
     }
 
@@ -326,11 +388,20 @@ export let syncPropagateWaitQueueProcessor = syncPropagateWaitQueue.process(asyn
           completedAt: new Date()
         }
       });
+      await appendSkillDestinationSyncLog(
+        data.skillDestinationSyncId,
+        `Repository update failed for ${repositoryName}.`
+      );
       continue;
     }
 
     pendingPropagationIds.push(propagation.id);
   }
+
+  await appendSkillDestinationSyncLogs({
+    skillDestinationSyncId: data.skillDestinationSyncId,
+    logs: copiedLogs
+  });
 
   if (failed) {
     await db.skillDestinationSync.updateMany({

--- a/src/systems/cargo/modules/skill/src/queues/sync/start.ts
+++ b/src/systems/cargo/modules/skill/src/queues/sync/start.ts
@@ -1,5 +1,6 @@
 import { createQueue, QueueRetryError } from '@lowerdeck/queue';
 import { db, env } from '@metorial-cargo/db';
+import { appendSkillDestinationSyncLog } from './_lib/logs';
 import { syncCollectQueue } from './collect';
 
 export let syncStartQueue = createQueue<{
@@ -31,6 +32,7 @@ export let syncStartQueueProcessor = syncStartQueue.process(async data => {
     where: { oid: sync.oid, status: 'pending' },
     data: { status: 'processing', startedAt: new Date() }
   });
+  await appendSkillDestinationSyncLog(data.skillDestinationSyncId, 'Starting sync.');
 
   // Cancel other syncs for the same destination
   await db.skillDestinationSync.updateMany({

--- a/src/systems/origin/apps/service/prisma/schema/scm.prisma
+++ b/src/systems/origin/apps/service/prisma/schema/scm.prisma
@@ -111,6 +111,9 @@ model ScmRepositorySync {
   ciState      String?
   attemptCount Int     @default(0)
 
+  /// [SyncLogEntry]
+  logs Json[] @default([])
+
   lastPolledAt DateTime?
   nextPollAt   DateTime?
   completedAt  DateTime?

--- a/src/systems/origin/apps/service/src/db.ts
+++ b/src/systems/origin/apps/service/src/db.ts
@@ -13,5 +13,6 @@ declare global {
       path: string;
       content: string;
     }[];
+    type SyncLogEntry = [number, string];
   }
 }

--- a/src/systems/origin/apps/service/src/presenters/scmRepositorySync.ts
+++ b/src/systems/origin/apps/service/src/presenters/scmRepositorySync.ts
@@ -20,6 +20,7 @@ export let scmRepositorySyncPresenter = (sync: ScmRepositorySync) => ({
   errorMessage: sync.errorMessage,
   ciState: sync.ciState,
   attemptCount: sync.attemptCount,
+  logs: sync.logs,
 
   lastPolledAt: sync.lastPolledAt,
   nextPollAt: sync.nextPollAt,

--- a/src/systems/origin/apps/service/src/queues/scm/repositorySync/_lib.ts
+++ b/src/systems/origin/apps/service/src/queues/scm/repositorySync/_lib.ts
@@ -1,5 +1,7 @@
 import { db } from '../../../db';
 
+export type RepositorySyncLogEntry = [number, string];
+
 export let logRepositorySyncQueueEvent = (
   stage: string,
   message: string,
@@ -12,6 +14,17 @@ export let logRepositorySyncQueueError = (
   error: unknown,
   d: Record<string, unknown>
 ) => {};
+
+export let appendRepositorySyncLog = async (syncId: string, message: string) => {
+  await db.scmRepositorySync.updateMany({
+    where: { id: syncId },
+    data: {
+      logs: {
+        push: [Date.now(), message] satisfies RepositorySyncLogEntry
+      }
+    }
+  });
+};
 
 export let markRepositorySyncFailed = async (syncId: string, error: unknown) => {
   let message = error instanceof Error ? error.message : String(error);
@@ -27,7 +40,10 @@ export let markRepositorySyncFailed = async (syncId: string, error: unknown) => 
       status: 'failed',
       errorMessage: message,
       completedAt: new Date(),
-      attemptCount: { increment: 1 }
+      attemptCount: { increment: 1 },
+      logs: {
+        push: [Date.now(), 'Repository update failed.'] satisfies RepositorySyncLogEntry
+      }
     }
   });
 };

--- a/src/systems/origin/apps/service/src/queues/scm/repositorySync/createBranch.ts
+++ b/src/systems/origin/apps/service/src/queues/scm/repositorySync/createBranch.ts
@@ -2,7 +2,12 @@ import { createQueue } from '@lowerdeck/queue';
 import { db } from '../../../db';
 import { env } from '../../../env';
 import { createRepositorySyncBranch } from '../../../lib/scmRepositorySyncProvider';
-import { logRepositorySyncQueueError, logRepositorySyncQueueEvent, markRepositorySyncFailed } from './_lib';
+import {
+  appendRepositorySyncLog,
+  logRepositorySyncQueueError,
+  logRepositorySyncQueueEvent,
+  markRepositorySyncFailed
+} from './_lib';
 import { syncContentsRepositorySyncQueue } from './syncContents';
 
 export let createBranchRepositorySyncQueue = createQueue<{ syncId: string }>({
@@ -58,7 +63,9 @@ export let createBranchRepositorySyncQueueProcessor = createBranchRepositorySync
         branchName: sync.branchName
       });
 
+      await appendRepositorySyncLog(sync.id, 'Preparing an update branch.');
       await createRepositorySyncBranch(sync);
+      await appendRepositorySyncLog(sync.id, 'Update branch is ready.');
       logRepositorySyncQueueEvent('createBranch', 'provider branch is ready', {
         syncId: sync.id,
         repoId: sync.repo.id,

--- a/src/systems/origin/apps/service/src/queues/scm/repositorySync/createPr.ts
+++ b/src/systems/origin/apps/service/src/queues/scm/repositorySync/createPr.ts
@@ -2,7 +2,12 @@ import { createQueue } from '@lowerdeck/queue';
 import { db } from '../../../db';
 import { env } from '../../../env';
 import { createRepositorySyncPullRequest } from '../../../lib/scmRepositorySyncProvider';
-import { logRepositorySyncQueueError, logRepositorySyncQueueEvent, markRepositorySyncFailed } from './_lib';
+import {
+  appendRepositorySyncLog,
+  logRepositorySyncQueueError,
+  logRepositorySyncQueueEvent,
+  markRepositorySyncFailed
+} from './_lib';
 import { waitForCiRepositorySyncQueue } from './waitForCi';
 
 export let createPrRepositorySyncQueue = createQueue<{ syncId: string }>({
@@ -10,96 +15,109 @@ export let createPrRepositorySyncQueue = createQueue<{ syncId: string }>({
   redisUrl: env.service.REDIS_URL
 });
 
-export let createPrRepositorySyncQueueProcessor = createPrRepositorySyncQueue.process(async data => {
-  try {
-    logRepositorySyncQueueEvent('createPr', 'processing queue item', {
-      syncId: data.syncId,
-      expectedStatus: 'creating_pr'
-    });
+export let createPrRepositorySyncQueueProcessor = createPrRepositorySyncQueue.process(
+  async data => {
+    try {
+      logRepositorySyncQueueEvent('createPr', 'processing queue item', {
+        syncId: data.syncId,
+        expectedStatus: 'creating_pr'
+      });
 
-    let sync = await db.scmRepositorySync.findFirst({
-      where: {
-        id: data.syncId,
-        status: 'creating_pr'
-      },
-      include: {
-        repo: {
-          include: {
-            installation: {
-              include: {
-                backend: true
+      let sync = await db.scmRepositorySync.findFirst({
+        where: {
+          id: data.syncId,
+          status: 'creating_pr'
+        },
+        include: {
+          repo: {
+            include: {
+              installation: {
+                include: {
+                  backend: true
+                }
               }
             }
           }
         }
-      }
-    });
-
-    if (!sync) {
-      logRepositorySyncQueueEvent('createPr', 'skipped sync because expected status was not present', {
-        syncId: data.syncId,
-        expectedStatus: 'creating_pr'
       });
-      return;
-    }
 
-    logRepositorySyncQueueEvent('createPr', 'creating provider pull request', {
-      syncId: sync.id,
-      repoId: sync.repo.id,
-      provider: sync.repo.provider,
-      owner: sync.repo.externalOwner,
-      repo: sync.repo.externalName,
-      baseBranch: sync.baseBranch,
-      branchName: sync.branchName,
-      enableAutoMerge: sync.enableAutoMerge
-    });
+      if (!sync) {
+        logRepositorySyncQueueEvent(
+          'createPr',
+          'skipped sync because expected status was not present',
+          {
+            syncId: data.syncId,
+            expectedStatus: 'creating_pr'
+          }
+        );
+        return;
+      }
 
-    let pr = await createRepositorySyncPullRequest(sync);
-    logRepositorySyncQueueEvent('createPr', 'provider pull request is ready', {
-      syncId: sync.id,
-      repoId: sync.repo.id,
-      providerPrId: pr.providerPrId,
-      providerPrUrl: pr.providerPrUrl
-    });
+      logRepositorySyncQueueEvent('createPr', 'creating provider pull request', {
+        syncId: sync.id,
+        repoId: sync.repo.id,
+        provider: sync.repo.provider,
+        owner: sync.repo.externalOwner,
+        repo: sync.repo.externalName,
+        baseBranch: sync.baseBranch,
+        branchName: sync.branchName,
+        enableAutoMerge: sync.enableAutoMerge
+      });
 
-    if (!sync.enableAutoMerge) {
+      await appendRepositorySyncLog(sync.id, 'Creating a pull request.');
+      let pr = await createRepositorySyncPullRequest(sync);
+      await appendRepositorySyncLog(sync.id, 'Pull request is ready.');
+      logRepositorySyncQueueEvent('createPr', 'provider pull request is ready', {
+        syncId: sync.id,
+        repoId: sync.repo.id,
+        providerPrId: pr.providerPrId,
+        providerPrUrl: pr.providerPrUrl
+      });
+
+      if (!sync.enableAutoMerge) {
+        await db.scmRepositorySync.update({
+          where: { oid: sync.oid },
+          data: {
+            status: 'complete_unmerged',
+            providerPrId: pr.providerPrId,
+            providerPrUrl: pr.providerPrUrl,
+            completedAt: new Date()
+          }
+        });
+        await appendRepositorySyncLog(
+          sync.id,
+          'Repository update is ready for manual review.'
+        );
+        logRepositorySyncQueueEvent('createPr', 'completed sync without auto merge', {
+          syncId: sync.id,
+          providerPrId: pr.providerPrId
+        });
+        return;
+      }
+
       await db.scmRepositorySync.update({
         where: { oid: sync.oid },
         data: {
-          status: 'complete_unmerged',
+          status: 'waiting_for_ci',
           providerPrId: pr.providerPrId,
-          providerPrUrl: pr.providerPrUrl,
-          completedAt: new Date()
+          providerPrUrl: pr.providerPrUrl
         }
       });
-      logRepositorySyncQueueEvent('createPr', 'completed sync without auto merge', {
+      await appendRepositorySyncLog(sync.id, 'Waiting for checks to pass.');
+      logRepositorySyncQueueEvent('createPr', 'transitioned sync to waiting_for_ci', {
         syncId: sync.id,
         providerPrId: pr.providerPrId
       });
-      return;
+
+      await waitForCiRepositorySyncQueue.add({ syncId: data.syncId });
+      logRepositorySyncQueueEvent('createPr', 'enqueued wait for CI stage', {
+        syncId: sync.id
+      });
+    } catch (e) {
+      logRepositorySyncQueueError('createPr', 'failed while processing queue item', e, {
+        syncId: data.syncId
+      });
+      await markRepositorySyncFailed(data.syncId, e);
     }
-
-    await db.scmRepositorySync.update({
-      where: { oid: sync.oid },
-      data: {
-        status: 'waiting_for_ci',
-        providerPrId: pr.providerPrId,
-        providerPrUrl: pr.providerPrUrl
-      }
-    });
-    logRepositorySyncQueueEvent('createPr', 'transitioned sync to waiting_for_ci', {
-      syncId: sync.id,
-      providerPrId: pr.providerPrId
-    });
-
-    await waitForCiRepositorySyncQueue.add({ syncId: data.syncId });
-    logRepositorySyncQueueEvent('createPr', 'enqueued wait for CI stage', {
-      syncId: sync.id
-    });
-  } catch (e) {
-    logRepositorySyncQueueError('createPr', 'failed while processing queue item', e, {
-      syncId: data.syncId
-    });
-    await markRepositorySyncFailed(data.syncId, e);
   }
-});
+);

--- a/src/systems/origin/apps/service/src/queues/scm/repositorySync/merge.ts
+++ b/src/systems/origin/apps/service/src/queues/scm/repositorySync/merge.ts
@@ -2,7 +2,12 @@ import { createQueue } from '@lowerdeck/queue';
 import { db } from '../../../db';
 import { env } from '../../../env';
 import { mergeRepositorySyncPullRequest } from '../../../lib/scmRepositorySyncProvider';
-import { logRepositorySyncQueueError, logRepositorySyncQueueEvent, markRepositorySyncFailed } from './_lib';
+import {
+  appendRepositorySyncLog,
+  logRepositorySyncQueueError,
+  logRepositorySyncQueueEvent,
+  markRepositorySyncFailed
+} from './_lib';
 
 export let mergeRepositorySyncQueue = createQueue<{ syncId: string }>({
   name: 'ori/rep-sync/merge',
@@ -35,10 +40,14 @@ export let mergeRepositorySyncQueueProcessor = mergeRepositorySyncQueue.process(
     });
 
     if (!sync) {
-      logRepositorySyncQueueEvent('merge', 'skipped sync because expected status was not present', {
-        syncId: data.syncId,
-        expectedStatus: 'merging'
-      });
+      logRepositorySyncQueueEvent(
+        'merge',
+        'skipped sync because expected status was not present',
+        {
+          syncId: data.syncId,
+          expectedStatus: 'merging'
+        }
+      );
       return;
     }
 
@@ -50,7 +59,9 @@ export let mergeRepositorySyncQueueProcessor = mergeRepositorySyncQueue.process(
       repo: sync.repo.externalName,
       providerPrId: sync.providerPrId
     });
+    await appendRepositorySyncLog(sync.id, 'Merging the pull request.');
     let merge = await mergeRepositorySyncPullRequest(sync);
+    await appendRepositorySyncLog(sync.id, 'Pull request merged.');
     logRepositorySyncQueueEvent('merge', 'provider pull request merged', {
       syncId: sync.id,
       repoId: sync.repo.id,
@@ -66,6 +77,7 @@ export let mergeRepositorySyncQueueProcessor = mergeRepositorySyncQueue.process(
         completedAt: new Date()
       }
     });
+    await appendRepositorySyncLog(sync.id, 'Repository update completed.');
     logRepositorySyncQueueEvent('merge', 'marked sync merged', {
       syncId: sync.id,
       mergeSha: merge.mergeSha

--- a/src/systems/origin/apps/service/src/queues/scm/repositorySync/start.ts
+++ b/src/systems/origin/apps/service/src/queues/scm/repositorySync/start.ts
@@ -1,8 +1,13 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db } from '../../../db';
 import { env } from '../../../env';
+import {
+  appendRepositorySyncLog,
+  logRepositorySyncQueueError,
+  logRepositorySyncQueueEvent,
+  markRepositorySyncFailed
+} from './_lib';
 import { createBranchRepositorySyncQueue } from './createBranch';
-import { logRepositorySyncQueueError, logRepositorySyncQueueEvent, markRepositorySyncFailed } from './_lib';
 
 export let startRepositorySyncQueue = createQueue<{ syncId: string }>({
   name: 'ori/rep-sync/start',
@@ -27,12 +32,18 @@ export let startRepositorySyncQueueProcessor = startRepositorySyncQueue.process(
     });
 
     if (updated.count === 0) {
-      logRepositorySyncQueueEvent('start', 'skipped sync because expected status was not present', {
-        syncId: data.syncId,
-        expectedStatus: 'pending'
-      });
+      logRepositorySyncQueueEvent(
+        'start',
+        'skipped sync because expected status was not present',
+        {
+          syncId: data.syncId,
+          expectedStatus: 'pending'
+        }
+      );
       return;
     }
+
+    await appendRepositorySyncLog(data.syncId, 'Starting repository update.');
 
     logRepositorySyncQueueEvent('start', 'transitioned sync to creating_branch', {
       syncId: data.syncId

--- a/src/systems/origin/apps/service/src/queues/scm/repositorySync/syncContents.ts
+++ b/src/systems/origin/apps/service/src/queues/scm/repositorySync/syncContents.ts
@@ -3,7 +3,12 @@ import { db } from '../../../db';
 import { env } from '../../../env';
 import { cleanupRepositorySyncBranchIfNoChanges } from '../../../lib/scmRepositorySyncProvider';
 import { codeBucketService } from '../../../services';
-import { logRepositorySyncQueueError, logRepositorySyncQueueEvent, markRepositorySyncFailed } from './_lib';
+import {
+  appendRepositorySyncLog,
+  logRepositorySyncQueueError,
+  logRepositorySyncQueueEvent,
+  markRepositorySyncFailed
+} from './_lib';
 import { createPrRepositorySyncQueue } from './createPr';
 
 export let syncContentsRepositorySyncQueue = createQueue<{ syncId: string }>({
@@ -62,6 +67,7 @@ export let syncContentsRepositorySyncQueueProcessor = syncContentsRepositorySync
         branchName: sync.branchName
       });
 
+      await appendRepositorySyncLog(sync.id, 'Writing the latest files.');
       await codeBucketService.exportCodeBucketToRepoNow({
         codeBucket: sync.codeBucket,
         repo: sync.repo,
@@ -69,6 +75,7 @@ export let syncContentsRepositorySyncQueueProcessor = syncContentsRepositorySync
         branchName: sync.branchName,
         commitMessage: sync.title
       });
+      await appendRepositorySyncLog(sync.id, 'Finished writing files.');
       logRepositorySyncQueueEvent('syncContents', 'exported code bucket to repo', {
         syncId: sync.id,
         repoId: sync.repo.id,
@@ -87,6 +94,7 @@ export let syncContentsRepositorySyncQueueProcessor = syncContentsRepositorySync
           }
         });
 
+        await appendRepositorySyncLog(sync.id, 'No file changes were needed.');
         logRepositorySyncQueueEvent('syncContents', 'completed sync with no changes', {
           syncId: sync.id,
           repoId: sync.repo.id,
@@ -107,6 +115,7 @@ export let syncContentsRepositorySyncQueueProcessor = syncContentsRepositorySync
         branchSha: branchChanges.branchSha
       });
 
+      await appendRepositorySyncLog(sync.id, 'File changes are ready for review.');
       await db.scmRepositorySync.update({
         where: { oid: sync.oid },
         data: {

--- a/src/systems/origin/apps/service/src/queues/scm/repositorySync/waitForCi.ts
+++ b/src/systems/origin/apps/service/src/queues/scm/repositorySync/waitForCi.ts
@@ -2,7 +2,12 @@ import { createQueue } from '@lowerdeck/queue';
 import { db } from '../../../db';
 import { env } from '../../../env';
 import { getRepositorySyncCiState } from '../../../lib/scmRepositorySyncProvider';
-import { logRepositorySyncQueueError, logRepositorySyncQueueEvent, markRepositorySyncFailed } from './_lib';
+import {
+  appendRepositorySyncLog,
+  logRepositorySyncQueueError,
+  logRepositorySyncQueueEvent,
+  markRepositorySyncFailed
+} from './_lib';
 import { mergeRepositorySyncQueue } from './merge';
 
 export let waitForCiRepositorySyncQueue = createQueue<{ syncId: string }>({
@@ -10,115 +15,124 @@ export let waitForCiRepositorySyncQueue = createQueue<{ syncId: string }>({
   redisUrl: env.service.REDIS_URL
 });
 
-export let waitForCiRepositorySyncQueueProcessor = waitForCiRepositorySyncQueue.process(async data => {
-  try {
-    logRepositorySyncQueueEvent('waitForCi', 'processing queue item', {
-      syncId: data.syncId,
-      expectedStatus: 'waiting_for_ci'
-    });
+export let waitForCiRepositorySyncQueueProcessor = waitForCiRepositorySyncQueue.process(
+  async data => {
+    try {
+      logRepositorySyncQueueEvent('waitForCi', 'processing queue item', {
+        syncId: data.syncId,
+        expectedStatus: 'waiting_for_ci'
+      });
 
-    let sync = await db.scmRepositorySync.findFirst({
-      where: {
-        id: data.syncId,
-        status: 'waiting_for_ci'
-      },
-      include: {
-        repo: {
-          include: {
-            installation: {
-              include: {
-                backend: true
+      let sync = await db.scmRepositorySync.findFirst({
+        where: {
+          id: data.syncId,
+          status: 'waiting_for_ci'
+        },
+        include: {
+          repo: {
+            include: {
+              installation: {
+                include: {
+                  backend: true
+                }
               }
             }
           }
         }
+      });
+
+      if (!sync) {
+        logRepositorySyncQueueEvent(
+          'waitForCi',
+          'skipped sync because expected status was not present',
+          {
+            syncId: data.syncId,
+            expectedStatus: 'waiting_for_ci'
+          }
+        );
+        return;
       }
-    });
 
-    if (!sync) {
-      logRepositorySyncQueueEvent('waitForCi', 'skipped sync because expected status was not present', {
-        syncId: data.syncId,
-        expectedStatus: 'waiting_for_ci'
-      });
-      return;
-    }
-
-    logRepositorySyncQueueEvent('waitForCi', 'checking provider CI state', {
-      syncId: sync.id,
-      repoId: sync.repo.id,
-      provider: sync.repo.provider,
-      owner: sync.repo.externalOwner,
-      repo: sync.repo.externalName,
-      branchName: sync.branchName,
-      providerPrId: sync.providerPrId
-    });
-    let ciState = await getRepositorySyncCiState(sync);
-    let now = new Date();
-    logRepositorySyncQueueEvent('waitForCi', 'provider CI state loaded', {
-      syncId: sync.id,
-      ciState
-    });
-
-    if (ciState === 'pending') {
-      let nextPollAt = new Date(now.getTime() + 60_000);
-
-      await db.scmRepositorySync.update({
-        where: { oid: sync.oid },
-        data: {
-          ciState,
-          lastPolledAt: now,
-          nextPollAt
-        }
-      });
-
-      await waitForCiRepositorySyncQueue.add({ syncId: data.syncId }, { delay: 60_000 });
-      logRepositorySyncQueueEvent('waitForCi', 'CI still pending; requeued poll', {
+      logRepositorySyncQueueEvent('waitForCi', 'checking provider CI state', {
         syncId: sync.id,
-        nextPollAt: nextPollAt.toISOString()
+        repoId: sync.repo.id,
+        provider: sync.repo.provider,
+        owner: sync.repo.externalOwner,
+        repo: sync.repo.externalName,
+        branchName: sync.branchName,
+        providerPrId: sync.providerPrId
       });
-      return;
-    }
-
-    if (ciState === 'failed') {
-      await db.scmRepositorySync.update({
-        where: { oid: sync.oid },
-        data: {
-          status: 'failed',
-          ciState,
-          lastPolledAt: now,
-          completedAt: now,
-          errorMessage: 'Repository checks failed'
-        }
-      });
-      logRepositorySyncQueueEvent('waitForCi', 'CI failed; marked sync failed', {
+      let ciState = await getRepositorySyncCiState(sync);
+      let now = new Date();
+      logRepositorySyncQueueEvent('waitForCi', 'provider CI state loaded', {
         syncId: sync.id,
         ciState
       });
-      return;
-    }
 
-    await db.scmRepositorySync.update({
-      where: { oid: sync.oid },
-      data: {
-        status: 'merging',
-        ciState,
-        lastPolledAt: now,
-        nextPollAt: null
+      if (ciState === 'pending') {
+        let nextPollAt = new Date(now.getTime() + 60_000);
+
+        await db.scmRepositorySync.update({
+          where: { oid: sync.oid },
+          data: {
+            ciState,
+            lastPolledAt: now,
+            nextPollAt
+          }
+        });
+        await appendRepositorySyncLog(sync.id, 'Checks are still running.');
+
+        await waitForCiRepositorySyncQueue.add({ syncId: data.syncId }, { delay: 60_000 });
+        logRepositorySyncQueueEvent('waitForCi', 'CI still pending; requeued poll', {
+          syncId: sync.id,
+          nextPollAt: nextPollAt.toISOString()
+        });
+        return;
       }
-    });
-    logRepositorySyncQueueEvent('waitForCi', 'CI succeeded; transitioned sync to merging', {
-      syncId: sync.id,
-      ciState
-    });
 
-    await mergeRepositorySyncQueue.add({ syncId: data.syncId });
-    logRepositorySyncQueueEvent('waitForCi', 'enqueued merge stage', {
-      syncId: sync.id
-    });
-  } catch (e) {
-    logRepositorySyncQueueError('waitForCi', 'failed while processing queue item', e, {
-      syncId: data.syncId
-    });
-    await markRepositorySyncFailed(data.syncId, e);
+      if (ciState === 'failed') {
+        await db.scmRepositorySync.update({
+          where: { oid: sync.oid },
+          data: {
+            status: 'failed',
+            ciState,
+            lastPolledAt: now,
+            completedAt: now,
+            errorMessage: 'Repository checks failed'
+          }
+        });
+        await appendRepositorySyncLog(sync.id, 'Checks failed.');
+        logRepositorySyncQueueEvent('waitForCi', 'CI failed; marked sync failed', {
+          syncId: sync.id,
+          ciState
+        });
+        return;
+      }
+
+      await db.scmRepositorySync.update({
+        where: { oid: sync.oid },
+        data: {
+          status: 'merging',
+          ciState,
+          lastPolledAt: now,
+          nextPollAt: null
+        }
+      });
+      await appendRepositorySyncLog(sync.id, 'Checks passed.');
+      logRepositorySyncQueueEvent('waitForCi', 'CI succeeded; transitioned sync to merging', {
+        syncId: sync.id,
+        ciState
+      });
+
+      await mergeRepositorySyncQueue.add({ syncId: data.syncId });
+      logRepositorySyncQueueEvent('waitForCi', 'enqueued merge stage', {
+        syncId: sync.id
+      });
+    } catch (e) {
+      logRepositorySyncQueueError('waitForCi', 'failed while processing queue item', e, {
+        syncId: data.syncId
+      });
+      await markRepositorySyncFailed(data.syncId, e);
+    }
   }
-});
+);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new JSON log fields to Cargo and Origin Prisma models and writes to them throughout async queue pipelines; risk is mainly around schema migration compatibility and increased write contention/size in long-running syncs.
> 
> **Overview**
> **Adds persisted sync logs end-to-end.** Cargo `SkillDestinationSync` and Origin `ScmRepositorySync` now include `logs` (`Json[]`) entries (typed as `[timestamp, message]`) and are exposed via the Origin presenter.
> 
> Cargo skill sync queues (`start`/`collect`/`process`/`propagate`/`finish`) now append human-readable progress messages to `SkillDestinationSync.logs`, including per-skill/plugin/marketplace actions and repo propagation milestones; repo propagation also copies and de-dupes Origin sync logs into Cargo with repository name prefixes.
> 
> Origin repository-sync queues now append stage logs (start/branch/contents/PR/CI/merge) and record a failure log when marking a sync failed; includes minor formatting-only refactors in queue processors and a small `setTimeout` formatting change in Cargo DB hook scheduling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b741ac263fb495a37e5bfae48cde06a8de76c82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->