### PR TITLE
Add skill sync cleanup

### DIFF
--- a/src/systems/cargo/modules/skill/src/queues/index.ts
+++ b/src/systems/cargo/modules/skill/src/queues/index.ts
@@ -12,6 +12,7 @@ import {
 import { skillExportQueueProcessor } from './export';
 import { lifecycleQueues } from './lifecycle';
 import { searchQueues } from './search';
+import { skillDestinationSyncCleanupCron } from './sync/cleanup';
 import { syncCollectQueueProcessor } from './sync/collect';
 import { syncFinishQueueProcessor } from './sync/finish';
 import { syncProcessQueueProcessor } from './sync/process';
@@ -38,6 +39,7 @@ export let skillQueueProcessor = combineQueueProcessors([
   syncPropagatePerformQueueProcessor,
   syncPropagateWaitQueueProcessor,
   syncFinishQueueProcessor,
+  skillDestinationSyncCleanupCron,
   skillExportQueueProcessor
 ]);
 

--- a/src/systems/cargo/modules/skill/src/queues/sync/cleanup.ts
+++ b/src/systems/cargo/modules/skill/src/queues/sync/cleanup.ts
@@ -1,0 +1,22 @@
+import { createCron } from '@lowerdeck/cron';
+import { db, env } from '@metorial-cargo/db';
+import { subDays } from 'date-fns';
+
+export let skillDestinationSyncCleanupCron = createCron(
+  {
+    redisUrl: env.service.REDIS_URL,
+    name: 'cargo/skill/sync/cleanup/cron',
+    cron: '0 0 * * *'
+  },
+  async () => {
+    let twoWeeksAgo = subDays(new Date(), 14);
+
+    await db.skillDestinationSync.deleteMany({
+      where: {
+        createdAt: {
+          lt: twoWeeksAgo
+        }
+      }
+    });
+  }
+);

--- a/src/systems/origin/apps/service/src/queues/cleanup.ts
+++ b/src/systems/origin/apps/service/src/queues/cleanup.ts
@@ -12,11 +12,20 @@ export let cleanupProcessor = createCron(
   async () => {
     let now = new Date();
     let oneWeekAgo = subDays(now, 7);
+    let twoWeeksAgo = subDays(now, 14);
 
     await db.scmRepositoryWebhookReceivedEvent.deleteMany({
       where: {
         createdAt: {
           lt: oneWeekAgo
+        }
+      }
+    });
+
+    await db.scmRepositorySync.deleteMany({
+      where: {
+        createdAt: {
+          lt: twoWeeksAgo
         }
       }
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches multiple subsystems (Prisma schema, sync queues, and origin code-bucket RPC/storage), so regressions could affect sync/export behavior and data retention. Changes are mostly additive but include removals of synthesis org-scope support and new file filtering/deletion behavior during skill serialization.
> 
> **Overview**
> Adds *skill destination sync observability and retention controls* in Cargo: `SkillDestinationSync` now stores `logs`, sync queues append step-by-step log entries (including copied Origin repo-sync logs), and a new daily cron deletes sync records older than 14 days.
> 
> Introduces *config-driven skill export filtering*: skill serialization now combines multiple `SkillConfiguration` sources, filters which store files are written based on allowed directories/extensions and script policy, and can delete paths from the code bucket via a new `SerializerContext.deletePath`.
> 
> Improves Origin code-bucket scalability by adding a streaming `GetBucketFilesWithContentStream` RPC, batching/iterating file-content reads, and switching GitHub/GitLab exports to iterator-based uploads (GitLab now batches commits to respect payload limits). Also refactors filesystem listing to a single `WalkBucketFiles` path with prefix normalization, adds tests, and makes zip import iteration async with error reporting.
> 
> Cleans up internal-client linking by mapping `internal*Identifier` Prisma fields to renamed DB columns, removing synthesis-related organization scope persistence, and tightening `getOrganizationService*` helpers to Cargo-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b14ea60364b23ed5c094015609c41e27094f60c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->