### PR TITLE
Force description for skills

### DIFF
--- a/src/systems/cargo/modules/skill/src/serializers/skill/index.ts
+++ b/src/systems/cargo/modules/skill/src/serializers/skill/index.ts
@@ -65,7 +65,8 @@ let applySkillDocumentFrontmatter = (content: string, input: SkillSerializerInpu
       input.skill.clientDescription ||
       givenFrontmatter.description ||
       input.skill.description ||
-      undefined,
+      input.skill.name ||
+      'Unknown Skill',
     license: input.skill.license || givenFrontmatter.license || undefined,
     compatibility: input.skill.compatibility || givenFrontmatter.compatibility || undefined,
     metadata: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes the fallback value used when serializing the `description` field in `SKILL.md` frontmatter, with no control-flow or data model changes.
> 
> **Overview**
> Skill document serialization now *forces a non-empty* `description` in `SKILL.md` frontmatter: if no client-provided, existing, or skill `description` is available, it falls back to `input.skill.name` and then `'Unknown Skill'` (instead of leaving it `undefined`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c790879c2d260725514786be49e7b32417ff40f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->