### PR TITLE
Clean up file filters

### DIFF
--- a/src/systems/cargo/modules/skill/src/index.ts
+++ b/src/systems/cargo/modules/skill/src/index.ts
@@ -1,2 +1,3 @@
 export * from './queues';
 export * from './services';
+export * from './lib/limits';

--- a/src/systems/cargo/modules/skill/src/lib/limits.ts
+++ b/src/systems/cargo/modules/skill/src/lib/limits.ts
@@ -1,0 +1,148 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { db } from '@metorial-cargo/db';
+
+export let maxSkillStoreFiles = 1000;
+export let maxSkillPluginSkills = 100;
+export let maxSkillMarketplacePlugins = 500;
+export let maxSkillMarketplaceSkills = 1000;
+
+export class CargoSkillLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CargoSkillLimitError';
+  }
+}
+
+export let toCargoSkillLimitServiceError = (error: CargoSkillLimitError) =>
+  new ServiceError(badRequestError({ message: error.message }));
+
+let assertLimit = (d: {
+  label: string;
+  currentCount: number;
+  additionalCount?: number;
+  max: number;
+}) => {
+  let projectedCount = d.currentCount + (d.additionalCount ?? 0);
+  if (projectedCount <= d.max) return;
+
+  throw new CargoSkillLimitError(
+    `${d.label} cannot exceed ${d.max}; this change would result in ${projectedCount}.`
+  );
+};
+
+export let countSkillStoreFiles = async (d: { storeOid: bigint }) =>
+  await db.storeItem.count({
+    where: {
+      storeOid: d.storeOid,
+      kind: { in: ['document', 'file'] }
+    }
+  });
+
+export let assertSkillStoreFileLimit = async (d: {
+  storeOid: bigint;
+  additionalCount?: number;
+}) => {
+  assertLimit({
+    label: 'Skill store files',
+    currentCount: await countSkillStoreFiles(d),
+    additionalCount: d.additionalCount,
+    max: maxSkillStoreFiles
+  });
+};
+
+export let countSkillPluginSkills = async (d: { skillPluginOid: bigint }) =>
+  await db.skillPluginSkill.count({
+    where: {
+      skillPluginOid: d.skillPluginOid,
+      status: 'active',
+      skill: {
+        status: 'active'
+      }
+    }
+  });
+
+export let assertSkillPluginSkillLimit = async (d: {
+  skillPluginOid: bigint;
+  additionalCount?: number;
+}) => {
+  assertLimit({
+    label: 'Plugin skills',
+    currentCount: await countSkillPluginSkills(d),
+    additionalCount: d.additionalCount,
+    max: maxSkillPluginSkills
+  });
+};
+
+export let countSkillMarketplacePlugins = async (d: { skillMarketplaceOid: bigint }) =>
+  await db.skillMarketplacePlugin.count({
+    where: {
+      skillMarketplaceOid: d.skillMarketplaceOid,
+      status: 'active',
+      skillPlugin: {
+        status: 'active'
+      }
+    }
+  });
+
+export let assertSkillMarketplacePluginLimit = async (d: {
+  skillMarketplaceOid: bigint;
+  additionalCount?: number;
+}) => {
+  assertLimit({
+    label: 'Marketplace plugins',
+    currentCount: await countSkillMarketplacePlugins(d),
+    additionalCount: d.additionalCount,
+    max: maxSkillMarketplacePlugins
+  });
+};
+
+export let countSkillMarketplaceSkills = async (d: { skillMarketplaceOid: bigint }) => {
+  let plugins = await db.skillMarketplacePlugin.findMany({
+    where: {
+      skillMarketplaceOid: d.skillMarketplaceOid,
+      status: 'active',
+      skillPlugin: {
+        status: 'active'
+      }
+    },
+    select: {
+      skillPlugin: {
+        select: {
+          skillPluginSkills: {
+            where: {
+              status: 'active',
+              skill: {
+                status: 'active'
+              }
+            },
+            select: {
+              oid: true
+            }
+          }
+        }
+      }
+    }
+  });
+
+  return plugins.reduce(
+    (count, plugin) => count + plugin.skillPlugin.skillPluginSkills.length,
+    0
+  );
+};
+
+export let assertSkillMarketplaceSkillLimit = async (d: {
+  skillMarketplaceOid: bigint;
+  additionalCount?: number;
+}) => {
+  assertLimit({
+    label: 'Marketplace skills',
+    currentCount: await countSkillMarketplaceSkills(d),
+    additionalCount: d.additionalCount,
+    max: maxSkillMarketplaceSkills
+  });
+};
+
+export let assertSkillMarketplaceLimits = async (d: { skillMarketplaceOid: bigint }) => {
+  await assertSkillMarketplacePluginLimit(d);
+  await assertSkillMarketplaceSkillLimit(d);
+};

--- a/src/systems/cargo/modules/skill/src/queues/sync/collect.ts
+++ b/src/systems/cargo/modules/skill/src/queues/sync/collect.ts
@@ -1,5 +1,6 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db, env } from '@metorial-cargo/db';
+import { CargoSkillLimitError } from '../../lib/limits';
 import { applyMarketplace } from '../../serializers/marketplace';
 import { applyPlugin } from '../../serializers/plugin';
 import { applySkill } from '../../serializers/skill';
@@ -141,6 +142,23 @@ let getSyncTaskNames = async (tasks: SyncTask[]) => {
   };
 };
 
