### PR TITLE
List marketplace syncs

### DIFF
--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_skills_marketplaces_repositories.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_skills_marketplaces_repositories.ts
@@ -19,8 +19,8 @@ import {
 } from '../resources';
 
 /**
- * @name Skill Marketplaces controller
- * @description Manage skill marketplaces for an instance.
+ * @name Skill Marketplace Repositories controller
+ * @description Manage repositories linked to skill marketplaces for an instance.
  *
  * @see https://metorial.com/api
  * @see https://metorial.com/docs

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_skills_plugins_repositories.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_skills_plugins_repositories.ts
@@ -19,8 +19,8 @@ import {
 } from '../resources';
 
 /**
- * @name Skill Plugins controller
- * @description Manage skill plugins for an instance.
+ * @name Skill Plugin Repositories controller
+ * @description Manage repositories linked to skill plugins for an instance.
  *
  * @see https://metorial.com/api
  * @see https://metorial.com/docs

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_skills_syncs.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_skills_syncs.ts
@@ -1,0 +1,102 @@
+import {
+  BaseMetorialEndpoint,
+  MetorialEndpointManager
+} from '@metorial/util-endpoint';
+
+import {
+  mapDashboardInstanceSkillsSyncsGetOutput,
+  mapDashboardInstanceSkillsSyncsListOutput,
+  mapDashboardInstanceSkillsSyncsListQuery,
+  type DashboardInstanceSkillsSyncsGetOutput,
+  type DashboardInstanceSkillsSyncsListOutput,
+  type DashboardInstanceSkillsSyncsListQuery
+} from '../resources';
+
+/**
+ * @name Skill Syncs controller
+ * @description View skill plugin and marketplace syncs for an instance.
+ *
+ * @see https://metorial.com/api
+ * @see https://metorial.com/docs
+ */
+export class MetorialDashboardInstanceSkillsSyncsEndpoint {
+  constructor(private readonly _manager: MetorialEndpointManager<any>) {}
+
+  // thin proxies so method bodies stay unchanged
+  private _get(request: any) {
+    return this._manager._get(request);
+  }
+  private _post(request: any) {
+    return this._manager._post(request);
+  }
+  private _put(request: any) {
+    return this._manager._put(request);
+  }
+  private _patch(request: any) {
+    return this._manager._patch(request);
+  }
+  private _delete(request: any) {
+    return this._manager._delete(request);
+  }
+
+  /**
+   * @name List skill syncs
+   * @description Returns a paginated list of skill syncs.
+   *
+   * @param `instanceId` - string
+   * @param `query` - DashboardInstanceSkillsSyncsListQuery
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceSkillsSyncsListOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  list(
+    instanceId: string,
+    query?: DashboardInstanceSkillsSyncsListQuery,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceSkillsSyncsListOutput> {
+    let path = `dashboard/instances/${instanceId}/skill-syncs`;
+
+    let request = {
+      path,
+
+      query: query
+        ? mapDashboardInstanceSkillsSyncsListQuery.transformTo(query)
+        : undefined,
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardInstanceSkillsSyncsListOutput
+    );
+  }
+
+  /**
+   * @name Get skill sync
+   * @description Retrieves a skill sync.
+   *
+   * @param `instanceId` - string
+   * @param `skillSyncId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceSkillsSyncsGetOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  get(
+    instanceId: string,
+    skillSyncId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceSkillsSyncsGetOutput> {
+    let path = `dashboard/instances/${instanceId}/skill-syncs/${skillSyncId}`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardInstanceSkillsSyncsGetOutput
+    );
+  }
+}

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/index.ts
@@ -130,6 +130,7 @@ export * from './dashboard_instance_skills_participants';
 export * from './dashboard_instance_skills_plugins';
 export * from './dashboard_instance_skills_plugins_repositories';
 export * from './dashboard_instance_skills_plugins_skills';
+export * from './dashboard_instance_skills_syncs';
 export * from './dashboard_instance_skills_versions';
 export * from './dashboard_instance_skills_versions_snapshot';
 export * from './dashboard_instance_stores';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/management_instance_skills_marketplaces_repositories.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/management_instance_skills_marketplaces_repositories.ts
@@ -19,8 +19,8 @@ import {
 } from '../resources';
 
 /**
- * @name Skill Marketplaces controller
- * @description Manage skill marketplaces for an instance.
+ * @name Skill Marketplace Repositories controller
+ * @description Manage repositories linked to skill marketplaces for an instance.
  *
  * @see https://metorial.com/api
  * @see https://metorial.com/docs

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/management_instance_skills_plugins_repositories.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/management_instance_skills_plugins_repositories.ts
@@ -19,8 +19,8 @@ import {
 } from '../resources';
 
 /**
- * @name Skill Plugins controller
- * @description Manage skill plugins for an instance.
+ * @name Skill Plugin Repositories controller
+ * @description Manage repositories linked to skill plugins for an instance.
  *
  * @see https://metorial.com/api
  * @see https://metorial.com/docs

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/skills_marketplaces_repositories.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/skills_marketplaces_repositories.ts
@@ -19,8 +19,8 @@ import {
 } from '../resources';
 
 /**
- * @name Skill Marketplaces controller
- * @description Manage skill marketplaces for an instance.
+ * @name Skill Marketplace Repositories controller
+ * @description Manage repositories linked to skill marketplaces for an instance.
  *
  * @see https://metorial.com/api
  * @see https://metorial.com/docs

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/skills_plugins_repositories.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/skills_plugins_repositories.ts
@@ -19,8 +19,8 @@ import {
 } from '../resources';
 
 /**
- * @name Skill Plugins controller
- * @description Manage skill plugins for an instance.
+ * @name Skill Plugin Repositories controller
+ * @description Manage repositories linked to skill plugins for an instance.
  *
  * @see https://metorial.com/api
  * @see https://metorial.com/docs

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/exports/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/exports/create.ts
@@ -59,6 +59,40 @@ export type DashboardInstanceSkillsExportsCreateOutput = {
     createdAt: Date;
     expiresAt: Date | null;
   } | null;
+  createdBy: {
+    type: 'organization_actor' | 'consumer' | 'unknown';
+    name: string;
+    imageUrl: string | null;
+    email: string | null;
+    organizationActor: {
+      object: 'organization.actor';
+      id: string;
+      type: 'member' | 'machine_access';
+      organizationId: string;
+      name: string;
+      email: string | null;
+      imageUrl: string;
+      teams: {
+        id: string;
+        name: string;
+        slug: string;
+        assignmentId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      }[];
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    consumer: {
+      object: 'consumer';
+      id: string;
+      name: string;
+      email: string;
+      imageUrl: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+  } | null;
   createdAt: Date;
   startedAt: Date | null;
   completedAt: Date | null;
@@ -148,6 +182,60 @@ export let mapDashboardInstanceSkillsExportsCreateOutput =
         url: mtMap.objectField('url', mtMap.passthrough()),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         expiresAt: mtMap.objectField('expires_at', mtMap.date())
+      })
+    ),
+    createdBy: mtMap.objectField(
+      'created_by',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+        email: mtMap.objectField('email', mtMap.passthrough()),
+        organizationActor: mtMap.objectField(
+          'organization_actor',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            organizationId: mtMap.objectField(
+              'organization_id',
+              mtMap.passthrough()
+            ),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            email: mtMap.objectField('email', mtMap.passthrough()),
+            imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+            teams: mtMap.objectField(
+              'teams',
+              mtMap.array(
+                mtMap.object({
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  assignmentId: mtMap.objectField(
+                    'assignment_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              )
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        consumer: mtMap.objectField(
+          'consumer',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            email: mtMap.objectField('email', mtMap.passthrough()),
+            imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        )
       })
     ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/exports/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/exports/get.ts
@@ -59,6 +59,40 @@ export type DashboardInstanceSkillsExportsGetOutput = {
     createdAt: Date;
     expiresAt: Date | null;
   } | null;
+  createdBy: {
+    type: 'organization_actor' | 'consumer' | 'unknown';
+    name: string;
+    imageUrl: string | null;
+    email: string | null;
+    organizationActor: {
+      object: 'organization.actor';
+      id: string;
+      type: 'member' | 'machine_access';
+      organizationId: string;
+      name: string;
+      email: string | null;
+      imageUrl: string;
+      teams: {
+        id: string;
+        name: string;
+        slug: string;
+        assignmentId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      }[];
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    consumer: {
+      object: 'consumer';
+      id: string;
+      name: string;
+      email: string;
+      imageUrl: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+  } | null;
   createdAt: Date;
   startedAt: Date | null;
   completedAt: Date | null;
@@ -148,6 +182,60 @@ export let mapDashboardInstanceSkillsExportsGetOutput =
         url: mtMap.objectField('url', mtMap.passthrough()),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         expiresAt: mtMap.objectField('expires_at', mtMap.date())
+      })
+    ),
+    createdBy: mtMap.objectField(
+      'created_by',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+        email: mtMap.objectField('email', mtMap.passthrough()),
+        organizationActor: mtMap.objectField(
+          'organization_actor',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            organizationId: mtMap.objectField(
+              'organization_id',
+              mtMap.passthrough()
+            ),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            email: mtMap.objectField('email', mtMap.passthrough()),
+            imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+            teams: mtMap.objectField(
+              'teams',
+              mtMap.array(
+                mtMap.object({
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  assignmentId: mtMap.objectField(
+                    'assignment_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              )
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        consumer: mtMap.objectField(
+          'consumer',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            email: mtMap.objectField('email', mtMap.passthrough()),
+            imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        )
       })
     ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/exports/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/exports/list.ts
@@ -60,6 +60,40 @@ export type DashboardInstanceSkillsExportsListOutput = {
       createdAt: Date;
       expiresAt: Date | null;
     } | null;
+    createdBy: {
+      type: 'organization_actor' | 'consumer' | 'unknown';
+      name: string;
+      imageUrl: string | null;
+      email: string | null;
+      organizationActor: {
+        object: 'organization.actor';
+        id: string;
+        type: 'member' | 'machine_access';
+        organizationId: string;
+        name: string;
+        email: string | null;
+        imageUrl: string;
+        teams: {
+          id: string;
+          name: string;
+          slug: string;
+          assignmentId: string;
+          createdAt: Date;
+          updatedAt: Date;
+        }[];
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      consumer: {
+        object: 'consumer';
+        id: string;
+        name: string;
+        email: string;
+        imageUrl: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+    } | null;
     createdAt: Date;
     startedAt: Date | null;
     completedAt: Date | null;
@@ -173,6 +207,63 @@ export let mapDashboardInstanceSkillsExportsListOutput =
               url: mtMap.objectField('url', mtMap.passthrough()),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               expiresAt: mtMap.objectField('expires_at', mtMap.date())
+            })
+          ),
+          createdBy: mtMap.objectField(
+            'created_by',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+              email: mtMap.objectField('email', mtMap.passthrough()),
+              organizationActor: mtMap.objectField(
+                'organization_actor',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  organizationId: mtMap.objectField(
+                    'organization_id',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  email: mtMap.objectField('email', mtMap.passthrough()),
+                  imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                  teams: mtMap.objectField(
+                    'teams',
+                    mtMap.array(
+                      mtMap.object({
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        slug: mtMap.objectField('slug', mtMap.passthrough()),
+                        assignmentId: mtMap.objectField(
+                          'assignment_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    )
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              consumer: mtMap.objectField(
+                'consumer',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  email: mtMap.objectField('email', mtMap.passthrough()),
+                  imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              )
             })
           ),
           createdAt: mtMap.objectField('created_at', mtMap.date()),

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/index.ts
@@ -12,5 +12,6 @@ export * from './marketplaces';
 export * from './participants';
 export * from './plugins';
 export * from './publish-consumer-skill';
+export * from './syncs';
 export * from './update';
 export * from './versions';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/syncs/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/syncs/get.ts
@@ -1,0 +1,79 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type DashboardInstanceSkillsSyncsGetOutput = {
+  object: 'skill.sync';
+  id: string;
+  status: 'pending' | 'completed' | 'failed' | 'processing' | 'canceled';
+  skillMarketplaceId: string | null;
+  skillPluginId: string | null;
+  logs: { timestamp: Date; message: string }[];
+  repositoryPropagations: {
+    object: 'skill.sync_repository_propagation';
+    id: string;
+    status: 'pending' | 'processing' | 'completed' | 'failed' | 'canceled';
+    repoId: string;
+    branchName: string;
+    prName: string;
+    prDescription: string | null;
+    commitMessage: string | null;
+    errorMessage: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+    startedAt: Date | null;
+    completedAt: Date | null;
+  }[];
+  createdAt: Date;
+  startedAt: Date | null;
+  completedAt: Date | null;
+};
+
+export let mapDashboardInstanceSkillsSyncsGetOutput =
+  mtMap.object<DashboardInstanceSkillsSyncsGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    skillMarketplaceId: mtMap.objectField(
+      'skill_marketplace_id',
+      mtMap.passthrough()
+    ),
+    skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
+    logs: mtMap.objectField(
+      'logs',
+      mtMap.array(
+        mtMap.object({
+          timestamp: mtMap.objectField('timestamp', mtMap.date()),
+          message: mtMap.objectField('message', mtMap.passthrough())
+        })
+      )
+    ),
+    repositoryPropagations: mtMap.objectField(
+      'repository_propagations',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          repoId: mtMap.objectField('repo_id', mtMap.passthrough()),
+          branchName: mtMap.objectField('branch_name', mtMap.passthrough()),
+          prName: mtMap.objectField('pr_name', mtMap.passthrough()),
+          prDescription: mtMap.objectField(
+            'pr_description',
+            mtMap.passthrough()
+          ),
+          commitMessage: mtMap.objectField(
+            'commit_message',
+            mtMap.passthrough()
+          ),
+          errorMessage: mtMap.objectField('error_message', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          startedAt: mtMap.objectField('started_at', mtMap.date()),
+          completedAt: mtMap.objectField('completed_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    startedAt: mtMap.objectField('started_at', mtMap.date()),
+    completedAt: mtMap.objectField('completed_at', mtMap.date())
+  });
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/syncs/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/syncs/index.ts
@@ -1,0 +1,2 @@
+export * from './get';
+export * from './list';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/syncs/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/syncs/list.ts
@@ -1,0 +1,183 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type DashboardInstanceSkillsSyncsListOutput = {
+  items: {
+    object: 'skill.sync';
+    id: string;
+    status: 'pending' | 'completed' | 'failed' | 'processing' | 'canceled';
+    skillMarketplaceId: string | null;
+    skillPluginId: string | null;
+    logs: { timestamp: Date; message: string }[];
+    repositoryPropagations: {
+      object: 'skill.sync_repository_propagation';
+      id: string;
+      status: 'pending' | 'processing' | 'completed' | 'failed' | 'canceled';
+      repoId: string;
+      branchName: string;
+      prName: string;
+      prDescription: string | null;
+      commitMessage: string | null;
+      errorMessage: string | null;
+      createdAt: Date;
+      updatedAt: Date;
+      startedAt: Date | null;
+      completedAt: Date | null;
+    }[];
+    createdAt: Date;
+    startedAt: Date | null;
+    completedAt: Date | null;
+  }[];
+  pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
+};
+
+export let mapDashboardInstanceSkillsSyncsListOutput =
+  mtMap.object<DashboardInstanceSkillsSyncsListOutput>({
+    items: mtMap.objectField(
+      'items',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          skillMarketplaceId: mtMap.objectField(
+            'skill_marketplace_id',
+            mtMap.passthrough()
+          ),
+          skillPluginId: mtMap.objectField(
+            'skill_plugin_id',
+            mtMap.passthrough()
+          ),
+          logs: mtMap.objectField(
+            'logs',
+            mtMap.array(
+              mtMap.object({
+                timestamp: mtMap.objectField('timestamp', mtMap.date()),
+                message: mtMap.objectField('message', mtMap.passthrough())
+              })
+            )
+          ),
+          repositoryPropagations: mtMap.objectField(
+            'repository_propagations',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                repoId: mtMap.objectField('repo_id', mtMap.passthrough()),
+                branchName: mtMap.objectField(
+                  'branch_name',
+                  mtMap.passthrough()
+                ),
+                prName: mtMap.objectField('pr_name', mtMap.passthrough()),
+                prDescription: mtMap.objectField(
+                  'pr_description',
+                  mtMap.passthrough()
+                ),
+                commitMessage: mtMap.objectField(
+                  'commit_message',
+                  mtMap.passthrough()
+                ),
+                errorMessage: mtMap.objectField(
+                  'error_message',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                startedAt: mtMap.objectField('started_at', mtMap.date()),
+                completedAt: mtMap.objectField('completed_at', mtMap.date())
+              })
+            )
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          startedAt: mtMap.objectField('started_at', mtMap.date()),
+          completedAt: mtMap.objectField('completed_at', mtMap.date())
+        })
+      )
+    ),
+    pagination: mtMap.objectField(
+      'pagination',
+      mtMap.object({
+        hasMoreBefore: mtMap.objectField(
+          'has_more_before',
+          mtMap.passthrough()
+        ),
+        hasMoreAfter: mtMap.objectField('has_more_after', mtMap.passthrough())
+      })
+    )
+  });
+
+export type DashboardInstanceSkillsSyncsListQuery = {
+  limit?: number | undefined;
+  after?: string | undefined;
+  before?: string | undefined;
+  cursor?: string | undefined;
+  order?: 'asc' | 'desc' | undefined;
+} & {
+  id?: string | string[] | undefined;
+  skillMarketplaceId?: string | string[] | undefined;
+  skillPluginId?: string | string[] | undefined;
+  status?:
+    | 'pending'
+    | 'completed'
+    | 'failed'
+    | 'processing'
+    | 'canceled'
+    | ('pending' | 'completed' | 'failed' | 'processing' | 'canceled')[]
+    | undefined;
+  createdAt?: { gt?: Date | undefined; lt?: Date | undefined } | undefined;
+};
+
+export let mapDashboardInstanceSkillsSyncsListQuery = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      limit: mtMap.objectField('limit', mtMap.passthrough()),
+      after: mtMap.objectField('after', mtMap.passthrough()),
+      before: mtMap.objectField('before', mtMap.passthrough()),
+      cursor: mtMap.objectField('cursor', mtMap.passthrough()),
+      order: mtMap.objectField('order', mtMap.passthrough()),
+      id: mtMap.objectField(
+        'id',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
+      skillMarketplaceId: mtMap.objectField(
+        'skill_marketplace_id',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
+      skillPluginId: mtMap.objectField(
+        'skill_plugin_id',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
+      status: mtMap.objectField(
+        'status',
+        mtMap.union([mtMap.unionOption('array', mtMap.union([]))])
+      ),
+      createdAt: mtMap.objectField(
+        'created_at',
+        mtMap.object({
+          gt: mtMap.objectField('gt', mtMap.date()),
+          lt: mtMap.objectField('lt', mtMap.date())
+        })
+      )
+    })
+  )
+]);
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/exports/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/exports/create.ts
@@ -59,6 +59,40 @@ export type ManagementInstanceSkillsExportsCreateOutput = {
     createdAt: Date;
     expiresAt: Date | null;
   } | null;
+  createdBy: {
+    type: 'organization_actor' | 'consumer' | 'unknown';
+    name: string;
+    imageUrl: string | null;
+    email: string | null;
+    organizationActor: {
+      object: 'organization.actor';
+      id: string;
+      type: 'member' | 'machine_access';
+      organizationId: string;
+      name: string;
+      email: string | null;
+      imageUrl: string;
+      teams: {
+        id: string;
+        name: string;
+        slug: string;
+        assignmentId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      }[];
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    consumer: {
+      object: 'consumer';
+      id: string;
+      name: string;
+      email: string;
+      imageUrl: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+  } | null;
   createdAt: Date;
   startedAt: Date | null;
   completedAt: Date | null;
@@ -148,6 +182,60 @@ export let mapManagementInstanceSkillsExportsCreateOutput =
         url: mtMap.objectField('url', mtMap.passthrough()),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         expiresAt: mtMap.objectField('expires_at', mtMap.date())
+      })
+    ),
+    createdBy: mtMap.objectField(
+      'created_by',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+        email: mtMap.objectField('email', mtMap.passthrough()),
+        organizationActor: mtMap.objectField(
+          'organization_actor',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            organizationId: mtMap.objectField(
+              'organization_id',
+              mtMap.passthrough()
+            ),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            email: mtMap.objectField('email', mtMap.passthrough()),
+            imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+            teams: mtMap.objectField(
+              'teams',
+              mtMap.array(
+                mtMap.object({
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  assignmentId: mtMap.objectField(
+                    'assignment_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              )
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        consumer: mtMap.objectField(
+          'consumer',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            email: mtMap.objectField('email', mtMap.passthrough()),
+            imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        )
       })
     ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/exports/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/exports/get.ts
@@ -59,6 +59,40 @@ export type ManagementInstanceSkillsExportsGetOutput = {
     createdAt: Date;
     expiresAt: Date | null;
   } | null;
+  createdBy: {
+    type: 'organization_actor' | 'consumer' | 'unknown';
+    name: string;
+    imageUrl: string | null;
+    email: string | null;
+    organizationActor: {
+      object: 'organization.actor';
+      id: string;
+      type: 'member' | 'machine_access';
+      organizationId: string;
+      name: string;
+      email: string | null;
+      imageUrl: string;
+      teams: {
+        id: string;
+        name: string;
+        slug: string;
+        assignmentId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      }[];
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    consumer: {
+      object: 'consumer';
+      id: string;
+      name: string;
+      email: string;
+      imageUrl: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+  } | null;
   createdAt: Date;
   startedAt: Date | null;
   completedAt: Date | null;
@@ -148,6 +182,60 @@ export let mapManagementInstanceSkillsExportsGetOutput =
         url: mtMap.objectField('url', mtMap.passthrough()),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         expiresAt: mtMap.objectField('expires_at', mtMap.date())
+      })
+    ),
+    createdBy: mtMap.objectField(
+      'created_by',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+        email: mtMap.objectField('email', mtMap.passthrough()),
+        organizationActor: mtMap.objectField(
+          'organization_actor',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            organizationId: mtMap.objectField(
+              'organization_id',
+              mtMap.passthrough()
+            ),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            email: mtMap.objectField('email', mtMap.passthrough()),
+            imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+            teams: mtMap.objectField(
+              'teams',
+              mtMap.array(
+                mtMap.object({
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  assignmentId: mtMap.objectField(
+                    'assignment_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              )
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        consumer: mtMap.objectField(
+          'consumer',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            email: mtMap.objectField('email', mtMap.passthrough()),
+            imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        )
       })
     ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/exports/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/exports/list.ts
@@ -60,6 +60,40 @@ export type ManagementInstanceSkillsExportsListOutput = {
       createdAt: Date;
       expiresAt: Date | null;
     } | null;
+    createdBy: {
+      type: 'organization_actor' | 'consumer' | 'unknown';
+      name: string;
+      imageUrl: string | null;
+      email: string | null;
+      organizationActor: {
+        object: 'organization.actor';
+        id: string;
+        type: 'member' | 'machine_access';
+        organizationId: string;
+        name: string;
+        email: string | null;
+        imageUrl: string;
+        teams: {
+          id: string;
+          name: string;
+          slug: string;
+          assignmentId: string;
+          createdAt: Date;
+          updatedAt: Date;
+        }[];
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      consumer: {
+        object: 'consumer';
+        id: string;
+        name: string;
+        email: string;
+        imageUrl: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+    } | null;
     createdAt: Date;
     startedAt: Date | null;
     completedAt: Date | null;
@@ -173,6 +207,63 @@ export let mapManagementInstanceSkillsExportsListOutput =
               url: mtMap.objectField('url', mtMap.passthrough()),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               expiresAt: mtMap.objectField('expires_at', mtMap.date())
+            })
+          ),
+          createdBy: mtMap.objectField(
+            'created_by',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+              email: mtMap.objectField('email', mtMap.passthrough()),
+              organizationActor: mtMap.objectField(
+                'organization_actor',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  organizationId: mtMap.objectField(
+                    'organization_id',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  email: mtMap.objectField('email', mtMap.passthrough()),
+                  imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                  teams: mtMap.objectField(
+                    'teams',
+                    mtMap.array(
+                      mtMap.object({
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        slug: mtMap.objectField('slug', mtMap.passthrough()),
+                        assignmentId: mtMap.objectField(
+                          'assignment_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    )
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              consumer: mtMap.objectField(
+                'consumer',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  email: mtMap.objectField('email', mtMap.passthrough()),
+                  imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              )
             })
           ),
           createdAt: mtMap.objectField('created_at', mtMap.date()),

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/exports/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/exports/create.ts
@@ -59,6 +59,40 @@ export type SkillsExportsCreateOutput = {
     createdAt: Date;
     expiresAt: Date | null;
   } | null;
+  createdBy: {
+    type: 'organization_actor' | 'consumer' | 'unknown';
+    name: string;
+    imageUrl: string | null;
+    email: string | null;
+    organizationActor: {
+      object: 'organization.actor';
+      id: string;
+      type: 'member' | 'machine_access';
+      organizationId: string;
+      name: string;
+      email: string | null;
+      imageUrl: string;
+      teams: {
+        id: string;
+        name: string;
+        slug: string;
+        assignmentId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      }[];
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    consumer: {
+      object: 'consumer';
+      id: string;
+      name: string;
+      email: string;
+      imageUrl: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+  } | null;
   createdAt: Date;
   startedAt: Date | null;
   completedAt: Date | null;
@@ -148,6 +182,60 @@ export let mapSkillsExportsCreateOutput =
         url: mtMap.objectField('url', mtMap.passthrough()),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         expiresAt: mtMap.objectField('expires_at', mtMap.date())
+      })
+    ),
+    createdBy: mtMap.objectField(
+      'created_by',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+        email: mtMap.objectField('email', mtMap.passthrough()),
+        organizationActor: mtMap.objectField(
+          'organization_actor',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            organizationId: mtMap.objectField(
+              'organization_id',
+              mtMap.passthrough()
+            ),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            email: mtMap.objectField('email', mtMap.passthrough()),
+            imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+            teams: mtMap.objectField(
+              'teams',
+              mtMap.array(
+                mtMap.object({
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  assignmentId: mtMap.objectField(
+                    'assignment_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              )
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        consumer: mtMap.objectField(
+          'consumer',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            email: mtMap.objectField('email', mtMap.passthrough()),
+            imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        )
       })
     ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/exports/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/exports/get.ts
@@ -59,6 +59,40 @@ export type SkillsExportsGetOutput = {
     createdAt: Date;
     expiresAt: Date | null;
   } | null;
+  createdBy: {
+    type: 'organization_actor' | 'consumer' | 'unknown';
+    name: string;
+    imageUrl: string | null;
+    email: string | null;
+    organizationActor: {
+      object: 'organization.actor';
+      id: string;
+      type: 'member' | 'machine_access';
+      organizationId: string;
+      name: string;
+      email: string | null;
+      imageUrl: string;
+      teams: {
+        id: string;
+        name: string;
+        slug: string;
+        assignmentId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      }[];
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    consumer: {
+      object: 'consumer';
+      id: string;
+      name: string;
+      email: string;
+      imageUrl: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+  } | null;
   createdAt: Date;
   startedAt: Date | null;
   completedAt: Date | null;
@@ -147,6 +181,60 @@ export let mapSkillsExportsGetOutput = mtMap.object<SkillsExportsGetOutput>({
       url: mtMap.objectField('url', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
       expiresAt: mtMap.objectField('expires_at', mtMap.date())
+    })
+  ),
+  createdBy: mtMap.objectField(
+    'created_by',
+    mtMap.object({
+      type: mtMap.objectField('type', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+      email: mtMap.objectField('email', mtMap.passthrough()),
+      organizationActor: mtMap.objectField(
+        'organization_actor',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          organizationId: mtMap.objectField(
+            'organization_id',
+            mtMap.passthrough()
+          ),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          email: mtMap.objectField('email', mtMap.passthrough()),
+          imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+          teams: mtMap.objectField(
+            'teams',
+            mtMap.array(
+              mtMap.object({
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                slug: mtMap.objectField('slug', mtMap.passthrough()),
+                assignmentId: mtMap.objectField(
+                  'assignment_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            )
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      consumer: mtMap.objectField(
+        'consumer',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          email: mtMap.objectField('email', mtMap.passthrough()),
+          imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
     })
   ),
   createdAt: mtMap.objectField('created_at', mtMap.date()),

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/exports/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/exports/list.ts
@@ -60,6 +60,40 @@ export type SkillsExportsListOutput = {
       createdAt: Date;
       expiresAt: Date | null;
     } | null;
+    createdBy: {
+      type: 'organization_actor' | 'consumer' | 'unknown';
+      name: string;
+      imageUrl: string | null;
+      email: string | null;
+      organizationActor: {
+        object: 'organization.actor';
+        id: string;
+        type: 'member' | 'machine_access';
+        organizationId: string;
+        name: string;
+        email: string | null;
+        imageUrl: string;
+        teams: {
+          id: string;
+          name: string;
+          slug: string;
+          assignmentId: string;
+          createdAt: Date;
+          updatedAt: Date;
+        }[];
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      consumer: {
+        object: 'consumer';
+        id: string;
+        name: string;
+        email: string;
+        imageUrl: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+    } | null;
     createdAt: Date;
     startedAt: Date | null;
     completedAt: Date | null;
@@ -166,6 +200,60 @@ export let mapSkillsExportsListOutput = mtMap.object<SkillsExportsListOutput>({
             url: mtMap.objectField('url', mtMap.passthrough()),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
             expiresAt: mtMap.objectField('expires_at', mtMap.date())
+          })
+        ),
+        createdBy: mtMap.objectField(
+          'created_by',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+            email: mtMap.objectField('email', mtMap.passthrough()),
+            organizationActor: mtMap.objectField(
+              'organization_actor',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                organizationId: mtMap.objectField(
+                  'organization_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                email: mtMap.objectField('email', mtMap.passthrough()),
+                imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                teams: mtMap.objectField(
+                  'teams',
+                  mtMap.array(
+                    mtMap.object({
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      slug: mtMap.objectField('slug', mtMap.passthrough()),
+                      assignmentId: mtMap.objectField(
+                        'assignment_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  )
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            consumer: mtMap.objectField(
+              'consumer',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                email: mtMap.objectField('email', mtMap.passthrough()),
+                imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            )
           })
         ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),

--- a/clients/metorial-dashboard/src/sdk.ts
+++ b/clients/metorial-dashboard/src/sdk.ts
@@ -115,6 +115,7 @@ import {
   MetorialDashboardInstanceSkillsPluginsEndpoint,
   MetorialDashboardInstanceSkillsPluginsRepositoriesEndpoint,
   MetorialDashboardInstanceSkillsPluginsSkillsEndpoint,
+  MetorialDashboardInstanceSkillsSyncsEndpoint,
   MetorialDashboardInstanceSkillsVersionsEndpoint,
   MetorialDashboardInstanceSkillsVersionsSnapshotEndpoint,
   MetorialDashboardInstanceSkillTemplatesEndpoint,
@@ -515,6 +516,8 @@ export let createMetorialDashboardSDK = sdkBuilder.build(
   }),
 
   skillExports: new MetorialDashboardInstanceSkillsExportsEndpoint(manager),
+
+  skillSyncs: new MetorialDashboardInstanceSkillsSyncsEndpoint(manager),
 
   magicMcp: {
     servers: Object.assign(new MetorialDashboardInstanceMagicMcpServersEndpoint(manager), {

--- a/src/backend/apis/core/src/controllers/index.ts
+++ b/src/backend/apis/core/src/controllers/index.ts
@@ -126,6 +126,7 @@ import {
   skillPluginController,
   skillPluginRepositoryController,
   skillPluginSkillController,
+  skillSyncController,
   skillTemplateController,
   skillTemplateItemController,
   skillVersionController,
@@ -547,6 +548,7 @@ export let dashboardController = Controller.create<any>(
     skillPluginController,
     skillPluginRepositoryController,
     skillPluginSkillController,
+    skillSyncController,
 
     consumerController,
     consumerSurfaceController,

--- a/src/backend/apis/core/src/controllers/instance/skills/index.ts
+++ b/src/backend/apis/core/src/controllers/instance/skills/index.ts
@@ -9,6 +9,7 @@ export * from './skillParticipant';
 export * from './skillPlugin';
 export * from './skillPluginRepository';
 export * from './skillPluginSkill';
+export * from './skillSync';
 export * from './skillGroup';
 export * from './skillGroupItem';
 export * from './skillItem';

--- a/src/backend/apis/core/src/controllers/instance/skills/skillSync.ts
+++ b/src/backend/apis/core/src/controllers/instance/skills/skillSync.ts
@@ -1,0 +1,104 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import { skillSyncService } from '@metorial/module-file';
+import { Controller, Path } from '@metorial/rest';
+import { dateFilterValidator } from '../../../lib/dateFilter';
+import { normalizeArrayParam } from '../../../lib/normalizeArrayParam';
+import { checkAccess } from '../../../middleware/checkAccess';
+import { hasFlags } from '../../../middleware/hasFlags';
+import { instanceGroup } from '../../../middleware/instanceGroup';
+import { isDashboardGroup } from '../../../middleware/isDashboard';
+import { skillSyncPresenter } from '../../../presenters';
+import { getSkillPluginAccess } from './skillPlugin';
+
+let readScopes = ['instance.skill:read'] as const;
+
+let statusValidator = v.enumOf([
+  'pending',
+  'completed',
+  'failed',
+  'processing',
+  'canceled'
+]);
+
+export let skillSyncGroup = instanceGroup
+  .use(hasFlags(['skills-enabled']))
+  .use(isDashboardGroup())
+  .use(async ctx => {
+    if (!ctx.params.skillSyncId) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'skillSyncId is required',
+          description: 'The skillSyncId path parameter is required.'
+        })
+      );
+    }
+
+    let skillSync = await skillSyncService.getSkillSyncById({
+      ...getSkillPluginAccess(ctx),
+      skillSyncId: ctx.params.skillSyncId
+    });
+
+    return { skillSync };
+  });
+
+export let skillSyncController = Controller.create(
+  {
+    name: 'Skill Syncs',
+    description: 'View skill plugin and marketplace syncs for an instance.'
+  },
+  {
+    list: instanceGroup
+      .get(Path('/dashboard/instances/:instanceId/skill-syncs', 'dashboard.instance.skills.syncs.list'), {
+        name: 'List skill syncs',
+        description: 'Returns a paginated list of skill syncs.'
+      })
+      .use(hasFlags(['skills-enabled']))
+      .use(isDashboardGroup())
+      .use(checkAccess({ possibleScopes: [...readScopes] }))
+      .outputList(skillSyncPresenter)
+      .query(
+        'default',
+        Paginator.validate(
+          v.object({
+            id: v.optional(v.union([v.string(), v.array(v.string())])),
+            skill_marketplace_id: v.optional(v.union([v.string(), v.array(v.string())])),
+            skill_plugin_id: v.optional(v.union([v.string(), v.array(v.string())])),
+            status: v.optional(v.union([statusValidator, v.array(statusValidator)])),
+            created_at: dateFilterValidator('skill sync creation time')
+          })
+        )
+      )
+      .do(async ctx => {
+        let paginator = await skillSyncService.listSkillSyncs({
+          ...getSkillPluginAccess(ctx),
+          ids: normalizeArrayParam(ctx.query.id),
+          skillMarketplaceIds: normalizeArrayParam(ctx.query.skill_marketplace_id),
+          skillPluginIds: normalizeArrayParam(ctx.query.skill_plugin_id),
+          statuses: normalizeArrayParam(ctx.query.status),
+          createdAt: ctx.query.created_at
+        });
+        let list = await paginator.run(ctx.query);
+
+        return Paginator.present(list, skillSync =>
+          skillSyncPresenter.present({ skillSync })
+        );
+      }),
+
+    get: skillSyncGroup
+      .get(
+        Path(
+          '/dashboard/instances/:instanceId/skill-syncs/:skillSyncId',
+          'dashboard.instance.skills.syncs.get'
+        ),
+        {
+          name: 'Get skill sync',
+          description: 'Retrieves a skill sync.'
+        }
+      )
+      .use(checkAccess({ possibleScopes: [...readScopes] }))
+      .output(skillSyncPresenter)
+      .do(async ctx => skillSyncPresenter.present({ skillSync: ctx.skillSync }))
+  }
+);

--- a/src/backend/apis/core/src/presenters/implementation/skills/index.ts
+++ b/src/backend/apis/core/src/presenters/implementation/skills/index.ts
@@ -9,6 +9,7 @@ export * from './skillParticipant';
 export * from './skillPlugin';
 export * from './skillPluginRepository';
 export * from './skillPluginSkill';
+export * from './skillSync';
 export * from './skillGroup';
 export * from './skillGroupItem';
 export * from './skillItem';

--- a/src/backend/apis/core/src/presenters/implementation/skills/skillSync.ts
+++ b/src/backend/apis/core/src/presenters/implementation/skills/skillSync.ts
@@ -1,0 +1,65 @@
+import { v } from '@lowerdeck/validation';
+import { Presenter } from '@metorial/presenter';
+import { skillSyncType } from '../../types';
+
+let skillSyncRepositoryPropagationSchema = v.object({
+  object: v.literal('skill.sync_repository_propagation'),
+  id: v.string(),
+  status: v.enumOf(['pending', 'processing', 'completed', 'failed', 'canceled']),
+  repo_id: v.string(),
+  branch_name: v.string(),
+  pr_name: v.string(),
+  pr_description: v.nullable(v.string()),
+  commit_message: v.nullable(v.string()),
+  error_message: v.nullable(v.string()),
+  created_at: v.date(),
+  updated_at: v.date(),
+  started_at: v.nullable(v.date()),
+  completed_at: v.nullable(v.date())
+});
+
+export let v1SkillSyncPresenter = Presenter.create(skillSyncType)
+  .presenter(async ({ skillSync }) => ({
+    object: 'skill.sync' as const,
+    id: skillSync.id,
+    status: skillSync.status,
+    skill_marketplace_id: skillSync.skillMarketplaceId ?? null,
+    skill_plugin_id: skillSync.skillPluginId ?? null,
+    logs: skillSync.logs.map(([ts, msg]) => ({
+      timestamp: new Date(ts),
+      message: msg
+    })),
+    repository_propagations: skillSync.repositoryPropagations.map(propagation => ({
+      object: 'skill.sync_repository_propagation' as const,
+      id: propagation.id,
+      status: propagation.status,
+      repo_id: propagation.repoId,
+      branch_name: propagation.branchName,
+      pr_name: propagation.prName,
+      pr_description: propagation.prDescription,
+      commit_message: propagation.commitMessage,
+      error_message: propagation.errorMessage,
+      created_at: propagation.createdAt,
+      updated_at: propagation.updatedAt,
+      started_at: propagation.startedAt,
+      completed_at: propagation.completedAt
+    })),
+    created_at: skillSync.createdAt,
+    started_at: skillSync.startedAt,
+    completed_at: skillSync.completedAt
+  }))
+  .schema(
+    v.object({
+      object: v.literal('skill.sync'),
+      id: v.string(),
+      status: v.enumOf(['pending', 'completed', 'failed', 'processing', 'canceled']),
+      skill_marketplace_id: v.nullable(v.string()),
+      skill_plugin_id: v.nullable(v.string()),
+      logs: v.array(v.object({ timestamp: v.date(), message: v.string() })),
+      repository_propagations: v.array(skillSyncRepositoryPropagationSchema),
+      created_at: v.date(),
+      started_at: v.nullable(v.date()),
+      completed_at: v.nullable(v.date())
+    })
+  )
+  .build();

--- a/src/backend/apis/core/src/presenters/index.ts
+++ b/src/backend/apis/core/src/presenters/index.ts
@@ -169,6 +169,7 @@ import {
   v1SkillPluginPresenter,
   v1SkillPluginRepositoryPresenter,
   v1SkillPluginSkillPresenter,
+  v1SkillSyncPresenter,
   v1SkillTemplateItemPresenter,
   v1SkillTemplatePresenter,
   v1SkillVersionPresenter,
@@ -340,6 +341,7 @@ import {
   skillPluginType,
   skillPluginRepositoryType,
   skillPluginSkillType,
+  skillSyncType,
   skillTemplateItemType,
   skillTemplateType,
   skillType,
@@ -614,6 +616,11 @@ export let skillPluginRepositoryPresenter = declarePresenter(skillPluginReposito
 export let skillPluginSkillPresenter = declarePresenter(skillPluginSkillType, {
   mt_2025_01_01_dashboard: v1SkillPluginSkillPresenter,
   mt_2026_01_01_magnetar: v1SkillPluginSkillPresenter
+});
+
+export let skillSyncPresenter = declarePresenter(skillSyncType, {
+  mt_2025_01_01_dashboard: v1SkillSyncPresenter,
+  mt_2026_01_01_magnetar: v1SkillSyncPresenter
 });
 
 export let skillParticipantPresenter = declarePresenter(skillParticipantType, {

--- a/src/backend/apis/core/src/presenters/types.ts
+++ b/src/backend/apis/core/src/presenters/types.ts
@@ -98,6 +98,7 @@ import type {
   EnrichedCargoSkillPlugin,
   EnrichedCargoSkillPluginRepository,
   EnrichedCargoSkillPluginSkill,
+  EnrichedCargoSkillSync,
   CargoSkillVersion,
   CargoSkillVersionSnapshot,
   EnrichedCargoStoreItem,
@@ -521,6 +522,10 @@ export let skillPluginRepositoryType = PresentableType.create<{
 export let skillPluginSkillType = PresentableType.create<{
   skillPluginSkill: EnrichedCargoSkillPluginSkill;
 }>()('skillPluginSkill');
+
+export let skillSyncType = PresentableType.create<{
+  skillSync: EnrichedCargoSkillSync;
+}>()('skillSync');
 
 export let skillParticipantType = PresentableType.create<{
   skillParticipant: EnrichedCargoSkillParticipant;

--- a/src/backend/modules/file/src/cargo.ts
+++ b/src/backend/modules/file/src/cargo.ts
@@ -85,6 +85,8 @@ export type CargoSkillConfigurationList = Awaited<
 >;
 export type CargoSkillExport = Awaited<ReturnType<typeof cargo.skillExport.get>>;
 export type CargoSkillExportList = Awaited<ReturnType<typeof cargo.skillExport.list>>;
+export type CargoSkillSync = Awaited<ReturnType<typeof cargo.skillSync.get>>;
+export type CargoSkillSyncList = Awaited<ReturnType<typeof cargo.skillSync.list>>;
 export type CargoSkillVersion = Awaited<ReturnType<typeof cargo.skillVersion.get>>;
 export type CargoSkillVersionList = Awaited<ReturnType<typeof cargo.skillVersion.list>>;
 export type CargoSkillVersionSnapshot = Awaited<

--- a/src/backend/modules/file/src/services/index.ts
+++ b/src/backend/modules/file/src/services/index.ts
@@ -19,6 +19,7 @@ export type {
   CargoSkillParticipant,
   CargoSkillPlugin,
   CargoSkillPluginSkill,
+  CargoSkillSync,
   CargoSkillVersion,
   CargoSkillVersionSnapshot,
   CargoStore,
@@ -45,6 +46,7 @@ export * from './skillMarketplaceRepository';
 export * from './skillParticipant';
 export * from './skillPlugin';
 export * from './skillPluginRepository';
+export * from './skillSync';
 export * from './skillVersion';
 export * from './store';
 export * from './storeItem';

--- a/src/backend/modules/file/src/services/skillSync.ts
+++ b/src/backend/modules/file/src/services/skillSync.ts
@@ -1,0 +1,72 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import { cargo, type CargoSkillSync } from '../cargo';
+import {
+  resolveCargoAccess,
+  type CargoAccessActor,
+  type CargoStorePermission
+} from './access';
+import type { FileOwner } from './file';
+
+type SkillSyncAccessInput = {
+  owner: FileOwner;
+  accessActor?: CargoAccessActor;
+  defaultPermissions?: CargoStorePermission[];
+  overridePermissions?: boolean;
+};
+
+export type EnrichedCargoSkillSync = CargoSkillSync;
+
+class SkillSyncServiceImpl {
+  async listSkillSyncs(
+    d: SkillSyncAccessInput & {
+      ids?: string[];
+      skillMarketplaceIds?: string[];
+      skillPluginIds?: string[];
+      statuses?: Array<'pending' | 'completed' | 'failed' | 'processing' | 'canceled'>;
+      createdAt?: any;
+    }
+  ) {
+    let { scope } = await resolveCargoAccess(d);
+
+    return Paginator.create(() => async input => {
+      let result = await cargo.skillSync.list({
+        tenantId: scope.tenantId,
+        environmentId: scope.environmentId,
+        skillSyncIds: d.ids,
+        skillMarketplaceIds: d.skillMarketplaceIds,
+        skillPluginIds: d.skillPluginIds,
+        statuses: d.statuses,
+        createdAt: d.createdAt,
+        ...input
+      });
+
+      return {
+        items: result.items,
+        pagination: {
+          hasNextPage: result.pagination.has_more_after,
+          hasPreviousPage: result.pagination.has_more_before
+        }
+      };
+    });
+  }
+
+  async getSkillSyncById(
+    d: SkillSyncAccessInput & {
+      skillSyncId: string;
+    }
+  ) {
+    let { scope } = await resolveCargoAccess(d);
+
+    return await cargo.skillSync.get({
+      tenantId: scope.tenantId,
+      environmentId: scope.environmentId,
+      skillSyncId: d.skillSyncId
+    });
+  }
+}
+
+export let skillSyncService = Service.create(
+  'fileSkillSync',
+  () => new SkillSyncServiceImpl()
+).build();

--- a/src/frontend/apps/dashboard/src/slices/product/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/index.tsx
@@ -278,6 +278,11 @@ let SkillMarketplacePage = dynamicPage(() =>
 let SkillMarketplaceEditorPage = dynamicPage(() =>
   import('./pages/(skills)/skill-marketplace/editor').then(c => c.SkillMarketplaceEditorPage)
 );
+let SkillMarketplaceSyncsPage = dynamicPage(() =>
+  import('./pages/(skills)/skill-marketplace/syncs').then(
+    c => c.SkillMarketplaceSyncsPage
+  )
+);
 let SkillMarketplaceSettingsPage = dynamicPage(() =>
   import('./pages/(skills)/skill-marketplace/settings').then(
     c => c.SkillMarketplaceSettingsPage
@@ -291,6 +296,9 @@ let SkillPluginPage = dynamicPage(() =>
 );
 let SkillPluginEditorPage = dynamicPage(() =>
   import('./pages/(skills)/skill-plugin/editor').then(c => c.SkillPluginEditorPage)
+);
+let SkillPluginSyncsPage = dynamicPage(() =>
+  import('./pages/(skills)/skill-plugin/syncs').then(c => c.SkillPluginSyncsPage)
 );
 let SkillPluginSettingsPage = dynamicPage(() =>
   import('./pages/(skills)/skill-plugin/settings').then(c => c.SkillPluginSettingsPage)
@@ -1262,6 +1270,10 @@ export let productHomeSlice = createSlice([
                 element: <SkillMarketplaceEditorPage />
               },
               {
+                path: 'syncs',
+                element: <SkillMarketplaceSyncsPage />
+              },
+              {
                 path: 'settings',
                 element: <SkillMarketplaceSettingsPage />
               }
@@ -1278,6 +1290,10 @@ export let productHomeSlice = createSlice([
               {
                 path: 'editor',
                 element: <SkillPluginEditorPage />
+              },
+              {
+                path: 'syncs',
+                element: <SkillPluginSyncsPage />
               },
               {
                 path: 'settings',

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-marketplace/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-marketplace/_layout.tsx
@@ -121,6 +121,10 @@ export let SkillMarketplaceLayout = () => {
                 to: Paths.instance.skillMarketplace(...marketplacePathParams, 'editor')
               },
               {
+                label: 'Syncs',
+                to: Paths.instance.skillMarketplace(...marketplacePathParams, 'syncs')
+              },
+              {
                 label: 'Settings',
                 to: Paths.instance.skillMarketplace(...marketplacePathParams, 'settings')
               }

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-marketplace/syncs.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-marketplace/syncs.tsx
@@ -1,0 +1,13 @@
+import { useParams } from 'react-router-dom';
+import { SkillSyncsTable } from '../skillSyncs';
+
+export let SkillMarketplaceSyncsPage = () => {
+  let { skillMarketplaceId } = useParams();
+
+  return (
+    <SkillSyncsTable
+      emptyMessage="No syncs found for this skill marketplace."
+      query={skillMarketplaceId ? { skillMarketplaceId, order: 'desc' } : null}
+    />
+  );
+};

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-plugin/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-plugin/_layout.tsx
@@ -117,6 +117,10 @@ export let SkillPluginLayout = () => {
                 to: Paths.instance.skillPlugin(...pluginPathParams, 'editor')
               },
               {
+                label: 'Syncs',
+                to: Paths.instance.skillPlugin(...pluginPathParams, 'syncs')
+              },
+              {
                 label: 'Settings',
                 to: Paths.instance.skillPlugin(...pluginPathParams, 'settings')
               }

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-plugin/syncs.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-plugin/syncs.tsx
@@ -1,0 +1,13 @@
+import { useParams } from 'react-router-dom';
+import { SkillSyncsTable } from '../skillSyncs';
+
+export let SkillPluginSyncsPage = () => {
+  let { skillPluginId } = useParams();
+
+  return (
+    <SkillSyncsTable
+      emptyMessage="No syncs found for this skill plugin."
+      query={skillPluginId ? { skillPluginId, order: 'desc' } : null}
+    />
+  );
+};

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skillSyncs.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skillSyncs.tsx
@@ -1,0 +1,220 @@
+import type {
+  DashboardInstanceSkillsSyncsGetOutput,
+  DashboardInstanceSkillsSyncsListQuery
+} from '@metorial/dashboard-sdk';
+import { renderWithLoader, renderWithPagination } from '@metorial/data-hooks';
+import { useCurrentInstance, useSkillSync, useSkillSyncs } from '@metorial/state';
+import { Attributes, Badge, Panel, RenderDate, Spacer, Text, theme } from '@metorial/ui';
+import { ID, Table } from '@metorial/ui-product';
+import { useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import styled from 'styled-components';
+import { RouterPanel } from '../../scenes/routerPanel';
+
+type SkillSync = DashboardInstanceSkillsSyncsGetOutput;
+
+let statusColor = (status: SkillSync['status']): 'blue' | 'gray' | 'red' | 'orange' =>
+  status === 'completed'
+    ? 'blue'
+    : status === 'failed' || status === 'canceled'
+      ? 'red'
+      : status === 'pending' || status === 'processing'
+        ? 'orange'
+        : 'gray';
+
+let SkillSyncStatusBadge = ({ status }: { status: SkillSync['status'] }) => (
+  <Badge color={statusColor(status)}>{status}</Badge>
+);
+
+export let SkillSyncsTable = ({
+  emptyMessage,
+  query
+}: {
+  emptyMessage: string;
+  query: DashboardInstanceSkillsSyncsListQuery | null;
+}) => {
+  let instance = useCurrentInstance();
+  let syncs = useSkillSyncs(
+    instance.data?.id,
+    query
+      ? {
+          ...query,
+          order: query.order ?? 'desc'
+        }
+      : null
+  );
+  let [_, setSearchParams] = useSearchParams();
+
+  return (
+    <>
+      {renderWithPagination(syncs)(syncs => (
+        <>
+          <Table
+            headers={['Status', 'Created', 'Duration']}
+            data={syncs.data.items.map(sync => ({
+              data: [
+                <SkillSyncStatusBadge status={sync.status} />,
+                <RenderDate date={sync.createdAt} />,
+                <SyncDuration sync={sync} />
+              ],
+              onClick: () =>
+                setSearchParams(params => {
+                  params.set('sync_id', sync.id);
+                  return params;
+                })
+            }))}
+          />
+
+          {syncs.data.items.length == 0 && (
+            <Text size="2" color="gray600" align="center" style={{ marginTop: 10 }}>
+              {emptyMessage}
+            </Text>
+          )}
+        </>
+      ))}
+
+      <RouterPanel param="sync_id" width={1000}>
+        {syncId => (
+          <>
+            <Panel.Header>
+              <Panel.Title>Sync Details</Panel.Title>
+            </Panel.Header>
+
+            <Panel.Content>
+              <SkillSyncDetails syncId={syncId} />
+            </Panel.Content>
+          </>
+        )}
+      </RouterPanel>
+    </>
+  );
+};
+
+let SyncDuration = ({ sync }: { sync: SkillSync }) => {
+  if (!sync.startedAt) return <Text color="gray600">Not started</Text>;
+  if (!sync.completedAt) return <Text color="gray600">In progress</Text>;
+
+  let durationMs = new Date(sync.completedAt).getTime() - new Date(sync.startedAt).getTime();
+  return <span>{Math.max(0, Math.round(durationMs / 1000))}s</span>;
+};
+
+let SkillSyncDetails = ({ syncId }: { syncId: string }) => {
+  let instance = useCurrentInstance();
+  let sync = useSkillSync(instance.data?.id, syncId);
+
+  return renderWithLoader({ sync })(({ sync }) => {
+    return (
+      <>
+        <Attributes
+          itemWidth="320px"
+          attributes={[
+            { label: 'Sync ID', content: <ID id={sync.data.id} /> },
+            { label: 'Status', content: <SkillSyncStatusBadge status={sync.data.status} /> },
+            {
+              label: 'Started',
+              content: sync.data.startedAt ? <RenderDate date={sync.data.startedAt} /> : 'N/A'
+            },
+            {
+              label: 'Completed',
+              content: sync.data.completedAt ? (
+                <RenderDate date={sync.data.completedAt} />
+              ) : (
+                'N/A'
+              )
+            }
+          ]}
+        />
+
+        <Spacer height={20} />
+        <Text size="3" weight="strong">
+          Repository Propagations
+        </Text>
+        <Spacer height={10} />
+        <Table
+          headers={['Status', 'Branch', 'PR', 'Completed']}
+          data={sync.data.repositoryPropagations.map(propagation => ({
+            data: [
+              <SkillSyncStatusBadge status={propagation.status} />,
+              propagation.branchName,
+              propagation.prName,
+              propagation.completedAt ? <RenderDate date={propagation.completedAt} /> : 'N/A'
+            ]
+          }))}
+        />
+        {sync.data.repositoryPropagations.length == 0 && (
+          <Text size="2" color="gray600" align="center" style={{ marginTop: 10 }}>
+            No repository propagations for this sync.
+          </Text>
+        )}
+
+        <Spacer height={20} />
+        <Text size="3" weight="strong">
+          Logs
+        </Text>
+        <Spacer height={10} />
+        <SkillSyncLogs logs={sync.data.logs} />
+      </>
+    );
+  });
+};
+
+let SkillSyncLogs = ({ logs }: { logs: SkillSync['logs'] }) => {
+  let wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let wrapper = wrapperRef.current;
+    if (!wrapper) return;
+    wrapper.scrollTop = wrapper.scrollHeight;
+  }, [logs]);
+
+  return (
+    <LogsWrapper ref={wrapperRef}>
+      {logs.map((log, i) => (
+        <LogLine key={`${log.timestamp.toISOString()}-${i}`}>
+          <LogTimestamp>
+            <RenderDate date={log.timestamp} />
+          </LogTimestamp>
+          <LogMessage>{log.message}</LogMessage>
+        </LogLine>
+      ))}
+      {logs.length == 0 && (
+        <div style={{ padding: 20 }}>
+          <Text size="2" color="gray600">
+            No logs for this sync.
+          </Text>
+        </div>
+      )}
+    </LogsWrapper>
+  );
+};
+
+let LogsWrapper = styled.div`
+  border: 1px solid ${theme.colors.gray300};
+  border-radius: 8px;
+  overflow: hidden;
+  background: ${theme.colors.gray100};
+  max-height: 400px;
+  overflow-y: auto;
+`;
+
+let LogLine = styled.div`
+  display: grid;
+  grid-template-columns: 180px 1fr;
+  gap: 12px;
+  padding: 10px 12px;
+  border-top: 1px solid ${theme.colors.gray300};
+
+  &:first-child {
+    border-top: 0;
+  }
+`;
+
+let LogTimestamp = styled.div`
+  color: ${theme.colors.gray600};
+  font-size: 13px;
+`;
+
+let LogMessage = styled.div`
+  font-size: 13px;
+  white-space: pre-wrap;
+`;

--- a/src/frontend/state/src/skills/index.ts
+++ b/src/frontend/state/src/skills/index.ts
@@ -2,5 +2,6 @@ export * from './loaders/skillExports';
 export * from './loaders/skillGroups';
 export * from './loaders/skillMarketplaces';
 export * from './loaders/skillPlugins';
+export * from './loaders/skillSyncs';
 export * from './loaders/skills';
 export * from './loaders/skillTemplates';

--- a/src/frontend/state/src/skills/loaders/skillSyncs.ts
+++ b/src/frontend/state/src/skills/loaders/skillSyncs.ts
@@ -1,0 +1,83 @@
+import type {
+  DashboardInstanceSkillsSyncsGetOutput,
+  DashboardInstanceSkillsSyncsListQuery
+} from '@metorial/dashboard-sdk';
+import { createLoader } from '@metorial/data-hooks';
+import { useEffect, useRef } from 'react';
+import { usePaginator } from '../../lib/usePaginator';
+import { withAuth } from '../../user';
+
+export type SkillSync = DashboardInstanceSkillsSyncsGetOutput;
+
+let toArrayIfString = <T extends string>(value: T | T[] | undefined) =>
+  typeof value === 'string' ? [value] : value;
+
+let normalizeSkillSyncsListQuery = (
+  query: DashboardInstanceSkillsSyncsListQuery
+): DashboardInstanceSkillsSyncsListQuery => ({
+  ...query,
+  id: toArrayIfString(query.id),
+  skillMarketplaceId: toArrayIfString(query.skillMarketplaceId),
+  skillPluginId: toArrayIfString(query.skillPluginId),
+  status: toArrayIfString(query.status as any) as any
+});
+
+export let skillSyncsLoader = createLoader({
+  name: 'skillSyncs',
+  parents: [],
+  fetch: (i: { instanceId: string } & DashboardInstanceSkillsSyncsListQuery) =>
+    withAuth(sdk => sdk.skillSyncs.list(i.instanceId, normalizeSkillSyncsListQuery(i))),
+  mutators: {}
+});
+
+export let useSkillSyncs = (
+  instanceId: string | null | undefined,
+  query?: DashboardInstanceSkillsSyncsListQuery | null
+) => {
+  let data = usePaginator(
+    pagination =>
+      skillSyncsLoader.use(
+        instanceId && query !== null ? { instanceId, ...pagination, ...(query ?? {}) } : null
+      ),
+    instanceId ? `${instanceId}:skillSyncs:${JSON.stringify(query ?? {})}` : null
+  );
+
+  let hasActiveSyncs = data.data?.items.some(sync =>
+    ['pending', 'processing'].includes(sync.status)
+  );
+  let refetchRef = useRef(data.refetch);
+  refetchRef.current = data.refetch;
+  useEffect(() => {
+    if (!hasActiveSyncs) return;
+    let id = setInterval(() => refetchRef.current(), 3000);
+    return () => clearInterval(id);
+  }, [hasActiveSyncs]);
+
+  return data;
+};
+
+export let skillSyncLoader = createLoader({
+  name: 'skillSync',
+  parents: [skillSyncsLoader],
+  fetch: (i: { instanceId: string; skillSyncId: string }) =>
+    withAuth(sdk => sdk.skillSyncs.get(i.instanceId, i.skillSyncId)),
+  mutators: {}
+});
+
+export let useSkillSync = (
+  instanceId: string | null | undefined,
+  skillSyncId: string | null | undefined
+) => {
+  let data = skillSyncLoader.use(instanceId && skillSyncId ? { instanceId, skillSyncId } : null);
+
+  let isActive = data.data?.status ? ['pending', 'processing'].includes(data.data.status) : false;
+  let refetchRef = useRef(data.refetch);
+  refetchRef.current = data.refetch;
+  useEffect(() => {
+    if (!isActive) return;
+    let id = setInterval(() => refetchRef.current(), 3000);
+    return () => clearInterval(id);
+  }, [isActive]);
+
+  return data;
+};

--- a/src/systems/cargo/modules/skill/src/serializers/skill/index.ts
+++ b/src/systems/cargo/modules/skill/src/serializers/skill/index.ts
@@ -216,7 +216,7 @@ export let applySkill = createApplicator('skill', async (input, context) => {
     });
 
     for (let item of items) {
-      if (item.path.startsWith('/agents/') || item.path.startsWith('/agents/')) continue;
+      if (item.path.startsWith('/agents/') || item.path.startsWith('agents/')) continue;
       if (!isAllowedBySkillConfig(item.path, config)) continue;
 
       if (item.kind === 'document' && item.document) {

--- a/src/systems/cargo/modules/skill/src/services/index.ts
+++ b/src/systems/cargo/modules/skill/src/services/index.ts
@@ -11,5 +11,6 @@ export * from './skillPlugin';
 export * from './skillPluginRepository';
 export * from './skillPluginSkill';
 export * from './skillRepository';
+export * from './skillSync';
 export * from './skillTemplate';
 export * from './skillVersion';

--- a/src/systems/cargo/modules/skill/src/services/skillSync.ts
+++ b/src/systems/cargo/modules/skill/src/services/skillSync.ts
@@ -1,0 +1,148 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import type { Prisma, SkillDestinationSyncStatus } from '@metorial-cargo/db';
+import { db, withTransaction } from '@metorial-cargo/db';
+import {
+  type DateFilter,
+  normalizeDateFilter,
+  resolveSkillMarketplaces,
+  resolveSkillPlugins
+} from '@metorial-cargo/list-utils';
+import type { CargoTenantEnvironment } from '@metorial-cargo/module-file';
+
+export let skillSyncInclude = {
+  destination: {
+    include: {
+      skillMarketplace: {
+        select: {
+          id: true,
+          tenantOid: true,
+          environmentOid: true
+        }
+      },
+      skillPlugin: {
+        select: {
+          id: true,
+          tenantOid: true,
+          environmentOid: true
+        }
+      }
+    }
+  },
+  repositoryPropagations: {
+    orderBy: {
+      createdAt: 'asc'
+    },
+    include: {
+      skillRepository: true
+    }
+  }
+} satisfies Prisma.SkillDestinationSyncInclude;
+
+export type SkillSyncRecord = Prisma.SkillDestinationSyncGetPayload<{
+  include: typeof skillSyncInclude;
+}>;
+
+export type SkillSyncStatusFilter = SkillDestinationSyncStatus;
+
+class SkillSyncServiceImpl {
+  private async getSkillSyncRecord(
+    d: CargoTenantEnvironment & {
+      skillSyncId: string;
+    }
+  ) {
+    return await withTransaction(
+      async db => {
+        let skillSync = await db.skillDestinationSync.findFirst({
+          where: {
+            id: d.skillSyncId,
+            destination: this.scopeDestinationWhere(d)
+          },
+          include: skillSyncInclude
+        });
+
+        if (!skillSync) {
+          throw new ServiceError(notFoundError('skill.sync', d.skillSyncId));
+        }
+
+        return skillSync;
+      },
+      { ifExists: true }
+    );
+  }
+
+  private scopeDestinationWhere(d: CargoTenantEnvironment): Prisma.SkillDestinationWhereInput {
+    return {
+      OR: [
+        {
+          skillMarketplace: {
+            tenantOid: d.tenant.oid,
+            environmentOid: d.environment.oid
+          }
+        },
+        {
+          skillPlugin: {
+            tenantOid: d.tenant.oid,
+            environmentOid: d.environment.oid
+          }
+        }
+      ]
+    };
+  }
+
+  async listSkillSyncs(
+    d: CargoTenantEnvironment & {
+      ids?: string[];
+      skillMarketplaceIds?: string[];
+      skillPluginIds?: string[];
+      statuses?: SkillSyncStatusFilter[];
+      createdAt?: DateFilter;
+    }
+  ) {
+    let skillMarketplaces = await resolveSkillMarketplaces(d, d.skillMarketplaceIds);
+    let skillPlugins = await resolveSkillPlugins(d, d.skillPluginIds);
+    let destinationFilters: Prisma.SkillDestinationWhereInput[] = [];
+
+    if (skillMarketplaces) {
+      destinationFilters.push({ skillMarketplace: { oid: skillMarketplaces.in } });
+    }
+    if (skillPlugins) {
+      destinationFilters.push({ skillPlugin: { oid: skillPlugins.in } });
+    }
+
+    return Paginator.create(({ prisma }) =>
+      prisma(
+        async opts =>
+          await db.skillDestinationSync.findMany({
+            ...opts,
+            where: {
+              id: d.ids?.length ? { in: d.ids } : undefined,
+              status: d.statuses?.length ? { in: d.statuses } : undefined,
+              createdAt: d.createdAt ? normalizeDateFilter(d.createdAt) : undefined,
+              destination: {
+                AND: [
+                  this.scopeDestinationWhere(d),
+                  destinationFilters.length ? { OR: destinationFilters } : undefined!
+                ].filter(Boolean)
+              }
+            },
+            include: skillSyncInclude
+          })
+      )
+    );
+  }
+
+  async getSkillSyncById(
+    d: CargoTenantEnvironment & {
+      skillSyncId: string;
+    }
+  ) {
+    return await this.getSkillSyncRecord(d);
+  }
+}
+
+export let skillSyncService = Service.create(
+  'cargoSkillSyncService',
+  () => new SkillSyncServiceImpl()
+).build();

--- a/src/systems/cargo/service/src/controllers/index.ts
+++ b/src/systems/cargo/service/src/controllers/index.ts
@@ -21,6 +21,7 @@ import { skillParticipantController } from './skillParticipant';
 import { skillPluginController } from './skillPlugin';
 import { skillPluginRepositoryController } from './skillPluginRepository';
 import { skillPluginSkillController } from './skillPluginSkill';
+import { skillSyncController } from './skillSync';
 import { skillTemplateController } from './skillTemplate';
 import { skillVersionController } from './skillVersion';
 import { storeController } from './store';
@@ -48,6 +49,7 @@ export let rootController = app.controller({
   skillPlugin: skillPluginController,
   skillPluginRepository: skillPluginRepositoryController,
   skillPluginSkill: skillPluginSkillController,
+  skillSync: skillSyncController,
   skillTemplate: skillTemplateController,
   skillVersion: skillVersionController,
   store: storeController,

--- a/src/systems/cargo/service/src/controllers/skillSync.ts
+++ b/src/systems/cargo/service/src/controllers/skillSync.ts
@@ -1,0 +1,67 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import { skillSyncService } from '@metorial-cargo/module-skill';
+import { skillSyncPresenter } from '../presenters';
+import { app } from './_app';
+import { dateFilterSchema } from './_dateFilter';
+import { tenantApp } from './tenant';
+
+export let skillSyncApp = tenantApp.use(async ctx => {
+  let skillSyncId = ctx.body.skillSyncId;
+  if (!skillSyncId) throw new Error('Skill sync ID is required');
+
+  let skillSync = await skillSyncService.getSkillSyncById({
+    tenant: ctx.tenant,
+    environment: ctx.environment,
+    skillSyncId
+  });
+
+  return { skillSync };
+});
+
+let statusFilterSchema = v.optional(
+  v.array(v.enumOf(['pending', 'completed', 'failed', 'processing', 'canceled']))
+);
+
+export let skillSyncController = app.controller({
+  list: tenantApp
+    .handler()
+    .input(
+      Paginator.validate(
+        v.object({
+          tenantId: v.string(),
+          environmentId: v.string(),
+          skillSyncIds: v.optional(v.array(v.string())),
+          skillMarketplaceIds: v.optional(v.array(v.string())),
+          skillPluginIds: v.optional(v.array(v.string())),
+          statuses: statusFilterSchema,
+          createdAt: dateFilterSchema
+        })
+      )
+    )
+    .do(async ctx => {
+      let paginator = await skillSyncService.listSkillSyncs({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        ids: ctx.input.skillSyncIds,
+        skillMarketplaceIds: ctx.input.skillMarketplaceIds,
+        skillPluginIds: ctx.input.skillPluginIds,
+        statuses: ctx.input.statuses,
+        createdAt: ctx.input.createdAt
+      });
+      let list = await paginator.run(ctx.input);
+
+      return Paginator.presentLight(list, skillSyncPresenter);
+    }),
+
+  get: skillSyncApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        skillSyncId: v.string()
+      })
+    )
+    .do(async ctx => skillSyncPresenter(ctx.skillSync))
+});

--- a/src/systems/cargo/service/src/controllers/tests/skill.e2e.test.ts
+++ b/src/systems/cargo/service/src/controllers/tests/skill.e2e.test.ts
@@ -136,9 +136,126 @@ let createTestSkillMarketplacePlugin = async (d: {
     }
   });
 
+let createTestSkillSync = async (d: {
+  destinationOid: bigint;
+  status: 'pending' | 'completed' | 'failed' | 'processing' | 'canceled';
+  logMessage: string;
+}) =>
+  await db.skillDestinationSync.create({
+    data: {
+      ...getId('skillDestinationSync'),
+      status: d.status,
+      destinationOid: d.destinationOid,
+      logs: [[Date.now(), d.logMessage]]
+    }
+  });
+
 describe('cargo skill.e2e', () => {
   beforeEach(async () => {
     await cleanDatabase();
+  });
+
+  it('lists and gets skill syncs by plugin and marketplace', async () => {
+    let { tenant, environment } = await createScope();
+    let scope = await getCargoScopeRecords({
+      tenantId: tenant.id,
+      environmentId: environment.id
+    });
+    let otherEnvironment = await cargoClient.environment.upsert({
+      tenantId: tenant.id,
+      identifier: 'staging',
+      name: 'Staging',
+      type: 'development'
+    });
+    let otherScope = await getCargoScopeRecords({
+      tenantId: tenant.id,
+      environmentId: otherEnvironment.id
+    });
+    let skillPlugin = await createTestSkillPlugin({
+      tenantOid: scope.tenant.oid,
+      environmentOid: scope.environment.oid,
+      name: 'Sync Plugin',
+      slug: 'sync-plugin'
+    });
+    let skillMarketplace = await createTestSkillMarketplace({
+      tenantOid: scope.tenant.oid,
+      environmentOid: scope.environment.oid,
+      name: 'Sync Marketplace',
+      slug: 'sync-marketplace'
+    });
+    let otherSkillPlugin = await createTestSkillPlugin({
+      tenantOid: otherScope.tenant.oid,
+      environmentOid: otherScope.environment.oid,
+      name: 'Other Sync Plugin',
+      slug: 'other-sync-plugin'
+    });
+    let pluginSync = await createTestSkillSync({
+      destinationOid: skillPlugin.destinationOid,
+      status: 'processing',
+      logMessage: 'Plugin sync started'
+    });
+    let marketplaceSync = await createTestSkillSync({
+      destinationOid: skillMarketplace.destinationOid,
+      status: 'completed',
+      logMessage: 'Marketplace sync completed'
+    });
+    let otherSync = await createTestSkillSync({
+      destinationOid: otherSkillPlugin.destinationOid,
+      status: 'processing',
+      logMessage: 'Other sync started'
+    });
+
+    let listedForPlugin = await cargoClient.skillSync.list({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      skillPluginIds: [skillPlugin.id],
+      limit: 10
+    });
+    let listedForMarketplace = await cargoClient.skillSync.list({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      skillMarketplaceIds: [skillMarketplace.id],
+      limit: 10
+    });
+    let listedForEnvironment = await cargoClient.skillSync.list({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      limit: 10
+    });
+    let fetched = await cargoClient.skillSync.get({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      skillSyncId: pluginSync.id
+    });
+
+    expect(listedForPlugin.items.map(item => item.id)).toEqual([pluginSync.id]);
+    expect(listedForPlugin.items[0]).toMatchObject({
+      object: 'cargo#skillSync',
+      id: pluginSync.id,
+      status: 'processing',
+      skillPluginId: skillPlugin.id
+    });
+    expect(listedForMarketplace.items.map(item => item.id)).toEqual([
+      marketplaceSync.id
+    ]);
+    expect(listedForMarketplace.items[0]).toMatchObject({
+      object: 'cargo#skillSync',
+      id: marketplaceSync.id,
+      status: 'completed',
+      skillMarketplaceId: skillMarketplace.id
+    });
+    expect(listedForEnvironment.items.map(item => item.id)).not.toContain(otherSync.id);
+    expect(fetched).toMatchObject({
+      id: pluginSync.id,
+      logs: [[expect.any(Number), 'Plugin sync started']]
+    });
+    await expect(
+      cargoClient.skillSync.get({
+        tenantId: tenant.id,
+        environmentId: environment.id,
+        skillSyncId: otherSync.id
+      })
+    ).rejects.toThrow();
   });
 
   it('filters skill exports by creator actor', async () => {

--- a/src/systems/cargo/service/src/presenters/index.ts
+++ b/src/systems/cargo/service/src/presenters/index.ts
@@ -21,6 +21,7 @@ export * from './skillPlugin';
 export * from './skillPluginRepository';
 export * from './skillPluginSkill';
 export * from './skillRepository';
+export * from './skillSync';
 export * from './skillTemplate';
 export * from './skillVersion';
 export * from './store';

--- a/src/systems/cargo/service/src/presenters/skillSync.ts
+++ b/src/systems/cargo/service/src/presenters/skillSync.ts
@@ -1,0 +1,40 @@
+import type { SkillSyncRecord } from '@metorial-cargo/module-skill';
+
+let skillSyncRepositoryPropagationPresenter = (
+  propagation: SkillSyncRecord['repositoryPropagations'][number]
+) => ({
+  object: 'cargo#skillSyncRepositoryPropagation',
+  id: propagation.id,
+  status: propagation.status,
+  originSyncId: propagation.originSyncId,
+  skillRepositoryId: propagation.skillRepository.id,
+  repoId: propagation.skillRepository.repoId,
+  branchName: propagation.branchName,
+  prName: propagation.prName,
+  prDescription: propagation.prDescription,
+  commitMessage: propagation.commitMessage,
+  errorMessage: propagation.errorMessage,
+  createdAt: propagation.createdAt,
+  updatedAt: propagation.updatedAt,
+  startedAt: propagation.startedAt,
+  completedAt: propagation.completedAt
+});
+
+export let skillSyncPresenter = (skillSync: SkillSyncRecord) => ({
+  object: 'cargo#skillSync',
+  id: skillSync.id,
+  status: skillSync.status,
+  isAtRepoSyncStage: skillSync.isAtRepoSyncStage,
+  skillMarketplaceId: skillSync.destination.skillMarketplace?.id,
+  skillPluginId: skillSync.destination.skillPlugin?.id,
+  prName: skillSync.prName,
+  prDescription: skillSync.prDescription,
+  commitMessage: skillSync.commitMessage,
+  logs: skillSync.logs,
+  repositoryPropagations: skillSync.repositoryPropagations.map(
+    skillSyncRepositoryPropagationPresenter
+  ),
+  createdAt: skillSync.createdAt,
+  startedAt: skillSync.startedAt,
+  completedAt: skillSync.completedAt
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new skill-sync APIs and UI plus changes to cargo sync processing (logging and file/deletion behavior), which could affect sync output and operational visibility. Also includes schema/client link adjustments that may impact internal tenant/environment identifier persistence.
> 
> **Overview**
> Adds end-to-end *skill sync visibility* for instances: new `GET /dashboard/instances/:instanceId/skill-syncs` + `GET .../:skillSyncId` endpoints (SDK resources/endpoints included), a new presenter/type, and dashboard pages/tables to browse syncs and view details/logs with auto-refresh while syncs are active.
> 
> Enhances Cargo skill sync execution by persisting structured `logs` on `SkillDestinationSync` and appending/copying log entries across collect/process/propagate/finish stages (including origin SCM sync logs), and updates skill serialization to **apply effective skill configuration policy** (combined configs + default) to filter exported files, optionally delete the `scripts/` path, and include config in the content hash.
> 
> Extends skill export outputs to include `createdBy` actor details, updates several generated endpoint docstrings (repositories controllers), adjusts Prisma mappings for internal tenant/environment identifiers, and removes/limits synthesis organization-scope linking in internal-client scope helpers. Updates code-bucket RPC definitions to add a streamed `GetBucketFilesWithContentStream` message/type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ace71b4a984760ef81a48482170c611643d5fb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->