### PR TITLE
Fix tool consumer filter

### DIFF
--- a/src/backend/apis/core/src/controllers/instance/sessions/_logFilterActors.ts
+++ b/src/backend/apis/core/src/controllers/instance/sessions/_logFilterActors.ts
@@ -7,9 +7,13 @@ export let resolveActorIdsForLogFilters = async (d: {
   consumerIds?: string[];
   identityIds?: string[];
 }) => {
+  let hasActorFilter = !!d.actorIds?.length;
+
   let actorIds = new Set(d.actorIds ?? []);
 
   if (d.consumerIds?.length) {
+    hasActorFilter = true;
+
     let consumerActors = await db.consumerActor.findMany({
       where: {
         instanceOid: d.instance.oid,
@@ -30,6 +34,8 @@ export let resolveActorIdsForLogFilters = async (d: {
   }
 
   if (d.identityIds?.length) {
+    hasActorFilter = true;
+
     let paginator = await subspaceIdentityService.list({
       instance: d.instance,
       allowDeleted: true,
@@ -45,5 +51,5 @@ export let resolveActorIdsForLogFilters = async (d: {
     }
   }
 
-  return actorIds.size ? [...actorIds] : undefined;
+  return hasActorFilter ? [...actorIds] : undefined;
 };

--- a/src/backend/apis/core/src/controllers/instance/sessions/toolCall.ts
+++ b/src/backend/apis/core/src/controllers/instance/sessions/toolCall.ts
@@ -3,12 +3,12 @@ import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
 import { subspaceToolCallService } from '@metorial/module-subspace';
 import { Controller } from '@metorial/rest';
-import { resolveActorIdsForLogFilters } from './_logFilterActors';
 import { dateFilterValidator } from '../../../lib/dateFilter';
 import { normalizeArrayParam } from '../../../lib/normalizeArrayParam';
 import { checkAccess } from '../../../middleware/checkAccess';
 import { instanceGroup, instancePath } from '../../../middleware/instanceGroup';
 import { toolCallPresenter } from '../../../presenters';
+import { resolveActorIdsForLogFilters } from './_logFilterActors';
 
 let toolCallGroup = instanceGroup.use(async ctx => {
   if (!ctx.params.toolCallId) {
@@ -91,6 +91,12 @@ export let toolCallController = Controller.create(
         let actorIds = await resolveActorIdsForLogFilters({
           instance: ctx.instance,
           actorIds: normalizeArrayParam(ctx.query.actor_id),
+          consumerIds: normalizeArrayParam(ctx.query.consumer_id),
+          identityIds: normalizeArrayParam(ctx.query.identity_id)
+        });
+
+        console.log('Resolved actor IDs for tool call list filters:', {
+          actorIds,
           consumerIds: normalizeArrayParam(ctx.query.consumer_id),
           identityIds: normalizeArrayParam(ctx.query.identity_id)
         });

--- a/src/backend/modules/subspace/src/services/identityActor.ts
+++ b/src/backend/modules/subspace/src/services/identityActor.ts
@@ -1,4 +1,5 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
 import {
   Consumer,
   ConsumerProfile,
@@ -67,6 +68,10 @@ export let subspaceIdentityActorService = createSubspaceService(
         let consumerActorIds = await resolveConsumerActorIds(arg0.consumerIds);
 
         arg0.ids = [...(arg0.ids ?? []), ...consumerActorIds];
+
+        if (!arg0.ids.length) {
+          return Paginator.create(({ prisma }) => prisma(async () => []));
+        }
       }
 
       let res = await inner.list(arg0);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes filtering semantics so consumer/identity filters that resolve to no actors now return an empty result set instead of dropping the actor filter, which could affect list/query behavior across sessions/tool-calls. Adds console logging in `toolCall` list that may be noisy in production if not intended.
> 
> **Overview**
> Fixes actor-resolution for session log filters so that providing `actor_id`, `consumer_id`, or `identity_id` always applies an actor filter (returning `[]` when nothing matches) instead of returning `undefined` and effectively disabling filtering.
> 
> Updates `subspaceIdentityActorService.list` to short-circuit with an empty `Paginator` when `consumerIds` resolve to no actor IDs, preventing an unfiltered/incorrect list call. Adds temporary debug logging of resolved actor IDs in the tool-call list endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51789f5855bd3629f701fd4963d4de72df9a7df0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->