+let failSyncForLimitError = async (d: { skillDestinationSyncId: string; error: unknown }) => {
+  if (!(d.error instanceof CargoSkillLimitError)) return false;
+
+  await db.skillDestinationSync.updateMany({
+    where: {
+      id: d.skillDestinationSyncId,
+      status: 'processing'
+    },
+    data: {
+      status: 'failed',
+      completedAt: new Date()
+    }
+  });
+  await appendSkillDestinationSyncLog(d.skillDestinationSyncId, d.error.message);
+  return true;
+};
+
 export let syncCollectQueueProcessor = syncCollectQueue.process(async data => {
   let sync = await db.skillDestinationSync.findUnique({
     where: { id: data.skillDestinationSyncId },
@@ -175,8 +193,16 @@ export let syncCollectQueueProcessor = syncCollectQueue.process(async data => {
     },
     input: Input
   ) => {
-    let initResult = await serializer.init(input);
-    return await serializer.getHash(input, initResult);
+    try {
+      let initResult = await serializer.init(input);
+      return await serializer.getHash(input, initResult);
+    } catch (error) {
+      if (await failSyncForLimitError({ skillDestinationSyncId: data.skillDestinationSyncId, error })) {
+        return null;
+      }
+
+      throw error;
+    }
   };
 
   let getCurrentMarketplaceItem = (marketplaceId: string) =>
@@ -230,6 +256,7 @@ export let syncCollectQueueProcessor = syncCollectQueue.process(async data => {
       let marketplaceHash = await getSerializerHash(applyMarketplace, {
         skillMarketplace: marketplace
       });
+      if (!marketplaceHash) return;
       let currentMarketplaceItem = getCurrentMarketplaceItem(marketplace.id);
 
       if (currentMarketplaceItem?.hash === marketplaceHash) {
@@ -253,6 +280,7 @@ export let syncCollectQueueProcessor = syncCollectQueue.process(async data => {
           skillMarketplace: marketplace,
           skillMarketplacePlugin
         });
+        if (!pluginHash) return;
         let currentPluginItem = getCurrentPluginItem(skillPlugin.id);
 
         if (currentPluginItem?.hash === pluginHash) {
@@ -269,6 +297,7 @@ export let syncCollectQueueProcessor = syncCollectQueue.process(async data => {
             skillMarketplace: marketplace,
             skillMarketplacePlugin
           });
+          if (!skillHash) return;
           let currentSkillItem = getCurrentSkillItem({
             skillId: skillPluginSkill.skill.id,
             skillPluginId: skillPlugin.id
@@ -323,6 +352,7 @@ export let syncCollectQueueProcessor = syncCollectQueue.process(async data => {
       };
 
       let pluginHash = await getSerializerHash(applyPlugin, { skillPlugin });
+      if (!pluginHash) return;
       let currentPluginItem = getCurrentPluginItem(skillPlugin.id);
 
       if (currentPluginItem?.hash === pluginHash) {
@@ -337,6 +367,7 @@ export let syncCollectQueueProcessor = syncCollectQueue.process(async data => {
           skillPlugin,
           skillPluginSkill
         });
+        if (!skillHash) return;
         let currentSkillItem = getCurrentSkillItem({
           skillId: skillPluginSkill.skill.id,
           skillPluginId: skillPlugin.id

--- a/src/systems/cargo/modules/skill/src/queues/sync/process.ts
+++ b/src/systems/cargo/modules/skill/src/queues/sync/process.ts
@@ -3,6 +3,7 @@ import { db, env, snowflake } from '@metorial-cargo/db';
 import { createCodeBucketClient } from '@metorial/code-bucket-service-generated';
 import path from 'path';
 import { BatchProcessor } from '../../lib/batchProcessor';
+import { CargoSkillLimitError } from '../../lib/limits';
 import type { SerializerContext } from '../../serializers/_lib/types';
 import { applyMarketplace } from '../../serializers/marketplace';
 import { applyPlugin, getPluginPath } from '../../serializers/plugin';
@@ -33,6 +34,23 @@ let contentToBytes = (content: string | Buffer | ArrayBuffer) => {
   if (typeof content === 'string') return Buffer.from(content, 'utf-8');
   if (content instanceof Buffer) return content;
   return Buffer.from(new Uint8Array(content));
+};
+
+let failSyncForLimitError = async (d: { skillDestinationSyncId: string; error: unknown }) => {
+  if (!(d.error instanceof CargoSkillLimitError)) return false;
+
+  await db.skillDestinationSync.updateMany({
+    where: {
+      id: d.skillDestinationSyncId,
+      status: 'processing'
+    },
+    data: {
+      status: 'failed',
+      completedAt: new Date()
+    }
+  });
+  await appendSkillDestinationSyncLog(d.skillDestinationSyncId, d.error.message);
+  return true;
 };
 
 export let syncProcessQueue = createQueue<{
@@ -143,13 +161,33 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
     },
     input: Input
   ) => {
-    let initResult = await serializer.init(input);
-    let hash = await serializer.getHash(input, initResult);
-    hashRef.current = hash;
+    let initResult: InitResult;
+    let hash: string;
 
-    if (item?.hash === hash) return;
+    try {
+      initResult = await serializer.init(input);
+      hash = await serializer.getHash(input, initResult);
+      hashRef.current = hash;
+    } catch (error) {
+      if (await failSyncForLimitError({ skillDestinationSyncId: data.skillDestinationSyncId, error })) {
+        return false;
+      }
 
-    await serializer.apply(input, context, initResult);
+      throw error;
+    }
+
+    if (item?.hash === hash) return true;
+
+    try {
+      await serializer.apply(input, context, initResult);
+      return true;
+    } catch (error) {
+      if (await failSyncForLimitError({ skillDestinationSyncId: data.skillDestinationSyncId, error })) {
+        return false;
+      }
+
+      throw error;
+    }
   };
 
   let loadSkillPlugin = async (skillPluginId: string) => {
@@ -277,13 +315,14 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
         data.skillDestinationSyncId,
         `Updating skill ${skillPluginSkill.skill.name ?? 'Untitled skill'}.`
       );
-      await applySerializer(applySkill, {
+      let applied = await applySerializer(applySkill, {
         skill: skillPluginSkill.skill,
         skillPlugin,
         skillPluginSkill,
         skillMarketplace,
         skillMarketplacePlugin
       });
+      if (!applied) return;
       await fileProcessor.flush();
 
       if (hashRef.current) {
@@ -326,11 +365,12 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
         data.skillDestinationSyncId,
         `Updating plugin ${skillPlugin.name}.`
       );
-      await applySerializer(applyPlugin, {
+      let applied = await applySerializer(applyPlugin, {
         skillPlugin,
         skillMarketplace,
         skillMarketplacePlugin
       });
+      if (!applied) return;
       await fileProcessor.flush();
 
       if (hashRef.current) {
@@ -347,7 +387,8 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
       data.skillDestinationSyncId,
       `Updating marketplace ${skillMarketplace.name}.`
     );
-    await applySerializer(applyMarketplace, { skillMarketplace });
+    let applied = await applySerializer(applyMarketplace, { skillMarketplace });
+    if (!applied) return;
     await fileProcessor.flush();
 
     if (hashRef.current) {

--- a/src/systems/cargo/modules/skill/src/serializers/marketplace/index.ts
+++ b/src/systems/cargo/modules/skill/src/serializers/marketplace/index.ts
@@ -1,6 +1,7 @@
 import { Hash } from '@lowerdeck/hash';
 import { db } from '@metorial-cargo/db';
 import semver from 'semver';
+import { assertSkillMarketplaceLimits } from '../../lib/limits';
 import { createApplicator } from '../_lib/apply';
 
 let json = (data: any) => JSON.stringify(data, null, 2);
@@ -34,6 +35,9 @@ export let applyMarketplace = createApplicator(
         }
       },
       orderBy: { id: 'asc' }
+    });
+    await assertSkillMarketplaceLimits({
+      skillMarketplaceOid: input.skillMarketplace.oid
     });
 
     let pluginHashes = plugins

--- a/src/systems/cargo/modules/skill/src/serializers/plugin/index.ts
+++ b/src/systems/cargo/modules/skill/src/serializers/plugin/index.ts
@@ -3,6 +3,7 @@ import { slugify } from '@lowerdeck/slugify';
 import { db, env } from '@metorial-cargo/db';
 import semver from 'semver';
 import { internalImageService } from '../../internal/image';
+import { assertSkillPluginSkillLimit } from '../../lib/limits';
 import { createApplicator } from '../_lib/apply';
 import type { PluginSerializerInput } from '../_lib/types';
 
@@ -28,6 +29,9 @@ export let applyPlugin = createApplicator(
         }
       },
       orderBy: { id: 'asc' }
+    });
+    await assertSkillPluginSkillLimit({
+      skillPluginOid: input.skillPlugin.oid
     });
 
     let skillHashes = skills

--- a/src/systems/cargo/modules/skill/src/serializers/skill/config.ts
+++ b/src/systems/cargo/modules/skill/src/serializers/skill/config.ts
@@ -1,0 +1,77 @@
+import {
+  isAllowedSkillPath,
+  safeNonScriptFileExtensions,
+  scriptsFolder
+} from '../../lib/files';
+
+export type SkillConfigurationPolicy = {
+  allowScripts: boolean;
+  allowedFileExtensions?: string[] | null;
+  allowNonStandardDirectories: boolean;
+};
+
+export let isRootSkillDocument = (path: string) => path.replace(/^\/+/, '') === 'SKILL.md';
+
+export let normalizeSkillPath = (path: string) => path.replace(/^\/+/, '');
+
+let normalizeFileExtension = (extension: string) => {
+  let normalized = extension.trim().toLowerCase();
+  if (!normalized) return null;
+  return normalized.startsWith('.') ? normalized : `.${normalized}`;
+};
+
+let getFileExtension = (path: string) => {
+  let fileName = normalizeSkillPath(path).split('/').at(-1) ?? '';
+  let dotIndex = fileName.lastIndexOf('.');
+  if (dotIndex <= 0 || dotIndex === fileName.length - 1) return null;
+  return normalizeFileExtension(fileName.slice(dotIndex));
+};
+
+let isScriptsPath = (path: string) => {
+  let normalizedPath = normalizeSkillPath(path);
+  return normalizedPath === scriptsFolder || normalizedPath.startsWith(`${scriptsFolder}/`);
+};
+
+export let getEffectiveAllowedFileExtensions = (config: SkillConfigurationPolicy) => {
+  let allowedExtensions = (config.allowedFileExtensions ?? [])
+    .map(normalizeFileExtension)
+    .filter((extension): extension is string => !!extension);
+
+  if (config.allowScripts) {
+    return {
+      shouldFilter: allowedExtensions.length > 0,
+      extensions: allowedExtensions
+    };
+  }
+
+  let safeExtensions = new Set(
+    safeNonScriptFileExtensions
+      .map(normalizeFileExtension)
+      .filter((extension): extension is string => !!extension)
+  );
+
+  return {
+    shouldFilter: true,
+    extensions: allowedExtensions.length
+      ? allowedExtensions.filter(extension => safeExtensions.has(extension))
+      : [...safeExtensions]
+  };
+};
+
+export let isAllowedBySkillConfig = (path: string, config: SkillConfigurationPolicy) => {
+  let normalizedPath = normalizeSkillPath(path);
+
+  if (isRootSkillDocument(normalizedPath)) return true;
+
+  if (!config.allowNonStandardDirectories && !isAllowedSkillPath(normalizedPath)) {
+    return false;
+  }
+
+  if (!config.allowScripts && isScriptsPath(normalizedPath)) return false;
+
+  let allowedExtensions = getEffectiveAllowedFileExtensions(config);
+  if (!allowedExtensions.shouldFilter) return true;
+
+  let extension = getFileExtension(normalizedPath);
+  return !!extension && allowedExtensions.extensions.includes(extension);
+};

--- a/src/systems/cargo/modules/skill/src/serializers/skill/index.test.ts
+++ b/src/systems/cargo/modules/skill/src/serializers/skill/index.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { isAllowedBySkillConfig } from './config';
+
+describe('skill serializer config filtering', () => {
+  it('always allows the root SKILL.md document', () => {
+    expect(
+      isAllowedBySkillConfig('/SKILL.md', {
+        allowScripts: true,
+        allowedFileExtensions: ['txt'],
+        allowNonStandardDirectories: true
+      })
+    ).toBe(true);
+
+    expect(
+      isAllowedBySkillConfig('SKILL.md', {
+        allowScripts: false,
+        allowedFileExtensions: ['txt'],
+        allowNonStandardDirectories: false
+      })
+    ).toBe(true);
+  });
+
+  it('continues filtering non-root markdown documents by extension config', () => {
+    expect(
+      isAllowedBySkillConfig('/references/SKILL.md', {
+        allowScripts: true,
+        allowedFileExtensions: ['txt'],
+        allowNonStandardDirectories: true
+      })
+    ).toBe(false);
+
+    expect(
+      isAllowedBySkillConfig('/references/readme.md', {
+        allowScripts: true,
+        allowedFileExtensions: ['txt'],
+        allowNonStandardDirectories: true
+      })
+    ).toBe(false);
+  });
+
+  it('keeps allowing files when extension filtering is disabled', () => {
+    expect(
+      isAllowedBySkillConfig('/references/readme.md', {
+        allowScripts: true,
+        allowedFileExtensions: [],
+        allowNonStandardDirectories: true
+      })
+    ).toBe(true);
+  });
+});

--- a/src/systems/cargo/modules/skill/src/serializers/skill/index.ts
+++ b/src/systems/cargo/modules/skill/src/serializers/skill/index.ts
@@ -11,6 +11,7 @@ import {
   safeNonScriptFileExtensions,
   scriptsFolder
 } from '../../lib/files';
+import { assertSkillStoreFileLimit } from '../../lib/limits';
 import { createApplicator } from '../_lib/apply';
 import type { SkillSerializerInput } from '../_lib/types';
 import { getPluginPath } from '../plugin';
@@ -180,6 +181,9 @@ export let applySkill = createApplicator(
   async input => {
     let skillStore = await db.store.findFirstOrThrow({
       where: { oid: input.skill.storeOid }
+    });
+    await assertSkillStoreFileLimit({
+      storeOid: skillStore.oid
     });
 
     let defaultConfig = await db.skillConfiguration.findFirst({

--- a/src/systems/cargo/modules/skill/src/serializers/skill/index.ts
+++ b/src/systems/cargo/modules/skill/src/serializers/skill/index.ts
@@ -6,15 +6,17 @@ import { fileService } from '@metorial-cargo/module-file';
 import PQueue from 'p-queue';
 import { parse, stringify } from 'yaml';
 import { combineConfigs } from '../../lib/combineConfigs';
-import {
-  isAllowedSkillPath,
-  safeNonScriptFileExtensions,
-  scriptsFolder
-} from '../../lib/files';
+import { scriptsFolder } from '../../lib/files';
 import { assertSkillStoreFileLimit } from '../../lib/limits';
 import { createApplicator } from '../_lib/apply';
 import type { SkillSerializerInput } from '../_lib/types';
 import { getPluginPath } from '../plugin';
+import {
+  getEffectiveAllowedFileExtensions,
+  isAllowedBySkillConfig,
+  isRootSkillDocument,
+  normalizeSkillPath
+} from './config';
 
 export let getSkillPath = (d: SkillSerializerInput) => {
   let inner = `skills/${d.skillPluginSkill.pluginSkillSlug}`;
@@ -35,16 +37,6 @@ let storeItemInclude = {
 } satisfies Prisma.StoreItemInclude;
 
 let frontmatterRegex = /^---[ \t]*\r?\n([\s\S]*?)^---[ \t]*(?:\r?\n|$)/m;
-
-let isRootSkillDocument = (path: string) => path.replace(/^\/+/, '') === 'SKILL.md';
-
-type SkillConfigurationPolicy = {
-  allowScripts: boolean;
-  allowedFileExtensions?: string[] | null;
-  allowNonStandardDirectories: boolean;
-};
-
-let normalizeSkillPath = (path: string) => path.replace(/^\/+/, '');
 
 let sanitizeSkillDocumentFileNamePart = (part: string) =>
   part
@@ -67,66 +59,6 @@ let normalizeSkillDocumentPath = (path: string) => {
   if (!sanitizedExtension.startsWith('.')) sanitizedExtension = `.${sanitizedExtension}`;
 
   return [...pathParts, `${sanitizedBaseName}${sanitizedExtension}`].join('/');
-};
-
-let normalizeFileExtension = (extension: string) => {
-  let normalized = extension.trim().toLowerCase();
-  if (!normalized) return null;
-  return normalized.startsWith('.') ? normalized : `.${normalized}`;
-};
-
-let getFileExtension = (path: string) => {
-  let fileName = normalizeSkillPath(path).split('/').at(-1) ?? '';
-  let dotIndex = fileName.lastIndexOf('.');
-  if (dotIndex <= 0 || dotIndex === fileName.length - 1) return null;
-  return normalizeFileExtension(fileName.slice(dotIndex));
-};
-
-let isScriptsPath = (path: string) => {
-  let normalizedPath = normalizeSkillPath(path);
-  return normalizedPath === scriptsFolder || normalizedPath.startsWith(`${scriptsFolder}/`);
-};
-
-let getEffectiveAllowedFileExtensions = (config: SkillConfigurationPolicy) => {
-  let allowedExtensions = (config.allowedFileExtensions ?? [])
-    .map(normalizeFileExtension)
-    .filter((extension): extension is string => !!extension);
-
-  if (config.allowScripts) {
-    return {
-      shouldFilter: allowedExtensions.length > 0,
-      extensions: allowedExtensions
-    };
-  }
-
-  let safeExtensions = new Set(
-    safeNonScriptFileExtensions
-      .map(normalizeFileExtension)
-      .filter((extension): extension is string => !!extension)
-  );
-
-  return {
-    shouldFilter: true,
-    extensions: allowedExtensions.length
-      ? allowedExtensions.filter(extension => safeExtensions.has(extension))
-      : [...safeExtensions]
-  };
-};
-
-let isAllowedBySkillConfig = (path: string, config: SkillConfigurationPolicy) => {
-  let normalizedPath = normalizeSkillPath(path);
-
-  if (!config.allowNonStandardDirectories && !isAllowedSkillPath(normalizedPath)) {
-    return false;
-  }
-
-  if (!config.allowScripts && isScriptsPath(normalizedPath)) return false;
-
-  let allowedExtensions = getEffectiveAllowedFileExtensions(config);
-  if (!allowedExtensions.shouldFilter) return true;
-
-  let extension = getFileExtension(normalizedPath);
-  return !!extension && allowedExtensions.extensions.includes(extension);
 };
 
 let isRecord = (value: unknown): value is Record<string, unknown> =>

--- a/src/systems/cargo/modules/skill/src/services/skillMarketplacePlugin.ts
+++ b/src/systems/cargo/modules/skill/src/services/skillMarketplacePlugin.ts
@@ -12,6 +12,12 @@ import {
   resolveSkillPlugins
 } from '@metorial-cargo/list-utils';
 import type { CargoTenantEnvironment } from '@metorial-cargo/module-file';
+import {
+  CargoSkillLimitError,
+  assertSkillMarketplacePluginLimit,
+  assertSkillMarketplaceSkillLimit,
+  toCargoSkillLimitServiceError
+} from '../lib/limits';
 import { enqueueSkillMarketplacePluginLifecycle } from '../queues/lifecycle';
 import type { SkillMarketplaceRecord } from './skillMarketplace';
 import { assertPluginIsNotManaged, skillPluginInclude } from './skillPlugin';
@@ -246,6 +252,31 @@ class SkillMarketplacePluginServiceImpl {
 
       let skillMarketplacePlugin = matches[0];
       let lifecycleEvent: 'created' | 'updated' = 'updated';
+      let activatesMarketplacePlugin =
+        !skillMarketplacePlugin || skillMarketplacePlugin.status !== 'active';
+
+      if (activatesMarketplacePlugin) {
+        try {
+          await assertSkillMarketplacePluginLimit({
+            skillMarketplaceOid: d.skillMarketplace.oid,
+            additionalCount: 1
+          });
+
+          await assertSkillMarketplaceSkillLimit({
+            skillMarketplaceOid: d.skillMarketplace.oid,
+            additionalCount: skillPlugin.skillPluginSkills.filter(
+              skillPluginSkill => skillPluginSkill.skill.status === 'active'
+            ).length
+          });
+        } catch (error) {
+          if (error instanceof CargoSkillLimitError) {
+            throw toCargoSkillLimitServiceError(error);
+          }
+
+          throw error;
+        }
+      }
+
       if (skillMarketplacePlugin) {
         if (skillMarketplacePlugin.pluginSlug !== pluginSlug) {
           throw new ServiceError(

--- a/src/systems/cargo/modules/skill/src/services/skillPluginSkill.ts
+++ b/src/systems/cargo/modules/skill/src/services/skillPluginSkill.ts
@@ -12,6 +12,12 @@ import {
   resolveSkills
 } from '@metorial-cargo/list-utils';
 import type { CargoTenantEnvironment } from '@metorial-cargo/module-file';
+import {
+  CargoSkillLimitError,
+  assertSkillMarketplaceSkillLimit,
+  assertSkillPluginSkillLimit,
+  toCargoSkillLimitServiceError
+} from '../lib/limits';
 import { enqueueSkillPluginSkillLifecycle } from '../queues/lifecycle';
 import type { SkillPluginRecord } from './skillPlugin';
 import { assertPluginIsNotManaged, skillPluginInclude } from './skillPlugin';
@@ -271,6 +277,44 @@ class SkillPluginSkillServiceImpl {
 
       let skillPluginSkill = matches[0];
       let lifecycleEvent: 'created' | 'updated' = 'updated';
+      let activatesSkillLink = !skillPluginSkill || skillPluginSkill.status !== 'active';
+      let activeSkillDelta = activatesSkillLink && skill.status === 'active' ? 1 : 0;
+
+      if (activeSkillDelta > 0) {
+        try {
+          await assertSkillPluginSkillLimit({
+            skillPluginOid: d.skillPlugin.oid,
+            additionalCount: activeSkillDelta
+          });
+
+          let marketplacePlugins = await db.skillMarketplacePlugin.findMany({
+            where: {
+              skillPluginOid: d.skillPlugin.oid,
+              status: 'active',
+              skillMarketplace: {
+                status: 'active'
+              }
+            },
+            select: {
+              skillMarketplaceOid: true
+            }
+          });
+
+          for (let marketplacePlugin of marketplacePlugins) {
+            await assertSkillMarketplaceSkillLimit({
+              skillMarketplaceOid: marketplacePlugin.skillMarketplaceOid,
+              additionalCount: activeSkillDelta
+            });
+          }
+        } catch (error) {
+          if (error instanceof CargoSkillLimitError) {
+            throw toCargoSkillLimitServiceError(error);
+          }
+
+          throw error;
+        }
+      }
+
       if (skillPluginSkill) {
         if (skillPluginSkill.pluginSkillSlug !== pluginSkillSlug) {
           throw new ServiceError(

--- a/src/systems/cargo/modules/store/src/services/storeItemMutation.ts
+++ b/src/systems/cargo/modules/store/src/services/storeItemMutation.ts
@@ -74,6 +74,7 @@ type NormalizedStoreItemOperation =
 
 let modifyOperationLimit = 500;
 let maxStoreItems = 1000;
+let maxSkillStoreFiles = 1000;
 let reservedSkillDocumentName = 'SKILL.md';
 let agentsDirectoryPath = '/agents/';
 
@@ -110,6 +111,23 @@ class StoreItemMutationServiceImpl {
           }
         }),
       { ifExists: true }
+    );
+  }
+
+  private async assertSkillStoreFileLimit(store: Pick<Store, 'oid'>, client: any = db) {
+    let fileCount = await client.storeItem.count({
+      where: {
+        storeOid: store.oid,
+        kind: { in: ['document', 'file'] }
+      }
+    });
+
+    if (fileCount <= maxSkillStoreFiles) return;
+
+    throw new ServiceError(
+      badRequestError({
+        message: `Skill store files cannot exceed ${maxSkillStoreFiles}; this change would result in ${fileCount}.`
+      })
     );
   }
 
@@ -1322,6 +1340,10 @@ class StoreItemMutationServiceImpl {
         itemCountDelta += 1;
       }
 
+      if (skill && result.created) {
+        await this.assertSkillStoreFileLimit(d.store, client);
+      }
+
       if (currentStore.itemCount + itemCountDelta > maxStoreItems) {
         throw new ServiceError(
           badRequestError({
@@ -1494,6 +1516,10 @@ class StoreItemMutationServiceImpl {
           });
           if (result.created) {
             itemCount += 1;
+          }
+
+          if (skill && result.created) {
+            await this.assertSkillStoreFileLimit(d.store, client);
           }
 
           if (itemCount > maxStoreItems) {

--- a/src/systems/cargo/service/src/controllers/tests/skill.e2e.test.ts
+++ b/src/systems/cargo/service/src/controllers/tests/skill.e2e.test.ts
@@ -1,10 +1,17 @@
 import { flushDocumentDraft } from '@metorial-cargo/module-doc';
-import { skillMarketplaceService, skillPluginService } from '@metorial-cargo/module-skill';
+import {
+  skillMarketplacePluginService,
+  skillMarketplaceService,
+  skillPluginService,
+  skillPluginSkillService
+} from '@metorial-cargo/module-skill';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { db, getId } from '../../db';
+import { db, getId, snowflake } from '../../db';
 import { storeVersionService } from '@metorial-cargo/module-store';
 import { cargoClient } from '../../test/client';
 import { cleanDatabase } from '../../test/setup';
+import { applyMarketplace } from '../../../../modules/skill/src/serializers/marketplace';
+import { applyPlugin } from '../../../../modules/skill/src/serializers/plugin';
 
 let subtractHours = (date: Date, hours: number) =>
   new Date(date.getTime() - hours * 60 * 60 * 1000);
@@ -149,6 +156,73 @@ let createTestSkillSync = async (d: {
       logs: [[Date.now(), d.logMessage]]
     }
   });
+
+let createManyTestSkills = async (d: {
+  tenantOid: bigint;
+  environmentOid: bigint;
+  count: number;
+  prefix: string;
+}) => {
+  let stores = Array.from({ length: d.count }, (_, idx) => ({
+    ...getId('store'),
+    name: `${d.prefix} Store ${idx}`,
+    access: 'private',
+    cloneType: null,
+    itemCount: 0,
+    tenantOid: d.tenantOid,
+    environmentOid: d.environmentOid,
+    lastEditedAt: new Date()
+  }));
+  let skills = stores.map((store, idx) => ({
+    oid: snowflake.nextId(),
+    id: `${d.prefix}-skill-${idx}`,
+    status: 'active',
+    name: `${d.prefix} Skill ${idx}`,
+    slug: `${d.prefix}-skill-${idx}`,
+    clientName: `${d.prefix} Skill ${idx}`,
+    tenantOid: d.tenantOid,
+    environmentOid: d.environmentOid,
+    storeOid: store.oid
+  }));
+
+  await db.store.createMany({ data: stores as any });
+  await db.skill.createMany({ data: skills as any });
+
+  return await db.skill.findMany({
+    where: { id: { in: skills.map(skill => skill.id) } },
+    orderBy: { id: 'asc' }
+  });
+};
+
+let createManyTestPlugins = async (d: {
+  tenantOid: bigint;
+  environmentOid: bigint;
+  count: number;
+  prefix: string;
+}) => {
+  let destinations = Array.from({ length: d.count }, (_, idx) => ({
+    ...getId('skillDestination'),
+    codeBucketId: `${d.prefix}-plugin-bucket-${idx}`
+  }));
+  let plugins = destinations.map((destination, idx) => ({
+    ...getId('skillPlugin'),
+    status: 'active',
+    isManaged: false,
+    name: `${d.prefix} Plugin ${idx}`,
+    slug: `${d.prefix}-plugin-${idx}`,
+    tenantOid: d.tenantOid,
+    environmentOid: d.environmentOid,
+    destinationOid: destination.oid
+  }));
+
+  await db.skillDestination.createMany({ data: destinations });
+  await db.skillPlugin.createMany({ data: plugins as any });
+
+  return await db.skillPlugin.findMany({
+    where: { id: { in: plugins.map(plugin => plugin.id) } },
+    orderBy: { id: 'asc' }
+  });
+};
 
 describe('cargo skill.e2e', () => {
   beforeEach(async () => {
@@ -491,6 +565,293 @@ describe('cargo skill.e2e', () => {
         storeId: created.storeId
       })
     ).rejects.toThrow('Cannot delete store: it is linked to a skill');
+  });
+
+  it('rejects adding more than 100 active skills to a plugin', async () => {
+    let { tenant, environment } = await createScope();
+    let scope = await getCargoScopeRecords({
+      tenantId: tenant.id,
+      environmentId: environment.id
+    });
+    let skillPluginRecord = await createTestSkillPlugin({
+      tenantOid: scope.tenant.oid,
+      environmentOid: scope.environment.oid,
+      name: 'Limited Plugin',
+      slug: 'limited-plugin'
+    });
+    let skillPlugin = await skillPluginService.getSkillPluginById({
+      tenant: scope.tenant,
+      environment: scope.environment,
+      skillPluginId: skillPluginRecord.id
+    });
+    let skills = await createManyTestSkills({
+      tenantOid: scope.tenant.oid,
+      environmentOid: scope.environment.oid,
+      count: 101,
+      prefix: 'plugin-limit'
+    });
+
+    await db.skillPluginSkill.createMany({
+      data: skills.slice(0, 100).map((skill, idx) => ({
+        ...getId('skillPluginSkill'),
+        status: 'active',
+        pluginSkillSlug: `plugin-limit-${idx}`,
+        skillOid: skill.oid,
+        skillPluginOid: skillPlugin.oid
+      }))
+    });
+
+    await expect(
+      skillPluginSkillService.addSkillPluginSkill({
+        tenant: scope.tenant,
+        environment: scope.environment,
+        skillPlugin,
+        input: {
+          skillId: skills[100]!.id
+        }
+      })
+    ).rejects.toThrow('Plugin skills cannot exceed 100');
+  });
+
+  it('rejects adding more than 500 active plugins to a marketplace', async () => {
+    let { tenant, environment } = await createScope();
+    let scope = await getCargoScopeRecords({
+      tenantId: tenant.id,
+      environmentId: environment.id
+    });
+    let skillMarketplaceRecord = await createTestSkillMarketplace({
+      tenantOid: scope.tenant.oid,
+      environmentOid: scope.environment.oid,
+      name: 'Limited Marketplace',
+      slug: 'limited-marketplace'
+    });
+    let skillMarketplace = await skillMarketplaceService.getSkillMarketplaceById({
+      tenant: scope.tenant,
+      environment: scope.environment,
+      skillMarketplaceId: skillMarketplaceRecord.id
+    });
+    let plugins = await createManyTestPlugins({
+      tenantOid: scope.tenant.oid,
+      environmentOid: scope.environment.oid,
+      count: 501,
+      prefix: 'marketplace-plugin-limit'
+    });
+
+    await db.skillMarketplacePlugin.createMany({
+      data: plugins.slice(0, 500).map((plugin, idx) => ({
+        ...getId('skillMarketplacePlugin'),
+        status: 'active',
+        pluginSlug: `marketplace-plugin-limit-${idx}`,
+        skillMarketplaceOid: skillMarketplace.oid,
+        skillPluginOid: plugin.oid
+      }))
+    });
+
+    await expect(
+      skillMarketplacePluginService.addSkillMarketplacePlugin({
+        tenant: scope.tenant,
+        environment: scope.environment,
+        skillMarketplace,
+        input: {
+          skillPluginId: plugins[500]!.id
+        }
+      })
+    ).rejects.toThrow('Marketplace plugins cannot exceed 500');
+  });
+
+  it('rejects adding marketplace plugins that would exceed 1000 active skills', async () => {
+    let { tenant, environment } = await createScope();
+    let scope = await getCargoScopeRecords({
+      tenantId: tenant.id,
+      environmentId: environment.id
+    });
+    let skillMarketplaceRecord = await createTestSkillMarketplace({
+      tenantOid: scope.tenant.oid,
+      environmentOid: scope.environment.oid,
+      name: 'Skill Limited Marketplace',
+      slug: 'skill-limited-marketplace'
+    });
+    let skillMarketplace = await skillMarketplaceService.getSkillMarketplaceById({
+      tenant: scope.tenant,
+      environment: scope.environment,
+      skillMarketplaceId: skillMarketplaceRecord.id
+    });
+    let skillPluginRecord = await createTestSkillPlugin({
+      tenantOid: scope.tenant.oid,
+      environmentOid: scope.environment.oid,
+      name: 'Oversized Marketplace Plugin',
+      slug: 'oversized-marketplace-plugin'
+    });
+    let skillPlugin = await skillPluginService.getSkillPluginById({
+      tenant: scope.tenant,
+      environment: scope.environment,
+      skillPluginId: skillPluginRecord.id
+    });
+    let skills = await createManyTestSkills({
+      tenantOid: scope.tenant.oid,
+      environmentOid: scope.environment.oid,
+      count: 1001,
+      prefix: 'marketplace-skill-limit'
+    });
+
+    await db.skillPluginSkill.createMany({
+      data: skills.map((skill, idx) => ({
+        ...getId('skillPluginSkill'),
+        status: 'active',
+        pluginSkillSlug: `marketplace-skill-limit-${idx}`,
+        skillOid: skill.oid,
+        skillPluginOid: skillPlugin.oid
+      }))
+    });
+
+    await expect(
+      skillMarketplacePluginService.addSkillMarketplacePlugin({
+        tenant: scope.tenant,
+        environment: scope.environment,
+        skillMarketplace,
+        input: {
+          skillPluginId: skillPlugin.id
+        }
+      })
+    ).rejects.toThrow('Marketplace skills cannot exceed 1000');
+  });
+
+  it('rejects creating the 1001st exportable file in a skill store', async () => {
+    let { tenant, environment } = await createScope();
+    let skill = await cargoClient.skill.create({
+      tenantId: tenant.id,
+      environmentId: environment.id,
+      skillId: 'csk_store_file_limit',
+      name: 'Store File Limited Skill'
+    });
+    let store = await db.store.findUniqueOrThrow({
+      where: { id: skill.storeId }
+    });
+    let currentExportableCount = await db.storeItem.count({
+      where: {
+        storeOid: store.oid,
+        kind: { in: ['document', 'file'] }
+      }
+    });
+
+    await db.storeItem.createMany({
+      data: Array.from({ length: 1000 - currentExportableCount }, (_, idx) => ({
+        ...getId('storeItem'),
+        kind: 'file',
+        path: `/limit-${idx}.txt`,
+        storeOid: store.oid
+      }))
+    });
+
+    await expect(
+      cargoClient.document.create({
+        tenantId: tenant.id,
+        environmentId: environment.id,
+        title: 'Too Many Files',
+        content: 'limit',
+        store: {
+          id: skill.storeId,
+          path: '/too-many.md'
+        }
+      })
+    ).rejects.toThrow('Skill store files cannot exceed 1000');
+  });
+
+  it('rejects oversized plugin and marketplace data during serializer initialization', async () => {
+    let { tenant, environment } = await createScope();
+    let scope = await getCargoScopeRecords({
+      tenantId: tenant.id,
+      environmentId: environment.id
+    });
+    let skillMarketplaceRecord = await createTestSkillMarketplace({
+      tenantOid: scope.tenant.oid,
+      environmentOid: scope.environment.oid,
+      name: 'Serializer Limited Marketplace',
+      slug: 'serializer-limited-marketplace'
+    });
+    let skillMarketplace = await skillMarketplaceService.getSkillMarketplaceById({
+      tenant: scope.tenant,
+      environment: scope.environment,
+      skillMarketplaceId: skillMarketplaceRecord.id
+    });
+    let skillPluginRecord = await createTestSkillPlugin({
+      tenantOid: scope.tenant.oid,
+      environmentOid: scope.environment.oid,
+      name: 'Serializer Limited Plugin',
+      slug: 'serializer-limited-plugin'
+    });
+    let skillPlugin = await skillPluginService.getSkillPluginById({
+      tenant: scope.tenant,
+      environment: scope.environment,
+      skillPluginId: skillPluginRecord.id
+    });
+    let skills = await createManyTestSkills({
+      tenantOid: scope.tenant.oid,
+      environmentOid: scope.environment.oid,
+      count: 101,
+      prefix: 'serializer-plugin-limit'
+    });
+
+    await db.skillPluginSkill.createMany({
+      data: skills.map((skill, idx) => ({
+        ...getId('skillPluginSkill'),
+        status: 'active',
+        pluginSkillSlug: `serializer-plugin-limit-${idx}`,
+        skillOid: skill.oid,
+        skillPluginOid: skillPlugin.oid
+      }))
+    });
+    await db.skillMarketplacePlugin.create({
+      data: {
+        ...getId('skillMarketplacePlugin'),
+        status: 'active',
+        pluginSlug: 'serializer-plugin-limit',
+        skillMarketplaceOid: skillMarketplace.oid,
+        skillPluginOid: skillPlugin.oid
+      }
+    });
+
+    await expect(
+      applyPlugin.init({
+        skillPlugin: {
+          ...skillPlugin,
+          skills: [],
+          skillConfiguration: null
+        }
+      } as any)
+    ).rejects.toThrow('Plugin skills cannot exceed 100');
+
+    let pluginLimitedMarketplaceRecord = await createTestSkillMarketplace({
+      tenantOid: scope.tenant.oid,
+      environmentOid: scope.environment.oid,
+      name: 'Serializer Plugin Limited Marketplace',
+      slug: 'serializer-plugin-limited-marketplace'
+    });
+    let pluginLimitedMarketplace = await skillMarketplaceService.getSkillMarketplaceById({
+      tenant: scope.tenant,
+      environment: scope.environment,
+      skillMarketplaceId: pluginLimitedMarketplaceRecord.id
+    });
+    let plugins = await createManyTestPlugins({
+      tenantOid: scope.tenant.oid,
+      environmentOid: scope.environment.oid,
+      count: 501,
+      prefix: 'serializer-marketplace-plugin-limit'
+    });
+
+    await db.skillMarketplacePlugin.createMany({
+      data: plugins.map((plugin, idx) => ({
+        ...getId('skillMarketplacePlugin'),
+        status: 'active',
+        pluginSlug: `serializer-marketplace-plugin-limit-${idx}`,
+        skillMarketplaceOid: pluginLimitedMarketplace.oid,
+        skillPluginOid: plugin.oid
+      }))
+    });
+
+    await expect(
+      applyMarketplace.init({ skillMarketplace: pluginLimitedMarketplace } as any)
+    ).rejects.toThrow('Marketplace plugins cannot exceed 500');
   });
 
   it('archives plugin links when archiving a plugin', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it introduces new skill sync APIs/UI and significantly refactors Cargo skill sync serialization/propagation logic while also adjusting Prisma schema mappings, which can affect data persistence and sync behavior.
> 
> **Overview**
> Adds **skill sync observability end-to-end**: new `GET /dashboard/instances/:instanceId/skill-syncs` + `GET .../:skillSyncId` backend controller/presenter, generated dashboard SDK endpoints/resources, and dashboard UI pages/tables to view sync status, per-repo propagation results, and logs for skill plugins/marketplaces.
> 
> Enhances Cargo sync execution with **persistent sync logs** (DB `logs` field + append/copy helpers), a daily cleanup cron for old sync rows, and more descriptive PR metadata (Add/Update/Remove) based on existing destination items.
> 
> Refactors Cargo skill serializers and sync processing to be **hash-driven and config/limit aware**: serializers now have `init`/`getHash`/`apply`, sync tasks skip unchanged items, bucket deletes are supported, file filtering is tightened via combined skill configuration policies (scripts/dirs/extensions) with filename normalization, and new hard limits (store files, plugin skills, marketplace plugins/skills) are enforced in serializers and linking services with explicit 400 errors.
> 
> Also updates skills export outputs to include `createdBy`, tweaks repository endpoint docstrings, and removes synthesis organization-scope linking support in internal clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a24cc5065bd056745e5a431a21ec9b209e152e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->