### PR TITLE
Add support for copilot

### DIFF
--- a/src/systems/cargo/modules/skill/src/serializers/marketplace/index.ts
+++ b/src/systems/cargo/modules/skill/src/serializers/marketplace/index.ts
@@ -117,4 +117,5 @@ export let applyMarketplace = createApplicator('marketplace', async (input, cont
   });
   await context.setFile('.cursor-plugin/marketplace.json', cursorAndClaudeMarketplace);
   await context.setFile('.claude-plugin/marketplace.json', cursorAndClaudeMarketplace);
+  await context.setFile('.github/plugin/marketplace.json', cursorAndClaudeMarketplace);
 });

--- a/src/systems/cargo/modules/skill/src/serializers/plugin/index.ts
+++ b/src/systems/cargo/modules/skill/src/serializers/plugin/index.ts
@@ -65,12 +65,13 @@ export let applyPlugin = createApplicator('plugin', async (input, context) => {
 
   context.setBasePath(getPluginPath(input));
 
-  let mcpJson = json({
+  let mcpServers = {
     metorial: {
       type: 'http',
       url: `${env.service.API_URL}/connect/plugin/${input.skillPlugin.slug}`
     }
-  });
+  };
+  let mcpJson = json(mcpServers);
   await context.setFile('mcp.json', mcpJson);
   await context.setFile('.mcp.json', mcpJson);
 
@@ -105,9 +106,9 @@ export let applyPlugin = createApplicator('plugin', async (input, context) => {
     description: input.skillPlugin.description,
     version: input.skillPlugin.version,
     author: {
-      name: 'Metorial',
-      email: 'hey@metorial.com'
-    }
+      name: 'Metorial'
+    },
+    mcpServers: mcpServers
   };
 
   let claudePlugin = json(baseInfo);
@@ -115,6 +116,14 @@ export let applyPlugin = createApplicator('plugin', async (input, context) => {
 
   let cursorPlugin = json(baseInfo);
   await context.setFile('.cursor-plugin/plugin.json', cursorPlugin);
+
+  let copilotPlugin = json({
+    ...baseInfo,
+    skills: 'skills/',
+    agents: 'agents/',
+    mcpServers: '.mcp.json'
+  });
+  await context.setFile('plugin.json', copilotPlugin);
 
   let codexPlugin = json({
     ...baseInfo,
@@ -181,6 +190,7 @@ export let applyPlugin = createApplicator('plugin', async (input, context) => {
     });
     await context.setFile('.cursor-plugin/marketplace.json', cursorAndClaudeMarketplace);
     await context.setFile('.claude-plugin/marketplace.json', cursorAndClaudeMarketplace);
+    await context.setFile('.github/plugin/marketplace.json', cursorAndClaudeMarketplace);
   }
 
   let cursor: string | null = null;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the generated plugin/marketplace JSON schemas and adds new output locations, which could break downstream consumers expecting the old manifest shape/paths.
> 
> **Overview**
> Adds GitHub/Copilot-friendly plugin packaging outputs.
> 
> `applyPlugin` now emits a root-level `plugin.json` for Copilot and adjusts MCP config generation by embedding `mcpServers` in the base manifest (and generating `mcp.json` from the same object). Marketplace generation for both standalone plugins and full marketplaces additionally writes the Cursor/Claude marketplace JSON to `.github/plugin/marketplace.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a85641693b522e5e7959b312fdea0875401f01a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->