### PR TITLE
Remove structured content for explorer

### DIFF
--- a/src/systems/subspace/modules/connection/src/mcp/sender.ts
+++ b/src/systems/subspace/modules/connection/src/mcp/sender.ts
@@ -411,8 +411,9 @@ export class McpSender {
               inputSchema: isMetorialExplorer
                 ? presented.inputJsonSchema
                 : (injectToolCallOperationIntoInputSchema(presented.inputJsonSchema) as any),
-              outputSchema:
-                presented.outputJsonSchema?.type === 'object'
+              outputSchema: isMetorialExplorer
+                ? undefined
+                : presented.outputJsonSchema?.type === 'object'
                   ? (mcpOutputSchemaNormalizer(presented.outputJsonSchema, {
                       isRoot: true
                     }) as any)
@@ -814,10 +815,18 @@ export class McpSender {
 
     if (!opts.waitForResponse) return { message: result.message };
 
+    let isMetorialExplorer = this.connection?.participant?.name === 'Metorial Explorer';
+    let res = await conduitResultToMcpMessage(result);
+
+    if (isMetorialExplorer) {
+      // @ts-ignore
+      delete res?.result?.structuredContent;
+    }
+
     return {
       store: true,
       message: result.message,
-      mcp: await conduitResultToMcpMessage(result)
+      mcp: res
     };
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: change is narrowly scoped to a single client identified by participant name, but could affect Explorer tool rendering/consumption if it relies on `outputSchema` or `structuredContent`.
> 
> **Overview**
> **Metorial Explorer MCP responses are simplified.** When listing tools, the sender now returns the raw `inputSchema` (no injected operation) and omits `outputSchema` entirely for the "Metorial Explorer" participant.
> 
> For `tools/call` responses, the sender post-processes the MCP result and removes `result.structuredContent` for that same participant before returning/storing the response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60323340491fe37da517985dab37826e596ebbd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->