### PR TITLE
Harden oauth urls

### DIFF
--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/index.ts
@@ -410,4 +410,5 @@ export * from './stores';
 export * from './stores_items';
 export * from './stores_participants';
 export * from './stores_permissions';
+export * from './test-helpers_consumer-oauth_authorizations';
 export * from './tool-calls';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/test-helpers_consumer-oauth_authorizations.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/test-helpers_consumer-oauth_authorizations.ts
@@ -1,0 +1,69 @@
+import {
+  BaseMetorialEndpoint,
+  MetorialEndpointManager
+} from '@metorial/util-endpoint';
+
+import {
+  mapTestHelpersConsumerOauthAuthorizationsCreateBody,
+  mapTestHelpersConsumerOauthAuthorizationsCreateOutput,
+  type TestHelpersConsumerOauthAuthorizationsCreateBody,
+  type TestHelpersConsumerOauthAuthorizationsCreateOutput
+} from '../resources';
+
+/**
+ * @name Test Helper Consumer OAuth controller
+ * @description Helpers for testing consumer OAuth flows.
+ *
+ * @see https://metorial.com/api
+ * @see https://metorial.com/docs
+ */
+export class MetorialTestHelpersConsumerOauthAuthorizationsEndpoint {
+  constructor(private readonly _manager: MetorialEndpointManager<any>) {}
+
+  // thin proxies so method bodies stay unchanged
+  private _get(request: any) {
+    return this._manager._get(request);
+  }
+  private _post(request: any) {
+    return this._manager._post(request);
+  }
+  private _put(request: any) {
+    return this._manager._put(request);
+  }
+  private _patch(request: any) {
+    return this._manager._patch(request);
+  }
+  private _delete(request: any) {
+    return this._manager._delete(request);
+  }
+
+  /**
+   * @name Create consumer OAuth test authorization
+   * @description Creates a single-use test authorization token for a consumer OAuth authorize URL.
+   *
+   * @param `body` - TestHelpersConsumerOauthAuthorizationsCreateBody
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns TestHelpersConsumerOauthAuthorizationsCreateOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  create(
+    body: TestHelpersConsumerOauthAuthorizationsCreateBody,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<TestHelpersConsumerOauthAuthorizationsCreateOutput> {
+    let path = 'test-helpers/consumer-oauth-authorizations';
+
+    let request = {
+      path,
+      body: mapTestHelpersConsumerOauthAuthorizationsCreateBody.transformTo(
+        body
+      ),
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._post(request).transform(
+      mapTestHelpersConsumerOauthAuthorizationsCreateOutput
+    );
+  }
+}

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/delete.ts
@@ -7,10 +7,11 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput = {
   name: string;
   description: string | null;
   metadata: Record<string, any> | null;
-  integrationInstanceGroupId: string;
   integrationId: string;
+  integrationInstanceGroupId: string;
   integrationInstanceId: string;
-  integrationProviderId: string;
+  integrationProviderId: string | null;
+  integrationInstanceProviderId: string;
   toolFilter:
     | { type: 'allow_all'; ignoreParentFilters: boolean }
     | {
@@ -27,6 +28,10 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput = {
       }
     | null;
   isOverrideToolFilter: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -63,65 +68,10 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -198,71 +148,10 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -304,264 +193,12 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
 export let mapDashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput =
-  mtMap.object<DashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationInstanceGroupId: mtMap.objectField(
-      'integration_instance_group_id',
-      mtMap.passthrough()
-    ),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    integrationProviderId: mtMap.objectField(
-      'integration_provider_id',
-      mtMap.passthrough()
-    ),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    isOverrideToolFilter: mtMap.objectField(
-      'is_override_tool_filter',
-      mtMap.passthrough()
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    integrationProvider: mtMap.objectField(
-      'integration_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        providerVersion: mtMap.objectField(
-          'provider_version',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            index: mtMap.objectField('index', mtMap.passthrough())
-          })
-        ),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
-                  mtMap.passthrough()
-                ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
-                            mtMap.passthrough()
-                          ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
-                          )
-                        })
-                      )
-                    ])
-                  )
-                )
-              })
-            )
-          ])
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        deployment: mtMap.objectField(
-          'deployment',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  )
-                })
-              )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        config: mtMap.objectField(
-          'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    integrationInstanceProvider: mtMap.objectField(
-      'integration_instance_provider',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
@@ -570,8 +207,20 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput =
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        integrationInstanceGroupId: mtMap.objectField(
+          'integration_instance_group_id',
+          mtMap.passthrough()
+        ),
         integrationInstanceId: mtMap.objectField(
           'integration_instance_id',
+          mtMap.passthrough()
+        ),
+        integrationProviderId: mtMap.objectField(
+          'integration_provider_id',
+          mtMap.passthrough()
+        ),
+        integrationInstanceProviderId: mtMap.objectField(
+          'integration_instance_provider_id',
           mtMap.passthrough()
         ),
         toolFilter: mtMap.objectField(
@@ -618,6 +267,9 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput =
           'is_override_tool_filter',
           mtMap.passthrough()
         ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date()),
         provider: mtMap.objectField(
           'provider',
           mtMap.object({
@@ -690,124 +342,18 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput =
                 )
               ])
             ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            deploymentId: mtMap.objectField(
+              'deployment_id',
+              mtMap.passthrough()
             ),
-            deployment: mtMap.objectField(
-              'deployment',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            authMethodId: mtMap.objectField(
+              'auth_method_id',
+              mtMap.passthrough()
             ),
-            authMethod: mtMap.objectField(
-              'auth_method',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                key: mtMap.objectField('key', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                capabilities: mtMap.objectField(
-                  'capabilities',
-                  mtMap.passthrough()
-                ),
-                inputSchema: mtMap.objectField(
-                  'input_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                outputSchema: mtMap.objectField(
-                  'output_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      scope: mtMap.objectField('scope', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      )
-                    })
-                  )
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                providerSpecificationId: mtMap.objectField(
-                  'provider_specification_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authCredentials: mtMap.objectField(
-              'auth_credentials',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(mtMap.passthrough())
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            authCredentialsId: mtMap.objectField(
+              'auth_credentials_id',
+              mtMap.passthrough()
             ),
             config: mtMap.objectField(
               'config',
@@ -834,41 +380,241 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput =
             archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
         ),
-        config: mtMap.objectField(
-          'config',
+        integrationInstanceProvider: mtMap.objectField(
+          'integration_instance_provider',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            integrationId: mtMap.objectField(
+              'integration_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceId: mtMap.objectField(
+              'integration_instance_id',
+              mtMap.passthrough()
+            ),
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
+            ),
+            isOverrideToolFilter: mtMap.objectField(
+              'is_override_tool_filter',
+              mtMap.passthrough()
+            ),
+            provider: mtMap.objectField(
+              'provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                slug: mtMap.objectField('slug', mtMap.passthrough()),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            integrationProvider: mtMap.objectField(
+              'integration_provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                providerVersion: mtMap.objectField(
+                  'provider_version',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    index: mtMap.objectField('index', mtMap.passthrough())
+                  })
+                ),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            ),
+            config: mtMap.objectField(
+              'config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            authConfig: mtMap.objectField(
+              'auth_config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
-        ),
-        authConfig: mtMap.objectField(
-          'auth_config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        )
       })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+    )
+  ]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/get.ts
@@ -7,10 +7,11 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersGetOutput = {
   name: string;
   description: string | null;
   metadata: Record<string, any> | null;
-  integrationInstanceGroupId: string;
   integrationId: string;
+  integrationInstanceGroupId: string;
   integrationInstanceId: string;
-  integrationProviderId: string;
+  integrationProviderId: string | null;
+  integrationInstanceProviderId: string;
   toolFilter:
     | { type: 'allow_all'; ignoreParentFilters: boolean }
     | {
@@ -27,6 +28,10 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersGetOutput = {
       }
     | null;
   isOverrideToolFilter: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -63,65 +68,10 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersGetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -198,71 +148,10 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersGetOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -304,264 +193,12 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersGetOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
 export let mapDashboardInstanceIntegrationInstanceGroupProvidersGetOutput =
-  mtMap.object<DashboardInstanceIntegrationInstanceGroupProvidersGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationInstanceGroupId: mtMap.objectField(
-      'integration_instance_group_id',
-      mtMap.passthrough()
-    ),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    integrationProviderId: mtMap.objectField(
-      'integration_provider_id',
-      mtMap.passthrough()
-    ),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    isOverrideToolFilter: mtMap.objectField(
-      'is_override_tool_filter',
-      mtMap.passthrough()
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    integrationProvider: mtMap.objectField(
-      'integration_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        providerVersion: mtMap.objectField(
-          'provider_version',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            index: mtMap.objectField('index', mtMap.passthrough())
-          })
-        ),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
-                  mtMap.passthrough()
-                ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
-                            mtMap.passthrough()
-                          ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
-                          )
-                        })
-                      )
-                    ])
-                  )
-                )
-              })
-            )
-          ])
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        deployment: mtMap.objectField(
-          'deployment',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  )
-                })
-              )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        config: mtMap.objectField(
-          'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    integrationInstanceProvider: mtMap.objectField(
-      'integration_instance_provider',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
@@ -570,8 +207,20 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersGetOutput =
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        integrationInstanceGroupId: mtMap.objectField(
+          'integration_instance_group_id',
+          mtMap.passthrough()
+        ),
         integrationInstanceId: mtMap.objectField(
           'integration_instance_id',
+          mtMap.passthrough()
+        ),
+        integrationProviderId: mtMap.objectField(
+          'integration_provider_id',
+          mtMap.passthrough()
+        ),
+        integrationInstanceProviderId: mtMap.objectField(
+          'integration_instance_provider_id',
           mtMap.passthrough()
         ),
         toolFilter: mtMap.objectField(
@@ -618,6 +267,9 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersGetOutput =
           'is_override_tool_filter',
           mtMap.passthrough()
         ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date()),
         provider: mtMap.objectField(
           'provider',
           mtMap.object({
@@ -690,124 +342,18 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersGetOutput =
                 )
               ])
             ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            deploymentId: mtMap.objectField(
+              'deployment_id',
+              mtMap.passthrough()
             ),
-            deployment: mtMap.objectField(
-              'deployment',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            authMethodId: mtMap.objectField(
+              'auth_method_id',
+              mtMap.passthrough()
             ),
-            authMethod: mtMap.objectField(
-              'auth_method',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                key: mtMap.objectField('key', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                capabilities: mtMap.objectField(
-                  'capabilities',
-                  mtMap.passthrough()
-                ),
-                inputSchema: mtMap.objectField(
-                  'input_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                outputSchema: mtMap.objectField(
-                  'output_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      scope: mtMap.objectField('scope', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      )
-                    })
-                  )
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                providerSpecificationId: mtMap.objectField(
-                  'provider_specification_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authCredentials: mtMap.objectField(
-              'auth_credentials',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(mtMap.passthrough())
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            authCredentialsId: mtMap.objectField(
+              'auth_credentials_id',
+              mtMap.passthrough()
             ),
             config: mtMap.objectField(
               'config',
@@ -834,41 +380,241 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersGetOutput =
             archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
         ),
-        config: mtMap.objectField(
-          'config',
+        integrationInstanceProvider: mtMap.objectField(
+          'integration_instance_provider',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            integrationId: mtMap.objectField(
+              'integration_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceId: mtMap.objectField(
+              'integration_instance_id',
+              mtMap.passthrough()
+            ),
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
+            ),
+            isOverrideToolFilter: mtMap.objectField(
+              'is_override_tool_filter',
+              mtMap.passthrough()
+            ),
+            provider: mtMap.objectField(
+              'provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                slug: mtMap.objectField('slug', mtMap.passthrough()),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            integrationProvider: mtMap.objectField(
+              'integration_provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                providerVersion: mtMap.objectField(
+                  'provider_version',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    index: mtMap.objectField('index', mtMap.passthrough())
+                  })
+                ),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            ),
+            config: mtMap.objectField(
+              'config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            authConfig: mtMap.objectField(
+              'auth_config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
-        ),
-        authConfig: mtMap.objectField(
-          'auth_config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        )
       })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+    )
+  ]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/list.ts
@@ -1,17 +1,18 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceIntegrationInstanceGroupProvidersListOutput = {
-  items: {
+  items: ({
     object: 'integration.instance.group.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -28,6 +29,10 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersListOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
     provider: {
       object: 'provider#preview';
       id: string;
@@ -64,71 +69,10 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersListOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -205,71 +149,10 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersListOutput = {
               ignoreParentFilters: boolean;
             }
           | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
         config: {
           object: 'provider.config#preview';
           id: string;
@@ -311,10 +194,7 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersListOutput = {
       updatedAt: Date;
       archivedAt: Date | null;
     };
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -323,315 +203,9 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
-            mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
@@ -646,8 +220,20 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersListOutput =
                 'integration_id',
                 mtMap.passthrough()
               ),
+              integrationInstanceGroupId: mtMap.objectField(
+                'integration_instance_group_id',
+                mtMap.passthrough()
+              ),
               integrationInstanceId: mtMap.objectField(
                 'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              integrationProviderId: mtMap.objectField(
+                'integration_provider_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceProviderId: mtMap.objectField(
+                'integration_instance_provider_id',
                 mtMap.passthrough()
               ),
               toolFilter: mtMap.objectField(
@@ -697,6 +283,9 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersListOutput =
                 'is_override_tool_filter',
                 mtMap.passthrough()
               ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date()),
               provider: mtMap.objectField(
                 'provider',
                 mtMap.object({
@@ -775,154 +364,21 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersListOutput =
                       )
                     ])
                   ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
                   ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  deploymentId: mtMap.objectField(
+                    'deployment_id',
+                    mtMap.passthrough()
                   ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  authMethodId: mtMap.objectField(
+                    'auth_method_id',
+                    mtMap.passthrough()
                   ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  authCredentialsId: mtMap.objectField(
+                    'auth_credentials_id',
+                    mtMap.passthrough()
                   ),
                   config: mtMap.objectField(
                     'config',
@@ -955,61 +411,276 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersListOutput =
                   archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
               ),
-              config: mtMap.objectField(
-                'config',
+              integrationInstanceProvider: mtMap.objectField(
+                'integration_instance_provider',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
+                  integrationId: mtMap.objectField(
+                    'integration_id',
                     mtMap.passthrough()
+                  ),
+                  integrationInstanceId: mtMap.objectField(
+                    'integration_instance_id',
+                    mtMap.passthrough()
+                  ),
+                  toolFilter: mtMap.objectField(
+                    'tool_filter',
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          ignoreParentFilters: mtMap.objectField(
+                            'ignore_parent_filters',
+                            mtMap.passthrough()
+                          ),
+                          filters: mtMap.objectField(
+                            'filters',
+                            mtMap.array(
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    keys: mtMap.objectField(
+                                      'keys',
+                                      mtMap.array(mtMap.passthrough())
+                                    ),
+                                    pattern: mtMap.objectField(
+                                      'pattern',
+                                      mtMap.passthrough()
+                                    ),
+                                    uris: mtMap.objectField(
+                                      'uris',
+                                      mtMap.array(mtMap.passthrough())
+                                    )
+                                  })
+                                )
+                              ])
+                            )
+                          )
+                        })
+                      )
+                    ])
+                  ),
+                  isOverrideToolFilter: mtMap.objectField(
+                    'is_override_tool_filter',
+                    mtMap.passthrough()
+                  ),
+                  provider: mtMap.objectField(
+                    'provider',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      slug: mtMap.objectField('slug', mtMap.passthrough()),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
+                  integrationProvider: mtMap.objectField(
+                    'integration_provider',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      providerVersion: mtMap.objectField(
+                        'provider_version',
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          index: mtMap.objectField('index', mtMap.passthrough())
+                        })
+                      ),
+                      status: mtMap.objectField('status', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      toolFilter: mtMap.objectField(
+                        'tool_filter',
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              ignoreParentFilters: mtMap.objectField(
+                                'ignore_parent_filters',
+                                mtMap.passthrough()
+                              ),
+                              filters: mtMap.objectField(
+                                'filters',
+                                mtMap.array(
+                                  mtMap.union([
+                                    mtMap.unionOption(
+                                      'object',
+                                      mtMap.object({
+                                        type: mtMap.objectField(
+                                          'type',
+                                          mtMap.passthrough()
+                                        ),
+                                        keys: mtMap.objectField(
+                                          'keys',
+                                          mtMap.array(mtMap.passthrough())
+                                        ),
+                                        pattern: mtMap.objectField(
+                                          'pattern',
+                                          mtMap.passthrough()
+                                        ),
+                                        uris: mtMap.objectField(
+                                          'uris',
+                                          mtMap.array(mtMap.passthrough())
+                                        )
+                                      })
+                                    )
+                                  ])
+                                )
+                              )
+                            })
+                          )
+                        ])
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      deploymentId: mtMap.objectField(
+                        'deployment_id',
+                        mtMap.passthrough()
+                      ),
+                      authMethodId: mtMap.objectField(
+                        'auth_method_id',
+                        mtMap.passthrough()
+                      ),
+                      authCredentialsId: mtMap.objectField(
+                        'auth_credentials_id',
+                        mtMap.passthrough()
+                      ),
+                      config: mtMap.objectField(
+                        'config',
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          isDefault: mtMap.objectField(
+                            'is_default',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          ),
+                          metadata: mtMap.objectField(
+                            'metadata',
+                            mtMap.passthrough()
+                          ),
+                          providerId: mtMap.objectField(
+                            'provider_id',
+                            mtMap.passthrough()
+                          ),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                    })
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
+                  authConfig: mtMap.objectField(
+                    'auth_config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
                   ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              )
             })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/set.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/set.ts
@@ -7,10 +7,11 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersSetOutput = {
   name: string;
   description: string | null;
   metadata: Record<string, any> | null;
-  integrationInstanceGroupId: string;
   integrationId: string;
+  integrationInstanceGroupId: string;
   integrationInstanceId: string;
-  integrationProviderId: string;
+  integrationProviderId: string | null;
+  integrationInstanceProviderId: string;
   toolFilter:
     | { type: 'allow_all'; ignoreParentFilters: boolean }
     | {
@@ -27,6 +28,10 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersSetOutput = {
       }
     | null;
   isOverrideToolFilter: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -63,65 +68,10 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersSetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -198,71 +148,10 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersSetOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -304,264 +193,12 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersSetOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
 export let mapDashboardInstanceIntegrationInstanceGroupProvidersSetOutput =
-  mtMap.object<DashboardInstanceIntegrationInstanceGroupProvidersSetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationInstanceGroupId: mtMap.objectField(
-      'integration_instance_group_id',
-      mtMap.passthrough()
-    ),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    integrationProviderId: mtMap.objectField(
-      'integration_provider_id',
-      mtMap.passthrough()
-    ),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    isOverrideToolFilter: mtMap.objectField(
-      'is_override_tool_filter',
-      mtMap.passthrough()
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    integrationProvider: mtMap.objectField(
-      'integration_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        providerVersion: mtMap.objectField(
-          'provider_version',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            index: mtMap.objectField('index', mtMap.passthrough())
-          })
-        ),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
-                  mtMap.passthrough()
-                ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
-                            mtMap.passthrough()
-                          ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
-                          )
-                        })
-                      )
-                    ])
-                  )
-                )
-              })
-            )
-          ])
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        deployment: mtMap.objectField(
-          'deployment',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  )
-                })
-              )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        config: mtMap.objectField(
-          'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    integrationInstanceProvider: mtMap.objectField(
-      'integration_instance_provider',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
@@ -570,8 +207,20 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersSetOutput =
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        integrationInstanceGroupId: mtMap.objectField(
+          'integration_instance_group_id',
+          mtMap.passthrough()
+        ),
         integrationInstanceId: mtMap.objectField(
           'integration_instance_id',
+          mtMap.passthrough()
+        ),
+        integrationProviderId: mtMap.objectField(
+          'integration_provider_id',
+          mtMap.passthrough()
+        ),
+        integrationInstanceProviderId: mtMap.objectField(
+          'integration_instance_provider_id',
           mtMap.passthrough()
         ),
         toolFilter: mtMap.objectField(
@@ -618,6 +267,9 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersSetOutput =
           'is_override_tool_filter',
           mtMap.passthrough()
         ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date()),
         provider: mtMap.objectField(
           'provider',
           mtMap.object({
@@ -690,124 +342,18 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersSetOutput =
                 )
               ])
             ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            deploymentId: mtMap.objectField(
+              'deployment_id',
+              mtMap.passthrough()
             ),
-            deployment: mtMap.objectField(
-              'deployment',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            authMethodId: mtMap.objectField(
+              'auth_method_id',
+              mtMap.passthrough()
             ),
-            authMethod: mtMap.objectField(
-              'auth_method',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                key: mtMap.objectField('key', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                capabilities: mtMap.objectField(
-                  'capabilities',
-                  mtMap.passthrough()
-                ),
-                inputSchema: mtMap.objectField(
-                  'input_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                outputSchema: mtMap.objectField(
-                  'output_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      scope: mtMap.objectField('scope', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      )
-                    })
-                  )
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                providerSpecificationId: mtMap.objectField(
-                  'provider_specification_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authCredentials: mtMap.objectField(
-              'auth_credentials',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(mtMap.passthrough())
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            authCredentialsId: mtMap.objectField(
+              'auth_credentials_id',
+              mtMap.passthrough()
             ),
             config: mtMap.objectField(
               'config',
@@ -834,43 +380,243 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersSetOutput =
             archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
         ),
-        config: mtMap.objectField(
-          'config',
+        integrationInstanceProvider: mtMap.objectField(
+          'integration_instance_provider',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            integrationId: mtMap.objectField(
+              'integration_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceId: mtMap.objectField(
+              'integration_instance_id',
+              mtMap.passthrough()
+            ),
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
+            ),
+            isOverrideToolFilter: mtMap.objectField(
+              'is_override_tool_filter',
+              mtMap.passthrough()
+            ),
+            provider: mtMap.objectField(
+              'provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                slug: mtMap.objectField('slug', mtMap.passthrough()),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            integrationProvider: mtMap.objectField(
+              'integration_provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                providerVersion: mtMap.objectField(
+                  'provider_version',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    index: mtMap.objectField('index', mtMap.passthrough())
+                  })
+                ),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            ),
+            config: mtMap.objectField(
+              'config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            authConfig: mtMap.objectField(
+              'auth_config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
-        ),
-        authConfig: mtMap.objectField(
-          'auth_config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        )
       })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+    )
+  ]);
 
 export type DashboardInstanceIntegrationInstanceGroupProvidersSetBody = {
   toolFilters?:

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/create.ts
@@ -18,10 +18,11 @@ export type DashboardInstanceIntegrationInstanceGroupsCreateOutput = {
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -38,289 +39,6 @@ export type DashboardInstanceIntegrationInstanceGroupsCreateOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } | null;
-    integrationInstanceProvider: {
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
@@ -328,338 +46,65 @@ export type DashboardInstanceIntegrationInstanceGroupsCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: {
+    object: 'integration.instance.group.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceGroupId: string;
+    integrationInstanceId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
 };
 
 export let mapDashboardInstanceIntegrationInstanceGroupsCreateOutput =
-  mtMap.object<DashboardInstanceIntegrationInstanceGroupsCreateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpEndpointId: mtMap.objectField(
-          'magic_mcp_endpoint_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
-            mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        implementation: mtMap.objectField(
+          'implementation',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            magicMcpEndpointId: mtMap.objectField(
+              'magic_mcp_endpoint_id',
+              mtMap.passthrough()
+            )
+          })
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
@@ -674,8 +119,20 @@ export let mapDashboardInstanceIntegrationInstanceGroupsCreateOutput =
                 'integration_id',
                 mtMap.passthrough()
               ),
+              integrationInstanceGroupId: mtMap.objectField(
+                'integration_instance_group_id',
+                mtMap.passthrough()
+              ),
               integrationInstanceId: mtMap.objectField(
                 'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              integrationProviderId: mtMap.objectField(
+                'integration_provider_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceProviderId: mtMap.objectField(
+                'integration_instance_provider_id',
                 mtMap.passthrough()
               ),
               toolFilter: mtMap.objectField(
@@ -725,325 +182,18 @@ export let mapDashboardInstanceIntegrationInstanceGroupsCreateOutput =
                 'is_override_tool_filter',
                 mtMap.passthrough()
               ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
               archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    )
+  ]);
 
 export type DashboardInstanceIntegrationInstanceGroupsCreateBody = {
   name: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/delete.ts
@@ -18,10 +18,11 @@ export type DashboardInstanceIntegrationInstanceGroupsDeleteOutput = {
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -38,289 +39,6 @@ export type DashboardInstanceIntegrationInstanceGroupsDeleteOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } | null;
-    integrationInstanceProvider: {
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
@@ -328,338 +46,65 @@ export type DashboardInstanceIntegrationInstanceGroupsDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: {
+    object: 'integration.instance.group.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceGroupId: string;
+    integrationInstanceId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
 };
 
 export let mapDashboardInstanceIntegrationInstanceGroupsDeleteOutput =
-  mtMap.object<DashboardInstanceIntegrationInstanceGroupsDeleteOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpEndpointId: mtMap.objectField(
-          'magic_mcp_endpoint_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
-            mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        implementation: mtMap.objectField(
+          'implementation',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            magicMcpEndpointId: mtMap.objectField(
+              'magic_mcp_endpoint_id',
+              mtMap.passthrough()
+            )
+          })
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
@@ -674,8 +119,20 @@ export let mapDashboardInstanceIntegrationInstanceGroupsDeleteOutput =
                 'integration_id',
                 mtMap.passthrough()
               ),
+              integrationInstanceGroupId: mtMap.objectField(
+                'integration_instance_group_id',
+                mtMap.passthrough()
+              ),
               integrationInstanceId: mtMap.objectField(
                 'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              integrationProviderId: mtMap.objectField(
+                'integration_provider_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceProviderId: mtMap.objectField(
+                'integration_instance_provider_id',
                 mtMap.passthrough()
               ),
               toolFilter: mtMap.objectField(
@@ -725,323 +182,16 @@ export let mapDashboardInstanceIntegrationInstanceGroupsDeleteOutput =
                 'is_override_tool_filter',
                 mtMap.passthrough()
               ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
               archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    )
+  ]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/get.ts
@@ -18,10 +18,11 @@ export type DashboardInstanceIntegrationInstanceGroupsGetOutput = {
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -38,289 +39,6 @@ export type DashboardInstanceIntegrationInstanceGroupsGetOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } | null;
-    integrationInstanceProvider: {
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
@@ -328,338 +46,65 @@ export type DashboardInstanceIntegrationInstanceGroupsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: {
+    object: 'integration.instance.group.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceGroupId: string;
+    integrationInstanceId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
 };
 
-export let mapDashboardInstanceIntegrationInstanceGroupsGetOutput =
-  mtMap.object<DashboardInstanceIntegrationInstanceGroupsGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
+export let mapDashboardInstanceIntegrationInstanceGroupsGetOutput = mtMap.union(
+  [
+    mtMap.unionOption(
+      'object',
       mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpEndpointId: mtMap.objectField(
-          'magic_mcp_endpoint_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
-            mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        implementation: mtMap.objectField(
+          'implementation',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            magicMcpEndpointId: mtMap.objectField(
+              'magic_mcp_endpoint_id',
+              mtMap.passthrough()
+            )
+          })
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
@@ -674,8 +119,20 @@ export let mapDashboardInstanceIntegrationInstanceGroupsGetOutput =
                 'integration_id',
                 mtMap.passthrough()
               ),
+              integrationInstanceGroupId: mtMap.objectField(
+                'integration_instance_group_id',
+                mtMap.passthrough()
+              ),
               integrationInstanceId: mtMap.objectField(
                 'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              integrationProviderId: mtMap.objectField(
+                'integration_provider_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceProviderId: mtMap.objectField(
+                'integration_instance_provider_id',
                 mtMap.passthrough()
               ),
               toolFilter: mtMap.objectField(
@@ -725,323 +182,17 @@ export let mapDashboardInstanceIntegrationInstanceGroupsGetOutput =
                 'is_override_tool_filter',
                 mtMap.passthrough()
               ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
               archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    )
+  ]
+);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceIntegrationInstanceGroupsListOutput = {
-  items: {
+  items: ({
     object: 'integration.instance.group';
     id: string;
     status: 'draft' | 'active' | 'archived' | 'deleted';
@@ -19,10 +19,11 @@ export type DashboardInstanceIntegrationInstanceGroupsListOutput = {
       name: string;
       description: string | null;
       metadata: Record<string, any> | null;
-      integrationInstanceGroupId: string;
       integrationId: string;
+      integrationInstanceGroupId: string;
       integrationInstanceId: string;
-      integrationProviderId: string;
+      integrationProviderId: string | null;
+      integrationInstanceProviderId: string;
       toolFilter:
         | { type: 'allow_all'; ignoreParentFilters: boolean }
         | {
@@ -39,289 +40,6 @@ export type DashboardInstanceIntegrationInstanceGroupsListOutput = {
           }
         | null;
       isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      } | null;
-      integrationInstanceProvider: {
-        object: 'integration.instance.provider';
-        id: string;
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        integrationId: string;
-        integrationInstanceId: string;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        isOverrideToolFilter: boolean;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        integrationProvider: {
-          object: 'integration.provider#snapshot';
-          id: string;
-          providerVersion: {
-            object: 'integration.provider.version';
-            id: string;
-            index: number;
-          };
-          status: 'active' | 'archived' | 'deleted';
-          name: string;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          toolFilter:
-            | { type: 'allow_all'; ignoreParentFilters: boolean }
-            | {
-                type: 'filter';
-                filters: (
-                  | { type: 'tool_keys'; keys: string[] }
-                  | { type: 'tool_regex'; pattern: string }
-                  | { type: 'resource_regex'; pattern: string }
-                  | { type: 'resource_uris'; uris: string[] }
-                  | { type: 'prompt_keys'; keys: string[] }
-                  | { type: 'prompt_regex'; pattern: string }
-                )[];
-                ignoreParentFilters: boolean;
-              }
-            | null;
-          provider: {
-            object: 'provider#preview';
-            id: string;
-            name: string;
-            description: string | null;
-            slug: string;
-            createdAt: Date;
-            updatedAt: Date;
-          };
-          deployment: {
-            object: 'provider.deployment#preview';
-            id: string;
-            isDefault: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          };
-          authMethod: {
-            object: 'provider.capabilities.auth_method';
-            id: string;
-            type: 'oauth' | 'token' | 'custom';
-            key: string;
-            name: string;
-            description: string | null;
-            capabilities: Record<string, any>;
-            inputSchema: {
-              type: 'json_schema';
-              schema: Record<string, any>;
-            } | null;
-            outputSchema: {
-              type: 'json_schema';
-              schema: Record<string, any>;
-            } | null;
-            scopes:
-              | {
-                  object: 'provider.capabilities.auth_method.scope';
-                  id: string;
-                  scope: string;
-                  name: string;
-                  description: string | null;
-                }[]
-              | null;
-            providerId: string;
-            providerSpecificationId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
-          authCredentials: {
-            object: 'provider.auth_credentials';
-            id: string;
-            type: 'oauth';
-            status: 'active' | 'archived' | 'deleted';
-            isDefault: boolean;
-            isManaged: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            scopes: string[] | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
-          config: {
-            object: 'provider.config#preview';
-            id: string;
-            isDefault: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
-          createdAt: Date;
-          updatedAt: Date;
-          archivedAt: Date | null;
-        };
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authConfig: {
-          object: 'provider.auth_config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
       createdAt: Date;
       updatedAt: Date;
       archivedAt: Date | null;
@@ -329,7 +47,40 @@ export type DashboardInstanceIntegrationInstanceGroupsListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
+  } & {
+    providers: {
+      object: 'integration.instance.group.provider';
+      id: string;
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      integrationId: string;
+      integrationInstanceGroupId: string;
+      integrationInstanceId: string;
+      integrationProviderId: string | null;
+      integrationInstanceProviderId: string;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      isOverrideToolFilter: boolean;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    }[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -338,407 +89,32 @@ export let mapDashboardInstanceIntegrationInstanceGroupsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          implementation: mtMap.objectField(
-            'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              magicMcpEndpointId: mtMap.objectField(
-                'magic_mcp_endpoint_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
-              )
-            })
-          ),
-          providers: mtMap.objectField(
-            'providers',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationInstanceGroupId: mtMap.objectField(
-                  'integration_instance_group_id',
-                  mtMap.passthrough()
-                ),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                integrationProviderId: mtMap.objectField(
-                  'integration_provider_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    provider: mtMap.objectField(
-                      'provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    deployment: mtMap.objectField(
-                      'deployment',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authMethod: mtMap.objectField(
-                      'auth_method',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        key: mtMap.objectField('key', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        capabilities: mtMap.objectField(
-                          'capabilities',
-                          mtMap.passthrough()
-                        ),
-                        inputSchema: mtMap.objectField(
-                          'input_schema',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            schema: mtMap.objectField(
-                              'schema',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        outputSchema: mtMap.objectField(
-                          'output_schema',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            schema: mtMap.objectField(
-                              'schema',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        scopes: mtMap.objectField(
-                          'scopes',
-                          mtMap.array(
-                            mtMap.object({
-                              object: mtMap.objectField(
-                                'object',
-                                mtMap.passthrough()
-                              ),
-                              id: mtMap.objectField('id', mtMap.passthrough()),
-                              scope: mtMap.objectField(
-                                'scope',
-                                mtMap.passthrough()
-                              ),
-                              name: mtMap.objectField(
-                                'name',
-                                mtMap.passthrough()
-                              ),
-                              description: mtMap.objectField(
-                                'description',
-                                mtMap.passthrough()
-                              )
-                            })
-                          )
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        providerSpecificationId: mtMap.objectField(
-                          'provider_specification_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authCredentials: mtMap.objectField(
-                      'auth_credentials',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        status: mtMap.objectField(
-                          'status',
-                          mtMap.passthrough()
-                        ),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        isManaged: mtMap.objectField(
-                          'is_managed',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        scopes: mtMap.objectField(
-                          'scopes',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                integrationInstanceProvider: mtMap.objectField(
-                  'integration_instance_provider',
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              implementation: mtMap.objectField(
+                'implementation',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  magicMcpEndpointId: mtMap.objectField(
+                    'magic_mcp_endpoint_id',
+                    mtMap.passthrough()
+                  )
+                })
+              ),
+              providers: mtMap.objectField(
+                'providers',
+                mtMap.array(
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
@@ -756,8 +132,20 @@ export let mapDashboardInstanceIntegrationInstanceGroupsListOutput =
                       'integration_id',
                       mtMap.passthrough()
                     ),
+                    integrationInstanceGroupId: mtMap.objectField(
+                      'integration_instance_group_id',
+                      mtMap.passthrough()
+                    ),
                     integrationInstanceId: mtMap.objectField(
                       'integration_instance_id',
+                      mtMap.passthrough()
+                    ),
+                    integrationProviderId: mtMap.objectField(
+                      'integration_provider_id',
+                      mtMap.passthrough()
+                    ),
+                    integrationInstanceProviderId: mtMap.objectField(
+                      'integration_instance_provider_id',
                       mtMap.passthrough()
                     ),
                     toolFilter: mtMap.objectField(
@@ -810,457 +198,18 @@ export let mapDashboardInstanceIntegrationInstanceGroupsListOutput =
                       'is_override_tool_filter',
                       mtMap.passthrough()
                     ),
-                    provider: mtMap.objectField(
-                      'provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    integrationProvider: mtMap.objectField(
-                      'integration_provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        providerVersion: mtMap.objectField(
-                          'provider_version',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            index: mtMap.objectField(
-                              'index',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        status: mtMap.objectField(
-                          'status',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        toolFilter: mtMap.objectField(
-                          'tool_filter',
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                ignoreParentFilters: mtMap.objectField(
-                                  'ignore_parent_filters',
-                                  mtMap.passthrough()
-                                ),
-                                filters: mtMap.objectField(
-                                  'filters',
-                                  mtMap.array(
-                                    mtMap.union([
-                                      mtMap.unionOption(
-                                        'object',
-                                        mtMap.object({
-                                          type: mtMap.objectField(
-                                            'type',
-                                            mtMap.passthrough()
-                                          ),
-                                          keys: mtMap.objectField(
-                                            'keys',
-                                            mtMap.array(mtMap.passthrough())
-                                          ),
-                                          pattern: mtMap.objectField(
-                                            'pattern',
-                                            mtMap.passthrough()
-                                          ),
-                                          uris: mtMap.objectField(
-                                            'uris',
-                                            mtMap.array(mtMap.passthrough())
-                                          )
-                                        })
-                                      )
-                                    ])
-                                  )
-                                )
-                              })
-                            )
-                          ])
-                        ),
-                        provider: mtMap.objectField(
-                          'provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            slug: mtMap.objectField(
-                              'slug',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        deployment: mtMap.objectField(
-                          'deployment',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authMethod: mtMap.objectField(
-                          'auth_method',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            key: mtMap.objectField('key', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            capabilities: mtMap.objectField(
-                              'capabilities',
-                              mtMap.passthrough()
-                            ),
-                            inputSchema: mtMap.objectField(
-                              'input_schema',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                schema: mtMap.objectField(
-                                  'schema',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            outputSchema: mtMap.objectField(
-                              'output_schema',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                schema: mtMap.objectField(
-                                  'schema',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(
-                                mtMap.object({
-                                  object: mtMap.objectField(
-                                    'object',
-                                    mtMap.passthrough()
-                                  ),
-                                  id: mtMap.objectField(
-                                    'id',
-                                    mtMap.passthrough()
-                                  ),
-                                  scope: mtMap.objectField(
-                                    'scope',
-                                    mtMap.passthrough()
-                                  ),
-                                  name: mtMap.objectField(
-                                    'name',
-                                    mtMap.passthrough()
-                                  ),
-                                  description: mtMap.objectField(
-                                    'description',
-                                    mtMap.passthrough()
-                                  )
-                                })
-                              )
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            providerSpecificationId: mtMap.objectField(
-                              'provider_specification_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authCredentials: mtMap.objectField(
-                          'auth_credentials',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            status: mtMap.objectField(
-                              'status',
-                              mtMap.passthrough()
-                            ),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            isManaged: mtMap.objectField(
-                              'is_managed',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        config: mtMap.objectField(
-                          'config',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField(
-                          'updated_at',
-                          mtMap.date()
-                        ),
-                        archivedAt: mtMap.objectField(
-                          'archived_at',
-                          mtMap.date()
-                        )
-                      })
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authConfig: mtMap.objectField(
-                      'auth_config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
                     createdAt: mtMap.objectField('created_at', mtMap.date()),
                     updatedAt: mtMap.objectField('updated_at', mtMap.date()),
                     archivedAt: mtMap.objectField('archived_at', mtMap.date())
                   })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+                )
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/update.ts
@@ -18,10 +18,11 @@ export type DashboardInstanceIntegrationInstanceGroupsUpdateOutput = {
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -38,289 +39,6 @@ export type DashboardInstanceIntegrationInstanceGroupsUpdateOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } | null;
-    integrationInstanceProvider: {
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
@@ -328,338 +46,65 @@ export type DashboardInstanceIntegrationInstanceGroupsUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: {
+    object: 'integration.instance.group.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceGroupId: string;
+    integrationInstanceId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
 };
 
 export let mapDashboardInstanceIntegrationInstanceGroupsUpdateOutput =
-  mtMap.object<DashboardInstanceIntegrationInstanceGroupsUpdateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpEndpointId: mtMap.objectField(
-          'magic_mcp_endpoint_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
-            mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        implementation: mtMap.objectField(
+          'implementation',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            magicMcpEndpointId: mtMap.objectField(
+              'magic_mcp_endpoint_id',
+              mtMap.passthrough()
+            )
+          })
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
@@ -674,8 +119,20 @@ export let mapDashboardInstanceIntegrationInstanceGroupsUpdateOutput =
                 'integration_id',
                 mtMap.passthrough()
               ),
+              integrationInstanceGroupId: mtMap.objectField(
+                'integration_instance_group_id',
+                mtMap.passthrough()
+              ),
               integrationInstanceId: mtMap.objectField(
                 'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              integrationProviderId: mtMap.objectField(
+                'integration_provider_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceProviderId: mtMap.objectField(
+                'integration_instance_provider_id',
                 mtMap.passthrough()
               ),
               toolFilter: mtMap.objectField(
@@ -725,325 +182,18 @@ export let mapDashboardInstanceIntegrationInstanceGroupsUpdateOutput =
                 'is_override_tool_filter',
                 mtMap.passthrough()
               ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
               archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    )
+  ]);
 
 export type DashboardInstanceIntegrationInstanceGroupsUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-providers/get.ts
@@ -61,65 +61,10 @@ export type DashboardInstanceIntegrationInstanceProvidersGetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -160,94 +105,71 @@ export type DashboardInstanceIntegrationInstanceProvidersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  integrationProvider: {
+    object: 'integration.provider#snapshot';
+    id: string;
+    providerVersion: {
+      object: 'integration.provider.version';
+      id: string;
+      index: number;
+    };
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  };
 };
 
 export let mapDashboardInstanceIntegrationInstanceProvidersGetOutput =
-  mtMap.object<DashboardInstanceIntegrationInstanceProvidersGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    isOverrideToolFilter: mtMap.objectField(
-      'is_override_tool_filter',
-      mtMap.passthrough()
-    ),
-    provider: mtMap.objectField(
-      'provider',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    integrationProvider: mtMap.objectField(
-      'integration_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        providerVersion: mtMap.objectField(
-          'provider_version',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            index: mtMap.objectField('index', mtMap.passthrough())
-          })
-        ),
         status: mtMap.objectField('status', mtMap.passthrough()),
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        integrationInstanceId: mtMap.objectField(
+          'integration_instance_id',
+          mtMap.passthrough()
+        ),
         toolFilter: mtMap.objectField(
           'tool_filter',
           mtMap.union([
@@ -288,6 +210,10 @@ export let mapDashboardInstanceIntegrationInstanceProvidersGetOutput =
             )
           ])
         ),
+        isOverrideToolFilter: mtMap.objectField(
+          'is_override_tool_filter',
+          mtMap.passthrough()
+        ),
         provider: mtMap.objectField(
           'provider',
           mtMap.object({
@@ -300,90 +226,102 @@ export let mapDashboardInstanceIntegrationInstanceProvidersGetOutput =
             updatedAt: mtMap.objectField('updated_at', mtMap.date())
           })
         ),
-        deployment: mtMap.objectField(
-          'deployment',
+        integrationProvider: mtMap.objectField(
+          'integration_provider',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
+            providerVersion: mtMap.objectField(
+              'provider_version',
               mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                index: mtMap.objectField('index', mtMap.passthrough())
               })
             ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  )
-                })
-              )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
             status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
             ),
             providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            deploymentId: mtMap.objectField(
+              'deployment_id',
+              mtMap.passthrough()
+            ),
+            authMethodId: mtMap.objectField(
+              'auth_method_id',
+              mtMap.passthrough()
+            ),
+            authCredentialsId: mtMap.objectField(
+              'auth_credentials_id',
+              mtMap.passthrough()
+            ),
+            config: mtMap.objectField(
+              'config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
         ),
         config: mtMap.objectField(
@@ -400,41 +338,24 @@ export let mapDashboardInstanceIntegrationInstanceProvidersGetOutput =
             updatedAt: mtMap.objectField('updated_at', mtMap.date())
           })
         ),
+        authConfig: mtMap.objectField(
+          'auth_config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date()),
         archivedAt: mtMap.objectField('archived_at', mtMap.date())
       })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authConfig: mtMap.objectField(
-      'auth_config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+    )
+  ]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-providers/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceIntegrationInstanceProvidersListOutput = {
-  items: {
+  items: ({
     object: 'integration.instance.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -62,71 +62,10 @@ export type DashboardInstanceIntegrationInstanceProvidersListOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -167,7 +106,54 @@ export type DashboardInstanceIntegrationInstanceProvidersListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -176,96 +162,12 @@ export let mapDashboardInstanceIntegrationInstanceProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
               status: mtMap.objectField('status', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
@@ -273,6 +175,14 @@ export let mapDashboardInstanceIntegrationInstanceProvidersListOutput =
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
               toolFilter: mtMap.objectField(
                 'tool_filter',
                 mtMap.union([
@@ -316,6 +226,10 @@ export let mapDashboardInstanceIntegrationInstanceProvidersListOutput =
                   )
                 ])
               ),
+              isOverrideToolFilter: mtMap.objectField(
+                'is_override_tool_filter',
+                mtMap.passthrough()
+              ),
               provider: mtMap.objectField(
                 'provider',
                 mtMap.object({
@@ -331,120 +245,114 @@ export let mapDashboardInstanceIntegrationInstanceProvidersListOutput =
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
               ),
-              deployment: mtMap.objectField(
-                'deployment',
+              integrationProvider: mtMap.objectField(
+                'integration_provider',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
+                  providerVersion: mtMap.objectField(
+                    'provider_version',
                     mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      index: mtMap.objectField('index', mtMap.passthrough())
                     })
                   ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
                   status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
+                  toolFilter: mtMap.objectField(
+                    'tool_filter',
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          ignoreParentFilters: mtMap.objectField(
+                            'ignore_parent_filters',
+                            mtMap.passthrough()
+                          ),
+                          filters: mtMap.objectField(
+                            'filters',
+                            mtMap.array(
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    keys: mtMap.objectField(
+                                      'keys',
+                                      mtMap.array(mtMap.passthrough())
+                                    ),
+                                    pattern: mtMap.objectField(
+                                      'pattern',
+                                      mtMap.passthrough()
+                                    ),
+                                    uris: mtMap.objectField(
+                                      'uris',
+                                      mtMap.array(mtMap.passthrough())
+                                    )
+                                  })
+                                )
+                              ])
+                            )
+                          )
+                        })
+                      )
+                    ])
                   ),
                   providerId: mtMap.objectField(
                     'provider_id',
                     mtMap.passthrough()
                   ),
+                  deploymentId: mtMap.objectField(
+                    'deployment_id',
+                    mtMap.passthrough()
+                  ),
+                  authMethodId: mtMap.objectField(
+                    'auth_method_id',
+                    mtMap.passthrough()
+                  ),
+                  authCredentialsId: mtMap.objectField(
+                    'auth_credentials_id',
+                    mtMap.passthrough()
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
               ),
               config: mtMap.objectField(
@@ -470,49 +378,35 @@ export let mapDashboardInstanceIntegrationInstanceProvidersListOutput =
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
               ),
+              authConfig: mtMap.objectField(
+                'auth_config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
               archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-providers/set.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-providers/set.ts
@@ -61,65 +61,10 @@ export type DashboardInstanceIntegrationInstanceProvidersSetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -160,94 +105,71 @@ export type DashboardInstanceIntegrationInstanceProvidersSetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  integrationProvider: {
+    object: 'integration.provider#snapshot';
+    id: string;
+    providerVersion: {
+      object: 'integration.provider.version';
+      id: string;
+      index: number;
+    };
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  };
 };
 
 export let mapDashboardInstanceIntegrationInstanceProvidersSetOutput =
-  mtMap.object<DashboardInstanceIntegrationInstanceProvidersSetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    isOverrideToolFilter: mtMap.objectField(
-      'is_override_tool_filter',
-      mtMap.passthrough()
-    ),
-    provider: mtMap.objectField(
-      'provider',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    integrationProvider: mtMap.objectField(
-      'integration_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        providerVersion: mtMap.objectField(
-          'provider_version',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            index: mtMap.objectField('index', mtMap.passthrough())
-          })
-        ),
         status: mtMap.objectField('status', mtMap.passthrough()),
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        integrationInstanceId: mtMap.objectField(
+          'integration_instance_id',
+          mtMap.passthrough()
+        ),
         toolFilter: mtMap.objectField(
           'tool_filter',
           mtMap.union([
@@ -288,6 +210,10 @@ export let mapDashboardInstanceIntegrationInstanceProvidersSetOutput =
             )
           ])
         ),
+        isOverrideToolFilter: mtMap.objectField(
+          'is_override_tool_filter',
+          mtMap.passthrough()
+        ),
         provider: mtMap.objectField(
           'provider',
           mtMap.object({
@@ -300,90 +226,102 @@ export let mapDashboardInstanceIntegrationInstanceProvidersSetOutput =
             updatedAt: mtMap.objectField('updated_at', mtMap.date())
           })
         ),
-        deployment: mtMap.objectField(
-          'deployment',
+        integrationProvider: mtMap.objectField(
+          'integration_provider',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
+            providerVersion: mtMap.objectField(
+              'provider_version',
               mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                index: mtMap.objectField('index', mtMap.passthrough())
               })
             ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  )
-                })
-              )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
             status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
             ),
             providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            deploymentId: mtMap.objectField(
+              'deployment_id',
+              mtMap.passthrough()
+            ),
+            authMethodId: mtMap.objectField(
+              'auth_method_id',
+              mtMap.passthrough()
+            ),
+            authCredentialsId: mtMap.objectField(
+              'auth_credentials_id',
+              mtMap.passthrough()
+            ),
+            config: mtMap.objectField(
+              'config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
         ),
         config: mtMap.objectField(
@@ -400,43 +338,26 @@ export let mapDashboardInstanceIntegrationInstanceProvidersSetOutput =
             updatedAt: mtMap.objectField('updated_at', mtMap.date())
           })
         ),
+        authConfig: mtMap.objectField(
+          'auth_config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date()),
         archivedAt: mtMap.objectField('archived_at', mtMap.date())
       })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authConfig: mtMap.objectField(
-      'auth_config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+    )
+  ]);
 
 export type DashboardInstanceIntegrationInstanceProvidersSetBody = {
   providerDeploymentId?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/create.ts
@@ -72,71 +72,10 @@ export type DashboardInstanceIntegrationInstancesCreateOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -181,64 +120,302 @@ export type DashboardInstanceIntegrationInstancesCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.instance.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    provider: {
+      object: 'provider#preview';
+      id: string;
+      name: string;
+      description: string | null;
+      slug: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    authConfig: {
+      object: 'provider.auth_config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
 };
 
-export let mapDashboardInstanceIntegrationInstancesCreateOutput =
-  mtMap.object<DashboardInstanceIntegrationInstancesCreateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    identityActorId: mtMap.objectField(
-      'identity_actor_id',
-      mtMap.passthrough()
-    ),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpServerId: mtMap.objectField(
-          'magic_mcp_server_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapDashboardInstanceIntegrationInstancesCreateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpServerId: mtMap.objectField(
+            'magic_mcp_server_id',
             mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
+          )
+        })
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -247,312 +424,161 @@ export let mapDashboardInstanceIntegrationInstancesCreateOutput =
                               'type',
                               mtMap.passthrough()
                             ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
                               mtMap.passthrough()
                             ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
                             )
                           })
                         )
                       ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
-                        )
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type DashboardInstanceIntegrationInstancesCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/delete.ts
@@ -72,71 +72,10 @@ export type DashboardInstanceIntegrationInstancesDeleteOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -181,64 +120,302 @@ export type DashboardInstanceIntegrationInstancesDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.instance.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    provider: {
+      object: 'provider#preview';
+      id: string;
+      name: string;
+      description: string | null;
+      slug: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    authConfig: {
+      object: 'provider.auth_config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
 };
 
-export let mapDashboardInstanceIntegrationInstancesDeleteOutput =
-  mtMap.object<DashboardInstanceIntegrationInstancesDeleteOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    identityActorId: mtMap.objectField(
-      'identity_actor_id',
-      mtMap.passthrough()
-    ),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpServerId: mtMap.objectField(
-          'magic_mcp_server_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapDashboardInstanceIntegrationInstancesDeleteOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpServerId: mtMap.objectField(
+            'magic_mcp_server_id',
             mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
+          )
+        })
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -247,310 +424,159 @@ export let mapDashboardInstanceIntegrationInstancesDeleteOutput =
                               'type',
                               mtMap.passthrough()
                             ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
                               mtMap.passthrough()
                             ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
                             )
                           })
                         )
                       ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
-                        )
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/get.ts
@@ -72,71 +72,10 @@ export type DashboardInstanceIntegrationInstancesGetOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -181,64 +120,302 @@ export type DashboardInstanceIntegrationInstancesGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.instance.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    provider: {
+      object: 'provider#preview';
+      id: string;
+      name: string;
+      description: string | null;
+      slug: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    authConfig: {
+      object: 'provider.auth_config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
 };
 
-export let mapDashboardInstanceIntegrationInstancesGetOutput =
-  mtMap.object<DashboardInstanceIntegrationInstancesGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    identityActorId: mtMap.objectField(
-      'identity_actor_id',
-      mtMap.passthrough()
-    ),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpServerId: mtMap.objectField(
-          'magic_mcp_server_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapDashboardInstanceIntegrationInstancesGetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpServerId: mtMap.objectField(
+            'magic_mcp_server_id',
             mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
+          )
+        })
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -247,310 +424,159 @@ export let mapDashboardInstanceIntegrationInstancesGetOutput =
                               'type',
                               mtMap.passthrough()
                             ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
                               mtMap.passthrough()
                             ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
                             )
                           })
                         )
                       ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
-                        )
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceIntegrationInstancesListOutput = {
-  items: {
+  items: ({
     object: 'integration.instance';
     id: string;
     status: 'draft' | 'active' | 'archived' | 'deleted';
@@ -76,71 +76,10 @@ export type DashboardInstanceIntegrationInstancesListOutput = {
               ignoreParentFilters: boolean;
             }
           | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
         config: {
           object: 'provider.config#preview';
           id: string;
@@ -185,7 +124,161 @@ export type DashboardInstanceIntegrationInstancesListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
+  } & {
+    providers: ({
+      object: 'integration.instance.provider';
+      id: string;
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      integrationId: string;
+      integrationInstanceId: string;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      isOverrideToolFilter: boolean;
+      provider: {
+        object: 'provider#preview';
+        id: string;
+        name: string;
+        description: string | null;
+        slug: string;
+        createdAt: Date;
+        updatedAt: Date;
+      };
+      integrationProvider: {
+        object: 'integration.provider#snapshot';
+        id: string;
+        providerVersion: {
+          object: 'integration.provider.version';
+          id: string;
+          index: number;
+        };
+        status: 'active' | 'archived' | 'deleted';
+        name: string;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        toolFilter:
+          | { type: 'allow_all'; ignoreParentFilters: boolean }
+          | {
+              type: 'filter';
+              filters: (
+                | { type: 'tool_keys'; keys: string[] }
+                | { type: 'tool_regex'; pattern: string }
+                | { type: 'resource_regex'; pattern: string }
+                | { type: 'resource_uris'; uris: string[] }
+                | { type: 'prompt_keys'; keys: string[] }
+                | { type: 'prompt_regex'; pattern: string }
+              )[];
+              ignoreParentFilters: boolean;
+            }
+          | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
+        config: {
+          object: 'provider.config#preview';
+          id: string;
+          isDefault: boolean;
+          name: string | null;
+          description: string | null;
+          metadata: Record<string, any> | null;
+          providerId: string;
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+        createdAt: Date;
+        updatedAt: Date;
+        archivedAt: Date | null;
+      };
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      authConfig: {
+        object: 'provider.auth_config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    } & {
+      integrationProvider: {
+        object: 'integration.provider#snapshot';
+        id: string;
+        providerVersion: {
+          object: 'integration.provider.version';
+          id: string;
+          index: number;
+        };
+        status: 'active' | 'archived' | 'deleted';
+        name: string;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        toolFilter:
+          | { type: 'allow_all'; ignoreParentFilters: boolean }
+          | {
+              type: 'filter';
+              filters: (
+                | { type: 'tool_keys'; keys: string[] }
+                | { type: 'tool_regex'; pattern: string }
+                | { type: 'resource_regex'; pattern: string }
+                | { type: 'resource_uris'; uris: string[] }
+                | { type: 'prompt_keys'; keys: string[] }
+                | { type: 'prompt_regex'; pattern: string }
+              )[];
+              ignoreParentFilters: boolean;
+            }
+          | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
+        config: {
+          object: 'provider.config#preview';
+          id: string;
+          isDefault: boolean;
+          name: string | null;
+          description: string | null;
+          metadata: Record<string, any> | null;
+          providerId: string;
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+        createdAt: Date;
+        updatedAt: Date;
+        archivedAt: Date | null;
+      };
+    })[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -194,345 +287,54 @@ export let mapDashboardInstanceIntegrationInstancesListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          identityActorId: mtMap.objectField(
-            'identity_actor_id',
-            mtMap.passthrough()
-          ),
-          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-          implementation: mtMap.objectField(
-            'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
-              )
-            })
-          ),
-          providers: mtMap.objectField(
-            'providers',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              identityActorId: mtMap.objectField(
+                'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              implementation: mtMap.objectField(
+                'implementation',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  magicMcpServerId: mtMap.objectField(
+                    'magic_mcp_server_id',
+                    mtMap.passthrough()
+                  )
+                })
+              ),
+              providers: mtMap.objectField(
+                'providers',
+                mtMap.array(
                   mtMap.union([
                     mtMap.unionOption(
                       'object',
                       mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    provider: mtMap.objectField(
-                      'provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    deployment: mtMap.objectField(
-                      'deployment',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authMethod: mtMap.objectField(
-                      'auth_method',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        key: mtMap.objectField('key', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        capabilities: mtMap.objectField(
-                          'capabilities',
-                          mtMap.passthrough()
-                        ),
-                        inputSchema: mtMap.objectField(
-                          'input_schema',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            schema: mtMap.objectField(
-                              'schema',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        outputSchema: mtMap.objectField(
-                          'output_schema',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            schema: mtMap.objectField(
-                              'schema',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        scopes: mtMap.objectField(
-                          'scopes',
-                          mtMap.array(
-                            mtMap.object({
-                              object: mtMap.objectField(
-                                'object',
-                                mtMap.passthrough()
-                              ),
-                              id: mtMap.objectField('id', mtMap.passthrough()),
-                              scope: mtMap.objectField(
-                                'scope',
-                                mtMap.passthrough()
-                              ),
-                              name: mtMap.objectField(
-                                'name',
-                                mtMap.passthrough()
-                              ),
-                              description: mtMap.objectField(
-                                'description',
-                                mtMap.passthrough()
-                              )
-                            })
-                          )
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        providerSpecificationId: mtMap.objectField(
-                          'provider_specification_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authCredentials: mtMap.objectField(
-                      'auth_credentials',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        type: mtMap.objectField('type', mtMap.passthrough()),
                         status: mtMap.objectField(
                           'status',
                           mtMap.passthrough()
                         ),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        isManaged: mtMap.objectField(
-                          'is_managed',
-                          mtMap.passthrough()
-                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
@@ -542,120 +344,351 @@ export let mapDashboardInstanceIntegrationInstancesListOutput =
                           'metadata',
                           mtMap.passthrough()
                         ),
-                        scopes: mtMap.objectField(
-                          'scopes',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
+                        integrationId: mtMap.objectField(
+                          'integration_id',
                           mtMap.passthrough()
+                        ),
+                        integrationInstanceId: mtMap.objectField(
+                          'integration_instance_id',
+                          mtMap.passthrough()
+                        ),
+                        toolFilter: mtMap.objectField(
+                          'tool_filter',
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                ignoreParentFilters: mtMap.objectField(
+                                  'ignore_parent_filters',
+                                  mtMap.passthrough()
+                                ),
+                                filters: mtMap.objectField(
+                                  'filters',
+                                  mtMap.array(
+                                    mtMap.union([
+                                      mtMap.unionOption(
+                                        'object',
+                                        mtMap.object({
+                                          type: mtMap.objectField(
+                                            'type',
+                                            mtMap.passthrough()
+                                          ),
+                                          keys: mtMap.objectField(
+                                            'keys',
+                                            mtMap.array(mtMap.passthrough())
+                                          ),
+                                          pattern: mtMap.objectField(
+                                            'pattern',
+                                            mtMap.passthrough()
+                                          ),
+                                          uris: mtMap.objectField(
+                                            'uris',
+                                            mtMap.array(mtMap.passthrough())
+                                          )
+                                        })
+                                      )
+                                    ])
+                                  )
+                                )
+                              })
+                            )
+                          ])
+                        ),
+                        isOverrideToolFilter: mtMap.objectField(
+                          'is_override_tool_filter',
+                          mtMap.passthrough()
+                        ),
+                        provider: mtMap.objectField(
+                          'provider',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            slug: mtMap.objectField(
+                              'slug',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        integrationProvider: mtMap.objectField(
+                          'integration_provider',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            providerVersion: mtMap.objectField(
+                              'provider_version',
+                              mtMap.object({
+                                object: mtMap.objectField(
+                                  'object',
+                                  mtMap.passthrough()
+                                ),
+                                id: mtMap.objectField(
+                                  'id',
+                                  mtMap.passthrough()
+                                ),
+                                index: mtMap.objectField(
+                                  'index',
+                                  mtMap.passthrough()
+                                )
+                              })
+                            ),
+                            status: mtMap.objectField(
+                              'status',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            toolFilter: mtMap.objectField(
+                              'tool_filter',
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    ignoreParentFilters: mtMap.objectField(
+                                      'ignore_parent_filters',
+                                      mtMap.passthrough()
+                                    ),
+                                    filters: mtMap.objectField(
+                                      'filters',
+                                      mtMap.array(
+                                        mtMap.union([
+                                          mtMap.unionOption(
+                                            'object',
+                                            mtMap.object({
+                                              type: mtMap.objectField(
+                                                'type',
+                                                mtMap.passthrough()
+                                              ),
+                                              keys: mtMap.objectField(
+                                                'keys',
+                                                mtMap.array(mtMap.passthrough())
+                                              ),
+                                              pattern: mtMap.objectField(
+                                                'pattern',
+                                                mtMap.passthrough()
+                                              ),
+                                              uris: mtMap.objectField(
+                                                'uris',
+                                                mtMap.array(mtMap.passthrough())
+                                              )
+                                            })
+                                          )
+                                        ])
+                                      )
+                                    )
+                                  })
+                                )
+                              ])
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            deploymentId: mtMap.objectField(
+                              'deployment_id',
+                              mtMap.passthrough()
+                            ),
+                            authMethodId: mtMap.objectField(
+                              'auth_method_id',
+                              mtMap.passthrough()
+                            ),
+                            authCredentialsId: mtMap.objectField(
+                              'auth_credentials_id',
+                              mtMap.passthrough()
+                            ),
+                            config: mtMap.objectField(
+                              'config',
+                              mtMap.object({
+                                object: mtMap.objectField(
+                                  'object',
+                                  mtMap.passthrough()
+                                ),
+                                id: mtMap.objectField(
+                                  'id',
+                                  mtMap.passthrough()
+                                ),
+                                isDefault: mtMap.objectField(
+                                  'is_default',
+                                  mtMap.passthrough()
+                                ),
+                                name: mtMap.objectField(
+                                  'name',
+                                  mtMap.passthrough()
+                                ),
+                                description: mtMap.objectField(
+                                  'description',
+                                  mtMap.passthrough()
+                                ),
+                                metadata: mtMap.objectField(
+                                  'metadata',
+                                  mtMap.passthrough()
+                                ),
+                                providerId: mtMap.objectField(
+                                  'provider_id',
+                                  mtMap.passthrough()
+                                ),
+                                createdAt: mtMap.objectField(
+                                  'created_at',
+                                  mtMap.date()
+                                ),
+                                updatedAt: mtMap.objectField(
+                                  'updated_at',
+                                  mtMap.date()
+                                )
+                              })
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            ),
+                            archivedAt: mtMap.objectField(
+                              'archived_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        config: mtMap.objectField(
+                          'config',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        authConfig: mtMap.objectField(
+                          'auth_config',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',
                           mtMap.date()
                         ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
+                        updatedAt: mtMap.objectField(
+                          'updated_at',
                           mtMap.date()
                         ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                        archivedAt: mtMap.objectField(
+                          'archived_at',
+                          mtMap.date()
+                        )
                       })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+                    )
+                  ])
+                )
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/update.ts
@@ -72,71 +72,10 @@ export type DashboardInstanceIntegrationInstancesUpdateOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -181,64 +120,302 @@ export type DashboardInstanceIntegrationInstancesUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.instance.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    provider: {
+      object: 'provider#preview';
+      id: string;
+      name: string;
+      description: string | null;
+      slug: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    authConfig: {
+      object: 'provider.auth_config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
 };
 
-export let mapDashboardInstanceIntegrationInstancesUpdateOutput =
-  mtMap.object<DashboardInstanceIntegrationInstancesUpdateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    identityActorId: mtMap.objectField(
-      'identity_actor_id',
-      mtMap.passthrough()
-    ),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpServerId: mtMap.objectField(
-          'magic_mcp_server_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapDashboardInstanceIntegrationInstancesUpdateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpServerId: mtMap.objectField(
+            'magic_mcp_server_id',
             mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
+          )
+        })
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -247,312 +424,161 @@ export let mapDashboardInstanceIntegrationInstancesUpdateOutput =
                               'type',
                               mtMap.passthrough()
                             ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
                               mtMap.passthrough()
                             ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
                             )
                           })
                         )
                       ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
-                        )
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type DashboardInstanceIntegrationInstancesUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/create.ts
@@ -23,6 +23,47 @@ export type DashboardInstanceIntegrationProvidersCreateOutput = {
         ignoreParentFilters: boolean;
       }
     | null;
+  providerId: string;
+  deploymentId: string;
+  authMethodId: string | null;
+  authCredentialsId: string | null;
+  config: {
+    object: 'provider.config#preview';
+    id: string;
+    isDefault: boolean;
+    name: string | null;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    providerId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  object: 'integration.provider';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  integrationId: string;
+  name: string;
+  description: string | null;
+  metadata: Record<string, any> | null;
+  toolFilter:
+    | { type: 'allow_all'; ignoreParentFilters: boolean }
+    | {
+        type: 'filter';
+        filters: (
+          | { type: 'tool_keys'; keys: string[] }
+          | { type: 'tool_regex'; pattern: string }
+          | { type: 'resource_regex'; pattern: string }
+          | { type: 'resource_uris'; uris: string[] }
+          | { type: 'prompt_keys'; keys: string[] }
+          | { type: 'prompt_regex'; pattern: string }
+        )[];
+        ignoreParentFilters: boolean;
+      }
+    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -82,178 +123,178 @@ export type DashboardInstanceIntegrationProvidersCreateOutput = {
     createdAt: Date;
     updatedAt: Date;
   } | null;
-  config: {
-    object: 'provider.config#preview';
-    id: string;
-    isDefault: boolean;
-    name: string | null;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    providerId: string;
-    createdAt: Date;
-    updatedAt: Date;
-  } | null;
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapDashboardInstanceIntegrationProvidersCreateOutput =
-  mtMap.object<DashboardInstanceIntegrationProvidersCreateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    deployment: mtMap.objectField(
-      'deployment',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authMethod: mtMap.objectField(
-      'auth_method',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        key: mtMap.objectField('key', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-        inputSchema: mtMap.objectField(
-          'input_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        outputSchema: mtMap.objectField(
-          'output_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        scopes: mtMap.objectField(
-          'scopes',
-          mtMap.array(
+export let mapDashboardInstanceIntegrationProvidersCreateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              scope: mtMap.objectField('scope', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField('description', mtMap.passthrough())
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
             })
           )
-        ),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        providerSpecificationId: mtMap.objectField(
-          'provider_specification_id',
-          mtMap.passthrough()
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authCredentials: mtMap.objectField(
-      'auth_credentials',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+        ])
+      ),
+      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+      authCredentialsId: mtMap.objectField(
+        'auth_credentials_id',
+        mtMap.passthrough()
+      ),
+      config: mtMap.objectField(
+        'config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      deployment: mtMap.objectField(
+        'deployment',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authMethod: mtMap.objectField(
+        'auth_method',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          key: mtMap.objectField('key', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+          inputSchema: mtMap.objectField(
+            'input_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          outputSchema: mtMap.objectField(
+            'output_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          scopes: mtMap.objectField(
+            'scopes',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                scope: mtMap.objectField('scope', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                )
+              })
+            )
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          providerSpecificationId: mtMap.objectField(
+            'provider_specification_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authCredentials: mtMap.objectField(
+        'auth_credentials',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 
 export type DashboardInstanceIntegrationProvidersCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/delete.ts
@@ -23,6 +23,47 @@ export type DashboardInstanceIntegrationProvidersDeleteOutput = {
         ignoreParentFilters: boolean;
       }
     | null;
+  providerId: string;
+  deploymentId: string;
+  authMethodId: string | null;
+  authCredentialsId: string | null;
+  config: {
+    object: 'provider.config#preview';
+    id: string;
+    isDefault: boolean;
+    name: string | null;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    providerId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  object: 'integration.provider';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  integrationId: string;
+  name: string;
+  description: string | null;
+  metadata: Record<string, any> | null;
+  toolFilter:
+    | { type: 'allow_all'; ignoreParentFilters: boolean }
+    | {
+        type: 'filter';
+        filters: (
+          | { type: 'tool_keys'; keys: string[] }
+          | { type: 'tool_regex'; pattern: string }
+          | { type: 'resource_regex'; pattern: string }
+          | { type: 'resource_uris'; uris: string[] }
+          | { type: 'prompt_keys'; keys: string[] }
+          | { type: 'prompt_regex'; pattern: string }
+        )[];
+        ignoreParentFilters: boolean;
+      }
+    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -82,176 +123,176 @@ export type DashboardInstanceIntegrationProvidersDeleteOutput = {
     createdAt: Date;
     updatedAt: Date;
   } | null;
-  config: {
-    object: 'provider.config#preview';
-    id: string;
-    isDefault: boolean;
-    name: string | null;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    providerId: string;
-    createdAt: Date;
-    updatedAt: Date;
-  } | null;
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapDashboardInstanceIntegrationProvidersDeleteOutput =
-  mtMap.object<DashboardInstanceIntegrationProvidersDeleteOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    deployment: mtMap.objectField(
-      'deployment',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authMethod: mtMap.objectField(
-      'auth_method',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        key: mtMap.objectField('key', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-        inputSchema: mtMap.objectField(
-          'input_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        outputSchema: mtMap.objectField(
-          'output_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        scopes: mtMap.objectField(
-          'scopes',
-          mtMap.array(
+export let mapDashboardInstanceIntegrationProvidersDeleteOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              scope: mtMap.objectField('scope', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField('description', mtMap.passthrough())
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
             })
           )
-        ),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        providerSpecificationId: mtMap.objectField(
-          'provider_specification_id',
-          mtMap.passthrough()
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authCredentials: mtMap.objectField(
-      'auth_credentials',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+        ])
+      ),
+      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+      authCredentialsId: mtMap.objectField(
+        'auth_credentials_id',
+        mtMap.passthrough()
+      ),
+      config: mtMap.objectField(
+        'config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      deployment: mtMap.objectField(
+        'deployment',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authMethod: mtMap.objectField(
+        'auth_method',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          key: mtMap.objectField('key', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+          inputSchema: mtMap.objectField(
+            'input_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          outputSchema: mtMap.objectField(
+            'output_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          scopes: mtMap.objectField(
+            'scopes',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                scope: mtMap.objectField('scope', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                )
+              })
+            )
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          providerSpecificationId: mtMap.objectField(
+            'provider_specification_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authCredentials: mtMap.objectField(
+        'auth_credentials',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/get.ts
@@ -23,6 +23,47 @@ export type DashboardInstanceIntegrationProvidersGetOutput = {
         ignoreParentFilters: boolean;
       }
     | null;
+  providerId: string;
+  deploymentId: string;
+  authMethodId: string | null;
+  authCredentialsId: string | null;
+  config: {
+    object: 'provider.config#preview';
+    id: string;
+    isDefault: boolean;
+    name: string | null;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    providerId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  object: 'integration.provider';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  integrationId: string;
+  name: string;
+  description: string | null;
+  metadata: Record<string, any> | null;
+  toolFilter:
+    | { type: 'allow_all'; ignoreParentFilters: boolean }
+    | {
+        type: 'filter';
+        filters: (
+          | { type: 'tool_keys'; keys: string[] }
+          | { type: 'tool_regex'; pattern: string }
+          | { type: 'resource_regex'; pattern: string }
+          | { type: 'resource_uris'; uris: string[] }
+          | { type: 'prompt_keys'; keys: string[] }
+          | { type: 'prompt_regex'; pattern: string }
+        )[];
+        ignoreParentFilters: boolean;
+      }
+    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -82,176 +123,176 @@ export type DashboardInstanceIntegrationProvidersGetOutput = {
     createdAt: Date;
     updatedAt: Date;
   } | null;
-  config: {
-    object: 'provider.config#preview';
-    id: string;
-    isDefault: boolean;
-    name: string | null;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    providerId: string;
-    createdAt: Date;
-    updatedAt: Date;
-  } | null;
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapDashboardInstanceIntegrationProvidersGetOutput =
-  mtMap.object<DashboardInstanceIntegrationProvidersGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    deployment: mtMap.objectField(
-      'deployment',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authMethod: mtMap.objectField(
-      'auth_method',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        key: mtMap.objectField('key', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-        inputSchema: mtMap.objectField(
-          'input_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        outputSchema: mtMap.objectField(
-          'output_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        scopes: mtMap.objectField(
-          'scopes',
-          mtMap.array(
+export let mapDashboardInstanceIntegrationProvidersGetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              scope: mtMap.objectField('scope', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField('description', mtMap.passthrough())
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
             })
           )
-        ),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        providerSpecificationId: mtMap.objectField(
-          'provider_specification_id',
-          mtMap.passthrough()
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authCredentials: mtMap.objectField(
-      'auth_credentials',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+        ])
+      ),
+      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+      authCredentialsId: mtMap.objectField(
+        'auth_credentials_id',
+        mtMap.passthrough()
+      ),
+      config: mtMap.objectField(
+        'config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      deployment: mtMap.objectField(
+        'deployment',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authMethod: mtMap.objectField(
+        'auth_method',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          key: mtMap.objectField('key', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+          inputSchema: mtMap.objectField(
+            'input_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          outputSchema: mtMap.objectField(
+            'output_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          scopes: mtMap.objectField(
+            'scopes',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                scope: mtMap.objectField('scope', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                )
+              })
+            )
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          providerSpecificationId: mtMap.objectField(
+            'provider_specification_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authCredentials: mtMap.objectField(
+        'auth_credentials',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/list.ts
@@ -1,7 +1,48 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceIntegrationProvidersListOutput = {
-  items: {
+  items: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
     object: 'integration.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -83,21 +124,7 @@ export type DashboardInstanceIntegrationProvidersListOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -106,191 +133,239 @@ export let mapDashboardInstanceIntegrationProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
                 mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
                     mtMap.passthrough()
                   ),
-                  filters: mtMap.objectField(
-                    'filters',
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+              provider: mtMap.objectField(
+                'provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              deployment: mtMap.objectField(
+                'deployment',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              authMethod: mtMap.objectField(
+                'auth_method',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  key: mtMap.objectField('key', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  capabilities: mtMap.objectField(
+                    'capabilities',
+                    mtMap.passthrough()
+                  ),
+                  inputSchema: mtMap.objectField(
+                    'input_schema',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      schema: mtMap.objectField('schema', mtMap.passthrough())
+                    })
+                  ),
+                  outputSchema: mtMap.objectField(
+                    'output_schema',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      schema: mtMap.objectField('schema', mtMap.passthrough())
+                    })
+                  ),
+                  scopes: mtMap.objectField(
+                    'scopes',
                     mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
+                      mtMap.object({
+                        object: mtMap.objectField(
                           'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
                         )
-                      ])
+                      })
                     )
-                  )
+                  ),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  providerSpecificationId: mtMap.objectField(
+                    'provider_specification_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              authCredentials: mtMap.objectField(
+                'auth_credentials',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  isManaged: mtMap.objectField(
+                    'is_managed',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  scopes: mtMap.objectField(
+                    'scopes',
+                    mtMap.array(mtMap.passthrough())
+                  ),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
               )
-            ])
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              capabilities: mtMap.objectField(
-                'capabilities',
-                mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    )
-                  })
-                )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/update.ts
@@ -23,6 +23,47 @@ export type DashboardInstanceIntegrationProvidersUpdateOutput = {
         ignoreParentFilters: boolean;
       }
     | null;
+  providerId: string;
+  deploymentId: string;
+  authMethodId: string | null;
+  authCredentialsId: string | null;
+  config: {
+    object: 'provider.config#preview';
+    id: string;
+    isDefault: boolean;
+    name: string | null;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    providerId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  object: 'integration.provider';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  integrationId: string;
+  name: string;
+  description: string | null;
+  metadata: Record<string, any> | null;
+  toolFilter:
+    | { type: 'allow_all'; ignoreParentFilters: boolean }
+    | {
+        type: 'filter';
+        filters: (
+          | { type: 'tool_keys'; keys: string[] }
+          | { type: 'tool_regex'; pattern: string }
+          | { type: 'resource_regex'; pattern: string }
+          | { type: 'resource_uris'; uris: string[] }
+          | { type: 'prompt_keys'; keys: string[] }
+          | { type: 'prompt_regex'; pattern: string }
+        )[];
+        ignoreParentFilters: boolean;
+      }
+    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -82,178 +123,178 @@ export type DashboardInstanceIntegrationProvidersUpdateOutput = {
     createdAt: Date;
     updatedAt: Date;
   } | null;
-  config: {
-    object: 'provider.config#preview';
-    id: string;
-    isDefault: boolean;
-    name: string | null;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    providerId: string;
-    createdAt: Date;
-    updatedAt: Date;
-  } | null;
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapDashboardInstanceIntegrationProvidersUpdateOutput =
-  mtMap.object<DashboardInstanceIntegrationProvidersUpdateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    deployment: mtMap.objectField(
-      'deployment',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authMethod: mtMap.objectField(
-      'auth_method',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        key: mtMap.objectField('key', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-        inputSchema: mtMap.objectField(
-          'input_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        outputSchema: mtMap.objectField(
-          'output_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        scopes: mtMap.objectField(
-          'scopes',
-          mtMap.array(
+export let mapDashboardInstanceIntegrationProvidersUpdateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              scope: mtMap.objectField('scope', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField('description', mtMap.passthrough())
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
             })
           )
-        ),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        providerSpecificationId: mtMap.objectField(
-          'provider_specification_id',
-          mtMap.passthrough()
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authCredentials: mtMap.objectField(
-      'auth_credentials',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+        ])
+      ),
+      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+      authCredentialsId: mtMap.objectField(
+        'auth_credentials_id',
+        mtMap.passthrough()
+      ),
+      config: mtMap.objectField(
+        'config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      deployment: mtMap.objectField(
+        'deployment',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authMethod: mtMap.objectField(
+        'auth_method',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          key: mtMap.objectField('key', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+          inputSchema: mtMap.objectField(
+            'input_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          outputSchema: mtMap.objectField(
+            'output_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          scopes: mtMap.objectField(
+            'scopes',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                scope: mtMap.objectField('scope', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                )
+              })
+            )
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          providerSpecificationId: mtMap.objectField(
+            'provider_specification_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authCredentials: mtMap.objectField(
+        'auth_credentials',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 
 export type DashboardInstanceIntegrationProvidersUpdateBody = {
   providerDeploymentId?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-setup-sessions/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-setup-sessions/create.ts
@@ -11,7 +11,6 @@ export type DashboardInstanceIntegrationSetupSessionsCreateOutput = {
   configuration: Record<string, any> | null;
   redirectUrl: string | null;
   integrationId: string;
-  integrationInstanceId: string;
   integrationInstance: {
     object: 'integration.instance';
     id: string;
@@ -87,71 +86,10 @@ export type DashboardInstanceIntegrationSetupSessionsCreateOutput = {
               ignoreParentFilters: boolean;
             }
           | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
         config: {
           object: 'provider.config#preview';
           id: string;
@@ -197,6 +135,11 @@ export type DashboardInstanceIntegrationSetupSessionsCreateOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
+  createdAt: Date;
+  updatedAt: Date;
+  expiresAt: Date;
+} & {
+  integrationInstanceId: string;
   steps: {
     object: 'integration.setup_session.step';
     id: string;
@@ -224,148 +167,57 @@ export type DashboardInstanceIntegrationSetupSessionsCreateOutput = {
     createdAt: Date;
     updatedAt: Date;
   }[];
-  createdAt: Date;
-  updatedAt: Date;
-  expiresAt: Date;
 };
 
 export let mapDashboardInstanceIntegrationSetupSessionsCreateOutput =
-  mtMap.object<DashboardInstanceIntegrationSetupSessionsCreateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    url: mtMap.objectField('url', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField('configuration', mtMap.passthrough()),
-    redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    integrationInstance: mtMap.objectField(
-      'integration_instance',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
         status: mtMap.objectField('status', mtMap.passthrough()),
+        url: mtMap.objectField('url', mtMap.passthrough()),
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        configuration: mtMap.objectField('configuration', mtMap.passthrough()),
+        redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        identityActorId: mtMap.objectField(
-          'identity_actor_id',
-          mtMap.passthrough()
-        ),
-        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-        implementation: mtMap.objectField(
-          'implementation',
+        integrationInstance: mtMap.objectField(
+          'integration_instance',
           mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            integrationId: mtMap.objectField(
+              'integration_id',
               mtMap.passthrough()
-            )
-          })
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              provider: mtMap.objectField(
-                'provider',
+            ),
+            identityActorId: mtMap.objectField(
+              'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            implementation: mtMap.objectField(
+              'implementation',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                magicMcpServerId: mtMap.objectField(
+                  'magic_mcp_server_id',
+                  mtMap.passthrough()
+                )
+              })
+            ),
+            providers: mtMap.objectField(
+              'providers',
+              mtMap.array(
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
                   status: mtMap.objectField('status', mtMap.passthrough()),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
@@ -373,6 +225,14 @@ export let mapDashboardInstanceIntegrationSetupSessionsCreateOutput =
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  integrationId: mtMap.objectField(
+                    'integration_id',
+                    mtMap.passthrough()
+                  ),
+                  integrationInstanceId: mtMap.objectField(
+                    'integration_instance_id',
+                    mtMap.passthrough()
+                  ),
                   toolFilter: mtMap.objectField(
                     'tool_filter',
                     mtMap.union([
@@ -416,6 +276,10 @@ export let mapDashboardInstanceIntegrationSetupSessionsCreateOutput =
                       )
                     ])
                   ),
+                  isOverrideToolFilter: mtMap.objectField(
+                    'is_override_tool_filter',
+                    mtMap.passthrough()
+                  ),
                   provider: mtMap.objectField(
                     'provider',
                     mtMap.object({
@@ -431,119 +295,23 @@ export let mapDashboardInstanceIntegrationSetupSessionsCreateOutput =
                       updatedAt: mtMap.objectField('updated_at', mtMap.date())
                     })
                   ),
-                  deployment: mtMap.objectField(
-                    'deployment',
+                  integrationProvider: mtMap.objectField(
+                    'integration_provider',
                     mtMap.object({
                       object: mtMap.objectField('object', mtMap.passthrough()),
                       id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
+                      providerVersion: mtMap.objectField(
+                        'provider_version',
                         mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
+                          object: mtMap.objectField(
+                            'object',
                             mtMap.passthrough()
-                          )
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          index: mtMap.objectField('index', mtMap.passthrough())
                         })
                       ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
                       status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
                       name: mtMap.objectField('name', mtMap.passthrough()),
                       description: mtMap.objectField(
                         'description',
@@ -553,16 +321,106 @@ export let mapDashboardInstanceIntegrationSetupSessionsCreateOutput =
                         'metadata',
                         mtMap.passthrough()
                       ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
+                      toolFilter: mtMap.objectField(
+                        'tool_filter',
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              ignoreParentFilters: mtMap.objectField(
+                                'ignore_parent_filters',
+                                mtMap.passthrough()
+                              ),
+                              filters: mtMap.objectField(
+                                'filters',
+                                mtMap.array(
+                                  mtMap.union([
+                                    mtMap.unionOption(
+                                      'object',
+                                      mtMap.object({
+                                        type: mtMap.objectField(
+                                          'type',
+                                          mtMap.passthrough()
+                                        ),
+                                        keys: mtMap.objectField(
+                                          'keys',
+                                          mtMap.array(mtMap.passthrough())
+                                        ),
+                                        pattern: mtMap.objectField(
+                                          'pattern',
+                                          mtMap.passthrough()
+                                        ),
+                                        uris: mtMap.objectField(
+                                          'uris',
+                                          mtMap.array(mtMap.passthrough())
+                                        )
+                                      })
+                                    )
+                                  ])
+                                )
+                              )
+                            })
+                          )
+                        ])
                       ),
                       providerId: mtMap.objectField(
                         'provider_id',
                         mtMap.passthrough()
                       ),
+                      deploymentId: mtMap.objectField(
+                        'deployment_id',
+                        mtMap.passthrough()
+                      ),
+                      authMethodId: mtMap.objectField(
+                        'auth_method_id',
+                        mtMap.passthrough()
+                      ),
+                      authCredentialsId: mtMap.objectField(
+                        'auth_credentials_id',
+                        mtMap.passthrough()
+                      ),
+                      config: mtMap.objectField(
+                        'config',
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          isDefault: mtMap.objectField(
+                            'is_default',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          ),
+                          metadata: mtMap.objectField(
+                            'metadata',
+                            mtMap.passthrough()
+                          ),
+                          providerId: mtMap.objectField(
+                            'provider_id',
+                            mtMap.passthrough()
+                          ),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
+                      ),
                       createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                      archivedAt: mtMap.objectField('archived_at', mtMap.date())
                     })
                   ),
                   config: mtMap.objectField(
@@ -591,112 +449,93 @@ export let mapDashboardInstanceIntegrationSetupSessionsCreateOutput =
                       updatedAt: mtMap.objectField('updated_at', mtMap.date())
                     })
                   ),
+                  authConfig: mtMap.objectField(
+                    'auth_config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
                   updatedAt: mtMap.objectField('updated_at', mtMap.date()),
                   archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
+              )
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          })
         ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    steps: mtMap.objectField(
-      'steps',
-      mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          url: mtMap.objectField('url', mtMap.passthrough()),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
+        expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+        integrationInstanceId: mtMap.objectField(
+          'integration_instance_id',
+          mtMap.passthrough()
+        ),
+        steps: mtMap.objectField(
+          'steps',
+          mtMap.array(
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              url: mtMap.objectField('url', mtMap.passthrough()),
+              integrationProviderId: mtMap.objectField(
+                'integration_provider_id',
                 mtMap.passthrough()
               ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              provider: mtMap.objectField(
+                'provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              providerSetupSessionId: mtMap.objectField(
+                'provider_setup_session_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceProviderId: mtMap.objectField(
+                'integration_instance_provider_id',
+                mtMap.passthrough()
+              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          ),
-          providerSetupSessionId: mtMap.objectField(
-            'provider_setup_session_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceProviderId: mtMap.objectField(
-            'integration_instance_provider_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    expiresAt: mtMap.objectField('expires_at', mtMap.date())
-  });
+          )
+        )
+      })
+    )
+  ]);
 
 export type DashboardInstanceIntegrationSetupSessionsCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-setup-sessions/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-setup-sessions/get.ts
@@ -11,7 +11,6 @@ export type DashboardInstanceIntegrationSetupSessionsGetOutput = {
   configuration: Record<string, any> | null;
   redirectUrl: string | null;
   integrationId: string;
-  integrationInstanceId: string;
   integrationInstance: {
     object: 'integration.instance';
     id: string;
@@ -87,71 +86,10 @@ export type DashboardInstanceIntegrationSetupSessionsGetOutput = {
               ignoreParentFilters: boolean;
             }
           | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
         config: {
           object: 'provider.config#preview';
           id: string;
@@ -197,6 +135,11 @@ export type DashboardInstanceIntegrationSetupSessionsGetOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
+  createdAt: Date;
+  updatedAt: Date;
+  expiresAt: Date;
+} & {
+  integrationInstanceId: string;
   steps: {
     object: 'integration.setup_session.step';
     id: string;
@@ -224,477 +167,369 @@ export type DashboardInstanceIntegrationSetupSessionsGetOutput = {
     createdAt: Date;
     updatedAt: Date;
   }[];
-  createdAt: Date;
-  updatedAt: Date;
-  expiresAt: Date;
 };
 
-export let mapDashboardInstanceIntegrationSetupSessionsGetOutput =
-  mtMap.object<DashboardInstanceIntegrationSetupSessionsGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    url: mtMap.objectField('url', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField('configuration', mtMap.passthrough()),
-    redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    integrationInstance: mtMap.objectField(
-      'integration_instance',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        identityActorId: mtMap.objectField(
-          'identity_actor_id',
-          mtMap.passthrough()
-        ),
-        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-        implementation: mtMap.objectField(
-          'implementation',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
-              mtMap.passthrough()
-            )
-          })
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    steps: mtMap.objectField(
-      'steps',
-      mtMap.array(
+export let mapDashboardInstanceIntegrationSetupSessionsGetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      url: mtMap.objectField('url', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField('configuration', mtMap.passthrough()),
+      redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstance: mtMap.objectField(
+        'integration_instance',
         mtMap.object({
           object: mtMap.objectField('object', mtMap.passthrough()),
           id: mtMap.objectField('id', mtMap.passthrough()),
           status: mtMap.objectField('status', mtMap.passthrough()),
-          url: mtMap.objectField('url', mtMap.passthrough()),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
           ),
-          provider: mtMap.objectField(
-            'provider',
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          implementation: mtMap.objectField(
+            'implementation',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              )
             })
           ),
-          providerSetupSessionId: mtMap.objectField(
-            'provider_setup_session_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceProviderId: mtMap.objectField(
-            'integration_instance_provider_id',
-            mtMap.passthrough()
+          providers: mtMap.objectField(
+            'providers',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
+                              mtMap.passthrough()
+                            ),
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
+                            )
+                          })
+                        )
+                      ])
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
           ),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
         })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      steps: mtMap.objectField(
+        'steps',
+        mtMap.array(
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            url: mtMap.objectField('url', mtMap.passthrough()),
+            integrationProviderId: mtMap.objectField(
+              'integration_provider_id',
+              mtMap.passthrough()
+            ),
+            provider: mtMap.objectField(
+              'provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                slug: mtMap.objectField('slug', mtMap.passthrough()),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            providerSetupSessionId: mtMap.objectField(
+              'provider_setup_session_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceProviderId: mtMap.objectField(
+              'integration_instance_provider_id',
+              mtMap.passthrough()
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        )
       )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    expiresAt: mtMap.objectField('expires_at', mtMap.date())
-  });
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-setup-sessions/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-setup-sessions/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceIntegrationSetupSessionsListOutput = {
-  items: {
+  items: ({
     object: 'integration.setup_session';
     id: string;
     status: 'pending' | 'successful' | 'expired' | 'archived' | 'deleted';
@@ -12,7 +12,6 @@ export type DashboardInstanceIntegrationSetupSessionsListOutput = {
     configuration: Record<string, any> | null;
     redirectUrl: string | null;
     integrationId: string;
-    integrationInstanceId: string;
     integrationInstance: {
       object: 'integration.instance';
       id: string;
@@ -88,71 +87,10 @@ export type DashboardInstanceIntegrationSetupSessionsListOutput = {
                 ignoreParentFilters: boolean;
               }
             | null;
-          provider: {
-            object: 'provider#preview';
-            id: string;
-            name: string;
-            description: string | null;
-            slug: string;
-            createdAt: Date;
-            updatedAt: Date;
-          };
-          deployment: {
-            object: 'provider.deployment#preview';
-            id: string;
-            isDefault: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          };
-          authMethod: {
-            object: 'provider.capabilities.auth_method';
-            id: string;
-            type: 'oauth' | 'token' | 'custom';
-            key: string;
-            name: string;
-            description: string | null;
-            capabilities: Record<string, any>;
-            inputSchema: {
-              type: 'json_schema';
-              schema: Record<string, any>;
-            } | null;
-            outputSchema: {
-              type: 'json_schema';
-              schema: Record<string, any>;
-            } | null;
-            scopes:
-              | {
-                  object: 'provider.capabilities.auth_method.scope';
-                  id: string;
-                  scope: string;
-                  name: string;
-                  description: string | null;
-                }[]
-              | null;
-            providerId: string;
-            providerSpecificationId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
-          authCredentials: {
-            object: 'provider.auth_credentials';
-            id: string;
-            type: 'oauth';
-            status: 'active' | 'archived' | 'deleted';
-            isDefault: boolean;
-            isManaged: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            scopes: string[] | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
+          providerId: string;
+          deploymentId: string;
+          authMethodId: string | null;
+          authCredentialsId: string | null;
           config: {
             object: 'provider.config#preview';
             id: string;
@@ -198,6 +136,11 @@ export type DashboardInstanceIntegrationSetupSessionsListOutput = {
       updatedAt: Date;
       archivedAt: Date | null;
     };
+    createdAt: Date;
+    updatedAt: Date;
+    expiresAt: Date;
+  } & {
+    integrationInstanceId: string;
     steps: {
       object: 'integration.setup_session.step';
       id: string;
@@ -225,10 +168,7 @@ export type DashboardInstanceIntegrationSetupSessionsListOutput = {
       createdAt: Date;
       updatedAt: Date;
     }[];
-    createdAt: Date;
-    updatedAt: Date;
-    expiresAt: Date;
-  }[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -237,175 +177,75 @@ export let mapDashboardInstanceIntegrationSetupSessionsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          url: mtMap.objectField('url', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          configuration: mtMap.objectField(
-            'configuration',
-            mtMap.passthrough()
-          ),
-          redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationInstance: mtMap.objectField(
-            'integration_instance',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
               status: mtMap.objectField('status', mtMap.passthrough()),
+              url: mtMap.objectField('url', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
                 'description',
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              configuration: mtMap.objectField(
+                'configuration',
+                mtMap.passthrough()
+              ),
+              redirectUrl: mtMap.objectField(
+                'redirect_url',
+                mtMap.passthrough()
+              ),
               integrationId: mtMap.objectField(
                 'integration_id',
                 mtMap.passthrough()
               ),
-              identityActorId: mtMap.objectField(
-                'identity_actor_id',
-                mtMap.passthrough()
-              ),
-              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-              implementation: mtMap.objectField(
-                'implementation',
+              integrationInstance: mtMap.objectField(
+                'integration_instance',
                 mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  magicMcpServerId: mtMap.objectField(
-                    'magic_mcp_server_id',
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
                     mtMap.passthrough()
-                  )
-                })
-              ),
-              providers: mtMap.objectField(
-                'providers',
-                mtMap.array(
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    integrationId: mtMap.objectField(
-                      'integration_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationInstanceId: mtMap.objectField(
-                      'integration_instance_id',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    isOverrideToolFilter: mtMap.objectField(
-                      'is_override_tool_filter',
-                      mtMap.passthrough()
-                    ),
-                    provider: mtMap.objectField(
-                      'provider',
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  integrationId: mtMap.objectField(
+                    'integration_id',
+                    mtMap.passthrough()
+                  ),
+                  identityActorId: mtMap.objectField(
+                    'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  implementation: mtMap.objectField(
+                    'implementation',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      magicMcpServerId: mtMap.objectField(
+                        'magic_mcp_server_id',
+                        mtMap.passthrough()
+                      )
+                    })
+                  ),
+                  providers: mtMap.objectField(
+                    'providers',
+                    mtMap.array(
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    integrationProvider: mtMap.objectField(
-                      'integration_provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        providerVersion: mtMap.objectField(
-                          'provider_version',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            index: mtMap.objectField(
-                              'index',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
                         status: mtMap.objectField(
                           'status',
                           mtMap.passthrough()
@@ -417,6 +257,14 @@ export let mapDashboardInstanceIntegrationSetupSessionsListOutput =
                         ),
                         metadata: mtMap.objectField(
                           'metadata',
+                          mtMap.passthrough()
+                        ),
+                        integrationId: mtMap.objectField(
+                          'integration_id',
+                          mtMap.passthrough()
+                        ),
+                        integrationInstanceId: mtMap.objectField(
+                          'integration_instance_id',
                           mtMap.passthrough()
                         ),
                         toolFilter: mtMap.objectField(
@@ -465,6 +313,10 @@ export let mapDashboardInstanceIntegrationSetupSessionsListOutput =
                             )
                           ])
                         ),
+                        isOverrideToolFilter: mtMap.objectField(
+                          'is_override_tool_filter',
+                          mtMap.passthrough()
+                        ),
                         provider: mtMap.objectField(
                           'provider',
                           mtMap.object({
@@ -495,164 +347,35 @@ export let mapDashboardInstanceIntegrationSetupSessionsListOutput =
                             )
                           })
                         ),
-                        deployment: mtMap.objectField(
-                          'deployment',
+                        integrationProvider: mtMap.objectField(
+                          'integration_provider',
                           mtMap.object({
                             object: mtMap.objectField(
                               'object',
                               mtMap.passthrough()
                             ),
                             id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authMethod: mtMap.objectField(
-                          'auth_method',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            key: mtMap.objectField('key', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            capabilities: mtMap.objectField(
-                              'capabilities',
-                              mtMap.passthrough()
-                            ),
-                            inputSchema: mtMap.objectField(
-                              'input_schema',
+                            providerVersion: mtMap.objectField(
+                              'provider_version',
                               mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
+                                object: mtMap.objectField(
+                                  'object',
                                   mtMap.passthrough()
                                 ),
-                                schema: mtMap.objectField(
-                                  'schema',
+                                id: mtMap.objectField(
+                                  'id',
+                                  mtMap.passthrough()
+                                ),
+                                index: mtMap.objectField(
+                                  'index',
                                   mtMap.passthrough()
                                 )
                               })
-                            ),
-                            outputSchema: mtMap.objectField(
-                              'output_schema',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                schema: mtMap.objectField(
-                                  'schema',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(
-                                mtMap.object({
-                                  object: mtMap.objectField(
-                                    'object',
-                                    mtMap.passthrough()
-                                  ),
-                                  id: mtMap.objectField(
-                                    'id',
-                                    mtMap.passthrough()
-                                  ),
-                                  scope: mtMap.objectField(
-                                    'scope',
-                                    mtMap.passthrough()
-                                  ),
-                                  name: mtMap.objectField(
-                                    'name',
-                                    mtMap.passthrough()
-                                  ),
-                                  description: mtMap.objectField(
-                                    'description',
-                                    mtMap.passthrough()
-                                  )
-                                })
-                              )
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            providerSpecificationId: mtMap.objectField(
-                              'provider_specification_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authCredentials: mtMap.objectField(
-                          'auth_credentials',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
                             ),
                             status: mtMap.objectField(
                               'status',
                               mtMap.passthrough()
                             ),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            isManaged: mtMap.objectField(
-                              'is_managed',
-                              mtMap.passthrough()
-                            ),
                             name: mtMap.objectField(
                               'name',
                               mtMap.passthrough()
@@ -665,13 +388,108 @@ export let mapDashboardInstanceIntegrationSetupSessionsListOutput =
                               'metadata',
                               mtMap.passthrough()
                             ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(mtMap.passthrough())
+                            toolFilter: mtMap.objectField(
+                              'tool_filter',
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    ignoreParentFilters: mtMap.objectField(
+                                      'ignore_parent_filters',
+                                      mtMap.passthrough()
+                                    ),
+                                    filters: mtMap.objectField(
+                                      'filters',
+                                      mtMap.array(
+                                        mtMap.union([
+                                          mtMap.unionOption(
+                                            'object',
+                                            mtMap.object({
+                                              type: mtMap.objectField(
+                                                'type',
+                                                mtMap.passthrough()
+                                              ),
+                                              keys: mtMap.objectField(
+                                                'keys',
+                                                mtMap.array(mtMap.passthrough())
+                                              ),
+                                              pattern: mtMap.objectField(
+                                                'pattern',
+                                                mtMap.passthrough()
+                                              ),
+                                              uris: mtMap.objectField(
+                                                'uris',
+                                                mtMap.array(mtMap.passthrough())
+                                              )
+                                            })
+                                          )
+                                        ])
+                                      )
+                                    )
+                                  })
+                                )
+                              ])
                             ),
                             providerId: mtMap.objectField(
                               'provider_id',
                               mtMap.passthrough()
+                            ),
+                            deploymentId: mtMap.objectField(
+                              'deployment_id',
+                              mtMap.passthrough()
+                            ),
+                            authMethodId: mtMap.objectField(
+                              'auth_method_id',
+                              mtMap.passthrough()
+                            ),
+                            authCredentialsId: mtMap.objectField(
+                              'auth_credentials_id',
+                              mtMap.passthrough()
+                            ),
+                            config: mtMap.objectField(
+                              'config',
+                              mtMap.object({
+                                object: mtMap.objectField(
+                                  'object',
+                                  mtMap.passthrough()
+                                ),
+                                id: mtMap.objectField(
+                                  'id',
+                                  mtMap.passthrough()
+                                ),
+                                isDefault: mtMap.objectField(
+                                  'is_default',
+                                  mtMap.passthrough()
+                                ),
+                                name: mtMap.objectField(
+                                  'name',
+                                  mtMap.passthrough()
+                                ),
+                                description: mtMap.objectField(
+                                  'description',
+                                  mtMap.passthrough()
+                                ),
+                                metadata: mtMap.objectField(
+                                  'metadata',
+                                  mtMap.passthrough()
+                                ),
+                                providerId: mtMap.objectField(
+                                  'provider_id',
+                                  mtMap.passthrough()
+                                ),
+                                createdAt: mtMap.objectField(
+                                  'created_at',
+                                  mtMap.date()
+                                ),
+                                updatedAt: mtMap.objectField(
+                                  'updated_at',
+                                  mtMap.date()
+                                )
+                              })
                             ),
                             createdAt: mtMap.objectField(
                               'created_at',
@@ -679,12 +497,54 @@ export let mapDashboardInstanceIntegrationSetupSessionsListOutput =
                             ),
                             updatedAt: mtMap.objectField(
                               'updated_at',
+                              mtMap.date()
+                            ),
+                            archivedAt: mtMap.objectField(
+                              'archived_at',
                               mtMap.date()
                             )
                           })
                         ),
                         config: mtMap.objectField(
                           'config',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        authConfig: mtMap.objectField(
+                          'auth_config',
                           mtMap.object({
                             object: mtMap.objectField(
                               'object',
@@ -734,126 +594,69 @@ export let mapDashboardInstanceIntegrationSetupSessionsListOutput =
                           mtMap.date()
                         )
                       })
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authConfig: mtMap.objectField(
-                      'auth_config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                )
+                    )
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                })
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          steps: mtMap.objectField(
-            'steps',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                url: mtMap.objectField('url', mtMap.passthrough()),
-                integrationProviderId: mtMap.objectField(
-                  'integration_provider_id',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
+              expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              steps: mtMap.objectField(
+                'steps',
+                mtMap.array(
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    url: mtMap.objectField('url', mtMap.passthrough()),
+                    integrationProviderId: mtMap.objectField(
+                      'integration_provider_id',
                       mtMap.passthrough()
                     ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    provider: mtMap.objectField(
+                      'provider',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        ),
+                        slug: mtMap.objectField('slug', mtMap.passthrough()),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    ),
+                    providerSetupSessionId: mtMap.objectField(
+                      'provider_setup_session_id',
+                      mtMap.passthrough()
+                    ),
+                    integrationInstanceProviderId: mtMap.objectField(
+                      'integration_instance_provider_id',
+                      mtMap.passthrough()
+                    ),
                     createdAt: mtMap.objectField('created_at', mtMap.date()),
                     updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
-                ),
-                providerSetupSessionId: mtMap.objectField(
-                  'provider_setup_session_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceProviderId: mtMap.objectField(
-                  'integration_instance_provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            )
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          expiresAt: mtMap.objectField('expires_at', mtMap.date())
-        })
+                )
+              )
+            })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/create.ts
@@ -40,6 +40,93 @@ export type DashboardInstanceIntegrationsCreateOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -99,265 +186,315 @@ export type DashboardInstanceIntegrationsCreateOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
+  })[];
 };
 
-export let mapDashboardInstanceIntegrationsCreateOutput =
-  mtMap.object<DashboardInstanceIntegrationsCreateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    slug: mtMap.objectField('slug', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField(
-      'configuration',
-      mtMap.object({
-        canAttachCustomToolFilters: mtMap.objectField(
-          'can_attach_custom_tool_filters',
-          mtMap.passthrough()
-        ),
-        canAttachCustomProviderConfig: mtMap.objectField(
-          'can_attach_custom_provider_config',
-          mtMap.passthrough()
-        ),
-        canOverrideToolFilters: mtMap.objectField(
-          'can_override_tool_filters',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            providerTemplateId: mtMap.objectField(
-              'provider_template_id',
-              mtMap.passthrough()
-            ),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
-              mtMap.passthrough()
-            )
-          })
-        )
-      ])
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapDashboardInstanceIntegrationsCreateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      slug: mtMap.objectField('slug', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField(
+        'configuration',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          canAttachCustomToolFilters: mtMap.objectField(
+            'can_attach_custom_tool_filters',
             mtMap.passthrough()
           ),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
+          canAttachCustomProviderConfig: mtMap.objectField(
+            'can_attach_custom_provider_config',
+            mtMap.passthrough()
           ),
-          provider: mtMap.objectField(
-            'provider',
+          canOverrideToolFilters: mtMap.objectField(
+            'can_override_tool_filters',
+            mtMap.passthrough()
+          )
+        })
+      ),
+      implementation: mtMap.objectField(
+        'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
               type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              providerTemplateId: mtMap.objectField(
+                'provider_template_id',
                 mtMap.passthrough()
               ),
-              capabilities: mtMap.objectField(
-                'capabilities',
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
+              )
+            })
+          )
+        ])
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
                     name: mtMap.objectField('name', mtMap.passthrough()),
                     description: mtMap.objectField(
                       'description',
                       mtMap.passthrough()
-                    )
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                deployment: mtMap.objectField(
+                  'deployment',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authMethod: mtMap.objectField(
+                  'auth_method',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    key: mtMap.objectField('key', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    capabilities: mtMap.objectField(
+                      'capabilities',
+                      mtMap.passthrough()
+                    ),
+                    inputSchema: mtMap.objectField(
+                      'input_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    outputSchema: mtMap.objectField(
+                      'output_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          scope: mtMap.objectField(
+                            'scope',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          )
+                        })
+                      )
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    providerSpecificationId: mtMap.objectField(
+                      'provider_specification_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authCredentials: mtMap.objectField(
+                  'auth_credentials',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    isManaged: mtMap.objectField(
+                      'is_managed',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(mtMap.passthrough())
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type DashboardInstanceIntegrationsCreateBody = {
   name: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/delete.ts
@@ -40,6 +40,93 @@ export type DashboardInstanceIntegrationsDeleteOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -99,263 +186,313 @@ export type DashboardInstanceIntegrationsDeleteOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
+  })[];
 };
 
-export let mapDashboardInstanceIntegrationsDeleteOutput =
-  mtMap.object<DashboardInstanceIntegrationsDeleteOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    slug: mtMap.objectField('slug', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField(
-      'configuration',
-      mtMap.object({
-        canAttachCustomToolFilters: mtMap.objectField(
-          'can_attach_custom_tool_filters',
-          mtMap.passthrough()
-        ),
-        canAttachCustomProviderConfig: mtMap.objectField(
-          'can_attach_custom_provider_config',
-          mtMap.passthrough()
-        ),
-        canOverrideToolFilters: mtMap.objectField(
-          'can_override_tool_filters',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            providerTemplateId: mtMap.objectField(
-              'provider_template_id',
-              mtMap.passthrough()
-            ),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
-              mtMap.passthrough()
-            )
-          })
-        )
-      ])
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapDashboardInstanceIntegrationsDeleteOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      slug: mtMap.objectField('slug', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField(
+        'configuration',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          canAttachCustomToolFilters: mtMap.objectField(
+            'can_attach_custom_tool_filters',
             mtMap.passthrough()
           ),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
+          canAttachCustomProviderConfig: mtMap.objectField(
+            'can_attach_custom_provider_config',
+            mtMap.passthrough()
           ),
-          provider: mtMap.objectField(
-            'provider',
+          canOverrideToolFilters: mtMap.objectField(
+            'can_override_tool_filters',
+            mtMap.passthrough()
+          )
+        })
+      ),
+      implementation: mtMap.objectField(
+        'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
               type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              providerTemplateId: mtMap.objectField(
+                'provider_template_id',
                 mtMap.passthrough()
               ),
-              capabilities: mtMap.objectField(
-                'capabilities',
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
+              )
+            })
+          )
+        ])
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
                     name: mtMap.objectField('name', mtMap.passthrough()),
                     description: mtMap.objectField(
                       'description',
                       mtMap.passthrough()
-                    )
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                deployment: mtMap.objectField(
+                  'deployment',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authMethod: mtMap.objectField(
+                  'auth_method',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    key: mtMap.objectField('key', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    capabilities: mtMap.objectField(
+                      'capabilities',
+                      mtMap.passthrough()
+                    ),
+                    inputSchema: mtMap.objectField(
+                      'input_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    outputSchema: mtMap.objectField(
+                      'output_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          scope: mtMap.objectField(
+                            'scope',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          )
+                        })
+                      )
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    providerSpecificationId: mtMap.objectField(
+                      'provider_specification_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authCredentials: mtMap.objectField(
+                  'auth_credentials',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    isManaged: mtMap.objectField(
+                      'is_managed',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(mtMap.passthrough())
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/get.ts
@@ -40,6 +40,93 @@ export type DashboardInstanceIntegrationsGetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -99,263 +186,313 @@ export type DashboardInstanceIntegrationsGetOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
+  })[];
 };
 
-export let mapDashboardInstanceIntegrationsGetOutput =
-  mtMap.object<DashboardInstanceIntegrationsGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    slug: mtMap.objectField('slug', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField(
-      'configuration',
-      mtMap.object({
-        canAttachCustomToolFilters: mtMap.objectField(
-          'can_attach_custom_tool_filters',
-          mtMap.passthrough()
-        ),
-        canAttachCustomProviderConfig: mtMap.objectField(
-          'can_attach_custom_provider_config',
-          mtMap.passthrough()
-        ),
-        canOverrideToolFilters: mtMap.objectField(
-          'can_override_tool_filters',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            providerTemplateId: mtMap.objectField(
-              'provider_template_id',
-              mtMap.passthrough()
-            ),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
-              mtMap.passthrough()
-            )
-          })
-        )
-      ])
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapDashboardInstanceIntegrationsGetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      slug: mtMap.objectField('slug', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField(
+        'configuration',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          canAttachCustomToolFilters: mtMap.objectField(
+            'can_attach_custom_tool_filters',
             mtMap.passthrough()
           ),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
+          canAttachCustomProviderConfig: mtMap.objectField(
+            'can_attach_custom_provider_config',
+            mtMap.passthrough()
           ),
-          provider: mtMap.objectField(
-            'provider',
+          canOverrideToolFilters: mtMap.objectField(
+            'can_override_tool_filters',
+            mtMap.passthrough()
+          )
+        })
+      ),
+      implementation: mtMap.objectField(
+        'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
               type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              providerTemplateId: mtMap.objectField(
+                'provider_template_id',
                 mtMap.passthrough()
               ),
-              capabilities: mtMap.objectField(
-                'capabilities',
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
+              )
+            })
+          )
+        ])
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
                     name: mtMap.objectField('name', mtMap.passthrough()),
                     description: mtMap.objectField(
                       'description',
                       mtMap.passthrough()
-                    )
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                deployment: mtMap.objectField(
+                  'deployment',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authMethod: mtMap.objectField(
+                  'auth_method',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    key: mtMap.objectField('key', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    capabilities: mtMap.objectField(
+                      'capabilities',
+                      mtMap.passthrough()
+                    ),
+                    inputSchema: mtMap.objectField(
+                      'input_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    outputSchema: mtMap.objectField(
+                      'output_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          scope: mtMap.objectField(
+                            'scope',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          )
+                        })
+                      )
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    providerSpecificationId: mtMap.objectField(
+                      'provider_specification_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authCredentials: mtMap.objectField(
+                  'auth_credentials',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    isManaged: mtMap.objectField(
+                      'is_managed',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(mtMap.passthrough())
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceIntegrationsListOutput = {
-  items: {
+  items: ({
     object: 'integration';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -19,6 +19,93 @@ export type DashboardInstanceIntegrationsListOutput = {
       | { type: 'magic_mcp_server'; magicMcpServerId: string }
       | null;
     providers: {
+      object: 'integration.provider';
+      id: string;
+      status: 'active' | 'archived' | 'deleted';
+      integrationId: string;
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    }[];
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    providers: ({
+      object: 'integration.provider';
+      id: string;
+      status: 'active' | 'archived' | 'deleted';
+      integrationId: string;
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    } & {
       object: 'integration.provider';
       id: string;
       status: 'active' | 'archived' | 'deleted';
@@ -106,25 +193,8 @@ export type DashboardInstanceIntegrationsListOutput = {
         createdAt: Date;
         updatedAt: Date;
       } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    }[];
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
+    })[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -133,286 +203,426 @@ export let mapDashboardInstanceIntegrationsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          configuration: mtMap.objectField(
-            'configuration',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              canAttachCustomToolFilters: mtMap.objectField(
-                'can_attach_custom_tool_filters',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              canAttachCustomProviderConfig: mtMap.objectField(
-                'can_attach_custom_provider_config',
-                mtMap.passthrough()
-              ),
-              canOverrideToolFilters: mtMap.objectField(
-                'can_override_tool_filters',
-                mtMap.passthrough()
-              )
-            })
-          ),
-          implementation: mtMap.objectField(
-            'implementation',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              configuration: mtMap.objectField(
+                'configuration',
                 mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  providerTemplateId: mtMap.objectField(
-                    'provider_template_id',
+                  canAttachCustomToolFilters: mtMap.objectField(
+                    'can_attach_custom_tool_filters',
                     mtMap.passthrough()
                   ),
-                  magicMcpServerId: mtMap.objectField(
-                    'magic_mcp_server_id',
+                  canAttachCustomProviderConfig: mtMap.objectField(
+                    'can_attach_custom_provider_config',
+                    mtMap.passthrough()
+                  ),
+                  canOverrideToolFilters: mtMap.objectField(
+                    'can_override_tool_filters',
                     mtMap.passthrough()
                   )
                 })
-              )
-            ])
-          ),
-          providers: mtMap.objectField(
-            'providers',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
+              ),
+              implementation: mtMap.objectField(
+                'implementation',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      providerTemplateId: mtMap.objectField(
+                        'provider_template_id',
+                        mtMap.passthrough()
+                      ),
+                      magicMcpServerId: mtMap.objectField(
+                        'magic_mcp_server_id',
+                        mtMap.passthrough()
+                      )
+                    })
+                  )
+                ])
+              ),
+              providers: mtMap.objectField(
+                'providers',
+                mtMap.array(
                   mtMap.union([
                     mtMap.unionOption(
                       'object',
                       mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
+                        object: mtMap.objectField(
+                          'object',
                           mtMap.passthrough()
                         ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        status: mtMap.objectField(
+                          'status',
+                          mtMap.passthrough()
+                        ),
+                        integrationId: mtMap.objectField(
+                          'integration_id',
+                          mtMap.passthrough()
+                        ),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        toolFilter: mtMap.objectField(
+                          'tool_filter',
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                ignoreParentFilters: mtMap.objectField(
+                                  'ignore_parent_filters',
+                                  mtMap.passthrough()
+                                ),
+                                filters: mtMap.objectField(
+                                  'filters',
+                                  mtMap.array(
+                                    mtMap.union([
+                                      mtMap.unionOption(
+                                        'object',
+                                        mtMap.object({
+                                          type: mtMap.objectField(
+                                            'type',
+                                            mtMap.passthrough()
+                                          ),
+                                          keys: mtMap.objectField(
+                                            'keys',
+                                            mtMap.array(mtMap.passthrough())
+                                          ),
+                                          pattern: mtMap.objectField(
+                                            'pattern',
+                                            mtMap.passthrough()
+                                          ),
+                                          uris: mtMap.objectField(
+                                            'uris',
+                                            mtMap.array(mtMap.passthrough())
+                                          )
+                                        })
+                                      )
+                                    ])
+                                  )
+                                )
+                              })
+                            )
+                          ])
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        deploymentId: mtMap.objectField(
+                          'deployment_id',
+                          mtMap.passthrough()
+                        ),
+                        authMethodId: mtMap.objectField(
+                          'auth_method_id',
+                          mtMap.passthrough()
+                        ),
+                        authCredentialsId: mtMap.objectField(
+                          'auth_credentials_id',
+                          mtMap.passthrough()
+                        ),
+                        config: mtMap.objectField(
+                          'config',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField(
+                          'updated_at',
+                          mtMap.date()
+                        ),
+                        archivedAt: mtMap.objectField(
+                          'archived_at',
+                          mtMap.date()
+                        ),
+                        provider: mtMap.objectField(
+                          'provider',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            slug: mtMap.objectField(
+                              'slug',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        deployment: mtMap.objectField(
+                          'deployment',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        authMethod: mtMap.objectField(
+                          'auth_method',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            key: mtMap.objectField('key', mtMap.passthrough()),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            capabilities: mtMap.objectField(
+                              'capabilities',
+                              mtMap.passthrough()
+                            ),
+                            inputSchema: mtMap.objectField(
+                              'input_schema',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                schema: mtMap.objectField(
+                                  'schema',
+                                  mtMap.passthrough()
+                                )
+                              })
+                            ),
+                            outputSchema: mtMap.objectField(
+                              'output_schema',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                schema: mtMap.objectField(
+                                  'schema',
+                                  mtMap.passthrough()
+                                )
+                              })
+                            ),
+                            scopes: mtMap.objectField(
+                              'scopes',
+                              mtMap.array(
                                 mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
+                                  object: mtMap.objectField(
+                                    'object',
                                     mtMap.passthrough()
                                   ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
+                                  id: mtMap.objectField(
+                                    'id',
                                     mtMap.passthrough()
                                   ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
+                                  scope: mtMap.objectField(
+                                    'scope',
+                                    mtMap.passthrough()
+                                  ),
+                                  name: mtMap.objectField(
+                                    'name',
+                                    mtMap.passthrough()
+                                  ),
+                                  description: mtMap.objectField(
+                                    'description',
+                                    mtMap.passthrough()
                                   )
                                 })
                               )
-                            ])
-                          )
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            providerSpecificationId: mtMap.objectField(
+                              'provider_specification_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        authCredentials: mtMap.objectField(
+                          'auth_credentials',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            status: mtMap.objectField(
+                              'status',
+                              mtMap.passthrough()
+                            ),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            isManaged: mtMap.objectField(
+                              'is_managed',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            scopes: mtMap.objectField(
+                              'scopes',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
                         )
                       })
                     )
                   ])
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                deployment: mtMap.objectField(
-                  'deployment',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authMethod: mtMap.objectField(
-                  'auth_method',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    key: mtMap.objectField('key', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    capabilities: mtMap.objectField(
-                      'capabilities',
-                      mtMap.passthrough()
-                    ),
-                    inputSchema: mtMap.objectField(
-                      'input_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    outputSchema: mtMap.objectField(
-                      'output_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          scope: mtMap.objectField(
-                            'scope',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          )
-                        })
-                      )
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    providerSpecificationId: mtMap.objectField(
-                      'provider_specification_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authCredentials: mtMap.objectField(
-                  'auth_credentials',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    isManaged: mtMap.objectField(
-                      'is_managed',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(mtMap.passthrough())
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+                )
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/update.ts
@@ -40,6 +40,93 @@ export type DashboardInstanceIntegrationsUpdateOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -99,265 +186,315 @@ export type DashboardInstanceIntegrationsUpdateOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
+  })[];
 };
 
-export let mapDashboardInstanceIntegrationsUpdateOutput =
-  mtMap.object<DashboardInstanceIntegrationsUpdateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    slug: mtMap.objectField('slug', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField(
-      'configuration',
-      mtMap.object({
-        canAttachCustomToolFilters: mtMap.objectField(
-          'can_attach_custom_tool_filters',
-          mtMap.passthrough()
-        ),
-        canAttachCustomProviderConfig: mtMap.objectField(
-          'can_attach_custom_provider_config',
-          mtMap.passthrough()
-        ),
-        canOverrideToolFilters: mtMap.objectField(
-          'can_override_tool_filters',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            providerTemplateId: mtMap.objectField(
-              'provider_template_id',
-              mtMap.passthrough()
-            ),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
-              mtMap.passthrough()
-            )
-          })
-        )
-      ])
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapDashboardInstanceIntegrationsUpdateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      slug: mtMap.objectField('slug', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField(
+        'configuration',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          canAttachCustomToolFilters: mtMap.objectField(
+            'can_attach_custom_tool_filters',
             mtMap.passthrough()
           ),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
+          canAttachCustomProviderConfig: mtMap.objectField(
+            'can_attach_custom_provider_config',
+            mtMap.passthrough()
           ),
-          provider: mtMap.objectField(
-            'provider',
+          canOverrideToolFilters: mtMap.objectField(
+            'can_override_tool_filters',
+            mtMap.passthrough()
+          )
+        })
+      ),
+      implementation: mtMap.objectField(
+        'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
               type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              providerTemplateId: mtMap.objectField(
+                'provider_template_id',
                 mtMap.passthrough()
               ),
-              capabilities: mtMap.objectField(
-                'capabilities',
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
+              )
+            })
+          )
+        ])
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
                     name: mtMap.objectField('name', mtMap.passthrough()),
                     description: mtMap.objectField(
                       'description',
                       mtMap.passthrough()
-                    )
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                deployment: mtMap.objectField(
+                  'deployment',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authMethod: mtMap.objectField(
+                  'auth_method',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    key: mtMap.objectField('key', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    capabilities: mtMap.objectField(
+                      'capabilities',
+                      mtMap.passthrough()
+                    ),
+                    inputSchema: mtMap.objectField(
+                      'input_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    outputSchema: mtMap.objectField(
+                      'output_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          scope: mtMap.objectField(
+                            'scope',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          )
+                        })
+                      )
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    providerSpecificationId: mtMap.objectField(
+                      'provider_specification_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authCredentials: mtMap.objectField(
+                  'auth_credentials',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    isManaged: mtMap.objectField(
+                      'is_managed',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(mtMap.passthrough())
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type DashboardInstanceIntegrationsUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/magic-mcp-endpoints/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/magic-mcp-endpoints/create.ts
@@ -124,6 +124,7 @@ export type DashboardInstanceMagicMcpEndpointsCreateBody = {
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
   consumerProfileId?: string | undefined;
+  skillPluginId?: string | undefined;
   magicMcpServers?:
     | {
         magicMcpServerId: string;
@@ -159,6 +160,7 @@ export let mapDashboardInstanceMagicMcpEndpointsCreateBody =
       'consumer_profile_id',
       mtMap.passthrough()
     ),
+    skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
     magicMcpServers: mtMap.objectField(
       'magic_mcp_servers',
       mtMap.array(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/index.ts
@@ -45,4 +45,5 @@ export * from './skill-groups';
 export * from './skill-templates';
 export * from './skills';
 export * from './stores';
+export * from './test-helpers';
 export * from './tool-calls';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/delete.ts
@@ -7,10 +7,11 @@ export type IntegrationInstanceGroupProvidersDeleteOutput = {
   name: string;
   description: string | null;
   metadata: Record<string, any> | null;
-  integrationInstanceGroupId: string;
   integrationId: string;
+  integrationInstanceGroupId: string;
   integrationInstanceId: string;
-  integrationProviderId: string;
+  integrationProviderId: string | null;
+  integrationInstanceProviderId: string;
   toolFilter:
     | { type: 'allow_all'; ignoreParentFilters: boolean }
     | {
@@ -27,6 +28,10 @@ export type IntegrationInstanceGroupProvidersDeleteOutput = {
       }
     | null;
   isOverrideToolFilter: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -63,65 +68,10 @@ export type IntegrationInstanceGroupProvidersDeleteOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -198,71 +148,10 @@ export type IntegrationInstanceGroupProvidersDeleteOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -304,571 +193,409 @@ export type IntegrationInstanceGroupProvidersDeleteOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapIntegrationInstanceGroupProvidersDeleteOutput =
-  mtMap.object<IntegrationInstanceGroupProvidersDeleteOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationInstanceGroupId: mtMap.objectField(
-      'integration_instance_group_id',
-      mtMap.passthrough()
-    ),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    integrationProviderId: mtMap.objectField(
-      'integration_provider_id',
-      mtMap.passthrough()
-    ),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
+export let mapIntegrationInstanceGroupProvidersDeleteOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceGroupId: mtMap.objectField(
+        'integration_instance_group_id',
+        mtMap.passthrough()
+      ),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      integrationProviderId: mtMap.objectField(
+        'integration_provider_id',
+        mtMap.passthrough()
+      ),
+      integrationInstanceProviderId: mtMap.objectField(
+        'integration_instance_provider_id',
+        mtMap.passthrough()
+      ),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
+            })
+          )
+        ])
+      ),
+      isOverrideToolFilter: mtMap.objectField(
+        'is_override_tool_filter',
+        mtMap.passthrough()
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      integrationProvider: mtMap.objectField(
+        'integration_provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          providerVersion: mtMap.objectField(
+            'provider_version',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              index: mtMap.objectField('index', mtMap.passthrough())
+            })
+          ),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
+            mtMap.passthrough()
+          ),
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
+            mtMap.passthrough()
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      ),
+      integrationInstanceProvider: mtMap.objectField(
+        'integration_instance_provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
                 mtMap.union([
                   mtMap.unionOption(
                     'object',
                     mtMap.object({
                       type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
                         mtMap.passthrough()
                       ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
                       )
                     })
                   )
                 ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    isOverrideToolFilter: mtMap.objectField(
-      'is_override_tool_filter',
-      mtMap.passthrough()
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    integrationProvider: mtMap.objectField(
-      'integration_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        providerVersion: mtMap.objectField(
-          'provider_version',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            index: mtMap.objectField('index', mtMap.passthrough())
-          })
-        ),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
-                  mtMap.passthrough()
-                ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
-                            mtMap.passthrough()
-                          ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
-                          )
-                        })
-                      )
-                    ])
-                  )
-                )
-              })
-            )
-          ])
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        deployment: mtMap.objectField(
-          'deployment',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
-                  )
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
-              )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        config: mtMap.objectField(
-          'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    integrationInstanceProvider: mtMap.objectField(
-      'integration_instance_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstanceId: mtMap.objectField(
-          'integration_instance_id',
-          mtMap.passthrough()
-        ),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
-                  mtMap.passthrough()
-                ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
-                            mtMap.passthrough()
-                          ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
-                          )
-                        })
-                      )
-                    ])
-                  )
-                )
-              })
-            )
-          ])
-        ),
-        isOverrideToolFilter: mtMap.objectField(
-          'is_override_tool_filter',
-          mtMap.passthrough()
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        integrationProvider: mtMap.objectField(
-          'integration_provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            providerVersion: mtMap.objectField(
-              'provider_version',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                index: mtMap.objectField('index', mtMap.passthrough())
-              })
-            ),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            deployment: mtMap.objectField(
-              'deployment',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authMethod: mtMap.objectField(
-              'auth_method',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                key: mtMap.objectField('key', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                capabilities: mtMap.objectField(
-                  'capabilities',
-                  mtMap.passthrough()
-                ),
-                inputSchema: mtMap.objectField(
-                  'input_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                outputSchema: mtMap.objectField(
-                  'output_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      scope: mtMap.objectField('scope', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      )
-                    })
-                  )
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                providerSpecificationId: mtMap.objectField(
-                  'provider_specification_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authCredentials: mtMap.objectField(
-              'auth_credentials',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(mtMap.passthrough())
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            config: mtMap.objectField(
-              'config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
-        ),
-        config: mtMap.objectField(
-          'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authConfig: mtMap.objectField(
-          'auth_config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/get.ts
@@ -7,10 +7,11 @@ export type IntegrationInstanceGroupProvidersGetOutput = {
   name: string;
   description: string | null;
   metadata: Record<string, any> | null;
-  integrationInstanceGroupId: string;
   integrationId: string;
+  integrationInstanceGroupId: string;
   integrationInstanceId: string;
-  integrationProviderId: string;
+  integrationProviderId: string | null;
+  integrationInstanceProviderId: string;
   toolFilter:
     | { type: 'allow_all'; ignoreParentFilters: boolean }
     | {
@@ -27,6 +28,10 @@ export type IntegrationInstanceGroupProvidersGetOutput = {
       }
     | null;
   isOverrideToolFilter: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -63,65 +68,10 @@ export type IntegrationInstanceGroupProvidersGetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -198,71 +148,10 @@ export type IntegrationInstanceGroupProvidersGetOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -304,571 +193,409 @@ export type IntegrationInstanceGroupProvidersGetOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapIntegrationInstanceGroupProvidersGetOutput =
-  mtMap.object<IntegrationInstanceGroupProvidersGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationInstanceGroupId: mtMap.objectField(
-      'integration_instance_group_id',
-      mtMap.passthrough()
-    ),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    integrationProviderId: mtMap.objectField(
-      'integration_provider_id',
-      mtMap.passthrough()
-    ),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
+export let mapIntegrationInstanceGroupProvidersGetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceGroupId: mtMap.objectField(
+        'integration_instance_group_id',
+        mtMap.passthrough()
+      ),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      integrationProviderId: mtMap.objectField(
+        'integration_provider_id',
+        mtMap.passthrough()
+      ),
+      integrationInstanceProviderId: mtMap.objectField(
+        'integration_instance_provider_id',
+        mtMap.passthrough()
+      ),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
+            })
+          )
+        ])
+      ),
+      isOverrideToolFilter: mtMap.objectField(
+        'is_override_tool_filter',
+        mtMap.passthrough()
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      integrationProvider: mtMap.objectField(
+        'integration_provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          providerVersion: mtMap.objectField(
+            'provider_version',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              index: mtMap.objectField('index', mtMap.passthrough())
+            })
+          ),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
+            mtMap.passthrough()
+          ),
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
+            mtMap.passthrough()
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      ),
+      integrationInstanceProvider: mtMap.objectField(
+        'integration_instance_provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
                 mtMap.union([
                   mtMap.unionOption(
                     'object',
                     mtMap.object({
                       type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
                         mtMap.passthrough()
                       ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
                       )
                     })
                   )
                 ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    isOverrideToolFilter: mtMap.objectField(
-      'is_override_tool_filter',
-      mtMap.passthrough()
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    integrationProvider: mtMap.objectField(
-      'integration_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        providerVersion: mtMap.objectField(
-          'provider_version',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            index: mtMap.objectField('index', mtMap.passthrough())
-          })
-        ),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
-                  mtMap.passthrough()
-                ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
-                            mtMap.passthrough()
-                          ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
-                          )
-                        })
-                      )
-                    ])
-                  )
-                )
-              })
-            )
-          ])
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        deployment: mtMap.objectField(
-          'deployment',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
-                  )
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
-              )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        config: mtMap.objectField(
-          'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    integrationInstanceProvider: mtMap.objectField(
-      'integration_instance_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstanceId: mtMap.objectField(
-          'integration_instance_id',
-          mtMap.passthrough()
-        ),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
-                  mtMap.passthrough()
-                ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
-                            mtMap.passthrough()
-                          ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
-                          )
-                        })
-                      )
-                    ])
-                  )
-                )
-              })
-            )
-          ])
-        ),
-        isOverrideToolFilter: mtMap.objectField(
-          'is_override_tool_filter',
-          mtMap.passthrough()
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        integrationProvider: mtMap.objectField(
-          'integration_provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            providerVersion: mtMap.objectField(
-              'provider_version',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                index: mtMap.objectField('index', mtMap.passthrough())
-              })
-            ),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            deployment: mtMap.objectField(
-              'deployment',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authMethod: mtMap.objectField(
-              'auth_method',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                key: mtMap.objectField('key', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                capabilities: mtMap.objectField(
-                  'capabilities',
-                  mtMap.passthrough()
-                ),
-                inputSchema: mtMap.objectField(
-                  'input_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                outputSchema: mtMap.objectField(
-                  'output_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      scope: mtMap.objectField('scope', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      )
-                    })
-                  )
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                providerSpecificationId: mtMap.objectField(
-                  'provider_specification_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authCredentials: mtMap.objectField(
-              'auth_credentials',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(mtMap.passthrough())
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            config: mtMap.objectField(
-              'config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
-        ),
-        config: mtMap.objectField(
-          'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authConfig: mtMap.objectField(
-          'auth_config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/list.ts
@@ -1,17 +1,18 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type IntegrationInstanceGroupProvidersListOutput = {
-  items: {
+  items: ({
     object: 'integration.instance.group.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -28,6 +29,10 @@ export type IntegrationInstanceGroupProvidersListOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
     provider: {
       object: 'provider#preview';
       id: string;
@@ -64,71 +69,10 @@ export type IntegrationInstanceGroupProvidersListOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -205,71 +149,10 @@ export type IntegrationInstanceGroupProvidersListOutput = {
               ignoreParentFilters: boolean;
             }
           | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
         config: {
           object: 'provider.config#preview';
           id: string;
@@ -311,10 +194,7 @@ export type IntegrationInstanceGroupProvidersListOutput = {
       updatedAt: Date;
       archivedAt: Date | null;
     };
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -323,315 +203,9 @@ export let mapIntegrationInstanceGroupProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
-            mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
@@ -646,8 +220,20 @@ export let mapIntegrationInstanceGroupProvidersListOutput =
                 'integration_id',
                 mtMap.passthrough()
               ),
+              integrationInstanceGroupId: mtMap.objectField(
+                'integration_instance_group_id',
+                mtMap.passthrough()
+              ),
               integrationInstanceId: mtMap.objectField(
                 'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              integrationProviderId: mtMap.objectField(
+                'integration_provider_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceProviderId: mtMap.objectField(
+                'integration_instance_provider_id',
                 mtMap.passthrough()
               ),
               toolFilter: mtMap.objectField(
@@ -697,6 +283,9 @@ export let mapIntegrationInstanceGroupProvidersListOutput =
                 'is_override_tool_filter',
                 mtMap.passthrough()
               ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date()),
               provider: mtMap.objectField(
                 'provider',
                 mtMap.object({
@@ -775,154 +364,21 @@ export let mapIntegrationInstanceGroupProvidersListOutput =
                       )
                     ])
                   ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
                   ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  deploymentId: mtMap.objectField(
+                    'deployment_id',
+                    mtMap.passthrough()
                   ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  authMethodId: mtMap.objectField(
+                    'auth_method_id',
+                    mtMap.passthrough()
                   ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  authCredentialsId: mtMap.objectField(
+                    'auth_credentials_id',
+                    mtMap.passthrough()
                   ),
                   config: mtMap.objectField(
                     'config',
@@ -955,61 +411,276 @@ export let mapIntegrationInstanceGroupProvidersListOutput =
                   archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
               ),
-              config: mtMap.objectField(
-                'config',
+              integrationInstanceProvider: mtMap.objectField(
+                'integration_instance_provider',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
+                  integrationId: mtMap.objectField(
+                    'integration_id',
                     mtMap.passthrough()
+                  ),
+                  integrationInstanceId: mtMap.objectField(
+                    'integration_instance_id',
+                    mtMap.passthrough()
+                  ),
+                  toolFilter: mtMap.objectField(
+                    'tool_filter',
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          ignoreParentFilters: mtMap.objectField(
+                            'ignore_parent_filters',
+                            mtMap.passthrough()
+                          ),
+                          filters: mtMap.objectField(
+                            'filters',
+                            mtMap.array(
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    keys: mtMap.objectField(
+                                      'keys',
+                                      mtMap.array(mtMap.passthrough())
+                                    ),
+                                    pattern: mtMap.objectField(
+                                      'pattern',
+                                      mtMap.passthrough()
+                                    ),
+                                    uris: mtMap.objectField(
+                                      'uris',
+                                      mtMap.array(mtMap.passthrough())
+                                    )
+                                  })
+                                )
+                              ])
+                            )
+                          )
+                        })
+                      )
+                    ])
+                  ),
+                  isOverrideToolFilter: mtMap.objectField(
+                    'is_override_tool_filter',
+                    mtMap.passthrough()
+                  ),
+                  provider: mtMap.objectField(
+                    'provider',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      slug: mtMap.objectField('slug', mtMap.passthrough()),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
+                  integrationProvider: mtMap.objectField(
+                    'integration_provider',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      providerVersion: mtMap.objectField(
+                        'provider_version',
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          index: mtMap.objectField('index', mtMap.passthrough())
+                        })
+                      ),
+                      status: mtMap.objectField('status', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      toolFilter: mtMap.objectField(
+                        'tool_filter',
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              ignoreParentFilters: mtMap.objectField(
+                                'ignore_parent_filters',
+                                mtMap.passthrough()
+                              ),
+                              filters: mtMap.objectField(
+                                'filters',
+                                mtMap.array(
+                                  mtMap.union([
+                                    mtMap.unionOption(
+                                      'object',
+                                      mtMap.object({
+                                        type: mtMap.objectField(
+                                          'type',
+                                          mtMap.passthrough()
+                                        ),
+                                        keys: mtMap.objectField(
+                                          'keys',
+                                          mtMap.array(mtMap.passthrough())
+                                        ),
+                                        pattern: mtMap.objectField(
+                                          'pattern',
+                                          mtMap.passthrough()
+                                        ),
+                                        uris: mtMap.objectField(
+                                          'uris',
+                                          mtMap.array(mtMap.passthrough())
+                                        )
+                                      })
+                                    )
+                                  ])
+                                )
+                              )
+                            })
+                          )
+                        ])
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      deploymentId: mtMap.objectField(
+                        'deployment_id',
+                        mtMap.passthrough()
+                      ),
+                      authMethodId: mtMap.objectField(
+                        'auth_method_id',
+                        mtMap.passthrough()
+                      ),
+                      authCredentialsId: mtMap.objectField(
+                        'auth_credentials_id',
+                        mtMap.passthrough()
+                      ),
+                      config: mtMap.objectField(
+                        'config',
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          isDefault: mtMap.objectField(
+                            'is_default',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          ),
+                          metadata: mtMap.objectField(
+                            'metadata',
+                            mtMap.passthrough()
+                          ),
+                          providerId: mtMap.objectField(
+                            'provider_id',
+                            mtMap.passthrough()
+                          ),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                    })
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
+                  authConfig: mtMap.objectField(
+                    'auth_config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
                   ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              )
             })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/set.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/set.ts
@@ -7,10 +7,11 @@ export type IntegrationInstanceGroupProvidersSetOutput = {
   name: string;
   description: string | null;
   metadata: Record<string, any> | null;
-  integrationInstanceGroupId: string;
   integrationId: string;
+  integrationInstanceGroupId: string;
   integrationInstanceId: string;
-  integrationProviderId: string;
+  integrationProviderId: string | null;
+  integrationInstanceProviderId: string;
   toolFilter:
     | { type: 'allow_all'; ignoreParentFilters: boolean }
     | {
@@ -27,6 +28,10 @@ export type IntegrationInstanceGroupProvidersSetOutput = {
       }
     | null;
   isOverrideToolFilter: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -63,65 +68,10 @@ export type IntegrationInstanceGroupProvidersSetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -198,71 +148,10 @@ export type IntegrationInstanceGroupProvidersSetOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -304,573 +193,411 @@ export type IntegrationInstanceGroupProvidersSetOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapIntegrationInstanceGroupProvidersSetOutput =
-  mtMap.object<IntegrationInstanceGroupProvidersSetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationInstanceGroupId: mtMap.objectField(
-      'integration_instance_group_id',
-      mtMap.passthrough()
-    ),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    integrationProviderId: mtMap.objectField(
-      'integration_provider_id',
-      mtMap.passthrough()
-    ),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
+export let mapIntegrationInstanceGroupProvidersSetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceGroupId: mtMap.objectField(
+        'integration_instance_group_id',
+        mtMap.passthrough()
+      ),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      integrationProviderId: mtMap.objectField(
+        'integration_provider_id',
+        mtMap.passthrough()
+      ),
+      integrationInstanceProviderId: mtMap.objectField(
+        'integration_instance_provider_id',
+        mtMap.passthrough()
+      ),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
+            })
+          )
+        ])
+      ),
+      isOverrideToolFilter: mtMap.objectField(
+        'is_override_tool_filter',
+        mtMap.passthrough()
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      integrationProvider: mtMap.objectField(
+        'integration_provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          providerVersion: mtMap.objectField(
+            'provider_version',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              index: mtMap.objectField('index', mtMap.passthrough())
+            })
+          ),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
+            mtMap.passthrough()
+          ),
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
+            mtMap.passthrough()
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      ),
+      integrationInstanceProvider: mtMap.objectField(
+        'integration_instance_provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
                 mtMap.union([
                   mtMap.unionOption(
                     'object',
                     mtMap.object({
                       type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
                         mtMap.passthrough()
                       ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
                       )
                     })
                   )
                 ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    isOverrideToolFilter: mtMap.objectField(
-      'is_override_tool_filter',
-      mtMap.passthrough()
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    integrationProvider: mtMap.objectField(
-      'integration_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        providerVersion: mtMap.objectField(
-          'provider_version',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            index: mtMap.objectField('index', mtMap.passthrough())
-          })
-        ),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
-                  mtMap.passthrough()
-                ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
-                            mtMap.passthrough()
-                          ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
-                          )
-                        })
-                      )
-                    ])
-                  )
-                )
-              })
-            )
-          ])
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        deployment: mtMap.objectField(
-          'deployment',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
-                  )
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
-              )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        config: mtMap.objectField(
-          'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    integrationInstanceProvider: mtMap.objectField(
-      'integration_instance_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstanceId: mtMap.objectField(
-          'integration_instance_id',
-          mtMap.passthrough()
-        ),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
-                  mtMap.passthrough()
-                ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
-                            mtMap.passthrough()
-                          ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
-                          )
-                        })
-                      )
-                    ])
-                  )
-                )
-              })
-            )
-          ])
-        ),
-        isOverrideToolFilter: mtMap.objectField(
-          'is_override_tool_filter',
-          mtMap.passthrough()
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        integrationProvider: mtMap.objectField(
-          'integration_provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            providerVersion: mtMap.objectField(
-              'provider_version',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                index: mtMap.objectField('index', mtMap.passthrough())
-              })
-            ),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            deployment: mtMap.objectField(
-              'deployment',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authMethod: mtMap.objectField(
-              'auth_method',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                key: mtMap.objectField('key', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                capabilities: mtMap.objectField(
-                  'capabilities',
-                  mtMap.passthrough()
-                ),
-                inputSchema: mtMap.objectField(
-                  'input_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                outputSchema: mtMap.objectField(
-                  'output_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      scope: mtMap.objectField('scope', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      )
-                    })
-                  )
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                providerSpecificationId: mtMap.objectField(
-                  'provider_specification_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authCredentials: mtMap.objectField(
-              'auth_credentials',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(mtMap.passthrough())
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            config: mtMap.objectField(
-              'config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
-        ),
-        config: mtMap.objectField(
-          'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authConfig: mtMap.objectField(
-          'auth_config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 
 export type IntegrationInstanceGroupProvidersSetBody = {
   toolFilters?:

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/create.ts
@@ -18,10 +18,11 @@ export type IntegrationInstanceGroupsCreateOutput = {
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -38,289 +39,6 @@ export type IntegrationInstanceGroupsCreateOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } | null;
-    integrationInstanceProvider: {
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
@@ -328,722 +46,150 @@ export type IntegrationInstanceGroupsCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: {
+    object: 'integration.instance.group.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceGroupId: string;
+    integrationInstanceId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
 };
 
-export let mapIntegrationInstanceGroupsCreateOutput =
-  mtMap.object<IntegrationInstanceGroupsCreateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpEndpointId: mtMap.objectField(
-          'magic_mcp_endpoint_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapIntegrationInstanceGroupsCreateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpEndpointId: mtMap.objectField(
+            'magic_mcp_endpoint_id',
             mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          )
         })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            integrationId: mtMap.objectField(
+              'integration_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceGroupId: mtMap.objectField(
+              'integration_instance_group_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceId: mtMap.objectField(
+              'integration_instance_id',
+              mtMap.passthrough()
+            ),
+            integrationProviderId: mtMap.objectField(
+              'integration_provider_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceProviderId: mtMap.objectField(
+              'integration_instance_provider_id',
+              mtMap.passthrough()
+            ),
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
+            ),
+            isOverrideToolFilter: mtMap.objectField(
+              'is_override_tool_filter',
+              mtMap.passthrough()
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          })
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type IntegrationInstanceGroupsCreateBody = {
   name: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/delete.ts
@@ -18,10 +18,11 @@ export type IntegrationInstanceGroupsDeleteOutput = {
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -38,289 +39,6 @@ export type IntegrationInstanceGroupsDeleteOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } | null;
-    integrationInstanceProvider: {
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
@@ -328,720 +46,148 @@ export type IntegrationInstanceGroupsDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: {
+    object: 'integration.instance.group.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceGroupId: string;
+    integrationInstanceId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
 };
 
-export let mapIntegrationInstanceGroupsDeleteOutput =
-  mtMap.object<IntegrationInstanceGroupsDeleteOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpEndpointId: mtMap.objectField(
-          'magic_mcp_endpoint_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapIntegrationInstanceGroupsDeleteOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpEndpointId: mtMap.objectField(
+            'magic_mcp_endpoint_id',
             mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          )
         })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            integrationId: mtMap.objectField(
+              'integration_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceGroupId: mtMap.objectField(
+              'integration_instance_group_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceId: mtMap.objectField(
+              'integration_instance_id',
+              mtMap.passthrough()
+            ),
+            integrationProviderId: mtMap.objectField(
+              'integration_provider_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceProviderId: mtMap.objectField(
+              'integration_instance_provider_id',
+              mtMap.passthrough()
+            ),
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
+            ),
+            isOverrideToolFilter: mtMap.objectField(
+              'is_override_tool_filter',
+              mtMap.passthrough()
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          })
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/get.ts
@@ -18,10 +18,11 @@ export type IntegrationInstanceGroupsGetOutput = {
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -38,289 +39,6 @@ export type IntegrationInstanceGroupsGetOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } | null;
-    integrationInstanceProvider: {
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
@@ -328,720 +46,148 @@ export type IntegrationInstanceGroupsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: {
+    object: 'integration.instance.group.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceGroupId: string;
+    integrationInstanceId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
 };
 
-export let mapIntegrationInstanceGroupsGetOutput =
-  mtMap.object<IntegrationInstanceGroupsGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpEndpointId: mtMap.objectField(
-          'magic_mcp_endpoint_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapIntegrationInstanceGroupsGetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpEndpointId: mtMap.objectField(
+            'magic_mcp_endpoint_id',
             mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          )
         })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            integrationId: mtMap.objectField(
+              'integration_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceGroupId: mtMap.objectField(
+              'integration_instance_group_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceId: mtMap.objectField(
+              'integration_instance_id',
+              mtMap.passthrough()
+            ),
+            integrationProviderId: mtMap.objectField(
+              'integration_provider_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceProviderId: mtMap.objectField(
+              'integration_instance_provider_id',
+              mtMap.passthrough()
+            ),
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
+            ),
+            isOverrideToolFilter: mtMap.objectField(
+              'is_override_tool_filter',
+              mtMap.passthrough()
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          })
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type IntegrationInstanceGroupsListOutput = {
-  items: {
+  items: ({
     object: 'integration.instance.group';
     id: string;
     status: 'draft' | 'active' | 'archived' | 'deleted';
@@ -19,10 +19,11 @@ export type IntegrationInstanceGroupsListOutput = {
       name: string;
       description: string | null;
       metadata: Record<string, any> | null;
-      integrationInstanceGroupId: string;
       integrationId: string;
+      integrationInstanceGroupId: string;
       integrationInstanceId: string;
-      integrationProviderId: string;
+      integrationProviderId: string | null;
+      integrationInstanceProviderId: string;
       toolFilter:
         | { type: 'allow_all'; ignoreParentFilters: boolean }
         | {
@@ -39,289 +40,6 @@ export type IntegrationInstanceGroupsListOutput = {
           }
         | null;
       isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      } | null;
-      integrationInstanceProvider: {
-        object: 'integration.instance.provider';
-        id: string;
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        integrationId: string;
-        integrationInstanceId: string;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        isOverrideToolFilter: boolean;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        integrationProvider: {
-          object: 'integration.provider#snapshot';
-          id: string;
-          providerVersion: {
-            object: 'integration.provider.version';
-            id: string;
-            index: number;
-          };
-          status: 'active' | 'archived' | 'deleted';
-          name: string;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          toolFilter:
-            | { type: 'allow_all'; ignoreParentFilters: boolean }
-            | {
-                type: 'filter';
-                filters: (
-                  | { type: 'tool_keys'; keys: string[] }
-                  | { type: 'tool_regex'; pattern: string }
-                  | { type: 'resource_regex'; pattern: string }
-                  | { type: 'resource_uris'; uris: string[] }
-                  | { type: 'prompt_keys'; keys: string[] }
-                  | { type: 'prompt_regex'; pattern: string }
-                )[];
-                ignoreParentFilters: boolean;
-              }
-            | null;
-          provider: {
-            object: 'provider#preview';
-            id: string;
-            name: string;
-            description: string | null;
-            slug: string;
-            createdAt: Date;
-            updatedAt: Date;
-          };
-          deployment: {
-            object: 'provider.deployment#preview';
-            id: string;
-            isDefault: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          };
-          authMethod: {
-            object: 'provider.capabilities.auth_method';
-            id: string;
-            type: 'oauth' | 'token' | 'custom';
-            key: string;
-            name: string;
-            description: string | null;
-            capabilities: Record<string, any>;
-            inputSchema: {
-              type: 'json_schema';
-              schema: Record<string, any>;
-            } | null;
-            outputSchema: {
-              type: 'json_schema';
-              schema: Record<string, any>;
-            } | null;
-            scopes:
-              | {
-                  object: 'provider.capabilities.auth_method.scope';
-                  id: string;
-                  scope: string;
-                  name: string;
-                  description: string | null;
-                }[]
-              | null;
-            providerId: string;
-            providerSpecificationId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
-          authCredentials: {
-            object: 'provider.auth_credentials';
-            id: string;
-            type: 'oauth';
-            status: 'active' | 'archived' | 'deleted';
-            isDefault: boolean;
-            isManaged: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            scopes: string[] | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
-          config: {
-            object: 'provider.config#preview';
-            id: string;
-            isDefault: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
-          createdAt: Date;
-          updatedAt: Date;
-          archivedAt: Date | null;
-        };
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authConfig: {
-          object: 'provider.auth_config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
       createdAt: Date;
       updatedAt: Date;
       archivedAt: Date | null;
@@ -329,7 +47,40 @@ export type IntegrationInstanceGroupsListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
+  } & {
+    providers: {
+      object: 'integration.instance.group.provider';
+      id: string;
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      integrationId: string;
+      integrationInstanceGroupId: string;
+      integrationInstanceId: string;
+      integrationProviderId: string | null;
+      integrationInstanceProviderId: string;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      isOverrideToolFilter: boolean;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    }[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -338,407 +89,32 @@ export let mapIntegrationInstanceGroupsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          implementation: mtMap.objectField(
-            'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              magicMcpEndpointId: mtMap.objectField(
-                'magic_mcp_endpoint_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
-              )
-            })
-          ),
-          providers: mtMap.objectField(
-            'providers',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationInstanceGroupId: mtMap.objectField(
-                  'integration_instance_group_id',
-                  mtMap.passthrough()
-                ),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                integrationProviderId: mtMap.objectField(
-                  'integration_provider_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    provider: mtMap.objectField(
-                      'provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    deployment: mtMap.objectField(
-                      'deployment',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authMethod: mtMap.objectField(
-                      'auth_method',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        key: mtMap.objectField('key', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        capabilities: mtMap.objectField(
-                          'capabilities',
-                          mtMap.passthrough()
-                        ),
-                        inputSchema: mtMap.objectField(
-                          'input_schema',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            schema: mtMap.objectField(
-                              'schema',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        outputSchema: mtMap.objectField(
-                          'output_schema',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            schema: mtMap.objectField(
-                              'schema',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        scopes: mtMap.objectField(
-                          'scopes',
-                          mtMap.array(
-                            mtMap.object({
-                              object: mtMap.objectField(
-                                'object',
-                                mtMap.passthrough()
-                              ),
-                              id: mtMap.objectField('id', mtMap.passthrough()),
-                              scope: mtMap.objectField(
-                                'scope',
-                                mtMap.passthrough()
-                              ),
-                              name: mtMap.objectField(
-                                'name',
-                                mtMap.passthrough()
-                              ),
-                              description: mtMap.objectField(
-                                'description',
-                                mtMap.passthrough()
-                              )
-                            })
-                          )
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        providerSpecificationId: mtMap.objectField(
-                          'provider_specification_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authCredentials: mtMap.objectField(
-                      'auth_credentials',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        status: mtMap.objectField(
-                          'status',
-                          mtMap.passthrough()
-                        ),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        isManaged: mtMap.objectField(
-                          'is_managed',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        scopes: mtMap.objectField(
-                          'scopes',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                integrationInstanceProvider: mtMap.objectField(
-                  'integration_instance_provider',
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              implementation: mtMap.objectField(
+                'implementation',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  magicMcpEndpointId: mtMap.objectField(
+                    'magic_mcp_endpoint_id',
+                    mtMap.passthrough()
+                  )
+                })
+              ),
+              providers: mtMap.objectField(
+                'providers',
+                mtMap.array(
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
@@ -756,8 +132,20 @@ export let mapIntegrationInstanceGroupsListOutput =
                       'integration_id',
                       mtMap.passthrough()
                     ),
+                    integrationInstanceGroupId: mtMap.objectField(
+                      'integration_instance_group_id',
+                      mtMap.passthrough()
+                    ),
                     integrationInstanceId: mtMap.objectField(
                       'integration_instance_id',
+                      mtMap.passthrough()
+                    ),
+                    integrationProviderId: mtMap.objectField(
+                      'integration_provider_id',
+                      mtMap.passthrough()
+                    ),
+                    integrationInstanceProviderId: mtMap.objectField(
+                      'integration_instance_provider_id',
                       mtMap.passthrough()
                     ),
                     toolFilter: mtMap.objectField(
@@ -810,457 +198,18 @@ export let mapIntegrationInstanceGroupsListOutput =
                       'is_override_tool_filter',
                       mtMap.passthrough()
                     ),
-                    provider: mtMap.objectField(
-                      'provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    integrationProvider: mtMap.objectField(
-                      'integration_provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        providerVersion: mtMap.objectField(
-                          'provider_version',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            index: mtMap.objectField(
-                              'index',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        status: mtMap.objectField(
-                          'status',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        toolFilter: mtMap.objectField(
-                          'tool_filter',
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                ignoreParentFilters: mtMap.objectField(
-                                  'ignore_parent_filters',
-                                  mtMap.passthrough()
-                                ),
-                                filters: mtMap.objectField(
-                                  'filters',
-                                  mtMap.array(
-                                    mtMap.union([
-                                      mtMap.unionOption(
-                                        'object',
-                                        mtMap.object({
-                                          type: mtMap.objectField(
-                                            'type',
-                                            mtMap.passthrough()
-                                          ),
-                                          keys: mtMap.objectField(
-                                            'keys',
-                                            mtMap.array(mtMap.passthrough())
-                                          ),
-                                          pattern: mtMap.objectField(
-                                            'pattern',
-                                            mtMap.passthrough()
-                                          ),
-                                          uris: mtMap.objectField(
-                                            'uris',
-                                            mtMap.array(mtMap.passthrough())
-                                          )
-                                        })
-                                      )
-                                    ])
-                                  )
-                                )
-                              })
-                            )
-                          ])
-                        ),
-                        provider: mtMap.objectField(
-                          'provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            slug: mtMap.objectField(
-                              'slug',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        deployment: mtMap.objectField(
-                          'deployment',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authMethod: mtMap.objectField(
-                          'auth_method',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            key: mtMap.objectField('key', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            capabilities: mtMap.objectField(
-                              'capabilities',
-                              mtMap.passthrough()
-                            ),
-                            inputSchema: mtMap.objectField(
-                              'input_schema',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                schema: mtMap.objectField(
-                                  'schema',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            outputSchema: mtMap.objectField(
-                              'output_schema',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                schema: mtMap.objectField(
-                                  'schema',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(
-                                mtMap.object({
-                                  object: mtMap.objectField(
-                                    'object',
-                                    mtMap.passthrough()
-                                  ),
-                                  id: mtMap.objectField(
-                                    'id',
-                                    mtMap.passthrough()
-                                  ),
-                                  scope: mtMap.objectField(
-                                    'scope',
-                                    mtMap.passthrough()
-                                  ),
-                                  name: mtMap.objectField(
-                                    'name',
-                                    mtMap.passthrough()
-                                  ),
-                                  description: mtMap.objectField(
-                                    'description',
-                                    mtMap.passthrough()
-                                  )
-                                })
-                              )
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            providerSpecificationId: mtMap.objectField(
-                              'provider_specification_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authCredentials: mtMap.objectField(
-                          'auth_credentials',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            status: mtMap.objectField(
-                              'status',
-                              mtMap.passthrough()
-                            ),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            isManaged: mtMap.objectField(
-                              'is_managed',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        config: mtMap.objectField(
-                          'config',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField(
-                          'updated_at',
-                          mtMap.date()
-                        ),
-                        archivedAt: mtMap.objectField(
-                          'archived_at',
-                          mtMap.date()
-                        )
-                      })
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authConfig: mtMap.objectField(
-                      'auth_config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
                     createdAt: mtMap.objectField('created_at', mtMap.date()),
                     updatedAt: mtMap.objectField('updated_at', mtMap.date()),
                     archivedAt: mtMap.objectField('archived_at', mtMap.date())
                   })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+                )
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/update.ts
@@ -18,10 +18,11 @@ export type IntegrationInstanceGroupsUpdateOutput = {
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -38,289 +39,6 @@ export type IntegrationInstanceGroupsUpdateOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } | null;
-    integrationInstanceProvider: {
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
@@ -328,722 +46,150 @@ export type IntegrationInstanceGroupsUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: {
+    object: 'integration.instance.group.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceGroupId: string;
+    integrationInstanceId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
 };
 
-export let mapIntegrationInstanceGroupsUpdateOutput =
-  mtMap.object<IntegrationInstanceGroupsUpdateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpEndpointId: mtMap.objectField(
-          'magic_mcp_endpoint_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapIntegrationInstanceGroupsUpdateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpEndpointId: mtMap.objectField(
+            'magic_mcp_endpoint_id',
             mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          )
         })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            integrationId: mtMap.objectField(
+              'integration_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceGroupId: mtMap.objectField(
+              'integration_instance_group_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceId: mtMap.objectField(
+              'integration_instance_id',
+              mtMap.passthrough()
+            ),
+            integrationProviderId: mtMap.objectField(
+              'integration_provider_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceProviderId: mtMap.objectField(
+              'integration_instance_provider_id',
+              mtMap.passthrough()
+            ),
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
+            ),
+            isOverrideToolFilter: mtMap.objectField(
+              'is_override_tool_filter',
+              mtMap.passthrough()
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          })
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type IntegrationInstanceGroupsUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-providers/get.ts
@@ -61,65 +61,10 @@ export type IntegrationInstanceProvidersGetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -160,281 +105,250 @@ export type IntegrationInstanceProvidersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  integrationProvider: {
+    object: 'integration.provider#snapshot';
+    id: string;
+    providerVersion: {
+      object: 'integration.provider.version';
+      id: string;
+      index: number;
+    };
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  };
 };
 
-export let mapIntegrationInstanceProvidersGetOutput =
-  mtMap.object<IntegrationInstanceProvidersGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    isOverrideToolFilter: mtMap.objectField(
-      'is_override_tool_filter',
-      mtMap.passthrough()
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    integrationProvider: mtMap.objectField(
-      'integration_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        providerVersion: mtMap.objectField(
-          'provider_version',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            index: mtMap.objectField('index', mtMap.passthrough())
-          })
-        ),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
-                  mtMap.passthrough()
-                ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
-                            mtMap.passthrough()
-                          ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
-                          )
-                        })
-                      )
-                    ])
-                  )
+export let mapIntegrationInstanceProvidersGetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
                 )
-              })
-            )
-          ])
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        deployment: mtMap.objectField(
-          'deployment',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
+              )
+            })
+          )
+        ])
+      ),
+      isOverrideToolFilter: mtMap.objectField(
+        'is_override_tool_filter',
+        mtMap.passthrough()
+      ),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      integrationProvider: mtMap.objectField(
+        'integration_provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          providerVersion: mtMap.objectField(
+            'provider_version',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              index: mtMap.objectField('index', mtMap.passthrough())
+            })
+          ),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
                 mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
                     mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
                   )
                 })
               )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        config: mtMap.objectField(
-          'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authConfig: mtMap.objectField(
-      'auth_config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
+            mtMap.passthrough()
+          ),
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
+            mtMap.passthrough()
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      ),
+      config: mtMap.objectField(
+        'config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authConfig: mtMap.objectField(
+        'auth_config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-providers/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type IntegrationInstanceProvidersListOutput = {
-  items: {
+  items: ({
     object: 'integration.instance.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -62,71 +62,10 @@ export type IntegrationInstanceProvidersListOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -167,7 +106,54 @@ export type IntegrationInstanceProvidersListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -176,96 +162,12 @@ export let mapIntegrationInstanceProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
               status: mtMap.objectField('status', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
@@ -273,6 +175,14 @@ export let mapIntegrationInstanceProvidersListOutput =
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
               toolFilter: mtMap.objectField(
                 'tool_filter',
                 mtMap.union([
@@ -316,6 +226,10 @@ export let mapIntegrationInstanceProvidersListOutput =
                   )
                 ])
               ),
+              isOverrideToolFilter: mtMap.objectField(
+                'is_override_tool_filter',
+                mtMap.passthrough()
+              ),
               provider: mtMap.objectField(
                 'provider',
                 mtMap.object({
@@ -331,120 +245,114 @@ export let mapIntegrationInstanceProvidersListOutput =
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
               ),
-              deployment: mtMap.objectField(
-                'deployment',
+              integrationProvider: mtMap.objectField(
+                'integration_provider',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
+                  providerVersion: mtMap.objectField(
+                    'provider_version',
                     mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      index: mtMap.objectField('index', mtMap.passthrough())
                     })
                   ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
                   status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
+                  toolFilter: mtMap.objectField(
+                    'tool_filter',
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          ignoreParentFilters: mtMap.objectField(
+                            'ignore_parent_filters',
+                            mtMap.passthrough()
+                          ),
+                          filters: mtMap.objectField(
+                            'filters',
+                            mtMap.array(
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    keys: mtMap.objectField(
+                                      'keys',
+                                      mtMap.array(mtMap.passthrough())
+                                    ),
+                                    pattern: mtMap.objectField(
+                                      'pattern',
+                                      mtMap.passthrough()
+                                    ),
+                                    uris: mtMap.objectField(
+                                      'uris',
+                                      mtMap.array(mtMap.passthrough())
+                                    )
+                                  })
+                                )
+                              ])
+                            )
+                          )
+                        })
+                      )
+                    ])
                   ),
                   providerId: mtMap.objectField(
                     'provider_id',
                     mtMap.passthrough()
                   ),
+                  deploymentId: mtMap.objectField(
+                    'deployment_id',
+                    mtMap.passthrough()
+                  ),
+                  authMethodId: mtMap.objectField(
+                    'auth_method_id',
+                    mtMap.passthrough()
+                  ),
+                  authCredentialsId: mtMap.objectField(
+                    'auth_credentials_id',
+                    mtMap.passthrough()
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
               ),
               config: mtMap.objectField(
@@ -470,49 +378,35 @@ export let mapIntegrationInstanceProvidersListOutput =
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
               ),
+              authConfig: mtMap.objectField(
+                'auth_config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
               archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-providers/set.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-providers/set.ts
@@ -61,65 +61,10 @@ export type IntegrationInstanceProvidersSetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -160,283 +105,252 @@ export type IntegrationInstanceProvidersSetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  integrationProvider: {
+    object: 'integration.provider#snapshot';
+    id: string;
+    providerVersion: {
+      object: 'integration.provider.version';
+      id: string;
+      index: number;
+    };
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  };
 };
 
-export let mapIntegrationInstanceProvidersSetOutput =
-  mtMap.object<IntegrationInstanceProvidersSetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    isOverrideToolFilter: mtMap.objectField(
-      'is_override_tool_filter',
-      mtMap.passthrough()
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    integrationProvider: mtMap.objectField(
-      'integration_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        providerVersion: mtMap.objectField(
-          'provider_version',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            index: mtMap.objectField('index', mtMap.passthrough())
-          })
-        ),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
-                  mtMap.passthrough()
-                ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
-                            mtMap.passthrough()
-                          ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
-                          )
-                        })
-                      )
-                    ])
-                  )
+export let mapIntegrationInstanceProvidersSetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
                 )
-              })
-            )
-          ])
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        deployment: mtMap.objectField(
-          'deployment',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
+              )
+            })
+          )
+        ])
+      ),
+      isOverrideToolFilter: mtMap.objectField(
+        'is_override_tool_filter',
+        mtMap.passthrough()
+      ),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      integrationProvider: mtMap.objectField(
+        'integration_provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          providerVersion: mtMap.objectField(
+            'provider_version',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              index: mtMap.objectField('index', mtMap.passthrough())
+            })
+          ),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
                 mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
                     mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
                   )
                 })
               )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        config: mtMap.objectField(
-          'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authConfig: mtMap.objectField(
-      'auth_config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
+            mtMap.passthrough()
+          ),
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
+            mtMap.passthrough()
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      ),
+      config: mtMap.objectField(
+        'config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authConfig: mtMap.objectField(
+        'auth_config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type IntegrationInstanceProvidersSetBody = {
   providerDeploymentId?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/create.ts
@@ -72,71 +72,10 @@ export type IntegrationInstancesCreateOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -181,64 +120,302 @@ export type IntegrationInstancesCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.instance.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    provider: {
+      object: 'provider#preview';
+      id: string;
+      name: string;
+      description: string | null;
+      slug: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    authConfig: {
+      object: 'provider.auth_config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
 };
 
-export let mapIntegrationInstancesCreateOutput =
-  mtMap.object<IntegrationInstancesCreateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    identityActorId: mtMap.objectField(
-      'identity_actor_id',
-      mtMap.passthrough()
-    ),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpServerId: mtMap.objectField(
-          'magic_mcp_server_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapIntegrationInstancesCreateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpServerId: mtMap.objectField(
+            'magic_mcp_server_id',
             mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
+          )
+        })
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -247,312 +424,161 @@ export let mapIntegrationInstancesCreateOutput =
                               'type',
                               mtMap.passthrough()
                             ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
                               mtMap.passthrough()
                             ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
                             )
                           })
                         )
                       ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
-                        )
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type IntegrationInstancesCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/delete.ts
@@ -72,71 +72,10 @@ export type IntegrationInstancesDeleteOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -181,64 +120,302 @@ export type IntegrationInstancesDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.instance.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    provider: {
+      object: 'provider#preview';
+      id: string;
+      name: string;
+      description: string | null;
+      slug: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    authConfig: {
+      object: 'provider.auth_config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
 };
 
-export let mapIntegrationInstancesDeleteOutput =
-  mtMap.object<IntegrationInstancesDeleteOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    identityActorId: mtMap.objectField(
-      'identity_actor_id',
-      mtMap.passthrough()
-    ),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpServerId: mtMap.objectField(
-          'magic_mcp_server_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapIntegrationInstancesDeleteOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpServerId: mtMap.objectField(
+            'magic_mcp_server_id',
             mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
+          )
+        })
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -247,310 +424,159 @@ export let mapIntegrationInstancesDeleteOutput =
                               'type',
                               mtMap.passthrough()
                             ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
                               mtMap.passthrough()
                             ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
                             )
                           })
                         )
                       ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
-                        )
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/get.ts
@@ -72,71 +72,10 @@ export type IntegrationInstancesGetOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -181,64 +120,302 @@ export type IntegrationInstancesGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.instance.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    provider: {
+      object: 'provider#preview';
+      id: string;
+      name: string;
+      description: string | null;
+      slug: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    authConfig: {
+      object: 'provider.auth_config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
 };
 
-export let mapIntegrationInstancesGetOutput =
-  mtMap.object<IntegrationInstancesGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    identityActorId: mtMap.objectField(
-      'identity_actor_id',
-      mtMap.passthrough()
-    ),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpServerId: mtMap.objectField(
-          'magic_mcp_server_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapIntegrationInstancesGetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpServerId: mtMap.objectField(
+            'magic_mcp_server_id',
             mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
+          )
+        })
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -247,310 +424,159 @@ export let mapIntegrationInstancesGetOutput =
                               'type',
                               mtMap.passthrough()
                             ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
                               mtMap.passthrough()
                             ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
                             )
                           })
                         )
                       ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
-                        )
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type IntegrationInstancesListOutput = {
-  items: {
+  items: ({
     object: 'integration.instance';
     id: string;
     status: 'draft' | 'active' | 'archived' | 'deleted';
@@ -76,71 +76,10 @@ export type IntegrationInstancesListOutput = {
               ignoreParentFilters: boolean;
             }
           | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
         config: {
           object: 'provider.config#preview';
           id: string;
@@ -185,7 +124,161 @@ export type IntegrationInstancesListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
+  } & {
+    providers: ({
+      object: 'integration.instance.provider';
+      id: string;
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      integrationId: string;
+      integrationInstanceId: string;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      isOverrideToolFilter: boolean;
+      provider: {
+        object: 'provider#preview';
+        id: string;
+        name: string;
+        description: string | null;
+        slug: string;
+        createdAt: Date;
+        updatedAt: Date;
+      };
+      integrationProvider: {
+        object: 'integration.provider#snapshot';
+        id: string;
+        providerVersion: {
+          object: 'integration.provider.version';
+          id: string;
+          index: number;
+        };
+        status: 'active' | 'archived' | 'deleted';
+        name: string;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        toolFilter:
+          | { type: 'allow_all'; ignoreParentFilters: boolean }
+          | {
+              type: 'filter';
+              filters: (
+                | { type: 'tool_keys'; keys: string[] }
+                | { type: 'tool_regex'; pattern: string }
+                | { type: 'resource_regex'; pattern: string }
+                | { type: 'resource_uris'; uris: string[] }
+                | { type: 'prompt_keys'; keys: string[] }
+                | { type: 'prompt_regex'; pattern: string }
+              )[];
+              ignoreParentFilters: boolean;
+            }
+          | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
+        config: {
+          object: 'provider.config#preview';
+          id: string;
+          isDefault: boolean;
+          name: string | null;
+          description: string | null;
+          metadata: Record<string, any> | null;
+          providerId: string;
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+        createdAt: Date;
+        updatedAt: Date;
+        archivedAt: Date | null;
+      };
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      authConfig: {
+        object: 'provider.auth_config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    } & {
+      integrationProvider: {
+        object: 'integration.provider#snapshot';
+        id: string;
+        providerVersion: {
+          object: 'integration.provider.version';
+          id: string;
+          index: number;
+        };
+        status: 'active' | 'archived' | 'deleted';
+        name: string;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        toolFilter:
+          | { type: 'allow_all'; ignoreParentFilters: boolean }
+          | {
+              type: 'filter';
+              filters: (
+                | { type: 'tool_keys'; keys: string[] }
+                | { type: 'tool_regex'; pattern: string }
+                | { type: 'resource_regex'; pattern: string }
+                | { type: 'resource_uris'; uris: string[] }
+                | { type: 'prompt_keys'; keys: string[] }
+                | { type: 'prompt_regex'; pattern: string }
+              )[];
+              ignoreParentFilters: boolean;
+            }
+          | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
+        config: {
+          object: 'provider.config#preview';
+          id: string;
+          isDefault: boolean;
+          name: string | null;
+          description: string | null;
+          metadata: Record<string, any> | null;
+          providerId: string;
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+        createdAt: Date;
+        updatedAt: Date;
+        archivedAt: Date | null;
+      };
+    })[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -194,345 +287,54 @@ export let mapIntegrationInstancesListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          identityActorId: mtMap.objectField(
-            'identity_actor_id',
-            mtMap.passthrough()
-          ),
-          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-          implementation: mtMap.objectField(
-            'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
-              )
-            })
-          ),
-          providers: mtMap.objectField(
-            'providers',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              identityActorId: mtMap.objectField(
+                'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              implementation: mtMap.objectField(
+                'implementation',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  magicMcpServerId: mtMap.objectField(
+                    'magic_mcp_server_id',
+                    mtMap.passthrough()
+                  )
+                })
+              ),
+              providers: mtMap.objectField(
+                'providers',
+                mtMap.array(
                   mtMap.union([
                     mtMap.unionOption(
                       'object',
                       mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    provider: mtMap.objectField(
-                      'provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    deployment: mtMap.objectField(
-                      'deployment',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authMethod: mtMap.objectField(
-                      'auth_method',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        key: mtMap.objectField('key', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        capabilities: mtMap.objectField(
-                          'capabilities',
-                          mtMap.passthrough()
-                        ),
-                        inputSchema: mtMap.objectField(
-                          'input_schema',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            schema: mtMap.objectField(
-                              'schema',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        outputSchema: mtMap.objectField(
-                          'output_schema',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            schema: mtMap.objectField(
-                              'schema',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        scopes: mtMap.objectField(
-                          'scopes',
-                          mtMap.array(
-                            mtMap.object({
-                              object: mtMap.objectField(
-                                'object',
-                                mtMap.passthrough()
-                              ),
-                              id: mtMap.objectField('id', mtMap.passthrough()),
-                              scope: mtMap.objectField(
-                                'scope',
-                                mtMap.passthrough()
-                              ),
-                              name: mtMap.objectField(
-                                'name',
-                                mtMap.passthrough()
-                              ),
-                              description: mtMap.objectField(
-                                'description',
-                                mtMap.passthrough()
-                              )
-                            })
-                          )
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        providerSpecificationId: mtMap.objectField(
-                          'provider_specification_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authCredentials: mtMap.objectField(
-                      'auth_credentials',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        type: mtMap.objectField('type', mtMap.passthrough()),
                         status: mtMap.objectField(
                           'status',
                           mtMap.passthrough()
                         ),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        isManaged: mtMap.objectField(
-                          'is_managed',
-                          mtMap.passthrough()
-                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
@@ -542,120 +344,351 @@ export let mapIntegrationInstancesListOutput =
                           'metadata',
                           mtMap.passthrough()
                         ),
-                        scopes: mtMap.objectField(
-                          'scopes',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
+                        integrationId: mtMap.objectField(
+                          'integration_id',
                           mtMap.passthrough()
+                        ),
+                        integrationInstanceId: mtMap.objectField(
+                          'integration_instance_id',
+                          mtMap.passthrough()
+                        ),
+                        toolFilter: mtMap.objectField(
+                          'tool_filter',
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                ignoreParentFilters: mtMap.objectField(
+                                  'ignore_parent_filters',
+                                  mtMap.passthrough()
+                                ),
+                                filters: mtMap.objectField(
+                                  'filters',
+                                  mtMap.array(
+                                    mtMap.union([
+                                      mtMap.unionOption(
+                                        'object',
+                                        mtMap.object({
+                                          type: mtMap.objectField(
+                                            'type',
+                                            mtMap.passthrough()
+                                          ),
+                                          keys: mtMap.objectField(
+                                            'keys',
+                                            mtMap.array(mtMap.passthrough())
+                                          ),
+                                          pattern: mtMap.objectField(
+                                            'pattern',
+                                            mtMap.passthrough()
+                                          ),
+                                          uris: mtMap.objectField(
+                                            'uris',
+                                            mtMap.array(mtMap.passthrough())
+                                          )
+                                        })
+                                      )
+                                    ])
+                                  )
+                                )
+                              })
+                            )
+                          ])
+                        ),
+                        isOverrideToolFilter: mtMap.objectField(
+                          'is_override_tool_filter',
+                          mtMap.passthrough()
+                        ),
+                        provider: mtMap.objectField(
+                          'provider',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            slug: mtMap.objectField(
+                              'slug',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        integrationProvider: mtMap.objectField(
+                          'integration_provider',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            providerVersion: mtMap.objectField(
+                              'provider_version',
+                              mtMap.object({
+                                object: mtMap.objectField(
+                                  'object',
+                                  mtMap.passthrough()
+                                ),
+                                id: mtMap.objectField(
+                                  'id',
+                                  mtMap.passthrough()
+                                ),
+                                index: mtMap.objectField(
+                                  'index',
+                                  mtMap.passthrough()
+                                )
+                              })
+                            ),
+                            status: mtMap.objectField(
+                              'status',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            toolFilter: mtMap.objectField(
+                              'tool_filter',
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    ignoreParentFilters: mtMap.objectField(
+                                      'ignore_parent_filters',
+                                      mtMap.passthrough()
+                                    ),
+                                    filters: mtMap.objectField(
+                                      'filters',
+                                      mtMap.array(
+                                        mtMap.union([
+                                          mtMap.unionOption(
+                                            'object',
+                                            mtMap.object({
+                                              type: mtMap.objectField(
+                                                'type',
+                                                mtMap.passthrough()
+                                              ),
+                                              keys: mtMap.objectField(
+                                                'keys',
+                                                mtMap.array(mtMap.passthrough())
+                                              ),
+                                              pattern: mtMap.objectField(
+                                                'pattern',
+                                                mtMap.passthrough()
+                                              ),
+                                              uris: mtMap.objectField(
+                                                'uris',
+                                                mtMap.array(mtMap.passthrough())
+                                              )
+                                            })
+                                          )
+                                        ])
+                                      )
+                                    )
+                                  })
+                                )
+                              ])
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            deploymentId: mtMap.objectField(
+                              'deployment_id',
+                              mtMap.passthrough()
+                            ),
+                            authMethodId: mtMap.objectField(
+                              'auth_method_id',
+                              mtMap.passthrough()
+                            ),
+                            authCredentialsId: mtMap.objectField(
+                              'auth_credentials_id',
+                              mtMap.passthrough()
+                            ),
+                            config: mtMap.objectField(
+                              'config',
+                              mtMap.object({
+                                object: mtMap.objectField(
+                                  'object',
+                                  mtMap.passthrough()
+                                ),
+                                id: mtMap.objectField(
+                                  'id',
+                                  mtMap.passthrough()
+                                ),
+                                isDefault: mtMap.objectField(
+                                  'is_default',
+                                  mtMap.passthrough()
+                                ),
+                                name: mtMap.objectField(
+                                  'name',
+                                  mtMap.passthrough()
+                                ),
+                                description: mtMap.objectField(
+                                  'description',
+                                  mtMap.passthrough()
+                                ),
+                                metadata: mtMap.objectField(
+                                  'metadata',
+                                  mtMap.passthrough()
+                                ),
+                                providerId: mtMap.objectField(
+                                  'provider_id',
+                                  mtMap.passthrough()
+                                ),
+                                createdAt: mtMap.objectField(
+                                  'created_at',
+                                  mtMap.date()
+                                ),
+                                updatedAt: mtMap.objectField(
+                                  'updated_at',
+                                  mtMap.date()
+                                )
+                              })
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            ),
+                            archivedAt: mtMap.objectField(
+                              'archived_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        config: mtMap.objectField(
+                          'config',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        authConfig: mtMap.objectField(
+                          'auth_config',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',
                           mtMap.date()
                         ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
+                        updatedAt: mtMap.objectField(
+                          'updated_at',
                           mtMap.date()
                         ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                        archivedAt: mtMap.objectField(
+                          'archived_at',
+                          mtMap.date()
+                        )
                       })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+                    )
+                  ])
+                )
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/update.ts
@@ -72,71 +72,10 @@ export type IntegrationInstancesUpdateOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -181,64 +120,302 @@ export type IntegrationInstancesUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.instance.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    provider: {
+      object: 'provider#preview';
+      id: string;
+      name: string;
+      description: string | null;
+      slug: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    authConfig: {
+      object: 'provider.auth_config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
 };
 
-export let mapIntegrationInstancesUpdateOutput =
-  mtMap.object<IntegrationInstancesUpdateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    identityActorId: mtMap.objectField(
-      'identity_actor_id',
-      mtMap.passthrough()
-    ),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpServerId: mtMap.objectField(
-          'magic_mcp_server_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapIntegrationInstancesUpdateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpServerId: mtMap.objectField(
+            'magic_mcp_server_id',
             mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
+          )
+        })
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -247,312 +424,161 @@ export let mapIntegrationInstancesUpdateOutput =
                               'type',
                               mtMap.passthrough()
                             ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
                               mtMap.passthrough()
                             ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
                             )
                           })
                         )
                       ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
-                        )
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type IntegrationInstancesUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/create.ts
@@ -23,6 +23,47 @@ export type IntegrationProvidersCreateOutput = {
         ignoreParentFilters: boolean;
       }
     | null;
+  providerId: string;
+  deploymentId: string;
+  authMethodId: string | null;
+  authCredentialsId: string | null;
+  config: {
+    object: 'provider.config#preview';
+    id: string;
+    isDefault: boolean;
+    name: string | null;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    providerId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  object: 'integration.provider';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  integrationId: string;
+  name: string;
+  description: string | null;
+  metadata: Record<string, any> | null;
+  toolFilter:
+    | { type: 'allow_all'; ignoreParentFilters: boolean }
+    | {
+        type: 'filter';
+        filters: (
+          | { type: 'tool_keys'; keys: string[] }
+          | { type: 'tool_regex'; pattern: string }
+          | { type: 'resource_regex'; pattern: string }
+          | { type: 'resource_uris'; uris: string[] }
+          | { type: 'prompt_keys'; keys: string[] }
+          | { type: 'prompt_regex'; pattern: string }
+        )[];
+        ignoreParentFilters: boolean;
+      }
+    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -82,178 +123,178 @@ export type IntegrationProvidersCreateOutput = {
     createdAt: Date;
     updatedAt: Date;
   } | null;
-  config: {
-    object: 'provider.config#preview';
-    id: string;
-    isDefault: boolean;
-    name: string | null;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    providerId: string;
-    createdAt: Date;
-    updatedAt: Date;
-  } | null;
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapIntegrationProvidersCreateOutput =
-  mtMap.object<IntegrationProvidersCreateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    deployment: mtMap.objectField(
-      'deployment',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authMethod: mtMap.objectField(
-      'auth_method',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        key: mtMap.objectField('key', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-        inputSchema: mtMap.objectField(
-          'input_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        outputSchema: mtMap.objectField(
-          'output_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        scopes: mtMap.objectField(
-          'scopes',
-          mtMap.array(
+export let mapIntegrationProvidersCreateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              scope: mtMap.objectField('scope', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField('description', mtMap.passthrough())
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
             })
           )
-        ),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        providerSpecificationId: mtMap.objectField(
-          'provider_specification_id',
-          mtMap.passthrough()
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authCredentials: mtMap.objectField(
-      'auth_credentials',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+        ])
+      ),
+      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+      authCredentialsId: mtMap.objectField(
+        'auth_credentials_id',
+        mtMap.passthrough()
+      ),
+      config: mtMap.objectField(
+        'config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      deployment: mtMap.objectField(
+        'deployment',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authMethod: mtMap.objectField(
+        'auth_method',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          key: mtMap.objectField('key', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+          inputSchema: mtMap.objectField(
+            'input_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          outputSchema: mtMap.objectField(
+            'output_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          scopes: mtMap.objectField(
+            'scopes',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                scope: mtMap.objectField('scope', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                )
+              })
+            )
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          providerSpecificationId: mtMap.objectField(
+            'provider_specification_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authCredentials: mtMap.objectField(
+        'auth_credentials',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 
 export type IntegrationProvidersCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/delete.ts
@@ -23,6 +23,47 @@ export type IntegrationProvidersDeleteOutput = {
         ignoreParentFilters: boolean;
       }
     | null;
+  providerId: string;
+  deploymentId: string;
+  authMethodId: string | null;
+  authCredentialsId: string | null;
+  config: {
+    object: 'provider.config#preview';
+    id: string;
+    isDefault: boolean;
+    name: string | null;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    providerId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  object: 'integration.provider';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  integrationId: string;
+  name: string;
+  description: string | null;
+  metadata: Record<string, any> | null;
+  toolFilter:
+    | { type: 'allow_all'; ignoreParentFilters: boolean }
+    | {
+        type: 'filter';
+        filters: (
+          | { type: 'tool_keys'; keys: string[] }
+          | { type: 'tool_regex'; pattern: string }
+          | { type: 'resource_regex'; pattern: string }
+          | { type: 'resource_uris'; uris: string[] }
+          | { type: 'prompt_keys'; keys: string[] }
+          | { type: 'prompt_regex'; pattern: string }
+        )[];
+        ignoreParentFilters: boolean;
+      }
+    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -82,176 +123,176 @@ export type IntegrationProvidersDeleteOutput = {
     createdAt: Date;
     updatedAt: Date;
   } | null;
-  config: {
-    object: 'provider.config#preview';
-    id: string;
-    isDefault: boolean;
-    name: string | null;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    providerId: string;
-    createdAt: Date;
-    updatedAt: Date;
-  } | null;
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapIntegrationProvidersDeleteOutput =
-  mtMap.object<IntegrationProvidersDeleteOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    deployment: mtMap.objectField(
-      'deployment',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authMethod: mtMap.objectField(
-      'auth_method',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        key: mtMap.objectField('key', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-        inputSchema: mtMap.objectField(
-          'input_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        outputSchema: mtMap.objectField(
-          'output_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        scopes: mtMap.objectField(
-          'scopes',
-          mtMap.array(
+export let mapIntegrationProvidersDeleteOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              scope: mtMap.objectField('scope', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField('description', mtMap.passthrough())
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
             })
           )
-        ),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        providerSpecificationId: mtMap.objectField(
-          'provider_specification_id',
-          mtMap.passthrough()
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authCredentials: mtMap.objectField(
-      'auth_credentials',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+        ])
+      ),
+      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+      authCredentialsId: mtMap.objectField(
+        'auth_credentials_id',
+        mtMap.passthrough()
+      ),
+      config: mtMap.objectField(
+        'config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      deployment: mtMap.objectField(
+        'deployment',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authMethod: mtMap.objectField(
+        'auth_method',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          key: mtMap.objectField('key', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+          inputSchema: mtMap.objectField(
+            'input_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          outputSchema: mtMap.objectField(
+            'output_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          scopes: mtMap.objectField(
+            'scopes',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                scope: mtMap.objectField('scope', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                )
+              })
+            )
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          providerSpecificationId: mtMap.objectField(
+            'provider_specification_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authCredentials: mtMap.objectField(
+        'auth_credentials',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/get.ts
@@ -23,6 +23,47 @@ export type IntegrationProvidersGetOutput = {
         ignoreParentFilters: boolean;
       }
     | null;
+  providerId: string;
+  deploymentId: string;
+  authMethodId: string | null;
+  authCredentialsId: string | null;
+  config: {
+    object: 'provider.config#preview';
+    id: string;
+    isDefault: boolean;
+    name: string | null;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    providerId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  object: 'integration.provider';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  integrationId: string;
+  name: string;
+  description: string | null;
+  metadata: Record<string, any> | null;
+  toolFilter:
+    | { type: 'allow_all'; ignoreParentFilters: boolean }
+    | {
+        type: 'filter';
+        filters: (
+          | { type: 'tool_keys'; keys: string[] }
+          | { type: 'tool_regex'; pattern: string }
+          | { type: 'resource_regex'; pattern: string }
+          | { type: 'resource_uris'; uris: string[] }
+          | { type: 'prompt_keys'; keys: string[] }
+          | { type: 'prompt_regex'; pattern: string }
+        )[];
+        ignoreParentFilters: boolean;
+      }
+    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -82,176 +123,176 @@ export type IntegrationProvidersGetOutput = {
     createdAt: Date;
     updatedAt: Date;
   } | null;
-  config: {
-    object: 'provider.config#preview';
-    id: string;
-    isDefault: boolean;
-    name: string | null;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    providerId: string;
-    createdAt: Date;
-    updatedAt: Date;
-  } | null;
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapIntegrationProvidersGetOutput =
-  mtMap.object<IntegrationProvidersGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    deployment: mtMap.objectField(
-      'deployment',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authMethod: mtMap.objectField(
-      'auth_method',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        key: mtMap.objectField('key', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-        inputSchema: mtMap.objectField(
-          'input_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        outputSchema: mtMap.objectField(
-          'output_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        scopes: mtMap.objectField(
-          'scopes',
-          mtMap.array(
+export let mapIntegrationProvidersGetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              scope: mtMap.objectField('scope', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField('description', mtMap.passthrough())
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
             })
           )
-        ),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        providerSpecificationId: mtMap.objectField(
-          'provider_specification_id',
-          mtMap.passthrough()
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authCredentials: mtMap.objectField(
-      'auth_credentials',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+        ])
+      ),
+      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+      authCredentialsId: mtMap.objectField(
+        'auth_credentials_id',
+        mtMap.passthrough()
+      ),
+      config: mtMap.objectField(
+        'config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      deployment: mtMap.objectField(
+        'deployment',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authMethod: mtMap.objectField(
+        'auth_method',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          key: mtMap.objectField('key', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+          inputSchema: mtMap.objectField(
+            'input_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          outputSchema: mtMap.objectField(
+            'output_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          scopes: mtMap.objectField(
+            'scopes',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                scope: mtMap.objectField('scope', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                )
+              })
+            )
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          providerSpecificationId: mtMap.objectField(
+            'provider_specification_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authCredentials: mtMap.objectField(
+        'auth_credentials',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/list.ts
@@ -1,7 +1,48 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type IntegrationProvidersListOutput = {
-  items: {
+  items: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
     object: 'integration.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -83,21 +124,7 @@ export type IntegrationProvidersListOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -106,191 +133,239 @@ export let mapIntegrationProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
                 mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
                     mtMap.passthrough()
                   ),
-                  filters: mtMap.objectField(
-                    'filters',
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+              provider: mtMap.objectField(
+                'provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              deployment: mtMap.objectField(
+                'deployment',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              authMethod: mtMap.objectField(
+                'auth_method',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  key: mtMap.objectField('key', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  capabilities: mtMap.objectField(
+                    'capabilities',
+                    mtMap.passthrough()
+                  ),
+                  inputSchema: mtMap.objectField(
+                    'input_schema',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      schema: mtMap.objectField('schema', mtMap.passthrough())
+                    })
+                  ),
+                  outputSchema: mtMap.objectField(
+                    'output_schema',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      schema: mtMap.objectField('schema', mtMap.passthrough())
+                    })
+                  ),
+                  scopes: mtMap.objectField(
+                    'scopes',
                     mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
+                      mtMap.object({
+                        object: mtMap.objectField(
                           'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
                         )
-                      ])
+                      })
                     )
-                  )
+                  ),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  providerSpecificationId: mtMap.objectField(
+                    'provider_specification_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              authCredentials: mtMap.objectField(
+                'auth_credentials',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  isManaged: mtMap.objectField(
+                    'is_managed',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  scopes: mtMap.objectField(
+                    'scopes',
+                    mtMap.array(mtMap.passthrough())
+                  ),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
               )
-            ])
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              capabilities: mtMap.objectField(
-                'capabilities',
-                mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    )
-                  })
-                )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/update.ts
@@ -23,6 +23,47 @@ export type IntegrationProvidersUpdateOutput = {
         ignoreParentFilters: boolean;
       }
     | null;
+  providerId: string;
+  deploymentId: string;
+  authMethodId: string | null;
+  authCredentialsId: string | null;
+  config: {
+    object: 'provider.config#preview';
+    id: string;
+    isDefault: boolean;
+    name: string | null;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    providerId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  object: 'integration.provider';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  integrationId: string;
+  name: string;
+  description: string | null;
+  metadata: Record<string, any> | null;
+  toolFilter:
+    | { type: 'allow_all'; ignoreParentFilters: boolean }
+    | {
+        type: 'filter';
+        filters: (
+          | { type: 'tool_keys'; keys: string[] }
+          | { type: 'tool_regex'; pattern: string }
+          | { type: 'resource_regex'; pattern: string }
+          | { type: 'resource_uris'; uris: string[] }
+          | { type: 'prompt_keys'; keys: string[] }
+          | { type: 'prompt_regex'; pattern: string }
+        )[];
+        ignoreParentFilters: boolean;
+      }
+    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -82,178 +123,178 @@ export type IntegrationProvidersUpdateOutput = {
     createdAt: Date;
     updatedAt: Date;
   } | null;
-  config: {
-    object: 'provider.config#preview';
-    id: string;
-    isDefault: boolean;
-    name: string | null;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    providerId: string;
-    createdAt: Date;
-    updatedAt: Date;
-  } | null;
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapIntegrationProvidersUpdateOutput =
-  mtMap.object<IntegrationProvidersUpdateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    deployment: mtMap.objectField(
-      'deployment',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authMethod: mtMap.objectField(
-      'auth_method',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        key: mtMap.objectField('key', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-        inputSchema: mtMap.objectField(
-          'input_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        outputSchema: mtMap.objectField(
-          'output_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        scopes: mtMap.objectField(
-          'scopes',
-          mtMap.array(
+export let mapIntegrationProvidersUpdateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              scope: mtMap.objectField('scope', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField('description', mtMap.passthrough())
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
             })
           )
-        ),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        providerSpecificationId: mtMap.objectField(
-          'provider_specification_id',
-          mtMap.passthrough()
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authCredentials: mtMap.objectField(
-      'auth_credentials',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+        ])
+      ),
+      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+      authCredentialsId: mtMap.objectField(
+        'auth_credentials_id',
+        mtMap.passthrough()
+      ),
+      config: mtMap.objectField(
+        'config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      deployment: mtMap.objectField(
+        'deployment',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authMethod: mtMap.objectField(
+        'auth_method',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          key: mtMap.objectField('key', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+          inputSchema: mtMap.objectField(
+            'input_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          outputSchema: mtMap.objectField(
+            'output_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          scopes: mtMap.objectField(
+            'scopes',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                scope: mtMap.objectField('scope', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                )
+              })
+            )
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          providerSpecificationId: mtMap.objectField(
+            'provider_specification_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authCredentials: mtMap.objectField(
+        'auth_credentials',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 
 export type IntegrationProvidersUpdateBody = {
   providerDeploymentId?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-setup-sessions/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-setup-sessions/create.ts
@@ -11,7 +11,6 @@ export type IntegrationSetupSessionsCreateOutput = {
   configuration: Record<string, any> | null;
   redirectUrl: string | null;
   integrationId: string;
-  integrationInstanceId: string;
   integrationInstance: {
     object: 'integration.instance';
     id: string;
@@ -87,71 +86,10 @@ export type IntegrationSetupSessionsCreateOutput = {
               ignoreParentFilters: boolean;
             }
           | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
         config: {
           object: 'provider.config#preview';
           id: string;
@@ -197,6 +135,11 @@ export type IntegrationSetupSessionsCreateOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
+  createdAt: Date;
+  updatedAt: Date;
+  expiresAt: Date;
+} & {
+  integrationInstanceId: string;
   steps: {
     object: 'integration.setup_session.step';
     id: string;
@@ -224,479 +167,371 @@ export type IntegrationSetupSessionsCreateOutput = {
     createdAt: Date;
     updatedAt: Date;
   }[];
-  createdAt: Date;
-  updatedAt: Date;
-  expiresAt: Date;
 };
 
-export let mapIntegrationSetupSessionsCreateOutput =
-  mtMap.object<IntegrationSetupSessionsCreateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    url: mtMap.objectField('url', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField('configuration', mtMap.passthrough()),
-    redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    integrationInstance: mtMap.objectField(
-      'integration_instance',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        identityActorId: mtMap.objectField(
-          'identity_actor_id',
-          mtMap.passthrough()
-        ),
-        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-        implementation: mtMap.objectField(
-          'implementation',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
-              mtMap.passthrough()
-            )
-          })
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    steps: mtMap.objectField(
-      'steps',
-      mtMap.array(
+export let mapIntegrationSetupSessionsCreateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      url: mtMap.objectField('url', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField('configuration', mtMap.passthrough()),
+      redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstance: mtMap.objectField(
+        'integration_instance',
         mtMap.object({
           object: mtMap.objectField('object', mtMap.passthrough()),
           id: mtMap.objectField('id', mtMap.passthrough()),
           status: mtMap.objectField('status', mtMap.passthrough()),
-          url: mtMap.objectField('url', mtMap.passthrough()),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
           ),
-          provider: mtMap.objectField(
-            'provider',
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          implementation: mtMap.objectField(
+            'implementation',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              )
             })
           ),
-          providerSetupSessionId: mtMap.objectField(
-            'provider_setup_session_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceProviderId: mtMap.objectField(
-            'integration_instance_provider_id',
-            mtMap.passthrough()
+          providers: mtMap.objectField(
+            'providers',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
+                              mtMap.passthrough()
+                            ),
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
+                            )
+                          })
+                        )
+                      ])
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
           ),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
         })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      steps: mtMap.objectField(
+        'steps',
+        mtMap.array(
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            url: mtMap.objectField('url', mtMap.passthrough()),
+            integrationProviderId: mtMap.objectField(
+              'integration_provider_id',
+              mtMap.passthrough()
+            ),
+            provider: mtMap.objectField(
+              'provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                slug: mtMap.objectField('slug', mtMap.passthrough()),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            providerSetupSessionId: mtMap.objectField(
+              'provider_setup_session_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceProviderId: mtMap.objectField(
+              'integration_instance_provider_id',
+              mtMap.passthrough()
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        )
       )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    expiresAt: mtMap.objectField('expires_at', mtMap.date())
-  });
+    })
+  )
+]);
 
 export type IntegrationSetupSessionsCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-setup-sessions/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-setup-sessions/get.ts
@@ -11,7 +11,6 @@ export type IntegrationSetupSessionsGetOutput = {
   configuration: Record<string, any> | null;
   redirectUrl: string | null;
   integrationId: string;
-  integrationInstanceId: string;
   integrationInstance: {
     object: 'integration.instance';
     id: string;
@@ -87,71 +86,10 @@ export type IntegrationSetupSessionsGetOutput = {
               ignoreParentFilters: boolean;
             }
           | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
         config: {
           object: 'provider.config#preview';
           id: string;
@@ -197,6 +135,11 @@ export type IntegrationSetupSessionsGetOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
+  createdAt: Date;
+  updatedAt: Date;
+  expiresAt: Date;
+} & {
+  integrationInstanceId: string;
   steps: {
     object: 'integration.setup_session.step';
     id: string;
@@ -224,477 +167,369 @@ export type IntegrationSetupSessionsGetOutput = {
     createdAt: Date;
     updatedAt: Date;
   }[];
-  createdAt: Date;
-  updatedAt: Date;
-  expiresAt: Date;
 };
 
-export let mapIntegrationSetupSessionsGetOutput =
-  mtMap.object<IntegrationSetupSessionsGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    url: mtMap.objectField('url', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField('configuration', mtMap.passthrough()),
-    redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    integrationInstance: mtMap.objectField(
-      'integration_instance',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        identityActorId: mtMap.objectField(
-          'identity_actor_id',
-          mtMap.passthrough()
-        ),
-        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-        implementation: mtMap.objectField(
-          'implementation',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
-              mtMap.passthrough()
-            )
-          })
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    steps: mtMap.objectField(
-      'steps',
-      mtMap.array(
+export let mapIntegrationSetupSessionsGetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      url: mtMap.objectField('url', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField('configuration', mtMap.passthrough()),
+      redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstance: mtMap.objectField(
+        'integration_instance',
         mtMap.object({
           object: mtMap.objectField('object', mtMap.passthrough()),
           id: mtMap.objectField('id', mtMap.passthrough()),
           status: mtMap.objectField('status', mtMap.passthrough()),
-          url: mtMap.objectField('url', mtMap.passthrough()),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
           ),
-          provider: mtMap.objectField(
-            'provider',
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          implementation: mtMap.objectField(
+            'implementation',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              )
             })
           ),
-          providerSetupSessionId: mtMap.objectField(
-            'provider_setup_session_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceProviderId: mtMap.objectField(
-            'integration_instance_provider_id',
-            mtMap.passthrough()
+          providers: mtMap.objectField(
+            'providers',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
+                              mtMap.passthrough()
+                            ),
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
+                            )
+                          })
+                        )
+                      ])
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
           ),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
         })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      steps: mtMap.objectField(
+        'steps',
+        mtMap.array(
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            url: mtMap.objectField('url', mtMap.passthrough()),
+            integrationProviderId: mtMap.objectField(
+              'integration_provider_id',
+              mtMap.passthrough()
+            ),
+            provider: mtMap.objectField(
+              'provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                slug: mtMap.objectField('slug', mtMap.passthrough()),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            providerSetupSessionId: mtMap.objectField(
+              'provider_setup_session_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceProviderId: mtMap.objectField(
+              'integration_instance_provider_id',
+              mtMap.passthrough()
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        )
       )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    expiresAt: mtMap.objectField('expires_at', mtMap.date())
-  });
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-setup-sessions/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-setup-sessions/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type IntegrationSetupSessionsListOutput = {
-  items: {
+  items: ({
     object: 'integration.setup_session';
     id: string;
     status: 'pending' | 'successful' | 'expired' | 'archived' | 'deleted';
@@ -12,7 +12,6 @@ export type IntegrationSetupSessionsListOutput = {
     configuration: Record<string, any> | null;
     redirectUrl: string | null;
     integrationId: string;
-    integrationInstanceId: string;
     integrationInstance: {
       object: 'integration.instance';
       id: string;
@@ -88,71 +87,10 @@ export type IntegrationSetupSessionsListOutput = {
                 ignoreParentFilters: boolean;
               }
             | null;
-          provider: {
-            object: 'provider#preview';
-            id: string;
-            name: string;
-            description: string | null;
-            slug: string;
-            createdAt: Date;
-            updatedAt: Date;
-          };
-          deployment: {
-            object: 'provider.deployment#preview';
-            id: string;
-            isDefault: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          };
-          authMethod: {
-            object: 'provider.capabilities.auth_method';
-            id: string;
-            type: 'oauth' | 'token' | 'custom';
-            key: string;
-            name: string;
-            description: string | null;
-            capabilities: Record<string, any>;
-            inputSchema: {
-              type: 'json_schema';
-              schema: Record<string, any>;
-            } | null;
-            outputSchema: {
-              type: 'json_schema';
-              schema: Record<string, any>;
-            } | null;
-            scopes:
-              | {
-                  object: 'provider.capabilities.auth_method.scope';
-                  id: string;
-                  scope: string;
-                  name: string;
-                  description: string | null;
-                }[]
-              | null;
-            providerId: string;
-            providerSpecificationId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
-          authCredentials: {
-            object: 'provider.auth_credentials';
-            id: string;
-            type: 'oauth';
-            status: 'active' | 'archived' | 'deleted';
-            isDefault: boolean;
-            isManaged: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            scopes: string[] | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
+          providerId: string;
+          deploymentId: string;
+          authMethodId: string | null;
+          authCredentialsId: string | null;
           config: {
             object: 'provider.config#preview';
             id: string;
@@ -198,6 +136,11 @@ export type IntegrationSetupSessionsListOutput = {
       updatedAt: Date;
       archivedAt: Date | null;
     };
+    createdAt: Date;
+    updatedAt: Date;
+    expiresAt: Date;
+  } & {
+    integrationInstanceId: string;
     steps: {
       object: 'integration.setup_session.step';
       id: string;
@@ -225,10 +168,7 @@ export type IntegrationSetupSessionsListOutput = {
       createdAt: Date;
       updatedAt: Date;
     }[];
-    createdAt: Date;
-    updatedAt: Date;
-    expiresAt: Date;
-  }[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -237,175 +177,75 @@ export let mapIntegrationSetupSessionsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          url: mtMap.objectField('url', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          configuration: mtMap.objectField(
-            'configuration',
-            mtMap.passthrough()
-          ),
-          redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationInstance: mtMap.objectField(
-            'integration_instance',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
               status: mtMap.objectField('status', mtMap.passthrough()),
+              url: mtMap.objectField('url', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
                 'description',
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              configuration: mtMap.objectField(
+                'configuration',
+                mtMap.passthrough()
+              ),
+              redirectUrl: mtMap.objectField(
+                'redirect_url',
+                mtMap.passthrough()
+              ),
               integrationId: mtMap.objectField(
                 'integration_id',
                 mtMap.passthrough()
               ),
-              identityActorId: mtMap.objectField(
-                'identity_actor_id',
-                mtMap.passthrough()
-              ),
-              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-              implementation: mtMap.objectField(
-                'implementation',
+              integrationInstance: mtMap.objectField(
+                'integration_instance',
                 mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  magicMcpServerId: mtMap.objectField(
-                    'magic_mcp_server_id',
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
                     mtMap.passthrough()
-                  )
-                })
-              ),
-              providers: mtMap.objectField(
-                'providers',
-                mtMap.array(
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    integrationId: mtMap.objectField(
-                      'integration_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationInstanceId: mtMap.objectField(
-                      'integration_instance_id',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    isOverrideToolFilter: mtMap.objectField(
-                      'is_override_tool_filter',
-                      mtMap.passthrough()
-                    ),
-                    provider: mtMap.objectField(
-                      'provider',
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  integrationId: mtMap.objectField(
+                    'integration_id',
+                    mtMap.passthrough()
+                  ),
+                  identityActorId: mtMap.objectField(
+                    'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  implementation: mtMap.objectField(
+                    'implementation',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      magicMcpServerId: mtMap.objectField(
+                        'magic_mcp_server_id',
+                        mtMap.passthrough()
+                      )
+                    })
+                  ),
+                  providers: mtMap.objectField(
+                    'providers',
+                    mtMap.array(
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    integrationProvider: mtMap.objectField(
-                      'integration_provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        providerVersion: mtMap.objectField(
-                          'provider_version',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            index: mtMap.objectField(
-                              'index',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
                         status: mtMap.objectField(
                           'status',
                           mtMap.passthrough()
@@ -417,6 +257,14 @@ export let mapIntegrationSetupSessionsListOutput =
                         ),
                         metadata: mtMap.objectField(
                           'metadata',
+                          mtMap.passthrough()
+                        ),
+                        integrationId: mtMap.objectField(
+                          'integration_id',
+                          mtMap.passthrough()
+                        ),
+                        integrationInstanceId: mtMap.objectField(
+                          'integration_instance_id',
                           mtMap.passthrough()
                         ),
                         toolFilter: mtMap.objectField(
@@ -465,6 +313,10 @@ export let mapIntegrationSetupSessionsListOutput =
                             )
                           ])
                         ),
+                        isOverrideToolFilter: mtMap.objectField(
+                          'is_override_tool_filter',
+                          mtMap.passthrough()
+                        ),
                         provider: mtMap.objectField(
                           'provider',
                           mtMap.object({
@@ -495,164 +347,35 @@ export let mapIntegrationSetupSessionsListOutput =
                             )
                           })
                         ),
-                        deployment: mtMap.objectField(
-                          'deployment',
+                        integrationProvider: mtMap.objectField(
+                          'integration_provider',
                           mtMap.object({
                             object: mtMap.objectField(
                               'object',
                               mtMap.passthrough()
                             ),
                             id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authMethod: mtMap.objectField(
-                          'auth_method',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            key: mtMap.objectField('key', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            capabilities: mtMap.objectField(
-                              'capabilities',
-                              mtMap.passthrough()
-                            ),
-                            inputSchema: mtMap.objectField(
-                              'input_schema',
+                            providerVersion: mtMap.objectField(
+                              'provider_version',
                               mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
+                                object: mtMap.objectField(
+                                  'object',
                                   mtMap.passthrough()
                                 ),
-                                schema: mtMap.objectField(
-                                  'schema',
+                                id: mtMap.objectField(
+                                  'id',
+                                  mtMap.passthrough()
+                                ),
+                                index: mtMap.objectField(
+                                  'index',
                                   mtMap.passthrough()
                                 )
                               })
-                            ),
-                            outputSchema: mtMap.objectField(
-                              'output_schema',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                schema: mtMap.objectField(
-                                  'schema',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(
-                                mtMap.object({
-                                  object: mtMap.objectField(
-                                    'object',
-                                    mtMap.passthrough()
-                                  ),
-                                  id: mtMap.objectField(
-                                    'id',
-                                    mtMap.passthrough()
-                                  ),
-                                  scope: mtMap.objectField(
-                                    'scope',
-                                    mtMap.passthrough()
-                                  ),
-                                  name: mtMap.objectField(
-                                    'name',
-                                    mtMap.passthrough()
-                                  ),
-                                  description: mtMap.objectField(
-                                    'description',
-                                    mtMap.passthrough()
-                                  )
-                                })
-                              )
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            providerSpecificationId: mtMap.objectField(
-                              'provider_specification_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authCredentials: mtMap.objectField(
-                          'auth_credentials',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
                             ),
                             status: mtMap.objectField(
                               'status',
                               mtMap.passthrough()
                             ),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            isManaged: mtMap.objectField(
-                              'is_managed',
-                              mtMap.passthrough()
-                            ),
                             name: mtMap.objectField(
                               'name',
                               mtMap.passthrough()
@@ -665,13 +388,108 @@ export let mapIntegrationSetupSessionsListOutput =
                               'metadata',
                               mtMap.passthrough()
                             ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(mtMap.passthrough())
+                            toolFilter: mtMap.objectField(
+                              'tool_filter',
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    ignoreParentFilters: mtMap.objectField(
+                                      'ignore_parent_filters',
+                                      mtMap.passthrough()
+                                    ),
+                                    filters: mtMap.objectField(
+                                      'filters',
+                                      mtMap.array(
+                                        mtMap.union([
+                                          mtMap.unionOption(
+                                            'object',
+                                            mtMap.object({
+                                              type: mtMap.objectField(
+                                                'type',
+                                                mtMap.passthrough()
+                                              ),
+                                              keys: mtMap.objectField(
+                                                'keys',
+                                                mtMap.array(mtMap.passthrough())
+                                              ),
+                                              pattern: mtMap.objectField(
+                                                'pattern',
+                                                mtMap.passthrough()
+                                              ),
+                                              uris: mtMap.objectField(
+                                                'uris',
+                                                mtMap.array(mtMap.passthrough())
+                                              )
+                                            })
+                                          )
+                                        ])
+                                      )
+                                    )
+                                  })
+                                )
+                              ])
                             ),
                             providerId: mtMap.objectField(
                               'provider_id',
                               mtMap.passthrough()
+                            ),
+                            deploymentId: mtMap.objectField(
+                              'deployment_id',
+                              mtMap.passthrough()
+                            ),
+                            authMethodId: mtMap.objectField(
+                              'auth_method_id',
+                              mtMap.passthrough()
+                            ),
+                            authCredentialsId: mtMap.objectField(
+                              'auth_credentials_id',
+                              mtMap.passthrough()
+                            ),
+                            config: mtMap.objectField(
+                              'config',
+                              mtMap.object({
+                                object: mtMap.objectField(
+                                  'object',
+                                  mtMap.passthrough()
+                                ),
+                                id: mtMap.objectField(
+                                  'id',
+                                  mtMap.passthrough()
+                                ),
+                                isDefault: mtMap.objectField(
+                                  'is_default',
+                                  mtMap.passthrough()
+                                ),
+                                name: mtMap.objectField(
+                                  'name',
+                                  mtMap.passthrough()
+                                ),
+                                description: mtMap.objectField(
+                                  'description',
+                                  mtMap.passthrough()
+                                ),
+                                metadata: mtMap.objectField(
+                                  'metadata',
+                                  mtMap.passthrough()
+                                ),
+                                providerId: mtMap.objectField(
+                                  'provider_id',
+                                  mtMap.passthrough()
+                                ),
+                                createdAt: mtMap.objectField(
+                                  'created_at',
+                                  mtMap.date()
+                                ),
+                                updatedAt: mtMap.objectField(
+                                  'updated_at',
+                                  mtMap.date()
+                                )
+                              })
                             ),
                             createdAt: mtMap.objectField(
                               'created_at',
@@ -679,12 +497,54 @@ export let mapIntegrationSetupSessionsListOutput =
                             ),
                             updatedAt: mtMap.objectField(
                               'updated_at',
+                              mtMap.date()
+                            ),
+                            archivedAt: mtMap.objectField(
+                              'archived_at',
                               mtMap.date()
                             )
                           })
                         ),
                         config: mtMap.objectField(
                           'config',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        authConfig: mtMap.objectField(
+                          'auth_config',
                           mtMap.object({
                             object: mtMap.objectField(
                               'object',
@@ -734,126 +594,69 @@ export let mapIntegrationSetupSessionsListOutput =
                           mtMap.date()
                         )
                       })
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authConfig: mtMap.objectField(
-                      'auth_config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                )
+                    )
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                })
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          steps: mtMap.objectField(
-            'steps',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                url: mtMap.objectField('url', mtMap.passthrough()),
-                integrationProviderId: mtMap.objectField(
-                  'integration_provider_id',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
+              expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              steps: mtMap.objectField(
+                'steps',
+                mtMap.array(
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    url: mtMap.objectField('url', mtMap.passthrough()),
+                    integrationProviderId: mtMap.objectField(
+                      'integration_provider_id',
                       mtMap.passthrough()
                     ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    provider: mtMap.objectField(
+                      'provider',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        ),
+                        slug: mtMap.objectField('slug', mtMap.passthrough()),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    ),
+                    providerSetupSessionId: mtMap.objectField(
+                      'provider_setup_session_id',
+                      mtMap.passthrough()
+                    ),
+                    integrationInstanceProviderId: mtMap.objectField(
+                      'integration_instance_provider_id',
+                      mtMap.passthrough()
+                    ),
                     createdAt: mtMap.objectField('created_at', mtMap.date()),
                     updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
-                ),
-                providerSetupSessionId: mtMap.objectField(
-                  'provider_setup_session_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceProviderId: mtMap.objectField(
-                  'integration_instance_provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            )
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          expiresAt: mtMap.objectField('expires_at', mtMap.date())
-        })
+                )
+              )
+            })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/create.ts
@@ -40,6 +40,93 @@ export type IntegrationsCreateOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -99,266 +186,315 @@ export type IntegrationsCreateOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
+  })[];
 };
 
-export let mapIntegrationsCreateOutput = mtMap.object<IntegrationsCreateOutput>(
-  {
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    slug: mtMap.objectField('slug', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField(
-      'configuration',
-      mtMap.object({
-        canAttachCustomToolFilters: mtMap.objectField(
-          'can_attach_custom_tool_filters',
-          mtMap.passthrough()
-        ),
-        canAttachCustomProviderConfig: mtMap.objectField(
-          'can_attach_custom_provider_config',
-          mtMap.passthrough()
-        ),
-        canOverrideToolFilters: mtMap.objectField(
-          'can_override_tool_filters',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            providerTemplateId: mtMap.objectField(
-              'provider_template_id',
-              mtMap.passthrough()
-            ),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
-              mtMap.passthrough()
-            )
-          })
-        )
-      ])
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapIntegrationsCreateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      slug: mtMap.objectField('slug', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField(
+        'configuration',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          canAttachCustomToolFilters: mtMap.objectField(
+            'can_attach_custom_tool_filters',
             mtMap.passthrough()
           ),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
+          canAttachCustomProviderConfig: mtMap.objectField(
+            'can_attach_custom_provider_config',
+            mtMap.passthrough()
           ),
-          provider: mtMap.objectField(
-            'provider',
+          canOverrideToolFilters: mtMap.objectField(
+            'can_override_tool_filters',
+            mtMap.passthrough()
+          )
+        })
+      ),
+      implementation: mtMap.objectField(
+        'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
               type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              providerTemplateId: mtMap.objectField(
+                'provider_template_id',
                 mtMap.passthrough()
               ),
-              capabilities: mtMap.objectField(
-                'capabilities',
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
+              )
+            })
+          )
+        ])
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
                     name: mtMap.objectField('name', mtMap.passthrough()),
                     description: mtMap.objectField(
                       'description',
                       mtMap.passthrough()
-                    )
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                deployment: mtMap.objectField(
+                  'deployment',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authMethod: mtMap.objectField(
+                  'auth_method',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    key: mtMap.objectField('key', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    capabilities: mtMap.objectField(
+                      'capabilities',
+                      mtMap.passthrough()
+                    ),
+                    inputSchema: mtMap.objectField(
+                      'input_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    outputSchema: mtMap.objectField(
+                      'output_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          scope: mtMap.objectField(
+                            'scope',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          )
+                        })
+                      )
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    providerSpecificationId: mtMap.objectField(
+                      'provider_specification_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authCredentials: mtMap.objectField(
+                  'auth_credentials',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    isManaged: mtMap.objectField(
+                      'is_managed',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(mtMap.passthrough())
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  }
-);
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type IntegrationsCreateBody = {
   name: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/delete.ts
@@ -40,6 +40,93 @@ export type IntegrationsDeleteOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -99,264 +186,313 @@ export type IntegrationsDeleteOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
+  })[];
 };
 
-export let mapIntegrationsDeleteOutput = mtMap.object<IntegrationsDeleteOutput>(
-  {
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    slug: mtMap.objectField('slug', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField(
-      'configuration',
-      mtMap.object({
-        canAttachCustomToolFilters: mtMap.objectField(
-          'can_attach_custom_tool_filters',
-          mtMap.passthrough()
-        ),
-        canAttachCustomProviderConfig: mtMap.objectField(
-          'can_attach_custom_provider_config',
-          mtMap.passthrough()
-        ),
-        canOverrideToolFilters: mtMap.objectField(
-          'can_override_tool_filters',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            providerTemplateId: mtMap.objectField(
-              'provider_template_id',
-              mtMap.passthrough()
-            ),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
-              mtMap.passthrough()
-            )
-          })
-        )
-      ])
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapIntegrationsDeleteOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      slug: mtMap.objectField('slug', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField(
+        'configuration',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          canAttachCustomToolFilters: mtMap.objectField(
+            'can_attach_custom_tool_filters',
             mtMap.passthrough()
           ),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
+          canAttachCustomProviderConfig: mtMap.objectField(
+            'can_attach_custom_provider_config',
+            mtMap.passthrough()
           ),
-          provider: mtMap.objectField(
-            'provider',
+          canOverrideToolFilters: mtMap.objectField(
+            'can_override_tool_filters',
+            mtMap.passthrough()
+          )
+        })
+      ),
+      implementation: mtMap.objectField(
+        'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
               type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              providerTemplateId: mtMap.objectField(
+                'provider_template_id',
                 mtMap.passthrough()
               ),
-              capabilities: mtMap.objectField(
-                'capabilities',
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
+              )
+            })
+          )
+        ])
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
                     name: mtMap.objectField('name', mtMap.passthrough()),
                     description: mtMap.objectField(
                       'description',
                       mtMap.passthrough()
-                    )
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                deployment: mtMap.objectField(
+                  'deployment',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authMethod: mtMap.objectField(
+                  'auth_method',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    key: mtMap.objectField('key', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    capabilities: mtMap.objectField(
+                      'capabilities',
+                      mtMap.passthrough()
+                    ),
+                    inputSchema: mtMap.objectField(
+                      'input_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    outputSchema: mtMap.objectField(
+                      'output_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          scope: mtMap.objectField(
+                            'scope',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          )
+                        })
+                      )
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    providerSpecificationId: mtMap.objectField(
+                      'provider_specification_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authCredentials: mtMap.objectField(
+                  'auth_credentials',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    isManaged: mtMap.objectField(
+                      'is_managed',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(mtMap.passthrough())
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  }
-);
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/get.ts
@@ -40,6 +40,93 @@ export type IntegrationsGetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -99,241 +186,313 @@ export type IntegrationsGetOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
+  })[];
 };
 
-export let mapIntegrationsGetOutput = mtMap.object<IntegrationsGetOutput>({
-  object: mtMap.objectField('object', mtMap.passthrough()),
-  id: mtMap.objectField('id', mtMap.passthrough()),
-  status: mtMap.objectField('status', mtMap.passthrough()),
-  slug: mtMap.objectField('slug', mtMap.passthrough()),
-  name: mtMap.objectField('name', mtMap.passthrough()),
-  description: mtMap.objectField('description', mtMap.passthrough()),
-  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-  configuration: mtMap.objectField(
-    'configuration',
+export let mapIntegrationsGetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
     mtMap.object({
-      canAttachCustomToolFilters: mtMap.objectField(
-        'can_attach_custom_tool_filters',
-        mtMap.passthrough()
-      ),
-      canAttachCustomProviderConfig: mtMap.objectField(
-        'can_attach_custom_provider_config',
-        mtMap.passthrough()
-      ),
-      canOverrideToolFilters: mtMap.objectField(
-        'can_override_tool_filters',
-        mtMap.passthrough()
-      )
-    })
-  ),
-  implementation: mtMap.objectField(
-    'implementation',
-    mtMap.union([
-      mtMap.unionOption(
-        'object',
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      slug: mtMap.objectField('slug', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField(
+        'configuration',
         mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          providerTemplateId: mtMap.objectField(
-            'provider_template_id',
+          canAttachCustomToolFilters: mtMap.objectField(
+            'can_attach_custom_tool_filters',
             mtMap.passthrough()
           ),
-          magicMcpServerId: mtMap.objectField(
-            'magic_mcp_server_id',
+          canAttachCustomProviderConfig: mtMap.objectField(
+            'can_attach_custom_provider_config',
+            mtMap.passthrough()
+          ),
+          canOverrideToolFilters: mtMap.objectField(
+            'can_override_tool_filters',
             mtMap.passthrough()
           )
         })
-      )
-    ])
-  ),
-  providers: mtMap.objectField(
-    'providers',
-    mtMap.array(
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
+      ),
+      implementation: mtMap.objectField(
+        'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              providerTemplateId: mtMap.objectField(
+                'provider_template_id',
+                mtMap.passthrough()
+              ),
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
+                mtMap.passthrough()
+              )
+            })
+          )
+        ])
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
           mtMap.union([
             mtMap.unionOption(
               'object',
               mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
                   mtMap.passthrough()
                 ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                deployment: mtMap.objectField(
+                  'deployment',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authMethod: mtMap.objectField(
+                  'auth_method',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    key: mtMap.objectField('key', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    capabilities: mtMap.objectField(
+                      'capabilities',
+                      mtMap.passthrough()
+                    ),
+                    inputSchema: mtMap.objectField(
+                      'input_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    outputSchema: mtMap.objectField(
+                      'output_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(
                         mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
+                          object: mtMap.objectField(
+                            'object',
                             mtMap.passthrough()
                           ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          scope: mtMap.objectField(
+                            'scope',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
                           )
                         })
                       )
-                    ])
-                  )
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    providerSpecificationId: mtMap.objectField(
+                      'provider_specification_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authCredentials: mtMap.objectField(
+                  'auth_credentials',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    isManaged: mtMap.objectField(
+                      'is_managed',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(mtMap.passthrough())
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
                 )
               })
             )
           ])
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        deployment: mtMap.objectField(
-          'deployment',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  )
-                })
-              )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        config: mtMap.objectField(
-          'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    )
-  ),
-  createdAt: mtMap.objectField('created_at', mtMap.date()),
-  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-});
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type IntegrationsListOutput = {
-  items: {
+  items: ({
     object: 'integration';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -19,6 +19,93 @@ export type IntegrationsListOutput = {
       | { type: 'magic_mcp_server'; magicMcpServerId: string }
       | null;
     providers: {
+      object: 'integration.provider';
+      id: string;
+      status: 'active' | 'archived' | 'deleted';
+      integrationId: string;
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    }[];
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    providers: ({
+      object: 'integration.provider';
+      id: string;
+      status: 'active' | 'archived' | 'deleted';
+      integrationId: string;
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    } & {
       object: 'integration.provider';
       id: string;
       status: 'active' | 'archived' | 'deleted';
@@ -106,25 +193,8 @@ export type IntegrationsListOutput = {
         createdAt: Date;
         updatedAt: Date;
       } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    }[];
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
+    })[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -132,274 +202,387 @@ export let mapIntegrationsListOutput = mtMap.object<IntegrationsListOutput>({
   items: mtMap.objectField(
     'items',
     mtMap.array(
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        configuration: mtMap.objectField(
-          'configuration',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
           mtMap.object({
-            canAttachCustomToolFilters: mtMap.objectField(
-              'can_attach_custom_tool_filters',
-              mtMap.passthrough()
-            ),
-            canAttachCustomProviderConfig: mtMap.objectField(
-              'can_attach_custom_provider_config',
-              mtMap.passthrough()
-            ),
-            canOverrideToolFilters: mtMap.objectField(
-              'can_override_tool_filters',
-              mtMap.passthrough()
-            )
-          })
-        ),
-        implementation: mtMap.objectField(
-          'implementation',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            slug: mtMap.objectField('slug', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            configuration: mtMap.objectField(
+              'configuration',
               mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                providerTemplateId: mtMap.objectField(
-                  'provider_template_id',
+                canAttachCustomToolFilters: mtMap.objectField(
+                  'can_attach_custom_tool_filters',
                   mtMap.passthrough()
                 ),
-                magicMcpServerId: mtMap.objectField(
-                  'magic_mcp_server_id',
+                canAttachCustomProviderConfig: mtMap.objectField(
+                  'can_attach_custom_provider_config',
+                  mtMap.passthrough()
+                ),
+                canOverrideToolFilters: mtMap.objectField(
+                  'can_override_tool_filters',
                   mtMap.passthrough()
                 )
               })
-            )
-          ])
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
+            ),
+            implementation: mtMap.objectField(
+              'implementation',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    providerTemplateId: mtMap.objectField(
+                      'provider_template_id',
+                      mtMap.passthrough()
+                    ),
+                    magicMcpServerId: mtMap.objectField(
+                      'magic_mcp_server_id',
+                      mtMap.passthrough()
+                    )
+                  })
+                )
+              ])
+            ),
+            providers: mtMap.objectField(
+              'providers',
+              mtMap.array(
                 mtMap.union([
                   mtMap.unionOption(
                     'object',
                     mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      status: mtMap.objectField('status', mtMap.passthrough()),
+                      integrationId: mtMap.objectField(
+                        'integration_id',
                         mtMap.passthrough()
                       ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      toolFilter: mtMap.objectField(
+                        'tool_filter',
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              ignoreParentFilters: mtMap.objectField(
+                                'ignore_parent_filters',
+                                mtMap.passthrough()
+                              ),
+                              filters: mtMap.objectField(
+                                'filters',
+                                mtMap.array(
+                                  mtMap.union([
+                                    mtMap.unionOption(
+                                      'object',
+                                      mtMap.object({
+                                        type: mtMap.objectField(
+                                          'type',
+                                          mtMap.passthrough()
+                                        ),
+                                        keys: mtMap.objectField(
+                                          'keys',
+                                          mtMap.array(mtMap.passthrough())
+                                        ),
+                                        pattern: mtMap.objectField(
+                                          'pattern',
+                                          mtMap.passthrough()
+                                        ),
+                                        uris: mtMap.objectField(
+                                          'uris',
+                                          mtMap.array(mtMap.passthrough())
+                                        )
+                                      })
+                                    )
+                                  ])
+                                )
+                              )
+                            })
+                          )
+                        ])
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      deploymentId: mtMap.objectField(
+                        'deployment_id',
+                        mtMap.passthrough()
+                      ),
+                      authMethodId: mtMap.objectField(
+                        'auth_method_id',
+                        mtMap.passthrough()
+                      ),
+                      authCredentialsId: mtMap.objectField(
+                        'auth_credentials_id',
+                        mtMap.passthrough()
+                      ),
+                      config: mtMap.objectField(
+                        'config',
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          isDefault: mtMap.objectField(
+                            'is_default',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          ),
+                          metadata: mtMap.objectField(
+                            'metadata',
+                            mtMap.passthrough()
+                          ),
+                          providerId: mtMap.objectField(
+                            'provider_id',
+                            mtMap.passthrough()
+                          ),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                      archivedAt: mtMap.objectField(
+                        'archived_at',
+                        mtMap.date()
+                      ),
+                      provider: mtMap.objectField(
+                        'provider',
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          ),
+                          slug: mtMap.objectField('slug', mtMap.passthrough()),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
+                      ),
+                      deployment: mtMap.objectField(
+                        'deployment',
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          isDefault: mtMap.objectField(
+                            'is_default',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          ),
+                          metadata: mtMap.objectField(
+                            'metadata',
+                            mtMap.passthrough()
+                          ),
+                          providerId: mtMap.objectField(
+                            'provider_id',
+                            mtMap.passthrough()
+                          ),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
+                      ),
+                      authMethod: mtMap.objectField(
+                        'auth_method',
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          key: mtMap.objectField('key', mtMap.passthrough()),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          ),
+                          capabilities: mtMap.objectField(
+                            'capabilities',
+                            mtMap.passthrough()
+                          ),
+                          inputSchema: mtMap.objectField(
+                            'input_schema',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              schema: mtMap.objectField(
+                                'schema',
+                                mtMap.passthrough()
+                              )
+                            })
+                          ),
+                          outputSchema: mtMap.objectField(
+                            'output_schema',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              schema: mtMap.objectField(
+                                'schema',
+                                mtMap.passthrough()
+                              )
+                            })
+                          ),
+                          scopes: mtMap.objectField(
+                            'scopes',
+                            mtMap.array(
                               mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
+                                object: mtMap.objectField(
+                                  'object',
                                   mtMap.passthrough()
                                 ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
+                                id: mtMap.objectField(
+                                  'id',
                                   mtMap.passthrough()
                                 ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
+                                scope: mtMap.objectField(
+                                  'scope',
+                                  mtMap.passthrough()
+                                ),
+                                name: mtMap.objectField(
+                                  'name',
+                                  mtMap.passthrough()
+                                ),
+                                description: mtMap.objectField(
+                                  'description',
+                                  mtMap.passthrough()
                                 )
                               })
                             )
-                          ])
-                        )
+                          ),
+                          providerId: mtMap.objectField(
+                            'provider_id',
+                            mtMap.passthrough()
+                          ),
+                          providerSpecificationId: mtMap.objectField(
+                            'provider_specification_id',
+                            mtMap.passthrough()
+                          ),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
+                      ),
+                      authCredentials: mtMap.objectField(
+                        'auth_credentials',
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          status: mtMap.objectField(
+                            'status',
+                            mtMap.passthrough()
+                          ),
+                          isDefault: mtMap.objectField(
+                            'is_default',
+                            mtMap.passthrough()
+                          ),
+                          isManaged: mtMap.objectField(
+                            'is_managed',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          ),
+                          metadata: mtMap.objectField(
+                            'metadata',
+                            mtMap.passthrough()
+                          ),
+                          scopes: mtMap.objectField(
+                            'scopes',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          providerId: mtMap.objectField(
+                            'provider_id',
+                            mtMap.passthrough()
+                          ),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
                       )
                     })
                   )
                 ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
+              )
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          })
+        )
+      ])
     )
   ),
   pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/update.ts
@@ -40,6 +40,93 @@ export type IntegrationsUpdateOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -99,266 +186,315 @@ export type IntegrationsUpdateOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
+  })[];
 };
 
-export let mapIntegrationsUpdateOutput = mtMap.object<IntegrationsUpdateOutput>(
-  {
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    slug: mtMap.objectField('slug', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField(
-      'configuration',
-      mtMap.object({
-        canAttachCustomToolFilters: mtMap.objectField(
-          'can_attach_custom_tool_filters',
-          mtMap.passthrough()
-        ),
-        canAttachCustomProviderConfig: mtMap.objectField(
-          'can_attach_custom_provider_config',
-          mtMap.passthrough()
-        ),
-        canOverrideToolFilters: mtMap.objectField(
-          'can_override_tool_filters',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            providerTemplateId: mtMap.objectField(
-              'provider_template_id',
-              mtMap.passthrough()
-            ),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
-              mtMap.passthrough()
-            )
-          })
-        )
-      ])
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapIntegrationsUpdateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      slug: mtMap.objectField('slug', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField(
+        'configuration',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          canAttachCustomToolFilters: mtMap.objectField(
+            'can_attach_custom_tool_filters',
             mtMap.passthrough()
           ),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
+          canAttachCustomProviderConfig: mtMap.objectField(
+            'can_attach_custom_provider_config',
+            mtMap.passthrough()
           ),
-          provider: mtMap.objectField(
-            'provider',
+          canOverrideToolFilters: mtMap.objectField(
+            'can_override_tool_filters',
+            mtMap.passthrough()
+          )
+        })
+      ),
+      implementation: mtMap.objectField(
+        'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
               type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              providerTemplateId: mtMap.objectField(
+                'provider_template_id',
                 mtMap.passthrough()
               ),
-              capabilities: mtMap.objectField(
-                'capabilities',
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
+              )
+            })
+          )
+        ])
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
                     name: mtMap.objectField('name', mtMap.passthrough()),
                     description: mtMap.objectField(
                       'description',
                       mtMap.passthrough()
-                    )
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                deployment: mtMap.objectField(
+                  'deployment',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authMethod: mtMap.objectField(
+                  'auth_method',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    key: mtMap.objectField('key', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    capabilities: mtMap.objectField(
+                      'capabilities',
+                      mtMap.passthrough()
+                    ),
+                    inputSchema: mtMap.objectField(
+                      'input_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    outputSchema: mtMap.objectField(
+                      'output_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          scope: mtMap.objectField(
+                            'scope',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          )
+                        })
+                      )
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    providerSpecificationId: mtMap.objectField(
+                      'provider_specification_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authCredentials: mtMap.objectField(
+                  'auth_credentials',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    isManaged: mtMap.objectField(
+                      'is_managed',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(mtMap.passthrough())
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  }
-);
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type IntegrationsUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/magic-mcp-endpoints/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/magic-mcp-endpoints/create.ts
@@ -124,6 +124,7 @@ export type MagicMcpEndpointsCreateBody = {
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
   consumerProfileId?: string | undefined;
+  skillPluginId?: string | undefined;
   magicMcpServers?:
     | {
         magicMcpServerId: string;
@@ -159,6 +160,7 @@ export let mapMagicMcpEndpointsCreateBody =
       'consumer_profile_id',
       mtMap.passthrough()
     ),
+    skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
     magicMcpServers: mtMap.objectField(
       'magic_mcp_servers',
       mtMap.array(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/delete.ts
@@ -7,10 +7,11 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersDeleteOutput = {
   name: string;
   description: string | null;
   metadata: Record<string, any> | null;
-  integrationInstanceGroupId: string;
   integrationId: string;
+  integrationInstanceGroupId: string;
   integrationInstanceId: string;
-  integrationProviderId: string;
+  integrationProviderId: string | null;
+  integrationInstanceProviderId: string;
   toolFilter:
     | { type: 'allow_all'; ignoreParentFilters: boolean }
     | {
@@ -27,6 +28,10 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersDeleteOutput = {
       }
     | null;
   isOverrideToolFilter: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -63,65 +68,10 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersDeleteOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -198,71 +148,10 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersDeleteOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -304,624 +193,428 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersDeleteOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
 export let mapManagementInstanceIntegrationInstanceGroupProvidersDeleteOutput =
-  mtMap.object<ManagementInstanceIntegrationInstanceGroupProvidersDeleteOutput>(
-    {
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationInstanceGroupId: mtMap.objectField(
-        'integration_instance_group_id',
-        mtMap.passthrough()
-      ),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      integrationInstanceId: mtMap.objectField(
-        'integration_instance_id',
-        mtMap.passthrough()
-      ),
-      integrationProviderId: mtMap.objectField(
-        'integration_provider_id',
-        mtMap.passthrough()
-      ),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        integrationInstanceGroupId: mtMap.objectField(
+          'integration_instance_group_id',
+          mtMap.passthrough()
+        ),
+        integrationInstanceId: mtMap.objectField(
+          'integration_instance_id',
+          mtMap.passthrough()
+        ),
+        integrationProviderId: mtMap.objectField(
+          'integration_provider_id',
+          mtMap.passthrough()
+        ),
+        integrationInstanceProviderId: mtMap.objectField(
+          'integration_instance_provider_id',
+          mtMap.passthrough()
+        ),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
+                  mtMap.passthrough()
+                ),
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
+                            mtMap.passthrough()
+                          ),
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
+                          )
+                        })
+                      )
+                    ])
+                  )
+                )
+              })
+            )
+          ])
+        ),
+        isOverrideToolFilter: mtMap.objectField(
+          'is_override_tool_filter',
+          mtMap.passthrough()
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+        provider: mtMap.objectField(
+          'provider',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            slug: mtMap.objectField('slug', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        integrationProvider: mtMap.objectField(
+          'integration_provider',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            providerVersion: mtMap.objectField(
+              'provider_version',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                index: mtMap.objectField('index', mtMap.passthrough())
+              })
+            ),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
+            ),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            deploymentId: mtMap.objectField(
+              'deployment_id',
+              mtMap.passthrough()
+            ),
+            authMethodId: mtMap.objectField(
+              'auth_method_id',
+              mtMap.passthrough()
+            ),
+            authCredentialsId: mtMap.objectField(
+              'auth_credentials_id',
+              mtMap.passthrough()
+            ),
+            config: mtMap.objectField(
+              'config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          })
+        ),
+        integrationInstanceProvider: mtMap.objectField(
+          'integration_instance_provider',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            integrationId: mtMap.objectField(
+              'integration_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceId: mtMap.objectField(
+              'integration_instance_id',
+              mtMap.passthrough()
+            ),
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
+            ),
+            isOverrideToolFilter: mtMap.objectField(
+              'is_override_tool_filter',
+              mtMap.passthrough()
+            ),
+            provider: mtMap.objectField(
+              'provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                slug: mtMap.objectField('slug', mtMap.passthrough()),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            integrationProvider: mtMap.objectField(
+              'integration_provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                providerVersion: mtMap.objectField(
+                  'provider_version',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    index: mtMap.objectField('index', mtMap.passthrough())
+                  })
+                ),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
                   mtMap.union([
                     mtMap.unionOption(
                       'object',
                       mtMap.object({
                         type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
                           mtMap.passthrough()
                         ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
                         )
                       })
                     )
                   ])
-                )
-              )
-            })
-          )
-        ])
-      ),
-      isOverrideToolFilter: mtMap.objectField(
-        'is_override_tool_filter',
-        mtMap.passthrough()
-      ),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      integrationProvider: mtMap.objectField(
-        'integration_provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          providerVersion: mtMap.objectField(
-            'provider_version',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              index: mtMap.objectField('index', mtMap.passthrough())
-            })
-          ),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              capabilities: mtMap.objectField(
-                'capabilities',
-                mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
                     name: mtMap.objectField('name', mtMap.passthrough()),
                     description: mtMap.objectField(
                       'description',
                       mtMap.passthrough()
-                    )
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
-                )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      ),
-      integrationInstanceProvider: mtMap.objectField(
-        'integration_instance_provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    }
-  );
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            ),
+            config: mtMap.objectField(
+              'config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            authConfig: mtMap.objectField(
+              'auth_config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          })
+        )
+      })
+    )
+  ]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/get.ts
@@ -7,10 +7,11 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersGetOutput = {
   name: string;
   description: string | null;
   metadata: Record<string, any> | null;
-  integrationInstanceGroupId: string;
   integrationId: string;
+  integrationInstanceGroupId: string;
   integrationInstanceId: string;
-  integrationProviderId: string;
+  integrationProviderId: string | null;
+  integrationInstanceProviderId: string;
   toolFilter:
     | { type: 'allow_all'; ignoreParentFilters: boolean }
     | {
@@ -27,6 +28,10 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersGetOutput = {
       }
     | null;
   isOverrideToolFilter: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -63,65 +68,10 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersGetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -198,71 +148,10 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersGetOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -304,264 +193,12 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersGetOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
 export let mapManagementInstanceIntegrationInstanceGroupProvidersGetOutput =
-  mtMap.object<ManagementInstanceIntegrationInstanceGroupProvidersGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationInstanceGroupId: mtMap.objectField(
-      'integration_instance_group_id',
-      mtMap.passthrough()
-    ),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    integrationProviderId: mtMap.objectField(
-      'integration_provider_id',
-      mtMap.passthrough()
-    ),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    isOverrideToolFilter: mtMap.objectField(
-      'is_override_tool_filter',
-      mtMap.passthrough()
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    integrationProvider: mtMap.objectField(
-      'integration_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        providerVersion: mtMap.objectField(
-          'provider_version',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            index: mtMap.objectField('index', mtMap.passthrough())
-          })
-        ),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
-                  mtMap.passthrough()
-                ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
-                            mtMap.passthrough()
-                          ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
-                          )
-                        })
-                      )
-                    ])
-                  )
-                )
-              })
-            )
-          ])
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        deployment: mtMap.objectField(
-          'deployment',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  )
-                })
-              )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        config: mtMap.objectField(
-          'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    integrationInstanceProvider: mtMap.objectField(
-      'integration_instance_provider',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
@@ -570,8 +207,20 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersGetOutput =
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        integrationInstanceGroupId: mtMap.objectField(
+          'integration_instance_group_id',
+          mtMap.passthrough()
+        ),
         integrationInstanceId: mtMap.objectField(
           'integration_instance_id',
+          mtMap.passthrough()
+        ),
+        integrationProviderId: mtMap.objectField(
+          'integration_provider_id',
+          mtMap.passthrough()
+        ),
+        integrationInstanceProviderId: mtMap.objectField(
+          'integration_instance_provider_id',
           mtMap.passthrough()
         ),
         toolFilter: mtMap.objectField(
@@ -618,6 +267,9 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersGetOutput =
           'is_override_tool_filter',
           mtMap.passthrough()
         ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date()),
         provider: mtMap.objectField(
           'provider',
           mtMap.object({
@@ -690,124 +342,18 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersGetOutput =
                 )
               ])
             ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            deploymentId: mtMap.objectField(
+              'deployment_id',
+              mtMap.passthrough()
             ),
-            deployment: mtMap.objectField(
-              'deployment',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            authMethodId: mtMap.objectField(
+              'auth_method_id',
+              mtMap.passthrough()
             ),
-            authMethod: mtMap.objectField(
-              'auth_method',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                key: mtMap.objectField('key', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                capabilities: mtMap.objectField(
-                  'capabilities',
-                  mtMap.passthrough()
-                ),
-                inputSchema: mtMap.objectField(
-                  'input_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                outputSchema: mtMap.objectField(
-                  'output_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      scope: mtMap.objectField('scope', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      )
-                    })
-                  )
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                providerSpecificationId: mtMap.objectField(
-                  'provider_specification_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authCredentials: mtMap.objectField(
-              'auth_credentials',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(mtMap.passthrough())
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            authCredentialsId: mtMap.objectField(
+              'auth_credentials_id',
+              mtMap.passthrough()
             ),
             config: mtMap.objectField(
               'config',
@@ -834,41 +380,241 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersGetOutput =
             archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
         ),
-        config: mtMap.objectField(
-          'config',
+        integrationInstanceProvider: mtMap.objectField(
+          'integration_instance_provider',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            integrationId: mtMap.objectField(
+              'integration_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceId: mtMap.objectField(
+              'integration_instance_id',
+              mtMap.passthrough()
+            ),
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
+            ),
+            isOverrideToolFilter: mtMap.objectField(
+              'is_override_tool_filter',
+              mtMap.passthrough()
+            ),
+            provider: mtMap.objectField(
+              'provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                slug: mtMap.objectField('slug', mtMap.passthrough()),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            integrationProvider: mtMap.objectField(
+              'integration_provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                providerVersion: mtMap.objectField(
+                  'provider_version',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    index: mtMap.objectField('index', mtMap.passthrough())
+                  })
+                ),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            ),
+            config: mtMap.objectField(
+              'config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            authConfig: mtMap.objectField(
+              'auth_config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
-        ),
-        authConfig: mtMap.objectField(
-          'auth_config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        )
       })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+    )
+  ]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/list.ts
@@ -1,17 +1,18 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceIntegrationInstanceGroupProvidersListOutput = {
-  items: {
+  items: ({
     object: 'integration.instance.group.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -28,6 +29,10 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersListOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
     provider: {
       object: 'provider#preview';
       id: string;
@@ -64,71 +69,10 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersListOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -205,71 +149,10 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersListOutput = {
               ignoreParentFilters: boolean;
             }
           | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
         config: {
           object: 'provider.config#preview';
           id: string;
@@ -311,10 +194,7 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersListOutput = {
       updatedAt: Date;
       archivedAt: Date | null;
     };
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -323,315 +203,9 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
-            mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
@@ -646,8 +220,20 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersListOutput =
                 'integration_id',
                 mtMap.passthrough()
               ),
+              integrationInstanceGroupId: mtMap.objectField(
+                'integration_instance_group_id',
+                mtMap.passthrough()
+              ),
               integrationInstanceId: mtMap.objectField(
                 'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              integrationProviderId: mtMap.objectField(
+                'integration_provider_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceProviderId: mtMap.objectField(
+                'integration_instance_provider_id',
                 mtMap.passthrough()
               ),
               toolFilter: mtMap.objectField(
@@ -697,6 +283,9 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersListOutput =
                 'is_override_tool_filter',
                 mtMap.passthrough()
               ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date()),
               provider: mtMap.objectField(
                 'provider',
                 mtMap.object({
@@ -775,154 +364,21 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersListOutput =
                       )
                     ])
                   ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
                   ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  deploymentId: mtMap.objectField(
+                    'deployment_id',
+                    mtMap.passthrough()
                   ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  authMethodId: mtMap.objectField(
+                    'auth_method_id',
+                    mtMap.passthrough()
                   ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  authCredentialsId: mtMap.objectField(
+                    'auth_credentials_id',
+                    mtMap.passthrough()
                   ),
                   config: mtMap.objectField(
                     'config',
@@ -955,61 +411,276 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersListOutput =
                   archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
               ),
-              config: mtMap.objectField(
-                'config',
+              integrationInstanceProvider: mtMap.objectField(
+                'integration_instance_provider',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
+                  integrationId: mtMap.objectField(
+                    'integration_id',
                     mtMap.passthrough()
+                  ),
+                  integrationInstanceId: mtMap.objectField(
+                    'integration_instance_id',
+                    mtMap.passthrough()
+                  ),
+                  toolFilter: mtMap.objectField(
+                    'tool_filter',
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          ignoreParentFilters: mtMap.objectField(
+                            'ignore_parent_filters',
+                            mtMap.passthrough()
+                          ),
+                          filters: mtMap.objectField(
+                            'filters',
+                            mtMap.array(
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    keys: mtMap.objectField(
+                                      'keys',
+                                      mtMap.array(mtMap.passthrough())
+                                    ),
+                                    pattern: mtMap.objectField(
+                                      'pattern',
+                                      mtMap.passthrough()
+                                    ),
+                                    uris: mtMap.objectField(
+                                      'uris',
+                                      mtMap.array(mtMap.passthrough())
+                                    )
+                                  })
+                                )
+                              ])
+                            )
+                          )
+                        })
+                      )
+                    ])
+                  ),
+                  isOverrideToolFilter: mtMap.objectField(
+                    'is_override_tool_filter',
+                    mtMap.passthrough()
+                  ),
+                  provider: mtMap.objectField(
+                    'provider',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      slug: mtMap.objectField('slug', mtMap.passthrough()),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
+                  integrationProvider: mtMap.objectField(
+                    'integration_provider',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      providerVersion: mtMap.objectField(
+                        'provider_version',
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          index: mtMap.objectField('index', mtMap.passthrough())
+                        })
+                      ),
+                      status: mtMap.objectField('status', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      toolFilter: mtMap.objectField(
+                        'tool_filter',
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              ignoreParentFilters: mtMap.objectField(
+                                'ignore_parent_filters',
+                                mtMap.passthrough()
+                              ),
+                              filters: mtMap.objectField(
+                                'filters',
+                                mtMap.array(
+                                  mtMap.union([
+                                    mtMap.unionOption(
+                                      'object',
+                                      mtMap.object({
+                                        type: mtMap.objectField(
+                                          'type',
+                                          mtMap.passthrough()
+                                        ),
+                                        keys: mtMap.objectField(
+                                          'keys',
+                                          mtMap.array(mtMap.passthrough())
+                                        ),
+                                        pattern: mtMap.objectField(
+                                          'pattern',
+                                          mtMap.passthrough()
+                                        ),
+                                        uris: mtMap.objectField(
+                                          'uris',
+                                          mtMap.array(mtMap.passthrough())
+                                        )
+                                      })
+                                    )
+                                  ])
+                                )
+                              )
+                            })
+                          )
+                        ])
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      deploymentId: mtMap.objectField(
+                        'deployment_id',
+                        mtMap.passthrough()
+                      ),
+                      authMethodId: mtMap.objectField(
+                        'auth_method_id',
+                        mtMap.passthrough()
+                      ),
+                      authCredentialsId: mtMap.objectField(
+                        'auth_credentials_id',
+                        mtMap.passthrough()
+                      ),
+                      config: mtMap.objectField(
+                        'config',
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          isDefault: mtMap.objectField(
+                            'is_default',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          ),
+                          metadata: mtMap.objectField(
+                            'metadata',
+                            mtMap.passthrough()
+                          ),
+                          providerId: mtMap.objectField(
+                            'provider_id',
+                            mtMap.passthrough()
+                          ),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                    })
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
+                  authConfig: mtMap.objectField(
+                    'auth_config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
                   ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              )
             })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/set.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/set.ts
@@ -7,10 +7,11 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersSetOutput = {
   name: string;
   description: string | null;
   metadata: Record<string, any> | null;
-  integrationInstanceGroupId: string;
   integrationId: string;
+  integrationInstanceGroupId: string;
   integrationInstanceId: string;
-  integrationProviderId: string;
+  integrationProviderId: string | null;
+  integrationInstanceProviderId: string;
   toolFilter:
     | { type: 'allow_all'; ignoreParentFilters: boolean }
     | {
@@ -27,6 +28,10 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersSetOutput = {
       }
     | null;
   isOverrideToolFilter: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -63,65 +68,10 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersSetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -198,71 +148,10 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersSetOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -304,264 +193,12 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersSetOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
 export let mapManagementInstanceIntegrationInstanceGroupProvidersSetOutput =
-  mtMap.object<ManagementInstanceIntegrationInstanceGroupProvidersSetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationInstanceGroupId: mtMap.objectField(
-      'integration_instance_group_id',
-      mtMap.passthrough()
-    ),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    integrationProviderId: mtMap.objectField(
-      'integration_provider_id',
-      mtMap.passthrough()
-    ),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    isOverrideToolFilter: mtMap.objectField(
-      'is_override_tool_filter',
-      mtMap.passthrough()
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    integrationProvider: mtMap.objectField(
-      'integration_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        providerVersion: mtMap.objectField(
-          'provider_version',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            index: mtMap.objectField('index', mtMap.passthrough())
-          })
-        ),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
-                  mtMap.passthrough()
-                ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
-                            mtMap.passthrough()
-                          ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
-                          )
-                        })
-                      )
-                    ])
-                  )
-                )
-              })
-            )
-          ])
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        deployment: mtMap.objectField(
-          'deployment',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  )
-                })
-              )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        config: mtMap.objectField(
-          'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    integrationInstanceProvider: mtMap.objectField(
-      'integration_instance_provider',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
@@ -570,8 +207,20 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersSetOutput =
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        integrationInstanceGroupId: mtMap.objectField(
+          'integration_instance_group_id',
+          mtMap.passthrough()
+        ),
         integrationInstanceId: mtMap.objectField(
           'integration_instance_id',
+          mtMap.passthrough()
+        ),
+        integrationProviderId: mtMap.objectField(
+          'integration_provider_id',
+          mtMap.passthrough()
+        ),
+        integrationInstanceProviderId: mtMap.objectField(
+          'integration_instance_provider_id',
           mtMap.passthrough()
         ),
         toolFilter: mtMap.objectField(
@@ -618,6 +267,9 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersSetOutput =
           'is_override_tool_filter',
           mtMap.passthrough()
         ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date()),
         provider: mtMap.objectField(
           'provider',
           mtMap.object({
@@ -690,124 +342,18 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersSetOutput =
                 )
               ])
             ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            deploymentId: mtMap.objectField(
+              'deployment_id',
+              mtMap.passthrough()
             ),
-            deployment: mtMap.objectField(
-              'deployment',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            authMethodId: mtMap.objectField(
+              'auth_method_id',
+              mtMap.passthrough()
             ),
-            authMethod: mtMap.objectField(
-              'auth_method',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                key: mtMap.objectField('key', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                capabilities: mtMap.objectField(
-                  'capabilities',
-                  mtMap.passthrough()
-                ),
-                inputSchema: mtMap.objectField(
-                  'input_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                outputSchema: mtMap.objectField(
-                  'output_schema',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    schema: mtMap.objectField('schema', mtMap.passthrough())
-                  })
-                ),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      scope: mtMap.objectField('scope', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      )
-                    })
-                  )
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                providerSpecificationId: mtMap.objectField(
-                  'provider_specification_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authCredentials: mtMap.objectField(
-              'auth_credentials',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                scopes: mtMap.objectField(
-                  'scopes',
-                  mtMap.array(mtMap.passthrough())
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
+            authCredentialsId: mtMap.objectField(
+              'auth_credentials_id',
+              mtMap.passthrough()
             ),
             config: mtMap.objectField(
               'config',
@@ -834,43 +380,243 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersSetOutput =
             archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
         ),
-        config: mtMap.objectField(
-          'config',
+        integrationInstanceProvider: mtMap.objectField(
+          'integration_instance_provider',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            integrationId: mtMap.objectField(
+              'integration_id',
+              mtMap.passthrough()
+            ),
+            integrationInstanceId: mtMap.objectField(
+              'integration_instance_id',
+              mtMap.passthrough()
+            ),
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
+            ),
+            isOverrideToolFilter: mtMap.objectField(
+              'is_override_tool_filter',
+              mtMap.passthrough()
+            ),
+            provider: mtMap.objectField(
+              'provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                slug: mtMap.objectField('slug', mtMap.passthrough()),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            integrationProvider: mtMap.objectField(
+              'integration_provider',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                providerVersion: mtMap.objectField(
+                  'provider_version',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    index: mtMap.objectField('index', mtMap.passthrough())
+                  })
+                ),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            ),
+            config: mtMap.objectField(
+              'config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            authConfig: mtMap.objectField(
+              'auth_config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
-        ),
-        authConfig: mtMap.objectField(
-          'auth_config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        )
       })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+    )
+  ]);
 
 export type ManagementInstanceIntegrationInstanceGroupProvidersSetBody = {
   toolFilters?:

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/create.ts
@@ -18,10 +18,11 @@ export type ManagementInstanceIntegrationInstanceGroupsCreateOutput = {
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -38,289 +39,6 @@ export type ManagementInstanceIntegrationInstanceGroupsCreateOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } | null;
-    integrationInstanceProvider: {
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
@@ -328,338 +46,65 @@ export type ManagementInstanceIntegrationInstanceGroupsCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: {
+    object: 'integration.instance.group.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceGroupId: string;
+    integrationInstanceId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
 };
 
 export let mapManagementInstanceIntegrationInstanceGroupsCreateOutput =
-  mtMap.object<ManagementInstanceIntegrationInstanceGroupsCreateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpEndpointId: mtMap.objectField(
-          'magic_mcp_endpoint_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
-            mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        implementation: mtMap.objectField(
+          'implementation',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            magicMcpEndpointId: mtMap.objectField(
+              'magic_mcp_endpoint_id',
+              mtMap.passthrough()
+            )
+          })
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
@@ -674,8 +119,20 @@ export let mapManagementInstanceIntegrationInstanceGroupsCreateOutput =
                 'integration_id',
                 mtMap.passthrough()
               ),
+              integrationInstanceGroupId: mtMap.objectField(
+                'integration_instance_group_id',
+                mtMap.passthrough()
+              ),
               integrationInstanceId: mtMap.objectField(
                 'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              integrationProviderId: mtMap.objectField(
+                'integration_provider_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceProviderId: mtMap.objectField(
+                'integration_instance_provider_id',
                 mtMap.passthrough()
               ),
               toolFilter: mtMap.objectField(
@@ -725,325 +182,18 @@ export let mapManagementInstanceIntegrationInstanceGroupsCreateOutput =
                 'is_override_tool_filter',
                 mtMap.passthrough()
               ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
               archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    )
+  ]);
 
 export type ManagementInstanceIntegrationInstanceGroupsCreateBody = {
   name: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/delete.ts
@@ -18,10 +18,11 @@ export type ManagementInstanceIntegrationInstanceGroupsDeleteOutput = {
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -38,289 +39,6 @@ export type ManagementInstanceIntegrationInstanceGroupsDeleteOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } | null;
-    integrationInstanceProvider: {
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
@@ -328,338 +46,65 @@ export type ManagementInstanceIntegrationInstanceGroupsDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: {
+    object: 'integration.instance.group.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceGroupId: string;
+    integrationInstanceId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
 };
 
 export let mapManagementInstanceIntegrationInstanceGroupsDeleteOutput =
-  mtMap.object<ManagementInstanceIntegrationInstanceGroupsDeleteOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpEndpointId: mtMap.objectField(
-          'magic_mcp_endpoint_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
-            mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        implementation: mtMap.objectField(
+          'implementation',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            magicMcpEndpointId: mtMap.objectField(
+              'magic_mcp_endpoint_id',
+              mtMap.passthrough()
+            )
+          })
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
@@ -674,8 +119,20 @@ export let mapManagementInstanceIntegrationInstanceGroupsDeleteOutput =
                 'integration_id',
                 mtMap.passthrough()
               ),
+              integrationInstanceGroupId: mtMap.objectField(
+                'integration_instance_group_id',
+                mtMap.passthrough()
+              ),
               integrationInstanceId: mtMap.objectField(
                 'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              integrationProviderId: mtMap.objectField(
+                'integration_provider_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceProviderId: mtMap.objectField(
+                'integration_instance_provider_id',
                 mtMap.passthrough()
               ),
               toolFilter: mtMap.objectField(
@@ -725,323 +182,16 @@ export let mapManagementInstanceIntegrationInstanceGroupsDeleteOutput =
                 'is_override_tool_filter',
                 mtMap.passthrough()
               ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
               archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    )
+  ]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/get.ts
@@ -18,10 +18,11 @@ export type ManagementInstanceIntegrationInstanceGroupsGetOutput = {
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -38,289 +39,6 @@ export type ManagementInstanceIntegrationInstanceGroupsGetOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } | null;
-    integrationInstanceProvider: {
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
@@ -328,338 +46,65 @@ export type ManagementInstanceIntegrationInstanceGroupsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: {
+    object: 'integration.instance.group.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceGroupId: string;
+    integrationInstanceId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
 };
 
 export let mapManagementInstanceIntegrationInstanceGroupsGetOutput =
-  mtMap.object<ManagementInstanceIntegrationInstanceGroupsGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpEndpointId: mtMap.objectField(
-          'magic_mcp_endpoint_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
-            mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        implementation: mtMap.objectField(
+          'implementation',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            magicMcpEndpointId: mtMap.objectField(
+              'magic_mcp_endpoint_id',
+              mtMap.passthrough()
+            )
+          })
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
@@ -674,8 +119,20 @@ export let mapManagementInstanceIntegrationInstanceGroupsGetOutput =
                 'integration_id',
                 mtMap.passthrough()
               ),
+              integrationInstanceGroupId: mtMap.objectField(
+                'integration_instance_group_id',
+                mtMap.passthrough()
+              ),
               integrationInstanceId: mtMap.objectField(
                 'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              integrationProviderId: mtMap.objectField(
+                'integration_provider_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceProviderId: mtMap.objectField(
+                'integration_instance_provider_id',
                 mtMap.passthrough()
               ),
               toolFilter: mtMap.objectField(
@@ -725,323 +182,16 @@ export let mapManagementInstanceIntegrationInstanceGroupsGetOutput =
                 'is_override_tool_filter',
                 mtMap.passthrough()
               ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
               archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    )
+  ]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceIntegrationInstanceGroupsListOutput = {
-  items: {
+  items: ({
     object: 'integration.instance.group';
     id: string;
     status: 'draft' | 'active' | 'archived' | 'deleted';
@@ -19,10 +19,11 @@ export type ManagementInstanceIntegrationInstanceGroupsListOutput = {
       name: string;
       description: string | null;
       metadata: Record<string, any> | null;
-      integrationInstanceGroupId: string;
       integrationId: string;
+      integrationInstanceGroupId: string;
       integrationInstanceId: string;
-      integrationProviderId: string;
+      integrationProviderId: string | null;
+      integrationInstanceProviderId: string;
       toolFilter:
         | { type: 'allow_all'; ignoreParentFilters: boolean }
         | {
@@ -39,289 +40,6 @@ export type ManagementInstanceIntegrationInstanceGroupsListOutput = {
           }
         | null;
       isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      } | null;
-      integrationInstanceProvider: {
-        object: 'integration.instance.provider';
-        id: string;
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        integrationId: string;
-        integrationInstanceId: string;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        isOverrideToolFilter: boolean;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        integrationProvider: {
-          object: 'integration.provider#snapshot';
-          id: string;
-          providerVersion: {
-            object: 'integration.provider.version';
-            id: string;
-            index: number;
-          };
-          status: 'active' | 'archived' | 'deleted';
-          name: string;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          toolFilter:
-            | { type: 'allow_all'; ignoreParentFilters: boolean }
-            | {
-                type: 'filter';
-                filters: (
-                  | { type: 'tool_keys'; keys: string[] }
-                  | { type: 'tool_regex'; pattern: string }
-                  | { type: 'resource_regex'; pattern: string }
-                  | { type: 'resource_uris'; uris: string[] }
-                  | { type: 'prompt_keys'; keys: string[] }
-                  | { type: 'prompt_regex'; pattern: string }
-                )[];
-                ignoreParentFilters: boolean;
-              }
-            | null;
-          provider: {
-            object: 'provider#preview';
-            id: string;
-            name: string;
-            description: string | null;
-            slug: string;
-            createdAt: Date;
-            updatedAt: Date;
-          };
-          deployment: {
-            object: 'provider.deployment#preview';
-            id: string;
-            isDefault: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          };
-          authMethod: {
-            object: 'provider.capabilities.auth_method';
-            id: string;
-            type: 'oauth' | 'token' | 'custom';
-            key: string;
-            name: string;
-            description: string | null;
-            capabilities: Record<string, any>;
-            inputSchema: {
-              type: 'json_schema';
-              schema: Record<string, any>;
-            } | null;
-            outputSchema: {
-              type: 'json_schema';
-              schema: Record<string, any>;
-            } | null;
-            scopes:
-              | {
-                  object: 'provider.capabilities.auth_method.scope';
-                  id: string;
-                  scope: string;
-                  name: string;
-                  description: string | null;
-                }[]
-              | null;
-            providerId: string;
-            providerSpecificationId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
-          authCredentials: {
-            object: 'provider.auth_credentials';
-            id: string;
-            type: 'oauth';
-            status: 'active' | 'archived' | 'deleted';
-            isDefault: boolean;
-            isManaged: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            scopes: string[] | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
-          config: {
-            object: 'provider.config#preview';
-            id: string;
-            isDefault: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
-          createdAt: Date;
-          updatedAt: Date;
-          archivedAt: Date | null;
-        };
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authConfig: {
-          object: 'provider.auth_config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
       createdAt: Date;
       updatedAt: Date;
       archivedAt: Date | null;
@@ -329,7 +47,40 @@ export type ManagementInstanceIntegrationInstanceGroupsListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
+  } & {
+    providers: {
+      object: 'integration.instance.group.provider';
+      id: string;
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      integrationId: string;
+      integrationInstanceGroupId: string;
+      integrationInstanceId: string;
+      integrationProviderId: string | null;
+      integrationInstanceProviderId: string;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      isOverrideToolFilter: boolean;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    }[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -338,407 +89,32 @@ export let mapManagementInstanceIntegrationInstanceGroupsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          implementation: mtMap.objectField(
-            'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              magicMcpEndpointId: mtMap.objectField(
-                'magic_mcp_endpoint_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
-              )
-            })
-          ),
-          providers: mtMap.objectField(
-            'providers',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationInstanceGroupId: mtMap.objectField(
-                  'integration_instance_group_id',
-                  mtMap.passthrough()
-                ),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                integrationProviderId: mtMap.objectField(
-                  'integration_provider_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    provider: mtMap.objectField(
-                      'provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    deployment: mtMap.objectField(
-                      'deployment',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authMethod: mtMap.objectField(
-                      'auth_method',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        key: mtMap.objectField('key', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        capabilities: mtMap.objectField(
-                          'capabilities',
-                          mtMap.passthrough()
-                        ),
-                        inputSchema: mtMap.objectField(
-                          'input_schema',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            schema: mtMap.objectField(
-                              'schema',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        outputSchema: mtMap.objectField(
-                          'output_schema',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            schema: mtMap.objectField(
-                              'schema',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        scopes: mtMap.objectField(
-                          'scopes',
-                          mtMap.array(
-                            mtMap.object({
-                              object: mtMap.objectField(
-                                'object',
-                                mtMap.passthrough()
-                              ),
-                              id: mtMap.objectField('id', mtMap.passthrough()),
-                              scope: mtMap.objectField(
-                                'scope',
-                                mtMap.passthrough()
-                              ),
-                              name: mtMap.objectField(
-                                'name',
-                                mtMap.passthrough()
-                              ),
-                              description: mtMap.objectField(
-                                'description',
-                                mtMap.passthrough()
-                              )
-                            })
-                          )
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        providerSpecificationId: mtMap.objectField(
-                          'provider_specification_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authCredentials: mtMap.objectField(
-                      'auth_credentials',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        status: mtMap.objectField(
-                          'status',
-                          mtMap.passthrough()
-                        ),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        isManaged: mtMap.objectField(
-                          'is_managed',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        scopes: mtMap.objectField(
-                          'scopes',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                integrationInstanceProvider: mtMap.objectField(
-                  'integration_instance_provider',
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              implementation: mtMap.objectField(
+                'implementation',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  magicMcpEndpointId: mtMap.objectField(
+                    'magic_mcp_endpoint_id',
+                    mtMap.passthrough()
+                  )
+                })
+              ),
+              providers: mtMap.objectField(
+                'providers',
+                mtMap.array(
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
@@ -756,8 +132,20 @@ export let mapManagementInstanceIntegrationInstanceGroupsListOutput =
                       'integration_id',
                       mtMap.passthrough()
                     ),
+                    integrationInstanceGroupId: mtMap.objectField(
+                      'integration_instance_group_id',
+                      mtMap.passthrough()
+                    ),
                     integrationInstanceId: mtMap.objectField(
                       'integration_instance_id',
+                      mtMap.passthrough()
+                    ),
+                    integrationProviderId: mtMap.objectField(
+                      'integration_provider_id',
+                      mtMap.passthrough()
+                    ),
+                    integrationInstanceProviderId: mtMap.objectField(
+                      'integration_instance_provider_id',
                       mtMap.passthrough()
                     ),
                     toolFilter: mtMap.objectField(
@@ -810,457 +198,18 @@ export let mapManagementInstanceIntegrationInstanceGroupsListOutput =
                       'is_override_tool_filter',
                       mtMap.passthrough()
                     ),
-                    provider: mtMap.objectField(
-                      'provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    integrationProvider: mtMap.objectField(
-                      'integration_provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        providerVersion: mtMap.objectField(
-                          'provider_version',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            index: mtMap.objectField(
-                              'index',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        status: mtMap.objectField(
-                          'status',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        toolFilter: mtMap.objectField(
-                          'tool_filter',
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                ignoreParentFilters: mtMap.objectField(
-                                  'ignore_parent_filters',
-                                  mtMap.passthrough()
-                                ),
-                                filters: mtMap.objectField(
-                                  'filters',
-                                  mtMap.array(
-                                    mtMap.union([
-                                      mtMap.unionOption(
-                                        'object',
-                                        mtMap.object({
-                                          type: mtMap.objectField(
-                                            'type',
-                                            mtMap.passthrough()
-                                          ),
-                                          keys: mtMap.objectField(
-                                            'keys',
-                                            mtMap.array(mtMap.passthrough())
-                                          ),
-                                          pattern: mtMap.objectField(
-                                            'pattern',
-                                            mtMap.passthrough()
-                                          ),
-                                          uris: mtMap.objectField(
-                                            'uris',
-                                            mtMap.array(mtMap.passthrough())
-                                          )
-                                        })
-                                      )
-                                    ])
-                                  )
-                                )
-                              })
-                            )
-                          ])
-                        ),
-                        provider: mtMap.objectField(
-                          'provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            slug: mtMap.objectField(
-                              'slug',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        deployment: mtMap.objectField(
-                          'deployment',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authMethod: mtMap.objectField(
-                          'auth_method',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            key: mtMap.objectField('key', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            capabilities: mtMap.objectField(
-                              'capabilities',
-                              mtMap.passthrough()
-                            ),
-                            inputSchema: mtMap.objectField(
-                              'input_schema',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                schema: mtMap.objectField(
-                                  'schema',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            outputSchema: mtMap.objectField(
-                              'output_schema',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                schema: mtMap.objectField(
-                                  'schema',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(
-                                mtMap.object({
-                                  object: mtMap.objectField(
-                                    'object',
-                                    mtMap.passthrough()
-                                  ),
-                                  id: mtMap.objectField(
-                                    'id',
-                                    mtMap.passthrough()
-                                  ),
-                                  scope: mtMap.objectField(
-                                    'scope',
-                                    mtMap.passthrough()
-                                  ),
-                                  name: mtMap.objectField(
-                                    'name',
-                                    mtMap.passthrough()
-                                  ),
-                                  description: mtMap.objectField(
-                                    'description',
-                                    mtMap.passthrough()
-                                  )
-                                })
-                              )
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            providerSpecificationId: mtMap.objectField(
-                              'provider_specification_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authCredentials: mtMap.objectField(
-                          'auth_credentials',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            status: mtMap.objectField(
-                              'status',
-                              mtMap.passthrough()
-                            ),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            isManaged: mtMap.objectField(
-                              'is_managed',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        config: mtMap.objectField(
-                          'config',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField(
-                          'updated_at',
-                          mtMap.date()
-                        ),
-                        archivedAt: mtMap.objectField(
-                          'archived_at',
-                          mtMap.date()
-                        )
-                      })
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authConfig: mtMap.objectField(
-                      'auth_config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
                     createdAt: mtMap.objectField('created_at', mtMap.date()),
                     updatedAt: mtMap.objectField('updated_at', mtMap.date()),
                     archivedAt: mtMap.objectField('archived_at', mtMap.date())
                   })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+                )
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/update.ts
@@ -18,10 +18,11 @@ export type ManagementInstanceIntegrationInstanceGroupsUpdateOutput = {
     name: string;
     description: string | null;
     metadata: Record<string, any> | null;
-    integrationInstanceGroupId: string;
     integrationId: string;
+    integrationInstanceGroupId: string;
     integrationInstanceId: string;
-    integrationProviderId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
     toolFilter:
       | { type: 'allow_all'; ignoreParentFilters: boolean }
       | {
@@ -38,289 +39,6 @@ export type ManagementInstanceIntegrationInstanceGroupsUpdateOutput = {
         }
       | null;
     isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } | null;
-    integrationInstanceProvider: {
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
@@ -328,338 +46,65 @@ export type ManagementInstanceIntegrationInstanceGroupsUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: {
+    object: 'integration.instance.group.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceGroupId: string;
+    integrationInstanceId: string;
+    integrationProviderId: string | null;
+    integrationInstanceProviderId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
 };
 
 export let mapManagementInstanceIntegrationInstanceGroupsUpdateOutput =
-  mtMap.object<ManagementInstanceIntegrationInstanceGroupsUpdateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpEndpointId: mtMap.objectField(
-          'magic_mcp_endpoint_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationInstanceGroupId: mtMap.objectField(
-            'integration_instance_group_id',
-            mtMap.passthrough()
-          ),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          integrationInstanceProvider: mtMap.objectField(
-            'integration_instance_provider',
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        implementation: mtMap.objectField(
+          'implementation',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            magicMcpEndpointId: mtMap.objectField(
+              'magic_mcp_endpoint_id',
+              mtMap.passthrough()
+            )
+          })
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
@@ -674,8 +119,20 @@ export let mapManagementInstanceIntegrationInstanceGroupsUpdateOutput =
                 'integration_id',
                 mtMap.passthrough()
               ),
+              integrationInstanceGroupId: mtMap.objectField(
+                'integration_instance_group_id',
+                mtMap.passthrough()
+              ),
               integrationInstanceId: mtMap.objectField(
                 'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              integrationProviderId: mtMap.objectField(
+                'integration_provider_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceProviderId: mtMap.objectField(
+                'integration_instance_provider_id',
                 mtMap.passthrough()
               ),
               toolFilter: mtMap.objectField(
@@ -725,325 +182,18 @@ export let mapManagementInstanceIntegrationInstanceGroupsUpdateOutput =
                 'is_override_tool_filter',
                 mtMap.passthrough()
               ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  deployment: mtMap.objectField(
-                    'deployment',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
               archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    )
+  ]);
 
 export type ManagementInstanceIntegrationInstanceGroupsUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-providers/get.ts
@@ -61,65 +61,10 @@ export type ManagementInstanceIntegrationInstanceProvidersGetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -160,94 +105,71 @@ export type ManagementInstanceIntegrationInstanceProvidersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  integrationProvider: {
+    object: 'integration.provider#snapshot';
+    id: string;
+    providerVersion: {
+      object: 'integration.provider.version';
+      id: string;
+      index: number;
+    };
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  };
 };
 
 export let mapManagementInstanceIntegrationInstanceProvidersGetOutput =
-  mtMap.object<ManagementInstanceIntegrationInstanceProvidersGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    isOverrideToolFilter: mtMap.objectField(
-      'is_override_tool_filter',
-      mtMap.passthrough()
-    ),
-    provider: mtMap.objectField(
-      'provider',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    integrationProvider: mtMap.objectField(
-      'integration_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        providerVersion: mtMap.objectField(
-          'provider_version',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            index: mtMap.objectField('index', mtMap.passthrough())
-          })
-        ),
         status: mtMap.objectField('status', mtMap.passthrough()),
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        integrationInstanceId: mtMap.objectField(
+          'integration_instance_id',
+          mtMap.passthrough()
+        ),
         toolFilter: mtMap.objectField(
           'tool_filter',
           mtMap.union([
@@ -288,6 +210,10 @@ export let mapManagementInstanceIntegrationInstanceProvidersGetOutput =
             )
           ])
         ),
+        isOverrideToolFilter: mtMap.objectField(
+          'is_override_tool_filter',
+          mtMap.passthrough()
+        ),
         provider: mtMap.objectField(
           'provider',
           mtMap.object({
@@ -300,90 +226,102 @@ export let mapManagementInstanceIntegrationInstanceProvidersGetOutput =
             updatedAt: mtMap.objectField('updated_at', mtMap.date())
           })
         ),
-        deployment: mtMap.objectField(
-          'deployment',
+        integrationProvider: mtMap.objectField(
+          'integration_provider',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
+            providerVersion: mtMap.objectField(
+              'provider_version',
               mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                index: mtMap.objectField('index', mtMap.passthrough())
               })
             ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  )
-                })
-              )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
             status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
             ),
             providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            deploymentId: mtMap.objectField(
+              'deployment_id',
+              mtMap.passthrough()
+            ),
+            authMethodId: mtMap.objectField(
+              'auth_method_id',
+              mtMap.passthrough()
+            ),
+            authCredentialsId: mtMap.objectField(
+              'auth_credentials_id',
+              mtMap.passthrough()
+            ),
+            config: mtMap.objectField(
+              'config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
         ),
         config: mtMap.objectField(
@@ -400,41 +338,24 @@ export let mapManagementInstanceIntegrationInstanceProvidersGetOutput =
             updatedAt: mtMap.objectField('updated_at', mtMap.date())
           })
         ),
+        authConfig: mtMap.objectField(
+          'auth_config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date()),
         archivedAt: mtMap.objectField('archived_at', mtMap.date())
       })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authConfig: mtMap.objectField(
-      'auth_config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+    )
+  ]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-providers/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceIntegrationInstanceProvidersListOutput = {
-  items: {
+  items: ({
     object: 'integration.instance.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -62,71 +62,10 @@ export type ManagementInstanceIntegrationInstanceProvidersListOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -167,7 +106,54 @@ export type ManagementInstanceIntegrationInstanceProvidersListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -176,96 +162,12 @@ export let mapManagementInstanceIntegrationInstanceProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
               status: mtMap.objectField('status', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
@@ -273,6 +175,14 @@ export let mapManagementInstanceIntegrationInstanceProvidersListOutput =
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
               toolFilter: mtMap.objectField(
                 'tool_filter',
                 mtMap.union([
@@ -316,6 +226,10 @@ export let mapManagementInstanceIntegrationInstanceProvidersListOutput =
                   )
                 ])
               ),
+              isOverrideToolFilter: mtMap.objectField(
+                'is_override_tool_filter',
+                mtMap.passthrough()
+              ),
               provider: mtMap.objectField(
                 'provider',
                 mtMap.object({
@@ -331,120 +245,114 @@ export let mapManagementInstanceIntegrationInstanceProvidersListOutput =
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
               ),
-              deployment: mtMap.objectField(
-                'deployment',
+              integrationProvider: mtMap.objectField(
+                'integration_provider',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
+                  providerVersion: mtMap.objectField(
+                    'provider_version',
                     mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      index: mtMap.objectField('index', mtMap.passthrough())
                     })
                   ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
                   status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
+                  toolFilter: mtMap.objectField(
+                    'tool_filter',
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          ignoreParentFilters: mtMap.objectField(
+                            'ignore_parent_filters',
+                            mtMap.passthrough()
+                          ),
+                          filters: mtMap.objectField(
+                            'filters',
+                            mtMap.array(
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    keys: mtMap.objectField(
+                                      'keys',
+                                      mtMap.array(mtMap.passthrough())
+                                    ),
+                                    pattern: mtMap.objectField(
+                                      'pattern',
+                                      mtMap.passthrough()
+                                    ),
+                                    uris: mtMap.objectField(
+                                      'uris',
+                                      mtMap.array(mtMap.passthrough())
+                                    )
+                                  })
+                                )
+                              ])
+                            )
+                          )
+                        })
+                      )
+                    ])
                   ),
                   providerId: mtMap.objectField(
                     'provider_id',
                     mtMap.passthrough()
                   ),
+                  deploymentId: mtMap.objectField(
+                    'deployment_id',
+                    mtMap.passthrough()
+                  ),
+                  authMethodId: mtMap.objectField(
+                    'auth_method_id',
+                    mtMap.passthrough()
+                  ),
+                  authCredentialsId: mtMap.objectField(
+                    'auth_credentials_id',
+                    mtMap.passthrough()
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
               ),
               config: mtMap.objectField(
@@ -470,49 +378,35 @@ export let mapManagementInstanceIntegrationInstanceProvidersListOutput =
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
               ),
+              authConfig: mtMap.objectField(
+                'auth_config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
               archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-providers/set.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-providers/set.ts
@@ -61,65 +61,10 @@ export type ManagementInstanceIntegrationInstanceProvidersSetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    deployment: {
-      object: 'provider.deployment#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    authMethod: {
-      object: 'provider.capabilities.auth_method';
-      id: string;
-      type: 'oauth' | 'token' | 'custom';
-      key: string;
-      name: string;
-      description: string | null;
-      capabilities: Record<string, any>;
-      inputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      outputSchema: { type: 'json_schema'; schema: Record<string, any> } | null;
-      scopes:
-        | {
-            object: 'provider.capabilities.auth_method.scope';
-            id: string;
-            scope: string;
-            name: string;
-            description: string | null;
-          }[]
-        | null;
-      providerId: string;
-      providerSpecificationId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authCredentials: {
-      object: 'provider.auth_credentials';
-      id: string;
-      type: 'oauth';
-      status: 'active' | 'archived' | 'deleted';
-      isDefault: boolean;
-      isManaged: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      scopes: string[] | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
     config: {
       object: 'provider.config#preview';
       id: string;
@@ -160,94 +105,71 @@ export type ManagementInstanceIntegrationInstanceProvidersSetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  integrationProvider: {
+    object: 'integration.provider#snapshot';
+    id: string;
+    providerVersion: {
+      object: 'integration.provider.version';
+      id: string;
+      index: number;
+    };
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  };
 };
 
 export let mapManagementInstanceIntegrationInstanceProvidersSetOutput =
-  mtMap.object<ManagementInstanceIntegrationInstanceProvidersSetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    isOverrideToolFilter: mtMap.objectField(
-      'is_override_tool_filter',
-      mtMap.passthrough()
-    ),
-    provider: mtMap.objectField(
-      'provider',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    integrationProvider: mtMap.objectField(
-      'integration_provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        providerVersion: mtMap.objectField(
-          'provider_version',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            index: mtMap.objectField('index', mtMap.passthrough())
-          })
-        ),
         status: mtMap.objectField('status', mtMap.passthrough()),
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        integrationInstanceId: mtMap.objectField(
+          'integration_instance_id',
+          mtMap.passthrough()
+        ),
         toolFilter: mtMap.objectField(
           'tool_filter',
           mtMap.union([
@@ -288,6 +210,10 @@ export let mapManagementInstanceIntegrationInstanceProvidersSetOutput =
             )
           ])
         ),
+        isOverrideToolFilter: mtMap.objectField(
+          'is_override_tool_filter',
+          mtMap.passthrough()
+        ),
         provider: mtMap.objectField(
           'provider',
           mtMap.object({
@@ -300,90 +226,102 @@ export let mapManagementInstanceIntegrationInstanceProvidersSetOutput =
             updatedAt: mtMap.objectField('updated_at', mtMap.date())
           })
         ),
-        deployment: mtMap.objectField(
-          'deployment',
+        integrationProvider: mtMap.objectField(
+          'integration_provider',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authMethod: mtMap.objectField(
-          'auth_method',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            key: mtMap.objectField('key', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            capabilities: mtMap.objectField(
-              'capabilities',
-              mtMap.passthrough()
-            ),
-            inputSchema: mtMap.objectField(
-              'input_schema',
+            providerVersion: mtMap.objectField(
+              'provider_version',
               mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                index: mtMap.objectField('index', mtMap.passthrough())
               })
             ),
-            outputSchema: mtMap.objectField(
-              'output_schema',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                schema: mtMap.objectField('schema', mtMap.passthrough())
-              })
-            ),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  scope: mtMap.objectField('scope', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  )
-                })
-              )
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            providerSpecificationId: mtMap.objectField(
-              'provider_specification_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authCredentials: mtMap.objectField(
-          'auth_credentials',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            type: mtMap.objectField('type', mtMap.passthrough()),
             status: mtMap.objectField('status', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            scopes: mtMap.objectField(
-              'scopes',
-              mtMap.array(mtMap.passthrough())
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
             ),
             providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            deploymentId: mtMap.objectField(
+              'deployment_id',
+              mtMap.passthrough()
+            ),
+            authMethodId: mtMap.objectField(
+              'auth_method_id',
+              mtMap.passthrough()
+            ),
+            authCredentialsId: mtMap.objectField(
+              'auth_credentials_id',
+              mtMap.passthrough()
+            ),
+            config: mtMap.objectField(
+              'config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
         ),
         config: mtMap.objectField(
@@ -400,43 +338,26 @@ export let mapManagementInstanceIntegrationInstanceProvidersSetOutput =
             updatedAt: mtMap.objectField('updated_at', mtMap.date())
           })
         ),
+        authConfig: mtMap.objectField(
+          'auth_config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date()),
         archivedAt: mtMap.objectField('archived_at', mtMap.date())
       })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authConfig: mtMap.objectField(
-      'auth_config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+    )
+  ]);
 
 export type ManagementInstanceIntegrationInstanceProvidersSetBody = {
   providerDeploymentId?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/create.ts
@@ -72,71 +72,10 @@ export type ManagementInstanceIntegrationInstancesCreateOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -181,64 +120,302 @@ export type ManagementInstanceIntegrationInstancesCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.instance.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    provider: {
+      object: 'provider#preview';
+      id: string;
+      name: string;
+      description: string | null;
+      slug: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    authConfig: {
+      object: 'provider.auth_config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
 };
 
-export let mapManagementInstanceIntegrationInstancesCreateOutput =
-  mtMap.object<ManagementInstanceIntegrationInstancesCreateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    identityActorId: mtMap.objectField(
-      'identity_actor_id',
-      mtMap.passthrough()
-    ),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpServerId: mtMap.objectField(
-          'magic_mcp_server_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapManagementInstanceIntegrationInstancesCreateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpServerId: mtMap.objectField(
+            'magic_mcp_server_id',
             mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
+          )
+        })
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -247,312 +424,161 @@ export let mapManagementInstanceIntegrationInstancesCreateOutput =
                               'type',
                               mtMap.passthrough()
                             ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
                               mtMap.passthrough()
                             ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
                             )
                           })
                         )
                       ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
-                        )
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type ManagementInstanceIntegrationInstancesCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/delete.ts
@@ -72,71 +72,10 @@ export type ManagementInstanceIntegrationInstancesDeleteOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -181,64 +120,302 @@ export type ManagementInstanceIntegrationInstancesDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.instance.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    provider: {
+      object: 'provider#preview';
+      id: string;
+      name: string;
+      description: string | null;
+      slug: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    authConfig: {
+      object: 'provider.auth_config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
 };
 
-export let mapManagementInstanceIntegrationInstancesDeleteOutput =
-  mtMap.object<ManagementInstanceIntegrationInstancesDeleteOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    identityActorId: mtMap.objectField(
-      'identity_actor_id',
-      mtMap.passthrough()
-    ),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpServerId: mtMap.objectField(
-          'magic_mcp_server_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapManagementInstanceIntegrationInstancesDeleteOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpServerId: mtMap.objectField(
+            'magic_mcp_server_id',
             mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
+          )
+        })
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -247,310 +424,159 @@ export let mapManagementInstanceIntegrationInstancesDeleteOutput =
                               'type',
                               mtMap.passthrough()
                             ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
                               mtMap.passthrough()
                             ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
                             )
                           })
                         )
                       ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
-                        )
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/get.ts
@@ -72,71 +72,10 @@ export type ManagementInstanceIntegrationInstancesGetOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -181,64 +120,302 @@ export type ManagementInstanceIntegrationInstancesGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.instance.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    provider: {
+      object: 'provider#preview';
+      id: string;
+      name: string;
+      description: string | null;
+      slug: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    authConfig: {
+      object: 'provider.auth_config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
 };
 
-export let mapManagementInstanceIntegrationInstancesGetOutput =
-  mtMap.object<ManagementInstanceIntegrationInstancesGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    identityActorId: mtMap.objectField(
-      'identity_actor_id',
-      mtMap.passthrough()
-    ),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpServerId: mtMap.objectField(
-          'magic_mcp_server_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapManagementInstanceIntegrationInstancesGetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpServerId: mtMap.objectField(
+            'magic_mcp_server_id',
             mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
+          )
+        })
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -247,310 +424,159 @@ export let mapManagementInstanceIntegrationInstancesGetOutput =
                               'type',
                               mtMap.passthrough()
                             ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
                               mtMap.passthrough()
                             ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
                             )
                           })
                         )
                       ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
-                        )
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceIntegrationInstancesListOutput = {
-  items: {
+  items: ({
     object: 'integration.instance';
     id: string;
     status: 'draft' | 'active' | 'archived' | 'deleted';
@@ -76,71 +76,10 @@ export type ManagementInstanceIntegrationInstancesListOutput = {
               ignoreParentFilters: boolean;
             }
           | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
         config: {
           object: 'provider.config#preview';
           id: string;
@@ -185,7 +124,161 @@ export type ManagementInstanceIntegrationInstancesListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
+  } & {
+    providers: ({
+      object: 'integration.instance.provider';
+      id: string;
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      integrationId: string;
+      integrationInstanceId: string;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      isOverrideToolFilter: boolean;
+      provider: {
+        object: 'provider#preview';
+        id: string;
+        name: string;
+        description: string | null;
+        slug: string;
+        createdAt: Date;
+        updatedAt: Date;
+      };
+      integrationProvider: {
+        object: 'integration.provider#snapshot';
+        id: string;
+        providerVersion: {
+          object: 'integration.provider.version';
+          id: string;
+          index: number;
+        };
+        status: 'active' | 'archived' | 'deleted';
+        name: string;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        toolFilter:
+          | { type: 'allow_all'; ignoreParentFilters: boolean }
+          | {
+              type: 'filter';
+              filters: (
+                | { type: 'tool_keys'; keys: string[] }
+                | { type: 'tool_regex'; pattern: string }
+                | { type: 'resource_regex'; pattern: string }
+                | { type: 'resource_uris'; uris: string[] }
+                | { type: 'prompt_keys'; keys: string[] }
+                | { type: 'prompt_regex'; pattern: string }
+              )[];
+              ignoreParentFilters: boolean;
+            }
+          | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
+        config: {
+          object: 'provider.config#preview';
+          id: string;
+          isDefault: boolean;
+          name: string | null;
+          description: string | null;
+          metadata: Record<string, any> | null;
+          providerId: string;
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+        createdAt: Date;
+        updatedAt: Date;
+        archivedAt: Date | null;
+      };
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      authConfig: {
+        object: 'provider.auth_config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    } & {
+      integrationProvider: {
+        object: 'integration.provider#snapshot';
+        id: string;
+        providerVersion: {
+          object: 'integration.provider.version';
+          id: string;
+          index: number;
+        };
+        status: 'active' | 'archived' | 'deleted';
+        name: string;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        toolFilter:
+          | { type: 'allow_all'; ignoreParentFilters: boolean }
+          | {
+              type: 'filter';
+              filters: (
+                | { type: 'tool_keys'; keys: string[] }
+                | { type: 'tool_regex'; pattern: string }
+                | { type: 'resource_regex'; pattern: string }
+                | { type: 'resource_uris'; uris: string[] }
+                | { type: 'prompt_keys'; keys: string[] }
+                | { type: 'prompt_regex'; pattern: string }
+              )[];
+              ignoreParentFilters: boolean;
+            }
+          | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
+        config: {
+          object: 'provider.config#preview';
+          id: string;
+          isDefault: boolean;
+          name: string | null;
+          description: string | null;
+          metadata: Record<string, any> | null;
+          providerId: string;
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+        createdAt: Date;
+        updatedAt: Date;
+        archivedAt: Date | null;
+      };
+    })[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -194,345 +287,54 @@ export let mapManagementInstanceIntegrationInstancesListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          identityActorId: mtMap.objectField(
-            'identity_actor_id',
-            mtMap.passthrough()
-          ),
-          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-          implementation: mtMap.objectField(
-            'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
-              )
-            })
-          ),
-          providers: mtMap.objectField(
-            'providers',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              identityActorId: mtMap.objectField(
+                'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              implementation: mtMap.objectField(
+                'implementation',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  magicMcpServerId: mtMap.objectField(
+                    'magic_mcp_server_id',
+                    mtMap.passthrough()
+                  )
+                })
+              ),
+              providers: mtMap.objectField(
+                'providers',
+                mtMap.array(
                   mtMap.union([
                     mtMap.unionOption(
                       'object',
                       mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    provider: mtMap.objectField(
-                      'provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    deployment: mtMap.objectField(
-                      'deployment',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authMethod: mtMap.objectField(
-                      'auth_method',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        key: mtMap.objectField('key', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        capabilities: mtMap.objectField(
-                          'capabilities',
-                          mtMap.passthrough()
-                        ),
-                        inputSchema: mtMap.objectField(
-                          'input_schema',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            schema: mtMap.objectField(
-                              'schema',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        outputSchema: mtMap.objectField(
-                          'output_schema',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            schema: mtMap.objectField(
-                              'schema',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
-                        scopes: mtMap.objectField(
-                          'scopes',
-                          mtMap.array(
-                            mtMap.object({
-                              object: mtMap.objectField(
-                                'object',
-                                mtMap.passthrough()
-                              ),
-                              id: mtMap.objectField('id', mtMap.passthrough()),
-                              scope: mtMap.objectField(
-                                'scope',
-                                mtMap.passthrough()
-                              ),
-                              name: mtMap.objectField(
-                                'name',
-                                mtMap.passthrough()
-                              ),
-                              description: mtMap.objectField(
-                                'description',
-                                mtMap.passthrough()
-                              )
-                            })
-                          )
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        providerSpecificationId: mtMap.objectField(
-                          'provider_specification_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authCredentials: mtMap.objectField(
-                      'auth_credentials',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        type: mtMap.objectField('type', mtMap.passthrough()),
                         status: mtMap.objectField(
                           'status',
                           mtMap.passthrough()
                         ),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        isManaged: mtMap.objectField(
-                          'is_managed',
-                          mtMap.passthrough()
-                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
@@ -542,120 +344,351 @@ export let mapManagementInstanceIntegrationInstancesListOutput =
                           'metadata',
                           mtMap.passthrough()
                         ),
-                        scopes: mtMap.objectField(
-                          'scopes',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
+                        integrationId: mtMap.objectField(
+                          'integration_id',
                           mtMap.passthrough()
+                        ),
+                        integrationInstanceId: mtMap.objectField(
+                          'integration_instance_id',
+                          mtMap.passthrough()
+                        ),
+                        toolFilter: mtMap.objectField(
+                          'tool_filter',
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                ignoreParentFilters: mtMap.objectField(
+                                  'ignore_parent_filters',
+                                  mtMap.passthrough()
+                                ),
+                                filters: mtMap.objectField(
+                                  'filters',
+                                  mtMap.array(
+                                    mtMap.union([
+                                      mtMap.unionOption(
+                                        'object',
+                                        mtMap.object({
+                                          type: mtMap.objectField(
+                                            'type',
+                                            mtMap.passthrough()
+                                          ),
+                                          keys: mtMap.objectField(
+                                            'keys',
+                                            mtMap.array(mtMap.passthrough())
+                                          ),
+                                          pattern: mtMap.objectField(
+                                            'pattern',
+                                            mtMap.passthrough()
+                                          ),
+                                          uris: mtMap.objectField(
+                                            'uris',
+                                            mtMap.array(mtMap.passthrough())
+                                          )
+                                        })
+                                      )
+                                    ])
+                                  )
+                                )
+                              })
+                            )
+                          ])
+                        ),
+                        isOverrideToolFilter: mtMap.objectField(
+                          'is_override_tool_filter',
+                          mtMap.passthrough()
+                        ),
+                        provider: mtMap.objectField(
+                          'provider',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            slug: mtMap.objectField(
+                              'slug',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        integrationProvider: mtMap.objectField(
+                          'integration_provider',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            providerVersion: mtMap.objectField(
+                              'provider_version',
+                              mtMap.object({
+                                object: mtMap.objectField(
+                                  'object',
+                                  mtMap.passthrough()
+                                ),
+                                id: mtMap.objectField(
+                                  'id',
+                                  mtMap.passthrough()
+                                ),
+                                index: mtMap.objectField(
+                                  'index',
+                                  mtMap.passthrough()
+                                )
+                              })
+                            ),
+                            status: mtMap.objectField(
+                              'status',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            toolFilter: mtMap.objectField(
+                              'tool_filter',
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    ignoreParentFilters: mtMap.objectField(
+                                      'ignore_parent_filters',
+                                      mtMap.passthrough()
+                                    ),
+                                    filters: mtMap.objectField(
+                                      'filters',
+                                      mtMap.array(
+                                        mtMap.union([
+                                          mtMap.unionOption(
+                                            'object',
+                                            mtMap.object({
+                                              type: mtMap.objectField(
+                                                'type',
+                                                mtMap.passthrough()
+                                              ),
+                                              keys: mtMap.objectField(
+                                                'keys',
+                                                mtMap.array(mtMap.passthrough())
+                                              ),
+                                              pattern: mtMap.objectField(
+                                                'pattern',
+                                                mtMap.passthrough()
+                                              ),
+                                              uris: mtMap.objectField(
+                                                'uris',
+                                                mtMap.array(mtMap.passthrough())
+                                              )
+                                            })
+                                          )
+                                        ])
+                                      )
+                                    )
+                                  })
+                                )
+                              ])
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            deploymentId: mtMap.objectField(
+                              'deployment_id',
+                              mtMap.passthrough()
+                            ),
+                            authMethodId: mtMap.objectField(
+                              'auth_method_id',
+                              mtMap.passthrough()
+                            ),
+                            authCredentialsId: mtMap.objectField(
+                              'auth_credentials_id',
+                              mtMap.passthrough()
+                            ),
+                            config: mtMap.objectField(
+                              'config',
+                              mtMap.object({
+                                object: mtMap.objectField(
+                                  'object',
+                                  mtMap.passthrough()
+                                ),
+                                id: mtMap.objectField(
+                                  'id',
+                                  mtMap.passthrough()
+                                ),
+                                isDefault: mtMap.objectField(
+                                  'is_default',
+                                  mtMap.passthrough()
+                                ),
+                                name: mtMap.objectField(
+                                  'name',
+                                  mtMap.passthrough()
+                                ),
+                                description: mtMap.objectField(
+                                  'description',
+                                  mtMap.passthrough()
+                                ),
+                                metadata: mtMap.objectField(
+                                  'metadata',
+                                  mtMap.passthrough()
+                                ),
+                                providerId: mtMap.objectField(
+                                  'provider_id',
+                                  mtMap.passthrough()
+                                ),
+                                createdAt: mtMap.objectField(
+                                  'created_at',
+                                  mtMap.date()
+                                ),
+                                updatedAt: mtMap.objectField(
+                                  'updated_at',
+                                  mtMap.date()
+                                )
+                              })
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            ),
+                            archivedAt: mtMap.objectField(
+                              'archived_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        config: mtMap.objectField(
+                          'config',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        authConfig: mtMap.objectField(
+                          'auth_config',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',
                           mtMap.date()
                         ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
+                        updatedAt: mtMap.objectField(
+                          'updated_at',
                           mtMap.date()
                         ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                        archivedAt: mtMap.objectField(
+                          'archived_at',
+                          mtMap.date()
+                        )
                       })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+                    )
+                  ])
+                )
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/update.ts
@@ -72,71 +72,10 @@ export type ManagementInstanceIntegrationInstancesUpdateOutput = {
             ignoreParentFilters: boolean;
           }
         | null;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      deployment: {
-        object: 'provider.deployment#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      authMethod: {
-        object: 'provider.capabilities.auth_method';
-        id: string;
-        type: 'oauth' | 'token' | 'custom';
-        key: string;
-        name: string;
-        description: string | null;
-        capabilities: Record<string, any>;
-        inputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        outputSchema: {
-          type: 'json_schema';
-          schema: Record<string, any>;
-        } | null;
-        scopes:
-          | {
-              object: 'provider.capabilities.auth_method.scope';
-              id: string;
-              scope: string;
-              name: string;
-              description: string | null;
-            }[]
-          | null;
-        providerId: string;
-        providerSpecificationId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authCredentials: {
-        object: 'provider.auth_credentials';
-        id: string;
-        type: 'oauth';
-        status: 'active' | 'archived' | 'deleted';
-        isDefault: boolean;
-        isManaged: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        scopes: string[] | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
       config: {
         object: 'provider.config#preview';
         id: string;
@@ -181,64 +120,302 @@ export type ManagementInstanceIntegrationInstancesUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.instance.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    integrationId: string;
+    integrationInstanceId: string;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    isOverrideToolFilter: boolean;
+    provider: {
+      object: 'provider#preview';
+      id: string;
+      name: string;
+      description: string | null;
+      slug: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    authConfig: {
+      object: 'provider.auth_config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    integrationProvider: {
+      object: 'integration.provider#snapshot';
+      id: string;
+      providerVersion: {
+        object: 'integration.provider.version';
+        id: string;
+        index: number;
+      };
+      status: 'active' | 'archived' | 'deleted';
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    };
+  })[];
 };
 
-export let mapManagementInstanceIntegrationInstancesUpdateOutput =
-  mtMap.object<ManagementInstanceIntegrationInstancesUpdateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    identityActorId: mtMap.objectField(
-      'identity_actor_id',
-      mtMap.passthrough()
-    ),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.object({
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        magicMcpServerId: mtMap.objectField(
-          'magic_mcp_server_id',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapManagementInstanceIntegrationInstancesUpdateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      implementation: mtMap.objectField(
+        'implementation',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          magicMcpServerId: mtMap.objectField(
+            'magic_mcp_server_id',
             mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
+          )
+        })
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -247,312 +424,161 @@ export let mapManagementInstanceIntegrationInstancesUpdateOutput =
                               'type',
                               mtMap.passthrough()
                             ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
                               mtMap.passthrough()
                             ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
                             )
                           })
                         )
                       ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
-                        )
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type ManagementInstanceIntegrationInstancesUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/create.ts
@@ -23,6 +23,47 @@ export type ManagementInstanceIntegrationProvidersCreateOutput = {
         ignoreParentFilters: boolean;
       }
     | null;
+  providerId: string;
+  deploymentId: string;
+  authMethodId: string | null;
+  authCredentialsId: string | null;
+  config: {
+    object: 'provider.config#preview';
+    id: string;
+    isDefault: boolean;
+    name: string | null;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    providerId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  object: 'integration.provider';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  integrationId: string;
+  name: string;
+  description: string | null;
+  metadata: Record<string, any> | null;
+  toolFilter:
+    | { type: 'allow_all'; ignoreParentFilters: boolean }
+    | {
+        type: 'filter';
+        filters: (
+          | { type: 'tool_keys'; keys: string[] }
+          | { type: 'tool_regex'; pattern: string }
+          | { type: 'resource_regex'; pattern: string }
+          | { type: 'resource_uris'; uris: string[] }
+          | { type: 'prompt_keys'; keys: string[] }
+          | { type: 'prompt_regex'; pattern: string }
+        )[];
+        ignoreParentFilters: boolean;
+      }
+    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -82,178 +123,178 @@ export type ManagementInstanceIntegrationProvidersCreateOutput = {
     createdAt: Date;
     updatedAt: Date;
   } | null;
-  config: {
-    object: 'provider.config#preview';
-    id: string;
-    isDefault: boolean;
-    name: string | null;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    providerId: string;
-    createdAt: Date;
-    updatedAt: Date;
-  } | null;
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapManagementInstanceIntegrationProvidersCreateOutput =
-  mtMap.object<ManagementInstanceIntegrationProvidersCreateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    deployment: mtMap.objectField(
-      'deployment',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authMethod: mtMap.objectField(
-      'auth_method',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        key: mtMap.objectField('key', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-        inputSchema: mtMap.objectField(
-          'input_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        outputSchema: mtMap.objectField(
-          'output_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        scopes: mtMap.objectField(
-          'scopes',
-          mtMap.array(
+export let mapManagementInstanceIntegrationProvidersCreateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              scope: mtMap.objectField('scope', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField('description', mtMap.passthrough())
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
             })
           )
-        ),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        providerSpecificationId: mtMap.objectField(
-          'provider_specification_id',
-          mtMap.passthrough()
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authCredentials: mtMap.objectField(
-      'auth_credentials',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+        ])
+      ),
+      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+      authCredentialsId: mtMap.objectField(
+        'auth_credentials_id',
+        mtMap.passthrough()
+      ),
+      config: mtMap.objectField(
+        'config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      deployment: mtMap.objectField(
+        'deployment',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authMethod: mtMap.objectField(
+        'auth_method',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          key: mtMap.objectField('key', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+          inputSchema: mtMap.objectField(
+            'input_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          outputSchema: mtMap.objectField(
+            'output_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          scopes: mtMap.objectField(
+            'scopes',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                scope: mtMap.objectField('scope', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                )
+              })
+            )
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          providerSpecificationId: mtMap.objectField(
+            'provider_specification_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authCredentials: mtMap.objectField(
+        'auth_credentials',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 
 export type ManagementInstanceIntegrationProvidersCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/delete.ts
@@ -23,6 +23,47 @@ export type ManagementInstanceIntegrationProvidersDeleteOutput = {
         ignoreParentFilters: boolean;
       }
     | null;
+  providerId: string;
+  deploymentId: string;
+  authMethodId: string | null;
+  authCredentialsId: string | null;
+  config: {
+    object: 'provider.config#preview';
+    id: string;
+    isDefault: boolean;
+    name: string | null;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    providerId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  object: 'integration.provider';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  integrationId: string;
+  name: string;
+  description: string | null;
+  metadata: Record<string, any> | null;
+  toolFilter:
+    | { type: 'allow_all'; ignoreParentFilters: boolean }
+    | {
+        type: 'filter';
+        filters: (
+          | { type: 'tool_keys'; keys: string[] }
+          | { type: 'tool_regex'; pattern: string }
+          | { type: 'resource_regex'; pattern: string }
+          | { type: 'resource_uris'; uris: string[] }
+          | { type: 'prompt_keys'; keys: string[] }
+          | { type: 'prompt_regex'; pattern: string }
+        )[];
+        ignoreParentFilters: boolean;
+      }
+    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -82,176 +123,176 @@ export type ManagementInstanceIntegrationProvidersDeleteOutput = {
     createdAt: Date;
     updatedAt: Date;
   } | null;
-  config: {
-    object: 'provider.config#preview';
-    id: string;
-    isDefault: boolean;
-    name: string | null;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    providerId: string;
-    createdAt: Date;
-    updatedAt: Date;
-  } | null;
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapManagementInstanceIntegrationProvidersDeleteOutput =
-  mtMap.object<ManagementInstanceIntegrationProvidersDeleteOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    deployment: mtMap.objectField(
-      'deployment',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authMethod: mtMap.objectField(
-      'auth_method',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        key: mtMap.objectField('key', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-        inputSchema: mtMap.objectField(
-          'input_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        outputSchema: mtMap.objectField(
-          'output_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        scopes: mtMap.objectField(
-          'scopes',
-          mtMap.array(
+export let mapManagementInstanceIntegrationProvidersDeleteOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              scope: mtMap.objectField('scope', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField('description', mtMap.passthrough())
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
             })
           )
-        ),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        providerSpecificationId: mtMap.objectField(
-          'provider_specification_id',
-          mtMap.passthrough()
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authCredentials: mtMap.objectField(
-      'auth_credentials',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+        ])
+      ),
+      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+      authCredentialsId: mtMap.objectField(
+        'auth_credentials_id',
+        mtMap.passthrough()
+      ),
+      config: mtMap.objectField(
+        'config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      deployment: mtMap.objectField(
+        'deployment',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authMethod: mtMap.objectField(
+        'auth_method',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          key: mtMap.objectField('key', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+          inputSchema: mtMap.objectField(
+            'input_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          outputSchema: mtMap.objectField(
+            'output_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          scopes: mtMap.objectField(
+            'scopes',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                scope: mtMap.objectField('scope', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                )
+              })
+            )
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          providerSpecificationId: mtMap.objectField(
+            'provider_specification_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authCredentials: mtMap.objectField(
+        'auth_credentials',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/get.ts
@@ -23,6 +23,47 @@ export type ManagementInstanceIntegrationProvidersGetOutput = {
         ignoreParentFilters: boolean;
       }
     | null;
+  providerId: string;
+  deploymentId: string;
+  authMethodId: string | null;
+  authCredentialsId: string | null;
+  config: {
+    object: 'provider.config#preview';
+    id: string;
+    isDefault: boolean;
+    name: string | null;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    providerId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  object: 'integration.provider';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  integrationId: string;
+  name: string;
+  description: string | null;
+  metadata: Record<string, any> | null;
+  toolFilter:
+    | { type: 'allow_all'; ignoreParentFilters: boolean }
+    | {
+        type: 'filter';
+        filters: (
+          | { type: 'tool_keys'; keys: string[] }
+          | { type: 'tool_regex'; pattern: string }
+          | { type: 'resource_regex'; pattern: string }
+          | { type: 'resource_uris'; uris: string[] }
+          | { type: 'prompt_keys'; keys: string[] }
+          | { type: 'prompt_regex'; pattern: string }
+        )[];
+        ignoreParentFilters: boolean;
+      }
+    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -82,176 +123,176 @@ export type ManagementInstanceIntegrationProvidersGetOutput = {
     createdAt: Date;
     updatedAt: Date;
   } | null;
-  config: {
-    object: 'provider.config#preview';
-    id: string;
-    isDefault: boolean;
-    name: string | null;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    providerId: string;
-    createdAt: Date;
-    updatedAt: Date;
-  } | null;
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapManagementInstanceIntegrationProvidersGetOutput =
-  mtMap.object<ManagementInstanceIntegrationProvidersGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    deployment: mtMap.objectField(
-      'deployment',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authMethod: mtMap.objectField(
-      'auth_method',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        key: mtMap.objectField('key', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-        inputSchema: mtMap.objectField(
-          'input_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        outputSchema: mtMap.objectField(
-          'output_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        scopes: mtMap.objectField(
-          'scopes',
-          mtMap.array(
+export let mapManagementInstanceIntegrationProvidersGetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              scope: mtMap.objectField('scope', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField('description', mtMap.passthrough())
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
             })
           )
-        ),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        providerSpecificationId: mtMap.objectField(
-          'provider_specification_id',
-          mtMap.passthrough()
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authCredentials: mtMap.objectField(
-      'auth_credentials',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+        ])
+      ),
+      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+      authCredentialsId: mtMap.objectField(
+        'auth_credentials_id',
+        mtMap.passthrough()
+      ),
+      config: mtMap.objectField(
+        'config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      deployment: mtMap.objectField(
+        'deployment',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authMethod: mtMap.objectField(
+        'auth_method',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          key: mtMap.objectField('key', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+          inputSchema: mtMap.objectField(
+            'input_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          outputSchema: mtMap.objectField(
+            'output_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          scopes: mtMap.objectField(
+            'scopes',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                scope: mtMap.objectField('scope', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                )
+              })
+            )
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          providerSpecificationId: mtMap.objectField(
+            'provider_specification_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authCredentials: mtMap.objectField(
+        'auth_credentials',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/list.ts
@@ -1,7 +1,48 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceIntegrationProvidersListOutput = {
-  items: {
+  items: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
     object: 'integration.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -83,21 +124,7 @@ export type ManagementInstanceIntegrationProvidersListOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -106,191 +133,239 @@ export let mapManagementInstanceIntegrationProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
                 mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
                     mtMap.passthrough()
                   ),
-                  filters: mtMap.objectField(
-                    'filters',
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+              provider: mtMap.objectField(
+                'provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              deployment: mtMap.objectField(
+                'deployment',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              authMethod: mtMap.objectField(
+                'auth_method',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  key: mtMap.objectField('key', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  capabilities: mtMap.objectField(
+                    'capabilities',
+                    mtMap.passthrough()
+                  ),
+                  inputSchema: mtMap.objectField(
+                    'input_schema',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      schema: mtMap.objectField('schema', mtMap.passthrough())
+                    })
+                  ),
+                  outputSchema: mtMap.objectField(
+                    'output_schema',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      schema: mtMap.objectField('schema', mtMap.passthrough())
+                    })
+                  ),
+                  scopes: mtMap.objectField(
+                    'scopes',
                     mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
+                      mtMap.object({
+                        object: mtMap.objectField(
                           'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
                         )
-                      ])
+                      })
                     )
-                  )
+                  ),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  providerSpecificationId: mtMap.objectField(
+                    'provider_specification_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              authCredentials: mtMap.objectField(
+                'auth_credentials',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  isManaged: mtMap.objectField(
+                    'is_managed',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  scopes: mtMap.objectField(
+                    'scopes',
+                    mtMap.array(mtMap.passthrough())
+                  ),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
               )
-            ])
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              capabilities: mtMap.objectField(
-                'capabilities',
-                mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    )
-                  })
-                )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/update.ts
@@ -23,6 +23,47 @@ export type ManagementInstanceIntegrationProvidersUpdateOutput = {
         ignoreParentFilters: boolean;
       }
     | null;
+  providerId: string;
+  deploymentId: string;
+  authMethodId: string | null;
+  authCredentialsId: string | null;
+  config: {
+    object: 'provider.config#preview';
+    id: string;
+    isDefault: boolean;
+    name: string | null;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    providerId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  object: 'integration.provider';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  integrationId: string;
+  name: string;
+  description: string | null;
+  metadata: Record<string, any> | null;
+  toolFilter:
+    | { type: 'allow_all'; ignoreParentFilters: boolean }
+    | {
+        type: 'filter';
+        filters: (
+          | { type: 'tool_keys'; keys: string[] }
+          | { type: 'tool_regex'; pattern: string }
+          | { type: 'resource_regex'; pattern: string }
+          | { type: 'resource_uris'; uris: string[] }
+          | { type: 'prompt_keys'; keys: string[] }
+          | { type: 'prompt_regex'; pattern: string }
+        )[];
+        ignoreParentFilters: boolean;
+      }
+    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -82,178 +123,178 @@ export type ManagementInstanceIntegrationProvidersUpdateOutput = {
     createdAt: Date;
     updatedAt: Date;
   } | null;
-  config: {
-    object: 'provider.config#preview';
-    id: string;
-    isDefault: boolean;
-    name: string | null;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    providerId: string;
-    createdAt: Date;
-    updatedAt: Date;
-  } | null;
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
 };
 
-export let mapManagementInstanceIntegrationProvidersUpdateOutput =
-  mtMap.object<ManagementInstanceIntegrationProvidersUpdateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    toolFilter: mtMap.objectField(
-      'tool_filter',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            ignoreParentFilters: mtMap.objectField(
-              'ignore_parent_filters',
-              mtMap.passthrough()
-            ),
-            filters: mtMap.objectField(
-              'filters',
-              mtMap.array(
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      keys: mtMap.objectField(
-                        'keys',
-                        mtMap.array(mtMap.passthrough())
-                      ),
-                      pattern: mtMap.objectField(
-                        'pattern',
-                        mtMap.passthrough()
-                      ),
-                      uris: mtMap.objectField(
-                        'uris',
-                        mtMap.array(mtMap.passthrough())
-                      )
-                    })
-                  )
-                ])
-              )
-            )
-          })
-        )
-      ])
-    ),
-    provider: mtMap.objectField(
-      'provider',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        slug: mtMap.objectField('slug', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    deployment: mtMap.objectField(
-      'deployment',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authMethod: mtMap.objectField(
-      'auth_method',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        key: mtMap.objectField('key', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-        inputSchema: mtMap.objectField(
-          'input_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        outputSchema: mtMap.objectField(
-          'output_schema',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            schema: mtMap.objectField('schema', mtMap.passthrough())
-          })
-        ),
-        scopes: mtMap.objectField(
-          'scopes',
-          mtMap.array(
+export let mapManagementInstanceIntegrationProvidersUpdateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              scope: mtMap.objectField('scope', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField('description', mtMap.passthrough())
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
+                          mtMap.passthrough()
+                        ),
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
+                        )
+                      })
+                    )
+                  ])
+                )
+              )
             })
           )
-        ),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        providerSpecificationId: mtMap.objectField(
-          'provider_specification_id',
-          mtMap.passthrough()
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    authCredentials: mtMap.objectField(
-      'auth_credentials',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        type: mtMap.objectField('type', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    config: mtMap.objectField(
-      'config',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-      })
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+        ])
+      ),
+      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+      authCredentialsId: mtMap.objectField(
+        'auth_credentials_id',
+        mtMap.passthrough()
+      ),
+      config: mtMap.objectField(
+        'config',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      deployment: mtMap.objectField(
+        'deployment',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authMethod: mtMap.objectField(
+        'auth_method',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          key: mtMap.objectField('key', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+          inputSchema: mtMap.objectField(
+            'input_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          outputSchema: mtMap.objectField(
+            'output_schema',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              schema: mtMap.objectField('schema', mtMap.passthrough())
+            })
+          ),
+          scopes: mtMap.objectField(
+            'scopes',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                scope: mtMap.objectField('scope', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                )
+              })
+            )
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          providerSpecificationId: mtMap.objectField(
+            'provider_specification_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      authCredentials: mtMap.objectField(
+        'auth_credentials',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    })
+  )
+]);
 
 export type ManagementInstanceIntegrationProvidersUpdateBody = {
   providerDeploymentId?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-setup-sessions/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-setup-sessions/create.ts
@@ -11,7 +11,6 @@ export type ManagementInstanceIntegrationSetupSessionsCreateOutput = {
   configuration: Record<string, any> | null;
   redirectUrl: string | null;
   integrationId: string;
-  integrationInstanceId: string;
   integrationInstance: {
     object: 'integration.instance';
     id: string;
@@ -87,71 +86,10 @@ export type ManagementInstanceIntegrationSetupSessionsCreateOutput = {
               ignoreParentFilters: boolean;
             }
           | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
         config: {
           object: 'provider.config#preview';
           id: string;
@@ -197,6 +135,11 @@ export type ManagementInstanceIntegrationSetupSessionsCreateOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
+  createdAt: Date;
+  updatedAt: Date;
+  expiresAt: Date;
+} & {
+  integrationInstanceId: string;
   steps: {
     object: 'integration.setup_session.step';
     id: string;
@@ -224,148 +167,57 @@ export type ManagementInstanceIntegrationSetupSessionsCreateOutput = {
     createdAt: Date;
     updatedAt: Date;
   }[];
-  createdAt: Date;
-  updatedAt: Date;
-  expiresAt: Date;
 };
 
 export let mapManagementInstanceIntegrationSetupSessionsCreateOutput =
-  mtMap.object<ManagementInstanceIntegrationSetupSessionsCreateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    url: mtMap.objectField('url', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField('configuration', mtMap.passthrough()),
-    redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    integrationInstance: mtMap.objectField(
-      'integration_instance',
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
         status: mtMap.objectField('status', mtMap.passthrough()),
+        url: mtMap.objectField('url', mtMap.passthrough()),
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        configuration: mtMap.objectField('configuration', mtMap.passthrough()),
+        redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        identityActorId: mtMap.objectField(
-          'identity_actor_id',
-          mtMap.passthrough()
-        ),
-        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-        implementation: mtMap.objectField(
-          'implementation',
+        integrationInstance: mtMap.objectField(
+          'integration_instance',
           mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            integrationId: mtMap.objectField(
+              'integration_id',
               mtMap.passthrough()
-            )
-          })
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              provider: mtMap.objectField(
-                'provider',
+            ),
+            identityActorId: mtMap.objectField(
+              'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            implementation: mtMap.objectField(
+              'implementation',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                magicMcpServerId: mtMap.objectField(
+                  'magic_mcp_server_id',
+                  mtMap.passthrough()
+                )
+              })
+            ),
+            providers: mtMap.objectField(
+              'providers',
+              mtMap.array(
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
                   status: mtMap.objectField('status', mtMap.passthrough()),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
@@ -373,6 +225,14 @@ export let mapManagementInstanceIntegrationSetupSessionsCreateOutput =
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  integrationId: mtMap.objectField(
+                    'integration_id',
+                    mtMap.passthrough()
+                  ),
+                  integrationInstanceId: mtMap.objectField(
+                    'integration_instance_id',
+                    mtMap.passthrough()
+                  ),
                   toolFilter: mtMap.objectField(
                     'tool_filter',
                     mtMap.union([
@@ -416,6 +276,10 @@ export let mapManagementInstanceIntegrationSetupSessionsCreateOutput =
                       )
                     ])
                   ),
+                  isOverrideToolFilter: mtMap.objectField(
+                    'is_override_tool_filter',
+                    mtMap.passthrough()
+                  ),
                   provider: mtMap.objectField(
                     'provider',
                     mtMap.object({
@@ -431,119 +295,23 @@ export let mapManagementInstanceIntegrationSetupSessionsCreateOutput =
                       updatedAt: mtMap.objectField('updated_at', mtMap.date())
                     })
                   ),
-                  deployment: mtMap.objectField(
-                    'deployment',
+                  integrationProvider: mtMap.objectField(
+                    'integration_provider',
                     mtMap.object({
                       object: mtMap.objectField('object', mtMap.passthrough()),
                       id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
+                      providerVersion: mtMap.objectField(
+                        'provider_version',
                         mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
+                          object: mtMap.objectField(
+                            'object',
                             mtMap.passthrough()
-                          )
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          index: mtMap.objectField('index', mtMap.passthrough())
                         })
                       ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
                       status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
                       name: mtMap.objectField('name', mtMap.passthrough()),
                       description: mtMap.objectField(
                         'description',
@@ -553,16 +321,106 @@ export let mapManagementInstanceIntegrationSetupSessionsCreateOutput =
                         'metadata',
                         mtMap.passthrough()
                       ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
+                      toolFilter: mtMap.objectField(
+                        'tool_filter',
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              ignoreParentFilters: mtMap.objectField(
+                                'ignore_parent_filters',
+                                mtMap.passthrough()
+                              ),
+                              filters: mtMap.objectField(
+                                'filters',
+                                mtMap.array(
+                                  mtMap.union([
+                                    mtMap.unionOption(
+                                      'object',
+                                      mtMap.object({
+                                        type: mtMap.objectField(
+                                          'type',
+                                          mtMap.passthrough()
+                                        ),
+                                        keys: mtMap.objectField(
+                                          'keys',
+                                          mtMap.array(mtMap.passthrough())
+                                        ),
+                                        pattern: mtMap.objectField(
+                                          'pattern',
+                                          mtMap.passthrough()
+                                        ),
+                                        uris: mtMap.objectField(
+                                          'uris',
+                                          mtMap.array(mtMap.passthrough())
+                                        )
+                                      })
+                                    )
+                                  ])
+                                )
+                              )
+                            })
+                          )
+                        ])
                       ),
                       providerId: mtMap.objectField(
                         'provider_id',
                         mtMap.passthrough()
                       ),
+                      deploymentId: mtMap.objectField(
+                        'deployment_id',
+                        mtMap.passthrough()
+                      ),
+                      authMethodId: mtMap.objectField(
+                        'auth_method_id',
+                        mtMap.passthrough()
+                      ),
+                      authCredentialsId: mtMap.objectField(
+                        'auth_credentials_id',
+                        mtMap.passthrough()
+                      ),
+                      config: mtMap.objectField(
+                        'config',
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          isDefault: mtMap.objectField(
+                            'is_default',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          ),
+                          metadata: mtMap.objectField(
+                            'metadata',
+                            mtMap.passthrough()
+                          ),
+                          providerId: mtMap.objectField(
+                            'provider_id',
+                            mtMap.passthrough()
+                          ),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
+                      ),
                       createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                      archivedAt: mtMap.objectField('archived_at', mtMap.date())
                     })
                   ),
                   config: mtMap.objectField(
@@ -591,112 +449,93 @@ export let mapManagementInstanceIntegrationSetupSessionsCreateOutput =
                       updatedAt: mtMap.objectField('updated_at', mtMap.date())
                     })
                   ),
+                  authConfig: mtMap.objectField(
+                    'auth_config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
                   updatedAt: mtMap.objectField('updated_at', mtMap.date()),
                   archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
+              )
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          })
         ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    steps: mtMap.objectField(
-      'steps',
-      mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          url: mtMap.objectField('url', mtMap.passthrough()),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
+        expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+        integrationInstanceId: mtMap.objectField(
+          'integration_instance_id',
+          mtMap.passthrough()
+        ),
+        steps: mtMap.objectField(
+          'steps',
+          mtMap.array(
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              url: mtMap.objectField('url', mtMap.passthrough()),
+              integrationProviderId: mtMap.objectField(
+                'integration_provider_id',
                 mtMap.passthrough()
               ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              provider: mtMap.objectField(
+                'provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              providerSetupSessionId: mtMap.objectField(
+                'provider_setup_session_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceProviderId: mtMap.objectField(
+                'integration_instance_provider_id',
+                mtMap.passthrough()
+              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          ),
-          providerSetupSessionId: mtMap.objectField(
-            'provider_setup_session_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceProviderId: mtMap.objectField(
-            'integration_instance_provider_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    expiresAt: mtMap.objectField('expires_at', mtMap.date())
-  });
+          )
+        )
+      })
+    )
+  ]);
 
 export type ManagementInstanceIntegrationSetupSessionsCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-setup-sessions/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-setup-sessions/get.ts
@@ -11,7 +11,6 @@ export type ManagementInstanceIntegrationSetupSessionsGetOutput = {
   configuration: Record<string, any> | null;
   redirectUrl: string | null;
   integrationId: string;
-  integrationInstanceId: string;
   integrationInstance: {
     object: 'integration.instance';
     id: string;
@@ -87,71 +86,10 @@ export type ManagementInstanceIntegrationSetupSessionsGetOutput = {
               ignoreParentFilters: boolean;
             }
           | null;
-        provider: {
-          object: 'provider#preview';
-          id: string;
-          name: string;
-          description: string | null;
-          slug: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        deployment: {
-          object: 'provider.deployment#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        };
-        authMethod: {
-          object: 'provider.capabilities.auth_method';
-          id: string;
-          type: 'oauth' | 'token' | 'custom';
-          key: string;
-          name: string;
-          description: string | null;
-          capabilities: Record<string, any>;
-          inputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          outputSchema: {
-            type: 'json_schema';
-            schema: Record<string, any>;
-          } | null;
-          scopes:
-            | {
-                object: 'provider.capabilities.auth_method.scope';
-                id: string;
-                scope: string;
-                name: string;
-                description: string | null;
-              }[]
-            | null;
-          providerId: string;
-          providerSpecificationId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        authCredentials: {
-          object: 'provider.auth_credentials';
-          id: string;
-          type: 'oauth';
-          status: 'active' | 'archived' | 'deleted';
-          isDefault: boolean;
-          isManaged: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          scopes: string[] | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
+        providerId: string;
+        deploymentId: string;
+        authMethodId: string | null;
+        authCredentialsId: string | null;
         config: {
           object: 'provider.config#preview';
           id: string;
@@ -197,6 +135,11 @@ export type ManagementInstanceIntegrationSetupSessionsGetOutput = {
     updatedAt: Date;
     archivedAt: Date | null;
   };
+  createdAt: Date;
+  updatedAt: Date;
+  expiresAt: Date;
+} & {
+  integrationInstanceId: string;
   steps: {
     object: 'integration.setup_session.step';
     id: string;
@@ -224,148 +167,57 @@ export type ManagementInstanceIntegrationSetupSessionsGetOutput = {
     createdAt: Date;
     updatedAt: Date;
   }[];
-  createdAt: Date;
-  updatedAt: Date;
-  expiresAt: Date;
 };
 
-export let mapManagementInstanceIntegrationSetupSessionsGetOutput =
-  mtMap.object<ManagementInstanceIntegrationSetupSessionsGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    url: mtMap.objectField('url', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField('configuration', mtMap.passthrough()),
-    redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
-    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-    integrationInstanceId: mtMap.objectField(
-      'integration_instance_id',
-      mtMap.passthrough()
-    ),
-    integrationInstance: mtMap.objectField(
-      'integration_instance',
+export let mapManagementInstanceIntegrationSetupSessionsGetOutput = mtMap.union(
+  [
+    mtMap.unionOption(
+      'object',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
         status: mtMap.objectField('status', mtMap.passthrough()),
+        url: mtMap.objectField('url', mtMap.passthrough()),
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        configuration: mtMap.objectField('configuration', mtMap.passthrough()),
+        redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        identityActorId: mtMap.objectField(
-          'identity_actor_id',
-          mtMap.passthrough()
-        ),
-        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-        implementation: mtMap.objectField(
-          'implementation',
+        integrationInstance: mtMap.objectField(
+          'integration_instance',
           mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            integrationId: mtMap.objectField(
+              'integration_id',
               mtMap.passthrough()
-            )
-          })
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              provider: mtMap.objectField(
-                'provider',
+            ),
+            identityActorId: mtMap.objectField(
+              'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            implementation: mtMap.objectField(
+              'implementation',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                magicMcpServerId: mtMap.objectField(
+                  'magic_mcp_server_id',
+                  mtMap.passthrough()
+                )
+              })
+            ),
+            providers: mtMap.objectField(
+              'providers',
+              mtMap.array(
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
                   status: mtMap.objectField('status', mtMap.passthrough()),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
@@ -373,6 +225,14 @@ export let mapManagementInstanceIntegrationSetupSessionsGetOutput =
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  integrationId: mtMap.objectField(
+                    'integration_id',
+                    mtMap.passthrough()
+                  ),
+                  integrationInstanceId: mtMap.objectField(
+                    'integration_instance_id',
+                    mtMap.passthrough()
+                  ),
                   toolFilter: mtMap.objectField(
                     'tool_filter',
                     mtMap.union([
@@ -416,6 +276,10 @@ export let mapManagementInstanceIntegrationSetupSessionsGetOutput =
                       )
                     ])
                   ),
+                  isOverrideToolFilter: mtMap.objectField(
+                    'is_override_tool_filter',
+                    mtMap.passthrough()
+                  ),
                   provider: mtMap.objectField(
                     'provider',
                     mtMap.object({
@@ -431,119 +295,23 @@ export let mapManagementInstanceIntegrationSetupSessionsGetOutput =
                       updatedAt: mtMap.objectField('updated_at', mtMap.date())
                     })
                   ),
-                  deployment: mtMap.objectField(
-                    'deployment',
+                  integrationProvider: mtMap.objectField(
+                    'integration_provider',
                     mtMap.object({
                       object: mtMap.objectField('object', mtMap.passthrough()),
                       id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authMethod: mtMap.objectField(
-                    'auth_method',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      key: mtMap.objectField('key', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      capabilities: mtMap.objectField(
-                        'capabilities',
-                        mtMap.passthrough()
-                      ),
-                      inputSchema: mtMap.objectField(
-                        'input_schema',
+                      providerVersion: mtMap.objectField(
+                        'provider_version',
                         mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
+                          object: mtMap.objectField(
+                            'object',
                             mtMap.passthrough()
-                          )
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          index: mtMap.objectField('index', mtMap.passthrough())
                         })
                       ),
-                      outputSchema: mtMap.objectField(
-                        'output_schema',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          schema: mtMap.objectField(
-                            'schema',
-                            mtMap.passthrough()
-                          )
-                        })
-                      ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            scope: mtMap.objectField(
-                              'scope',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            )
-                          })
-                        )
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      providerSpecificationId: mtMap.objectField(
-                        'provider_specification_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authCredentials: mtMap.objectField(
-                    'auth_credentials',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      type: mtMap.objectField('type', mtMap.passthrough()),
                       status: mtMap.objectField('status', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      isManaged: mtMap.objectField(
-                        'is_managed',
-                        mtMap.passthrough()
-                      ),
                       name: mtMap.objectField('name', mtMap.passthrough()),
                       description: mtMap.objectField(
                         'description',
@@ -553,16 +321,106 @@ export let mapManagementInstanceIntegrationSetupSessionsGetOutput =
                         'metadata',
                         mtMap.passthrough()
                       ),
-                      scopes: mtMap.objectField(
-                        'scopes',
-                        mtMap.array(mtMap.passthrough())
+                      toolFilter: mtMap.objectField(
+                        'tool_filter',
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              ignoreParentFilters: mtMap.objectField(
+                                'ignore_parent_filters',
+                                mtMap.passthrough()
+                              ),
+                              filters: mtMap.objectField(
+                                'filters',
+                                mtMap.array(
+                                  mtMap.union([
+                                    mtMap.unionOption(
+                                      'object',
+                                      mtMap.object({
+                                        type: mtMap.objectField(
+                                          'type',
+                                          mtMap.passthrough()
+                                        ),
+                                        keys: mtMap.objectField(
+                                          'keys',
+                                          mtMap.array(mtMap.passthrough())
+                                        ),
+                                        pattern: mtMap.objectField(
+                                          'pattern',
+                                          mtMap.passthrough()
+                                        ),
+                                        uris: mtMap.objectField(
+                                          'uris',
+                                          mtMap.array(mtMap.passthrough())
+                                        )
+                                      })
+                                    )
+                                  ])
+                                )
+                              )
+                            })
+                          )
+                        ])
                       ),
                       providerId: mtMap.objectField(
                         'provider_id',
                         mtMap.passthrough()
                       ),
+                      deploymentId: mtMap.objectField(
+                        'deployment_id',
+                        mtMap.passthrough()
+                      ),
+                      authMethodId: mtMap.objectField(
+                        'auth_method_id',
+                        mtMap.passthrough()
+                      ),
+                      authCredentialsId: mtMap.objectField(
+                        'auth_credentials_id',
+                        mtMap.passthrough()
+                      ),
+                      config: mtMap.objectField(
+                        'config',
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          isDefault: mtMap.objectField(
+                            'is_default',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          ),
+                          metadata: mtMap.objectField(
+                            'metadata',
+                            mtMap.passthrough()
+                          ),
+                          providerId: mtMap.objectField(
+                            'provider_id',
+                            mtMap.passthrough()
+                          ),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
+                      ),
                       createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                      archivedAt: mtMap.objectField('archived_at', mtMap.date())
                     })
                   ),
                   config: mtMap.objectField(
@@ -591,110 +449,92 @@ export let mapManagementInstanceIntegrationSetupSessionsGetOutput =
                       updatedAt: mtMap.objectField('updated_at', mtMap.date())
                     })
                   ),
+                  authConfig: mtMap.objectField(
+                    'auth_config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
                   updatedAt: mtMap.objectField('updated_at', mtMap.date()),
                   archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
+              )
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          })
         ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
-      })
-    ),
-    steps: mtMap.objectField(
-      'steps',
-      mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          url: mtMap.objectField('url', mtMap.passthrough()),
-          integrationProviderId: mtMap.objectField(
-            'integration_provider_id',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
+        expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+        integrationInstanceId: mtMap.objectField(
+          'integration_instance_id',
+          mtMap.passthrough()
+        ),
+        steps: mtMap.objectField(
+          'steps',
+          mtMap.array(
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              url: mtMap.objectField('url', mtMap.passthrough()),
+              integrationProviderId: mtMap.objectField(
+                'integration_provider_id',
                 mtMap.passthrough()
               ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              provider: mtMap.objectField(
+                'provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              providerSetupSessionId: mtMap.objectField(
+                'provider_setup_session_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceProviderId: mtMap.objectField(
+                'integration_instance_provider_id',
+                mtMap.passthrough()
+              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          ),
-          providerSetupSessionId: mtMap.objectField(
-            'provider_setup_session_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceProviderId: mtMap.objectField(
-            'integration_instance_provider_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    expiresAt: mtMap.objectField('expires_at', mtMap.date())
-  });
+          )
+        )
+      })
+    )
+  ]
+);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-setup-sessions/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-setup-sessions/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceIntegrationSetupSessionsListOutput = {
-  items: {
+  items: ({
     object: 'integration.setup_session';
     id: string;
     status: 'pending' | 'successful' | 'expired' | 'archived' | 'deleted';
@@ -12,7 +12,6 @@ export type ManagementInstanceIntegrationSetupSessionsListOutput = {
     configuration: Record<string, any> | null;
     redirectUrl: string | null;
     integrationId: string;
-    integrationInstanceId: string;
     integrationInstance: {
       object: 'integration.instance';
       id: string;
@@ -88,71 +87,10 @@ export type ManagementInstanceIntegrationSetupSessionsListOutput = {
                 ignoreParentFilters: boolean;
               }
             | null;
-          provider: {
-            object: 'provider#preview';
-            id: string;
-            name: string;
-            description: string | null;
-            slug: string;
-            createdAt: Date;
-            updatedAt: Date;
-          };
-          deployment: {
-            object: 'provider.deployment#preview';
-            id: string;
-            isDefault: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          };
-          authMethod: {
-            object: 'provider.capabilities.auth_method';
-            id: string;
-            type: 'oauth' | 'token' | 'custom';
-            key: string;
-            name: string;
-            description: string | null;
-            capabilities: Record<string, any>;
-            inputSchema: {
-              type: 'json_schema';
-              schema: Record<string, any>;
-            } | null;
-            outputSchema: {
-              type: 'json_schema';
-              schema: Record<string, any>;
-            } | null;
-            scopes:
-              | {
-                  object: 'provider.capabilities.auth_method.scope';
-                  id: string;
-                  scope: string;
-                  name: string;
-                  description: string | null;
-                }[]
-              | null;
-            providerId: string;
-            providerSpecificationId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
-          authCredentials: {
-            object: 'provider.auth_credentials';
-            id: string;
-            type: 'oauth';
-            status: 'active' | 'archived' | 'deleted';
-            isDefault: boolean;
-            isManaged: boolean;
-            name: string | null;
-            description: string | null;
-            metadata: Record<string, any> | null;
-            scopes: string[] | null;
-            providerId: string;
-            createdAt: Date;
-            updatedAt: Date;
-          } | null;
+          providerId: string;
+          deploymentId: string;
+          authMethodId: string | null;
+          authCredentialsId: string | null;
           config: {
             object: 'provider.config#preview';
             id: string;
@@ -198,6 +136,11 @@ export type ManagementInstanceIntegrationSetupSessionsListOutput = {
       updatedAt: Date;
       archivedAt: Date | null;
     };
+    createdAt: Date;
+    updatedAt: Date;
+    expiresAt: Date;
+  } & {
+    integrationInstanceId: string;
     steps: {
       object: 'integration.setup_session.step';
       id: string;
@@ -225,10 +168,7 @@ export type ManagementInstanceIntegrationSetupSessionsListOutput = {
       createdAt: Date;
       updatedAt: Date;
     }[];
-    createdAt: Date;
-    updatedAt: Date;
-    expiresAt: Date;
-  }[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -237,175 +177,75 @@ export let mapManagementInstanceIntegrationSetupSessionsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          url: mtMap.objectField('url', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          configuration: mtMap.objectField(
-            'configuration',
-            mtMap.passthrough()
-          ),
-          redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          integrationInstance: mtMap.objectField(
-            'integration_instance',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
               status: mtMap.objectField('status', mtMap.passthrough()),
+              url: mtMap.objectField('url', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
                 'description',
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              configuration: mtMap.objectField(
+                'configuration',
+                mtMap.passthrough()
+              ),
+              redirectUrl: mtMap.objectField(
+                'redirect_url',
+                mtMap.passthrough()
+              ),
               integrationId: mtMap.objectField(
                 'integration_id',
                 mtMap.passthrough()
               ),
-              identityActorId: mtMap.objectField(
-                'identity_actor_id',
-                mtMap.passthrough()
-              ),
-              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-              implementation: mtMap.objectField(
-                'implementation',
+              integrationInstance: mtMap.objectField(
+                'integration_instance',
                 mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  magicMcpServerId: mtMap.objectField(
-                    'magic_mcp_server_id',
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
                     mtMap.passthrough()
-                  )
-                })
-              ),
-              providers: mtMap.objectField(
-                'providers',
-                mtMap.array(
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    integrationId: mtMap.objectField(
-                      'integration_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationInstanceId: mtMap.objectField(
-                      'integration_instance_id',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    isOverrideToolFilter: mtMap.objectField(
-                      'is_override_tool_filter',
-                      mtMap.passthrough()
-                    ),
-                    provider: mtMap.objectField(
-                      'provider',
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  integrationId: mtMap.objectField(
+                    'integration_id',
+                    mtMap.passthrough()
+                  ),
+                  identityActorId: mtMap.objectField(
+                    'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  implementation: mtMap.objectField(
+                    'implementation',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      magicMcpServerId: mtMap.objectField(
+                        'magic_mcp_server_id',
+                        mtMap.passthrough()
+                      )
+                    })
+                  ),
+                  providers: mtMap.objectField(
+                    'providers',
+                    mtMap.array(
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    integrationProvider: mtMap.objectField(
-                      'integration_provider',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        providerVersion: mtMap.objectField(
-                          'provider_version',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            index: mtMap.objectField(
-                              'index',
-                              mtMap.passthrough()
-                            )
-                          })
-                        ),
                         status: mtMap.objectField(
                           'status',
                           mtMap.passthrough()
@@ -417,6 +257,14 @@ export let mapManagementInstanceIntegrationSetupSessionsListOutput =
                         ),
                         metadata: mtMap.objectField(
                           'metadata',
+                          mtMap.passthrough()
+                        ),
+                        integrationId: mtMap.objectField(
+                          'integration_id',
+                          mtMap.passthrough()
+                        ),
+                        integrationInstanceId: mtMap.objectField(
+                          'integration_instance_id',
                           mtMap.passthrough()
                         ),
                         toolFilter: mtMap.objectField(
@@ -465,6 +313,10 @@ export let mapManagementInstanceIntegrationSetupSessionsListOutput =
                             )
                           ])
                         ),
+                        isOverrideToolFilter: mtMap.objectField(
+                          'is_override_tool_filter',
+                          mtMap.passthrough()
+                        ),
                         provider: mtMap.objectField(
                           'provider',
                           mtMap.object({
@@ -495,164 +347,35 @@ export let mapManagementInstanceIntegrationSetupSessionsListOutput =
                             )
                           })
                         ),
-                        deployment: mtMap.objectField(
-                          'deployment',
+                        integrationProvider: mtMap.objectField(
+                          'integration_provider',
                           mtMap.object({
                             object: mtMap.objectField(
                               'object',
                               mtMap.passthrough()
                             ),
                             id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authMethod: mtMap.objectField(
-                          'auth_method',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            key: mtMap.objectField('key', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            capabilities: mtMap.objectField(
-                              'capabilities',
-                              mtMap.passthrough()
-                            ),
-                            inputSchema: mtMap.objectField(
-                              'input_schema',
+                            providerVersion: mtMap.objectField(
+                              'provider_version',
                               mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
+                                object: mtMap.objectField(
+                                  'object',
                                   mtMap.passthrough()
                                 ),
-                                schema: mtMap.objectField(
-                                  'schema',
+                                id: mtMap.objectField(
+                                  'id',
+                                  mtMap.passthrough()
+                                ),
+                                index: mtMap.objectField(
+                                  'index',
                                   mtMap.passthrough()
                                 )
                               })
-                            ),
-                            outputSchema: mtMap.objectField(
-                              'output_schema',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                schema: mtMap.objectField(
-                                  'schema',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(
-                                mtMap.object({
-                                  object: mtMap.objectField(
-                                    'object',
-                                    mtMap.passthrough()
-                                  ),
-                                  id: mtMap.objectField(
-                                    'id',
-                                    mtMap.passthrough()
-                                  ),
-                                  scope: mtMap.objectField(
-                                    'scope',
-                                    mtMap.passthrough()
-                                  ),
-                                  name: mtMap.objectField(
-                                    'name',
-                                    mtMap.passthrough()
-                                  ),
-                                  description: mtMap.objectField(
-                                    'description',
-                                    mtMap.passthrough()
-                                  )
-                                })
-                              )
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            providerSpecificationId: mtMap.objectField(
-                              'provider_specification_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authCredentials: mtMap.objectField(
-                          'auth_credentials',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
                             ),
                             status: mtMap.objectField(
                               'status',
                               mtMap.passthrough()
                             ),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            isManaged: mtMap.objectField(
-                              'is_managed',
-                              mtMap.passthrough()
-                            ),
                             name: mtMap.objectField(
                               'name',
                               mtMap.passthrough()
@@ -665,13 +388,108 @@ export let mapManagementInstanceIntegrationSetupSessionsListOutput =
                               'metadata',
                               mtMap.passthrough()
                             ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(mtMap.passthrough())
+                            toolFilter: mtMap.objectField(
+                              'tool_filter',
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    ignoreParentFilters: mtMap.objectField(
+                                      'ignore_parent_filters',
+                                      mtMap.passthrough()
+                                    ),
+                                    filters: mtMap.objectField(
+                                      'filters',
+                                      mtMap.array(
+                                        mtMap.union([
+                                          mtMap.unionOption(
+                                            'object',
+                                            mtMap.object({
+                                              type: mtMap.objectField(
+                                                'type',
+                                                mtMap.passthrough()
+                                              ),
+                                              keys: mtMap.objectField(
+                                                'keys',
+                                                mtMap.array(mtMap.passthrough())
+                                              ),
+                                              pattern: mtMap.objectField(
+                                                'pattern',
+                                                mtMap.passthrough()
+                                              ),
+                                              uris: mtMap.objectField(
+                                                'uris',
+                                                mtMap.array(mtMap.passthrough())
+                                              )
+                                            })
+                                          )
+                                        ])
+                                      )
+                                    )
+                                  })
+                                )
+                              ])
                             ),
                             providerId: mtMap.objectField(
                               'provider_id',
                               mtMap.passthrough()
+                            ),
+                            deploymentId: mtMap.objectField(
+                              'deployment_id',
+                              mtMap.passthrough()
+                            ),
+                            authMethodId: mtMap.objectField(
+                              'auth_method_id',
+                              mtMap.passthrough()
+                            ),
+                            authCredentialsId: mtMap.objectField(
+                              'auth_credentials_id',
+                              mtMap.passthrough()
+                            ),
+                            config: mtMap.objectField(
+                              'config',
+                              mtMap.object({
+                                object: mtMap.objectField(
+                                  'object',
+                                  mtMap.passthrough()
+                                ),
+                                id: mtMap.objectField(
+                                  'id',
+                                  mtMap.passthrough()
+                                ),
+                                isDefault: mtMap.objectField(
+                                  'is_default',
+                                  mtMap.passthrough()
+                                ),
+                                name: mtMap.objectField(
+                                  'name',
+                                  mtMap.passthrough()
+                                ),
+                                description: mtMap.objectField(
+                                  'description',
+                                  mtMap.passthrough()
+                                ),
+                                metadata: mtMap.objectField(
+                                  'metadata',
+                                  mtMap.passthrough()
+                                ),
+                                providerId: mtMap.objectField(
+                                  'provider_id',
+                                  mtMap.passthrough()
+                                ),
+                                createdAt: mtMap.objectField(
+                                  'created_at',
+                                  mtMap.date()
+                                ),
+                                updatedAt: mtMap.objectField(
+                                  'updated_at',
+                                  mtMap.date()
+                                )
+                              })
                             ),
                             createdAt: mtMap.objectField(
                               'created_at',
@@ -679,12 +497,54 @@ export let mapManagementInstanceIntegrationSetupSessionsListOutput =
                             ),
                             updatedAt: mtMap.objectField(
                               'updated_at',
+                              mtMap.date()
+                            ),
+                            archivedAt: mtMap.objectField(
+                              'archived_at',
                               mtMap.date()
                             )
                           })
                         ),
                         config: mtMap.objectField(
                           'config',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        authConfig: mtMap.objectField(
+                          'auth_config',
                           mtMap.object({
                             object: mtMap.objectField(
                               'object',
@@ -734,126 +594,69 @@ export let mapManagementInstanceIntegrationSetupSessionsListOutput =
                           mtMap.date()
                         )
                       })
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    authConfig: mtMap.objectField(
-                      'auth_config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                )
+                    )
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                })
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          steps: mtMap.objectField(
-            'steps',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                url: mtMap.objectField('url', mtMap.passthrough()),
-                integrationProviderId: mtMap.objectField(
-                  'integration_provider_id',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
+              expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              steps: mtMap.objectField(
+                'steps',
+                mtMap.array(
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    url: mtMap.objectField('url', mtMap.passthrough()),
+                    integrationProviderId: mtMap.objectField(
+                      'integration_provider_id',
                       mtMap.passthrough()
                     ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    provider: mtMap.objectField(
+                      'provider',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        ),
+                        slug: mtMap.objectField('slug', mtMap.passthrough()),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    ),
+                    providerSetupSessionId: mtMap.objectField(
+                      'provider_setup_session_id',
+                      mtMap.passthrough()
+                    ),
+                    integrationInstanceProviderId: mtMap.objectField(
+                      'integration_instance_provider_id',
+                      mtMap.passthrough()
+                    ),
                     createdAt: mtMap.objectField('created_at', mtMap.date()),
                     updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
-                ),
-                providerSetupSessionId: mtMap.objectField(
-                  'provider_setup_session_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceProviderId: mtMap.objectField(
-                  'integration_instance_provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            )
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          expiresAt: mtMap.objectField('expires_at', mtMap.date())
-        })
+                )
+              )
+            })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/create.ts
@@ -40,6 +40,93 @@ export type ManagementInstanceIntegrationsCreateOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -99,265 +186,315 @@ export type ManagementInstanceIntegrationsCreateOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
+  })[];
 };
 
-export let mapManagementInstanceIntegrationsCreateOutput =
-  mtMap.object<ManagementInstanceIntegrationsCreateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    slug: mtMap.objectField('slug', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField(
-      'configuration',
-      mtMap.object({
-        canAttachCustomToolFilters: mtMap.objectField(
-          'can_attach_custom_tool_filters',
-          mtMap.passthrough()
-        ),
-        canAttachCustomProviderConfig: mtMap.objectField(
-          'can_attach_custom_provider_config',
-          mtMap.passthrough()
-        ),
-        canOverrideToolFilters: mtMap.objectField(
-          'can_override_tool_filters',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            providerTemplateId: mtMap.objectField(
-              'provider_template_id',
-              mtMap.passthrough()
-            ),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
-              mtMap.passthrough()
-            )
-          })
-        )
-      ])
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapManagementInstanceIntegrationsCreateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      slug: mtMap.objectField('slug', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField(
+        'configuration',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          canAttachCustomToolFilters: mtMap.objectField(
+            'can_attach_custom_tool_filters',
             mtMap.passthrough()
           ),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
+          canAttachCustomProviderConfig: mtMap.objectField(
+            'can_attach_custom_provider_config',
+            mtMap.passthrough()
           ),
-          provider: mtMap.objectField(
-            'provider',
+          canOverrideToolFilters: mtMap.objectField(
+            'can_override_tool_filters',
+            mtMap.passthrough()
+          )
+        })
+      ),
+      implementation: mtMap.objectField(
+        'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
               type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              providerTemplateId: mtMap.objectField(
+                'provider_template_id',
                 mtMap.passthrough()
               ),
-              capabilities: mtMap.objectField(
-                'capabilities',
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
+              )
+            })
+          )
+        ])
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
                     name: mtMap.objectField('name', mtMap.passthrough()),
                     description: mtMap.objectField(
                       'description',
                       mtMap.passthrough()
-                    )
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                deployment: mtMap.objectField(
+                  'deployment',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authMethod: mtMap.objectField(
+                  'auth_method',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    key: mtMap.objectField('key', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    capabilities: mtMap.objectField(
+                      'capabilities',
+                      mtMap.passthrough()
+                    ),
+                    inputSchema: mtMap.objectField(
+                      'input_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    outputSchema: mtMap.objectField(
+                      'output_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          scope: mtMap.objectField(
+                            'scope',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          )
+                        })
+                      )
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    providerSpecificationId: mtMap.objectField(
+                      'provider_specification_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authCredentials: mtMap.objectField(
+                  'auth_credentials',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    isManaged: mtMap.objectField(
+                      'is_managed',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(mtMap.passthrough())
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type ManagementInstanceIntegrationsCreateBody = {
   name: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/delete.ts
@@ -40,6 +40,93 @@ export type ManagementInstanceIntegrationsDeleteOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -99,263 +186,313 @@ export type ManagementInstanceIntegrationsDeleteOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
+  })[];
 };
 
-export let mapManagementInstanceIntegrationsDeleteOutput =
-  mtMap.object<ManagementInstanceIntegrationsDeleteOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    slug: mtMap.objectField('slug', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField(
-      'configuration',
-      mtMap.object({
-        canAttachCustomToolFilters: mtMap.objectField(
-          'can_attach_custom_tool_filters',
-          mtMap.passthrough()
-        ),
-        canAttachCustomProviderConfig: mtMap.objectField(
-          'can_attach_custom_provider_config',
-          mtMap.passthrough()
-        ),
-        canOverrideToolFilters: mtMap.objectField(
-          'can_override_tool_filters',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            providerTemplateId: mtMap.objectField(
-              'provider_template_id',
-              mtMap.passthrough()
-            ),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
-              mtMap.passthrough()
-            )
-          })
-        )
-      ])
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapManagementInstanceIntegrationsDeleteOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      slug: mtMap.objectField('slug', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField(
+        'configuration',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          canAttachCustomToolFilters: mtMap.objectField(
+            'can_attach_custom_tool_filters',
             mtMap.passthrough()
           ),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
+          canAttachCustomProviderConfig: mtMap.objectField(
+            'can_attach_custom_provider_config',
+            mtMap.passthrough()
           ),
-          provider: mtMap.objectField(
-            'provider',
+          canOverrideToolFilters: mtMap.objectField(
+            'can_override_tool_filters',
+            mtMap.passthrough()
+          )
+        })
+      ),
+      implementation: mtMap.objectField(
+        'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
               type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              providerTemplateId: mtMap.objectField(
+                'provider_template_id',
                 mtMap.passthrough()
               ),
-              capabilities: mtMap.objectField(
-                'capabilities',
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
+              )
+            })
+          )
+        ])
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
                     name: mtMap.objectField('name', mtMap.passthrough()),
                     description: mtMap.objectField(
                       'description',
                       mtMap.passthrough()
-                    )
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                deployment: mtMap.objectField(
+                  'deployment',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authMethod: mtMap.objectField(
+                  'auth_method',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    key: mtMap.objectField('key', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    capabilities: mtMap.objectField(
+                      'capabilities',
+                      mtMap.passthrough()
+                    ),
+                    inputSchema: mtMap.objectField(
+                      'input_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    outputSchema: mtMap.objectField(
+                      'output_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          scope: mtMap.objectField(
+                            'scope',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          )
+                        })
+                      )
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    providerSpecificationId: mtMap.objectField(
+                      'provider_specification_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authCredentials: mtMap.objectField(
+                  'auth_credentials',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    isManaged: mtMap.objectField(
+                      'is_managed',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(mtMap.passthrough())
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/get.ts
@@ -40,6 +40,93 @@ export type ManagementInstanceIntegrationsGetOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -99,263 +186,313 @@ export type ManagementInstanceIntegrationsGetOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
+  })[];
 };
 
-export let mapManagementInstanceIntegrationsGetOutput =
-  mtMap.object<ManagementInstanceIntegrationsGetOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    slug: mtMap.objectField('slug', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField(
-      'configuration',
-      mtMap.object({
-        canAttachCustomToolFilters: mtMap.objectField(
-          'can_attach_custom_tool_filters',
-          mtMap.passthrough()
-        ),
-        canAttachCustomProviderConfig: mtMap.objectField(
-          'can_attach_custom_provider_config',
-          mtMap.passthrough()
-        ),
-        canOverrideToolFilters: mtMap.objectField(
-          'can_override_tool_filters',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            providerTemplateId: mtMap.objectField(
-              'provider_template_id',
-              mtMap.passthrough()
-            ),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
-              mtMap.passthrough()
-            )
-          })
-        )
-      ])
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapManagementInstanceIntegrationsGetOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      slug: mtMap.objectField('slug', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField(
+        'configuration',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          canAttachCustomToolFilters: mtMap.objectField(
+            'can_attach_custom_tool_filters',
             mtMap.passthrough()
           ),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
+          canAttachCustomProviderConfig: mtMap.objectField(
+            'can_attach_custom_provider_config',
+            mtMap.passthrough()
           ),
-          provider: mtMap.objectField(
-            'provider',
+          canOverrideToolFilters: mtMap.objectField(
+            'can_override_tool_filters',
+            mtMap.passthrough()
+          )
+        })
+      ),
+      implementation: mtMap.objectField(
+        'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
               type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              providerTemplateId: mtMap.objectField(
+                'provider_template_id',
                 mtMap.passthrough()
               ),
-              capabilities: mtMap.objectField(
-                'capabilities',
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
+              )
+            })
+          )
+        ])
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
                     name: mtMap.objectField('name', mtMap.passthrough()),
                     description: mtMap.objectField(
                       'description',
                       mtMap.passthrough()
-                    )
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                deployment: mtMap.objectField(
+                  'deployment',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authMethod: mtMap.objectField(
+                  'auth_method',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    key: mtMap.objectField('key', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    capabilities: mtMap.objectField(
+                      'capabilities',
+                      mtMap.passthrough()
+                    ),
+                    inputSchema: mtMap.objectField(
+                      'input_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    outputSchema: mtMap.objectField(
+                      'output_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          scope: mtMap.objectField(
+                            'scope',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          )
+                        })
+                      )
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    providerSpecificationId: mtMap.objectField(
+                      'provider_specification_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authCredentials: mtMap.objectField(
+                  'auth_credentials',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    isManaged: mtMap.objectField(
+                      'is_managed',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(mtMap.passthrough())
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceIntegrationsListOutput = {
-  items: {
+  items: ({
     object: 'integration';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -19,6 +19,93 @@ export type ManagementInstanceIntegrationsListOutput = {
       | { type: 'magic_mcp_server'; magicMcpServerId: string }
       | null;
     providers: {
+      object: 'integration.provider';
+      id: string;
+      status: 'active' | 'archived' | 'deleted';
+      integrationId: string;
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    }[];
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    providers: ({
+      object: 'integration.provider';
+      id: string;
+      status: 'active' | 'archived' | 'deleted';
+      integrationId: string;
+      name: string;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      toolFilter:
+        | { type: 'allow_all'; ignoreParentFilters: boolean }
+        | {
+            type: 'filter';
+            filters: (
+              | { type: 'tool_keys'; keys: string[] }
+              | { type: 'tool_regex'; pattern: string }
+              | { type: 'resource_regex'; pattern: string }
+              | { type: 'resource_uris'; uris: string[] }
+              | { type: 'prompt_keys'; keys: string[] }
+              | { type: 'prompt_regex'; pattern: string }
+            )[];
+            ignoreParentFilters: boolean;
+          }
+        | null;
+      providerId: string;
+      deploymentId: string;
+      authMethodId: string | null;
+      authCredentialsId: string | null;
+      config: {
+        object: 'provider.config#preview';
+        id: string;
+        isDefault: boolean;
+        name: string | null;
+        description: string | null;
+        metadata: Record<string, any> | null;
+        providerId: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      createdAt: Date;
+      updatedAt: Date;
+      archivedAt: Date | null;
+    } & {
       object: 'integration.provider';
       id: string;
       status: 'active' | 'archived' | 'deleted';
@@ -106,25 +193,8 @@ export type ManagementInstanceIntegrationsListOutput = {
         createdAt: Date;
         updatedAt: Date;
       } | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    }[];
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
+    })[];
+  })[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -133,286 +203,426 @@ export let mapManagementInstanceIntegrationsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          configuration: mtMap.objectField(
-            'configuration',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              canAttachCustomToolFilters: mtMap.objectField(
-                'can_attach_custom_tool_filters',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              canAttachCustomProviderConfig: mtMap.objectField(
-                'can_attach_custom_provider_config',
-                mtMap.passthrough()
-              ),
-              canOverrideToolFilters: mtMap.objectField(
-                'can_override_tool_filters',
-                mtMap.passthrough()
-              )
-            })
-          ),
-          implementation: mtMap.objectField(
-            'implementation',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              configuration: mtMap.objectField(
+                'configuration',
                 mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  providerTemplateId: mtMap.objectField(
-                    'provider_template_id',
+                  canAttachCustomToolFilters: mtMap.objectField(
+                    'can_attach_custom_tool_filters',
                     mtMap.passthrough()
                   ),
-                  magicMcpServerId: mtMap.objectField(
-                    'magic_mcp_server_id',
+                  canAttachCustomProviderConfig: mtMap.objectField(
+                    'can_attach_custom_provider_config',
+                    mtMap.passthrough()
+                  ),
+                  canOverrideToolFilters: mtMap.objectField(
+                    'can_override_tool_filters',
                     mtMap.passthrough()
                   )
                 })
-              )
-            ])
-          ),
-          providers: mtMap.objectField(
-            'providers',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
+              ),
+              implementation: mtMap.objectField(
+                'implementation',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      providerTemplateId: mtMap.objectField(
+                        'provider_template_id',
+                        mtMap.passthrough()
+                      ),
+                      magicMcpServerId: mtMap.objectField(
+                        'magic_mcp_server_id',
+                        mtMap.passthrough()
+                      )
+                    })
+                  )
+                ])
+              ),
+              providers: mtMap.objectField(
+                'providers',
+                mtMap.array(
                   mtMap.union([
                     mtMap.unionOption(
                       'object',
                       mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
+                        object: mtMap.objectField(
+                          'object',
                           mtMap.passthrough()
                         ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        status: mtMap.objectField(
+                          'status',
+                          mtMap.passthrough()
+                        ),
+                        integrationId: mtMap.objectField(
+                          'integration_id',
+                          mtMap.passthrough()
+                        ),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        toolFilter: mtMap.objectField(
+                          'tool_filter',
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                ignoreParentFilters: mtMap.objectField(
+                                  'ignore_parent_filters',
+                                  mtMap.passthrough()
+                                ),
+                                filters: mtMap.objectField(
+                                  'filters',
+                                  mtMap.array(
+                                    mtMap.union([
+                                      mtMap.unionOption(
+                                        'object',
+                                        mtMap.object({
+                                          type: mtMap.objectField(
+                                            'type',
+                                            mtMap.passthrough()
+                                          ),
+                                          keys: mtMap.objectField(
+                                            'keys',
+                                            mtMap.array(mtMap.passthrough())
+                                          ),
+                                          pattern: mtMap.objectField(
+                                            'pattern',
+                                            mtMap.passthrough()
+                                          ),
+                                          uris: mtMap.objectField(
+                                            'uris',
+                                            mtMap.array(mtMap.passthrough())
+                                          )
+                                        })
+                                      )
+                                    ])
+                                  )
+                                )
+                              })
+                            )
+                          ])
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        deploymentId: mtMap.objectField(
+                          'deployment_id',
+                          mtMap.passthrough()
+                        ),
+                        authMethodId: mtMap.objectField(
+                          'auth_method_id',
+                          mtMap.passthrough()
+                        ),
+                        authCredentialsId: mtMap.objectField(
+                          'auth_credentials_id',
+                          mtMap.passthrough()
+                        ),
+                        config: mtMap.objectField(
+                          'config',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField(
+                          'updated_at',
+                          mtMap.date()
+                        ),
+                        archivedAt: mtMap.objectField(
+                          'archived_at',
+                          mtMap.date()
+                        ),
+                        provider: mtMap.objectField(
+                          'provider',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            slug: mtMap.objectField(
+                              'slug',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        deployment: mtMap.objectField(
+                          'deployment',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        authMethod: mtMap.objectField(
+                          'auth_method',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            key: mtMap.objectField('key', mtMap.passthrough()),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            capabilities: mtMap.objectField(
+                              'capabilities',
+                              mtMap.passthrough()
+                            ),
+                            inputSchema: mtMap.objectField(
+                              'input_schema',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                schema: mtMap.objectField(
+                                  'schema',
+                                  mtMap.passthrough()
+                                )
+                              })
+                            ),
+                            outputSchema: mtMap.objectField(
+                              'output_schema',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                schema: mtMap.objectField(
+                                  'schema',
+                                  mtMap.passthrough()
+                                )
+                              })
+                            ),
+                            scopes: mtMap.objectField(
+                              'scopes',
+                              mtMap.array(
                                 mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
+                                  object: mtMap.objectField(
+                                    'object',
                                     mtMap.passthrough()
                                   ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
+                                  id: mtMap.objectField(
+                                    'id',
                                     mtMap.passthrough()
                                   ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
+                                  scope: mtMap.objectField(
+                                    'scope',
+                                    mtMap.passthrough()
+                                  ),
+                                  name: mtMap.objectField(
+                                    'name',
+                                    mtMap.passthrough()
+                                  ),
+                                  description: mtMap.objectField(
+                                    'description',
+                                    mtMap.passthrough()
                                   )
                                 })
                               )
-                            ])
-                          )
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            providerSpecificationId: mtMap.objectField(
+                              'provider_specification_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
+                        ),
+                        authCredentials: mtMap.objectField(
+                          'auth_credentials',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            status: mtMap.objectField(
+                              'status',
+                              mtMap.passthrough()
+                            ),
+                            isDefault: mtMap.objectField(
+                              'is_default',
+                              mtMap.passthrough()
+                            ),
+                            isManaged: mtMap.objectField(
+                              'is_managed',
+                              mtMap.passthrough()
+                            ),
+                            name: mtMap.objectField(
+                              'name',
+                              mtMap.passthrough()
+                            ),
+                            description: mtMap.objectField(
+                              'description',
+                              mtMap.passthrough()
+                            ),
+                            metadata: mtMap.objectField(
+                              'metadata',
+                              mtMap.passthrough()
+                            ),
+                            scopes: mtMap.objectField(
+                              'scopes',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            providerId: mtMap.objectField(
+                              'provider_id',
+                              mtMap.passthrough()
+                            ),
+                            createdAt: mtMap.objectField(
+                              'created_at',
+                              mtMap.date()
+                            ),
+                            updatedAt: mtMap.objectField(
+                              'updated_at',
+                              mtMap.date()
+                            )
+                          })
                         )
                       })
                     )
                   ])
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                deployment: mtMap.objectField(
-                  'deployment',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authMethod: mtMap.objectField(
-                  'auth_method',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    key: mtMap.objectField('key', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    capabilities: mtMap.objectField(
-                      'capabilities',
-                      mtMap.passthrough()
-                    ),
-                    inputSchema: mtMap.objectField(
-                      'input_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    outputSchema: mtMap.objectField(
-                      'output_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          scope: mtMap.objectField(
-                            'scope',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          )
-                        })
-                      )
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    providerSpecificationId: mtMap.objectField(
-                      'provider_specification_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authCredentials: mtMap.objectField(
-                  'auth_credentials',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    isManaged: mtMap.objectField(
-                      'is_managed',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(mtMap.passthrough())
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
+                )
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          )
+        ])
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/update.ts
@@ -40,6 +40,93 @@ export type ManagementInstanceIntegrationsUpdateOutput = {
           ignoreParentFilters: boolean;
         }
       | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+} & {
+  providers: ({
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
+    providerId: string;
+    deploymentId: string;
+    authMethodId: string | null;
+    authCredentialsId: string | null;
+    config: {
+      object: 'provider.config#preview';
+      id: string;
+      isDefault: boolean;
+      name: string | null;
+      description: string | null;
+      metadata: Record<string, any> | null;
+      providerId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  } & {
+    object: 'integration.provider';
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    integrationId: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    toolFilter:
+      | { type: 'allow_all'; ignoreParentFilters: boolean }
+      | {
+          type: 'filter';
+          filters: (
+            | { type: 'tool_keys'; keys: string[] }
+            | { type: 'tool_regex'; pattern: string }
+            | { type: 'resource_regex'; pattern: string }
+            | { type: 'resource_uris'; uris: string[] }
+            | { type: 'prompt_keys'; keys: string[] }
+            | { type: 'prompt_regex'; pattern: string }
+          )[];
+          ignoreParentFilters: boolean;
+        }
+      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -99,265 +186,315 @@ export type ManagementInstanceIntegrationsUpdateOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
+  })[];
 };
 
-export let mapManagementInstanceIntegrationsUpdateOutput =
-  mtMap.object<ManagementInstanceIntegrationsUpdateOutput>({
-    object: mtMap.objectField('object', mtMap.passthrough()),
-    id: mtMap.objectField('id', mtMap.passthrough()),
-    status: mtMap.objectField('status', mtMap.passthrough()),
-    slug: mtMap.objectField('slug', mtMap.passthrough()),
-    name: mtMap.objectField('name', mtMap.passthrough()),
-    description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-    configuration: mtMap.objectField(
-      'configuration',
-      mtMap.object({
-        canAttachCustomToolFilters: mtMap.objectField(
-          'can_attach_custom_tool_filters',
-          mtMap.passthrough()
-        ),
-        canAttachCustomProviderConfig: mtMap.objectField(
-          'can_attach_custom_provider_config',
-          mtMap.passthrough()
-        ),
-        canOverrideToolFilters: mtMap.objectField(
-          'can_override_tool_filters',
-          mtMap.passthrough()
-        )
-      })
-    ),
-    implementation: mtMap.objectField(
-      'implementation',
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            providerTemplateId: mtMap.objectField(
-              'provider_template_id',
-              mtMap.passthrough()
-            ),
-            magicMcpServerId: mtMap.objectField(
-              'magic_mcp_server_id',
-              mtMap.passthrough()
-            )
-          })
-        )
-      ])
-    ),
-    providers: mtMap.objectField(
-      'providers',
-      mtMap.array(
+export let mapManagementInstanceIntegrationsUpdateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      slug: mtMap.objectField('slug', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      configuration: mtMap.objectField(
+        'configuration',
         mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          canAttachCustomToolFilters: mtMap.objectField(
+            'can_attach_custom_tool_filters',
             mtMap.passthrough()
           ),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
+          canAttachCustomProviderConfig: mtMap.objectField(
+            'can_attach_custom_provider_config',
+            mtMap.passthrough()
           ),
-          provider: mtMap.objectField(
-            'provider',
+          canOverrideToolFilters: mtMap.objectField(
+            'can_override_tool_filters',
+            mtMap.passthrough()
+          )
+        })
+      ),
+      implementation: mtMap.objectField(
+        'implementation',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          deployment: mtMap.objectField(
-            'deployment',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authMethod: mtMap.objectField(
-            'auth_method',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
               type: mtMap.objectField('type', mtMap.passthrough()),
-              key: mtMap.objectField('key', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              providerTemplateId: mtMap.objectField(
+                'provider_template_id',
                 mtMap.passthrough()
               ),
-              capabilities: mtMap.objectField(
-                'capabilities',
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              inputSchema: mtMap.objectField(
-                'input_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              outputSchema: mtMap.objectField(
-                'output_schema',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  schema: mtMap.objectField('schema', mtMap.passthrough())
-                })
-              ),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(
+              )
+            })
+          )
+        ])
+      ),
+      providers: mtMap.objectField(
+        'providers',
+        mtMap.array(
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
                   mtMap.object({
                     object: mtMap.objectField('object', mtMap.passthrough()),
                     id: mtMap.objectField('id', mtMap.passthrough()),
-                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
                     name: mtMap.objectField('name', mtMap.passthrough()),
                     description: mtMap.objectField(
                       'description',
                       mtMap.passthrough()
-                    )
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                deployment: mtMap.objectField(
+                  'deployment',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authMethod: mtMap.objectField(
+                  'auth_method',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    key: mtMap.objectField('key', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    capabilities: mtMap.objectField(
+                      'capabilities',
+                      mtMap.passthrough()
+                    ),
+                    inputSchema: mtMap.objectField(
+                      'input_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    outputSchema: mtMap.objectField(
+                      'output_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          scope: mtMap.objectField(
+                            'scope',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          )
+                        })
+                      )
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    providerSpecificationId: mtMap.objectField(
+                      'provider_specification_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authCredentials: mtMap.objectField(
+                  'auth_credentials',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    isManaged: mtMap.objectField(
+                      'is_managed',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(mtMap.passthrough())
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              providerSpecificationId: mtMap.objectField(
-                'provider_specification_id',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authCredentials: mtMap.objectField(
-            'auth_credentials',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              scopes: mtMap.objectField(
-                'scopes',
-                mtMap.array(mtMap.passthrough())
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    ),
-    createdAt: mtMap.objectField('created_at', mtMap.date()),
-    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-  });
+              })
+            )
+          ])
+        )
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date())
+    })
+  )
+]);
 
 export type ManagementInstanceIntegrationsUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/magic-mcp-endpoints/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/magic-mcp-endpoints/create.ts
@@ -124,6 +124,7 @@ export type ManagementInstanceMagicMcpEndpointsCreateBody = {
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
   consumerProfileId?: string | undefined;
+  skillPluginId?: string | undefined;
   magicMcpServers?:
     | {
         magicMcpServerId: string;
@@ -159,6 +160,7 @@ export let mapManagementInstanceMagicMcpEndpointsCreateBody =
       'consumer_profile_id',
       mtMap.passthrough()
     ),
+    skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
     magicMcpServers: mtMap.objectField(
       'magic_mcp_servers',
       mtMap.array(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/test-helpers/consumer-oauth/authorizations/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/test-helpers/consumer-oauth/authorizations/create.ts
@@ -1,0 +1,40 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type TestHelpersConsumerOauthAuthorizationsCreateOutput = {
+  object: 'test_helper.consumer_oauth_authorization';
+  id: string;
+  url: string;
+  expiresAt: Date;
+  createdAt: Date;
+};
+
+export let mapTestHelpersConsumerOauthAuthorizationsCreateOutput =
+  mtMap.object<TestHelpersConsumerOauthAuthorizationsCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    url: mtMap.objectField('url', mtMap.passthrough()),
+    expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+    createdAt: mtMap.objectField('created_at', mtMap.date())
+  });
+
+export type TestHelpersConsumerOauthAuthorizationsCreateBody = {
+  instanceId: string;
+  url: string;
+  consumerProfileId: string;
+  magicMcpEndpointId: string;
+};
+
+export let mapTestHelpersConsumerOauthAuthorizationsCreateBody =
+  mtMap.object<TestHelpersConsumerOauthAuthorizationsCreateBody>({
+    instanceId: mtMap.objectField('instance_id', mtMap.passthrough()),
+    url: mtMap.objectField('url', mtMap.passthrough()),
+    consumerProfileId: mtMap.objectField(
+      'consumer_profile_id',
+      mtMap.passthrough()
+    ),
+    magicMcpEndpointId: mtMap.objectField(
+      'magic_mcp_endpoint_id',
+      mtMap.passthrough()
+    )
+  });
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/test-helpers/consumer-oauth/authorizations/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/test-helpers/consumer-oauth/authorizations/index.ts
@@ -1,0 +1,1 @@
+export * from './create';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/test-helpers/consumer-oauth/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/test-helpers/consumer-oauth/index.ts
@@ -1,0 +1,1 @@
+export * from './authorizations';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/test-helpers/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/test-helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './consumer-oauth';

--- a/src/backend/apis/core/src/controllers/_categories.ts
+++ b/src/backend/apis/core/src/controllers/_categories.ts
@@ -1,61 +1,73 @@
 import { createCategory } from '@metorial/rest';
 
+let indexCounter = 0;
+let getIndexHint = () => {
+  indexCounter += 10;
+  return indexCounter;
+};
+
 export let providerDocsCategory = createCategory({
   id: 'provider',
   name: 'Providers',
-  indexHint: 10
-});
-
-export let customProviderDocsCategory = createCategory({
-  id: 'custom-provider',
-  name: 'Custom Providers',
-  indexHint: 35
-});
-
-export let sessionDocsCategory = createCategory({
-  id: 'session',
-  name: 'Sessions',
-  indexHint: 20
-});
-
-export let identityDocsCategory = createCategory({
-  id: 'identity',
-  name: 'Identity',
-  indexHint: 45
-});
-
-export let configurationDocsCategory = createCategory({
-  id: 'configuration',
-  name: 'Configurations',
-  indexHint: 30
-});
-
-export let callbackDocsCategory = createCategory({
-  id: 'callback',
-  name: 'Callbacks',
-  indexHint: 40
+  indexHint: getIndexHint()
 });
 
 export let integrationDocsCategory = createCategory({
   id: 'integration',
   name: 'Integrations',
-  indexHint: 15
+  indexHint: getIndexHint()
 });
 
-export let fileCollectionDocsCategory = createCategory({
-  id: 'file-collection',
-  name: 'File Collections',
-  indexHint: 18
+export let sessionDocsCategory = createCategory({
+  id: 'session',
+  name: 'Sessions',
+  indexHint: getIndexHint()
+});
+
+export let configurationDocsCategory = createCategory({
+  id: 'configuration',
+  name: 'Configurations',
+  indexHint: getIndexHint()
+});
+
+export let skillDocsCategory = createCategory({
+  id: 'skill',
+  name: 'Magic Skills',
+  indexHint: getIndexHint()
+});
+
+export let magicMcpDocsCategory = createCategory({
+  id: 'magic-mcp',
+  name: 'Magic MCP',
+  indexHint: getIndexHint()
+});
+
+export let callbackDocsCategory = createCategory({
+  id: 'callback',
+  name: 'Callbacks',
+  indexHint: getIndexHint()
 });
 
 export let portalDocsCategory = createCategory({
   id: 'portal',
   name: 'Portals',
-  indexHint: 19
+  indexHint: getIndexHint()
 });
 
-export let skillDocsCategory = createCategory({
-  id: 'skill',
-  name: 'Skills',
-  indexHint: 25
+export let identityDocsCategory = createCategory({
+  id: 'identity',
+  name: 'Identity',
+  indexHint: getIndexHint()
+});
+
+export let customProviderDocsCategory = createCategory({
+  id: 'custom-provider',
+  name: 'Custom Providers',
+  indexHint: getIndexHint()
+});
+
+export let fileCollectionDocsCategory = createCategory({
+  id: 'file-collection',
+  name: 'File Collections',
+  indexHint: getIndexHint()
 });

--- a/src/backend/apis/core/src/controllers/index.ts
+++ b/src/backend/apis/core/src/controllers/index.ts
@@ -6,6 +6,7 @@ import {
   fileCollectionDocsCategory,
   identityDocsCategory,
   integrationDocsCategory,
+  magicMcpDocsCategory,
   portalDocsCategory,
   providerDocsCategory,
   sessionDocsCategory,
@@ -285,6 +286,18 @@ let setControllerDocsMetadata = <
 ].forEach(controller =>
   setControllerDocsMetadata(controller, {
     category: fileCollectionDocsCategory
+  })
+);
+
+[
+  magicMcpEndpointController,
+  magicMcpServerController,
+  magicMcpSessionController,
+  magicMcpTokenController,
+  magicMcpGroupController
+].forEach(controller =>
+  setControllerDocsMetadata(controller, {
+    category: magicMcpDocsCategory
   })
 );
 

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integration.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integration.ts
@@ -2,7 +2,10 @@ import { v } from '@lowerdeck/validation';
 import { SubspaceIntegrationPreview } from '@metorial/module-subspace';
 import { Presenter } from '@metorial/presenter';
 import { integrationType } from '../../../types';
-import { v1IntegrationProviderPresenter } from './integrationProvider';
+import {
+  dashboardIntegrationProviderPresenter,
+  v1IntegrationProviderPresenter
+} from './integrationProvider';
 
 export let v1IntegrationPresenter = Presenter.create(integrationType)
   .presenter(async ({ integration }, opts) => ({
@@ -111,3 +114,26 @@ export let v1IntegrationPreviewPresenter = Object.assign(
     })
   }
 );
+
+export let dashboardIntegrationPresenter = Presenter.create(integrationType)
+  .presenter(async ({ integration }, opts) => {
+    let inner = await v1IntegrationPresenter.present({ integration }, opts).run();
+
+    return {
+      ...inner,
+      providers: await Promise.all(
+        integration.providers.map(integrationProvider =>
+          dashboardIntegrationProviderPresenter.present({ integrationProvider }, opts).run()
+        )
+      )
+    };
+  })
+  .schema(
+    v.intersection([
+      v1IntegrationPresenter.schema,
+      v.object({
+        providers: v.array(dashboardIntegrationProviderPresenter.schema)
+      })
+    ])
+  )
+  .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstance.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstance.ts
@@ -1,7 +1,10 @@
 import { v } from '@lowerdeck/validation';
 import { Presenter } from '@metorial/presenter';
 import { integrationInstanceType } from '../../../types';
-import { v1IntegrationInstanceProviderPresenter } from './integrationInstanceProvider';
+import {
+  dashboardIntegrationInstanceProviderPresenter,
+  v1IntegrationInstanceProviderPresenter
+} from './integrationInstanceProvider';
 
 export let v1IntegrationInstancePresenter = Presenter.create(integrationInstanceType)
   .presenter(async ({ integrationInstance }, opts) => ({
@@ -53,5 +56,32 @@ export let v1IntegrationInstancePresenter = Presenter.create(integrationInstance
       updated_at: v.date(),
       archived_at: v.nullable(v.date())
     })
+  )
+  .build();
+
+export let dashboardIntegrationInstancePresenter = Presenter.create(integrationInstanceType)
+  .presenter(async ({ integrationInstance }, opts) => {
+    let inner = await v1IntegrationInstancePresenter
+      .present({ integrationInstance }, opts)
+      .run();
+
+    return {
+      ...inner,
+      providers: await Promise.all(
+        integrationInstance.providers.map(integrationInstanceProvider =>
+          dashboardIntegrationInstanceProviderPresenter
+            .present({ integrationInstanceProvider }, opts)
+            .run()
+        )
+      )
+    };
+  })
+  .schema(
+    v.intersection([
+      v1IntegrationInstancePresenter.schema,
+      v.object({
+        providers: v.array(dashboardIntegrationInstanceProviderPresenter.schema)
+      })
+    ])
   )
   .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstanceGroup.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstanceGroup.ts
@@ -49,3 +49,32 @@ export let v1IntegrationInstanceGroupPresenter = Presenter.create(integrationIns
     })
   )
   .build();
+
+export let dashboardIntegrationInstanceGroupPresenter = Presenter.create(
+  integrationInstanceGroupType
+)
+  .presenter(async ({ integrationInstanceGroup }, opts) => {
+    let inner = await v1IntegrationInstanceGroupPresenter
+      .present({ integrationInstanceGroup }, opts)
+      .run();
+
+    return {
+      ...inner,
+      providers: await Promise.all(
+        integrationInstanceGroup.providers.map(integrationInstanceGroupProvider =>
+          v1IntegrationInstanceGroupProviderPresenter
+            .present({ integrationInstanceGroupProvider }, opts)
+            .run()
+        )
+      )
+    };
+  })
+  .schema(
+    v.intersection([
+      v1IntegrationInstanceGroupPresenter.schema,
+      v.object({
+        providers: v.array(v1IntegrationInstanceGroupProviderPresenter.schema)
+      })
+    ])
+  )
+  .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstanceGroupProvider.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstanceGroupProvider.ts
@@ -4,7 +4,10 @@ import { integrationInstanceGroupProviderType } from '../../../types';
 import { toolFilterPresenter } from '../../_shared/toolFilter';
 import { v1ProviderPreview } from '../provider';
 import { v1IntegrationInstanceProviderPresenter } from './integrationInstanceProvider';
-import { v1IntegrationProviderSnapshot } from './integrationProvider';
+import {
+  dashboardIntegrationProviderSnapshot,
+  v1IntegrationProviderSnapshot
+} from './integrationProvider';
 
 let presentToolFilter = (toolFilter: PrismaJson.ToolFilter | null | undefined) =>
   toolFilter ? toolFilterPresenter(toolFilter as any) : null;
@@ -19,28 +22,17 @@ export let v1IntegrationInstanceGroupProviderPresenter = Presenter.create(
     name: integrationInstanceGroupProvider.name,
     description: integrationInstanceGroupProvider.description,
     metadata: integrationInstanceGroupProvider.metadata,
-    integration_instance_group_id: integrationInstanceGroupProvider.integrationInstanceGroupId,
+
     integration_id: integrationInstanceGroupProvider.integrationId,
+    integration_instance_group_id: integrationInstanceGroupProvider.integrationInstanceGroupId,
     integration_instance_id: integrationInstanceGroupProvider.integrationInstanceId,
-    integration_provider_id: integrationInstanceGroupProvider.integrationProviderId,
+    integration_provider_id: integrationInstanceGroupProvider.integrationProvider?.id ?? null,
+    integration_instance_provider_id:
+      integrationInstanceGroupProvider.integrationInstanceProvider.id,
+
     tool_filter: presentToolFilter(integrationInstanceGroupProvider.toolFilter),
     is_override_tool_filter: integrationInstanceGroupProvider.isOverrideToolFilter,
-    provider: v1ProviderPreview(integrationInstanceGroupProvider.provider),
-    integration_provider: integrationInstanceGroupProvider.integrationProvider
-      ? await v1IntegrationProviderSnapshot(
-          integrationInstanceGroupProvider.integrationProvider,
-          opts
-        )
-      : null,
-    integration_instance_provider: await v1IntegrationInstanceProviderPresenter
-      .present(
-        {
-          integrationInstanceProvider:
-            integrationInstanceGroupProvider.integrationInstanceProvider
-        },
-        opts
-      )
-      .run(),
+
     created_at: integrationInstanceGroupProvider.createdAt,
     updated_at: integrationInstanceGroupProvider.updatedAt,
     archived_at: integrationInstanceGroupProvider.archivedAt
@@ -53,18 +45,60 @@ export let v1IntegrationInstanceGroupProviderPresenter = Presenter.create(
       name: v.string(),
       description: v.nullable(v.string()),
       metadata: v.nullable(v.record(v.any())),
-      integration_instance_group_id: v.string(),
+
       integration_id: v.string(),
+      integration_instance_group_id: v.string(),
       integration_instance_id: v.string(),
-      integration_provider_id: v.string(),
+      integration_provider_id: v.nullable(v.string()),
+      integration_instance_provider_id: v.string(),
+
       tool_filter: v.nullable(toolFilterPresenter.schema),
       is_override_tool_filter: v.boolean(),
-      provider: v1ProviderPreview.schema,
-      integration_provider: v.nullable(v1IntegrationProviderSnapshot.schema),
-      integration_instance_provider: v1IntegrationInstanceProviderPresenter.schema,
+
       created_at: v.date(),
       updated_at: v.date(),
       archived_at: v.nullable(v.date())
     })
+  )
+  .build();
+
+export let dashboardIntegrationInstanceGroupProviderPresenter = Presenter.create(
+  integrationInstanceGroupProviderType
+)
+  .presenter(async ({ integrationInstanceGroupProvider }, opts) => {
+    let inner = await v1IntegrationInstanceGroupProviderPresenter
+      .present({ integrationInstanceGroupProvider }, opts)
+      .run();
+
+    return {
+      ...inner,
+
+      provider: v1ProviderPreview(integrationInstanceGroupProvider.provider),
+      integration_provider: integrationInstanceGroupProvider.integrationProvider
+        ? await dashboardIntegrationProviderSnapshot(
+            integrationInstanceGroupProvider.integrationProvider,
+            opts
+          )
+        : null,
+      integration_instance_provider: await v1IntegrationInstanceProviderPresenter
+        .present(
+          {
+            integrationInstanceProvider:
+              integrationInstanceGroupProvider.integrationInstanceProvider
+          },
+          opts
+        )
+        .run()
+    };
+  })
+  .schema(
+    v.intersection([
+      v1IntegrationInstanceGroupProviderPresenter.schema,
+      v.object({
+        provider: v1ProviderPreview.schema,
+        integration_provider: v.nullable(v1IntegrationProviderSnapshot.schema),
+        integration_instance_provider: v1IntegrationInstanceProviderPresenter.schema
+      })
+    ])
   )
   .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstanceProvider.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstanceProvider.ts
@@ -5,7 +5,10 @@ import { toolFilterPresenter } from '../../_shared/toolFilter';
 import { v1ProviderAuthConfigPreviewPresenter } from '../auth/authConfigPreview';
 import { v1ProviderConfigPreviewPresenter } from '../config/configPreview';
 import { v1ProviderPreview } from '../provider';
-import { v1IntegrationProviderSnapshot } from './integrationProvider';
+import {
+  dashboardIntegrationProviderSnapshot,
+  v1IntegrationProviderSnapshot
+} from './integrationProvider';
 
 let presentToolFilter = (toolFilter: PrismaJson.ToolFilter | null | undefined) =>
   toolFilter ? toolFilterPresenter(toolFilter as any) : null;
@@ -63,5 +66,31 @@ export let v1IntegrationInstanceProviderPresenter = Presenter.create(
       updated_at: v.date(),
       archived_at: v.nullable(v.date())
     })
+  )
+  .build();
+
+export let dashboardIntegrationInstanceProviderPresenter = Presenter.create(
+  integrationInstanceProviderType
+)
+  .presenter(async ({ integrationInstanceProvider }, opts) => {
+    let inner = await v1IntegrationInstanceProviderPresenter
+      .present({ integrationInstanceProvider }, opts)
+      .run();
+
+    return {
+      ...inner,
+      integration_provider: await dashboardIntegrationProviderSnapshot(
+        integrationInstanceProvider.integrationProvider,
+        opts
+      )
+    };
+  })
+  .schema(
+    v.intersection([
+      v1IntegrationInstanceProviderPresenter.schema,
+      v.object({
+        integration_provider: v1IntegrationProviderSnapshot.schema
+      })
+    ])
   )
   .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationProvider.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationProvider.ts
@@ -30,20 +30,10 @@ export let v1IntegrationProviderSnapshot = Object.assign(
       description: integrationProvider.description,
       metadata: integrationProvider.metadata,
       tool_filter: presentToolFilter(integrationProvider.toolFilter),
-      provider: v1ProviderPreview(integrationProvider.provider),
-      deployment: await v1ProviderDeploymentPreviewPresenter
-        .present({ deployment: integrationProvider.deployment }, opts)
-        .run(),
-      auth_method: integrationProvider.authMethod
-        ? await v1ProviderAuthMethodPresenter
-            .present({ authMethod: integrationProvider.authMethod }, opts)
-            .run()
-        : null,
-      auth_credentials: integrationProvider.authCredentials
-        ? await v1ProviderAuthCredentialsPresenter
-            .present({ authCredentials: integrationProvider.authCredentials }, opts)
-            .run()
-        : null,
+      provider_id: integrationProvider.provider.id,
+      deployment_id: integrationProvider.deployment.id,
+      auth_method_id: integrationProvider.authMethod?.id ?? null,
+      auth_credentials_id: integrationProvider.authCredentials?.id ?? null,
       config: integrationProvider.config
         ? await v1ProviderConfigPreviewPresenter
             .present({ config: integrationProvider.config }, opts)
@@ -68,15 +58,51 @@ export let v1IntegrationProviderSnapshot = Object.assign(
       description: v.nullable(v.string()),
       metadata: v.nullable(v.record(v.any())),
       tool_filter: v.nullable(toolFilterPresenter.schema),
-      provider: v1ProviderPreview.schema,
-      deployment: v1ProviderDeploymentPreviewPresenter.schema,
-      auth_method: v.nullable(v1ProviderAuthMethodPresenter.schema),
-      auth_credentials: v.nullable(v1ProviderAuthCredentialsPresenter.schema),
+      provider_id: v.string(),
+      deployment_id: v.string(),
+      auth_method_id: v.nullable(v.string()),
+      auth_credentials_id: v.nullable(v.string()),
       config: v.nullable(v1ProviderConfigPreviewPresenter.schema),
       created_at: v.date(),
       updated_at: v.date(),
       archived_at: v.nullable(v.date())
     })
+  }
+);
+
+export let dashboardIntegrationProviderSnapshot = Object.assign(
+  async (integrationProvider: SubspaceIntegrationInstanceProviderSnapshot, opts?: any) => {
+    let inner = v1IntegrationProviderSnapshot(integrationProvider, opts);
+
+    return {
+      ...inner,
+
+      provider: v1ProviderPreview(integrationProvider.provider),
+      deployment: await v1ProviderDeploymentPreviewPresenter
+        .present({ deployment: integrationProvider.deployment }, opts)
+        .run(),
+      auth_method: integrationProvider.authMethod
+        ? await v1ProviderAuthMethodPresenter
+            .present({ authMethod: integrationProvider.authMethod }, opts)
+            .run()
+        : null,
+      auth_credentials: integrationProvider.authCredentials
+        ? await v1ProviderAuthCredentialsPresenter
+            .present({ authCredentials: integrationProvider.authCredentials }, opts)
+            .run()
+        : null
+    };
+  },
+  {
+    schema: v.intersection([
+      v1IntegrationProviderSnapshot.schema,
+      v.object({
+        provider: v1ProviderPreview.schema,
+        deployment: v1ProviderDeploymentPreviewPresenter.schema,
+        auth_method: v.nullable(v1ProviderAuthMethodPresenter.schema),
+        auth_credentials: v.nullable(v1ProviderAuthCredentialsPresenter.schema)
+      })
+    ])
   }
 );
 
@@ -90,20 +116,10 @@ export let v1IntegrationProviderPresenter = Presenter.create(integrationProvider
     description: integrationProvider.description,
     metadata: integrationProvider.metadata,
     tool_filter: presentToolFilter(integrationProvider.toolFilter),
-    provider: v1ProviderPreview(integrationProvider.provider),
-    deployment: await v1ProviderDeploymentPreviewPresenter
-      .present({ deployment: integrationProvider.deployment }, opts)
-      .run(),
-    auth_method: integrationProvider.authMethod
-      ? await v1ProviderAuthMethodPresenter
-          .present({ authMethod: integrationProvider.authMethod }, opts)
-          .run()
-      : null,
-    auth_credentials: integrationProvider.authCredentials
-      ? await v1ProviderAuthCredentialsPresenter
-          .present({ authCredentials: integrationProvider.authCredentials }, opts)
-          .run()
-      : null,
+    provider_id: integrationProvider.provider.id,
+    deployment_id: integrationProvider.deployment.id,
+    auth_method_id: integrationProvider.authMethod?.id ?? null,
+    auth_credentials_id: integrationProvider.authCredentials?.id ?? null,
     config: integrationProvider.config
       ? await v1ProviderConfigPreviewPresenter
           .present({ config: integrationProvider.config }, opts)
@@ -123,14 +139,59 @@ export let v1IntegrationProviderPresenter = Presenter.create(integrationProvider
       description: v.nullable(v.string()),
       metadata: v.nullable(v.record(v.any())),
       tool_filter: v.nullable(toolFilterPresenter.schema),
-      provider: v1ProviderPreview.schema,
-      deployment: v1ProviderDeploymentPreviewPresenter.schema,
-      auth_method: v.nullable(v1ProviderAuthMethodPresenter.schema),
-      auth_credentials: v.nullable(v1ProviderAuthCredentialsPresenter.schema),
+      provider_id: v.string(),
+      deployment_id: v.string(),
+      auth_method_id: v.nullable(v.string()),
+      auth_credentials_id: v.nullable(v.string()),
       config: v.nullable(v1ProviderConfigPreviewPresenter.schema),
       created_at: v.date(),
       updated_at: v.date(),
       archived_at: v.nullable(v.date())
     })
+  )
+  .build();
+
+export let dashboardIntegrationProviderPresenter = Presenter.create(integrationProviderType)
+  .presenter(async ({ integrationProvider }, opts) => {
+    let inner = await v1IntegrationProviderPresenter
+      .present({ integrationProvider }, opts)
+      .run();
+
+    return {
+      ...inner,
+      provider: v1ProviderPreview(integrationProvider.provider),
+      deployment: await v1ProviderDeploymentPreviewPresenter
+        .present({ deployment: integrationProvider.deployment }, opts)
+        .run(),
+      auth_method: integrationProvider.authMethod
+        ? await v1ProviderAuthMethodPresenter
+            .present({ authMethod: integrationProvider.authMethod }, opts)
+            .run()
+        : null,
+      auth_credentials: integrationProvider.authCredentials
+        ? await v1ProviderAuthCredentialsPresenter
+            .present({ authCredentials: integrationProvider.authCredentials }, opts)
+            .run()
+        : null
+    };
+  })
+  .schema(
+    v.intersection([
+      v1IntegrationProviderPresenter.schema,
+      v.object({
+        object: v.literal('integration.provider'),
+        id: v.string(),
+        status: v.enumOf(['active', 'archived', 'deleted']),
+        integration_id: v.string(),
+        name: v.string(),
+        description: v.nullable(v.string()),
+        metadata: v.nullable(v.record(v.any())),
+        tool_filter: v.nullable(toolFilterPresenter.schema),
+        provider: v1ProviderPreview.schema,
+        deployment: v1ProviderDeploymentPreviewPresenter.schema,
+        auth_method: v.nullable(v1ProviderAuthMethodPresenter.schema),
+        auth_credentials: v.nullable(v1ProviderAuthCredentialsPresenter.schema)
+      })
+    ])
   )
   .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationSetupSession.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationSetupSession.ts
@@ -60,14 +60,14 @@ export let v1IntegrationSetupSessionPresenter = Presenter.create(integrationSetu
     name: integrationSetupSession.name,
     description: integrationSetupSession.description,
     metadata: integrationSetupSession.metadata,
-    configuration: setupSessionConfigurationPresenter(integrationSetupSession.configuration),
+    configuration: setupSessionConfigurationPresenter(
+      integrationSetupSession.configuration
+    ) as any,
     redirect_url: integrationSetupSession.redirectUrl,
     integration_id: integrationSetupSession.integrationId,
-    integration_instance_id: integrationSetupSession.integrationInstanceId,
     integration_instance: await v1IntegrationInstancePresenter
       .present({ integrationInstance: integrationSetupSession.integrationInstance }, opts)
       .run(),
-    steps: integrationSetupSession.steps.map(setupSessionStepPresenter),
     created_at: integrationSetupSession.createdAt,
     updated_at: integrationSetupSession.updatedAt,
     expires_at: integrationSetupSession.expiresAt
@@ -84,33 +84,56 @@ export let v1IntegrationSetupSessionPresenter = Presenter.create(integrationSetu
       configuration: v.nullable(v.record(v.any())),
       redirect_url: v.nullable(v.string()),
       integration_id: v.string(),
-      integration_instance_id: v.string(),
       integration_instance: v1IntegrationInstancePresenter.schema,
-      steps: v.array(
-        v.object({
-          object: v.literal('integration.setup_session.step'),
-          id: v.string(),
-          status: v.enumOf([
-            'configured',
-            'pending',
-            'failed',
-            'completed',
-            'expired',
-            'archived',
-            'deleted'
-          ]),
-          url: v.string(),
-          integration_provider_id: v.string(),
-          provider: v1ProviderPreview.schema,
-          provider_setup_session_id: v.nullable(v.string()),
-          integration_instance_provider_id: v.nullable(v.string()),
-          created_at: v.date(),
-          updated_at: v.date()
-        })
-      ),
       created_at: v.date(),
       updated_at: v.date(),
       expires_at: v.date()
-    }) as any
+    })
+  )
+  .build();
+
+export let dashboardIntegrationSetupSessionPresenter = Presenter.create(
+  integrationSetupSessionType
+)
+  .presenter(async ({ integrationSetupSession }, opts) => {
+    let inner = await v1IntegrationSetupSessionPresenter
+      .present({ integrationSetupSession }, opts)
+      .run();
+
+    return {
+      ...inner,
+      integration_instance_id: integrationSetupSession.integrationInstanceId,
+      steps: integrationSetupSession.steps.map(setupSessionStepPresenter)
+    };
+  })
+  .schema(
+    v.intersection([
+      v1IntegrationSetupSessionPresenter.schema,
+      v.object({
+        integration_instance_id: v.string(),
+        steps: v.array(
+          v.object({
+            object: v.literal('integration.setup_session.step'),
+            id: v.string(),
+            status: v.enumOf([
+              'configured',
+              'pending',
+              'failed',
+              'completed',
+              'expired',
+              'archived',
+              'deleted'
+            ]),
+            url: v.string(),
+            integration_provider_id: v.string(),
+            provider: v1ProviderPreview.schema,
+            provider_setup_session_id: v.nullable(v.string()),
+            integration_instance_provider_id: v.nullable(v.string()),
+            created_at: v.date(),
+            updated_at: v.date()
+          })
+        )
+      })
+    ])
   )
   .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/magicMcp/magicMcpServerProvider.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/magicMcp/magicMcpServerProvider.ts
@@ -11,7 +11,7 @@ import {
   v1ProviderConfigPreviewPresenter,
   v1ProviderDeploymentPreviewPresenter
 } from '../config';
-import { v1IntegrationProviderSnapshot } from '../integrations';
+import { dashboardIntegrationProviderSnapshot } from '../integrations';
 import { v1ProviderPreview } from '../provider';
 
 let presentToolFilter = (toolFilter: PrismaJson.ToolFilter | null | undefined) =>
@@ -19,7 +19,7 @@ let presentToolFilter = (toolFilter: PrismaJson.ToolFilter | null | undefined) =
 
 export let v1MagicMcpServerProviderPresenter = Presenter.create(magicMcpServerProviderType)
   .presenter(async ({ magicMcpServer, magicMcpServerProvider }, opts) => {
-    let integrationProvider = await v1IntegrationProviderSnapshot(
+    let integrationProvider: any = await dashboardIntegrationProviderSnapshot(
       magicMcpServerProvider.integrationProvider,
       opts
     );

--- a/src/backend/apis/core/src/presenters/index.ts
+++ b/src/backend/apis/core/src/presenters/index.ts
@@ -11,6 +11,13 @@ import {
   dashboardCustomProviderPresenter,
   dashboardFilePresenter,
   dashboardIdentityActorPresenter,
+  dashboardIntegrationInstanceGroupPresenter,
+  dashboardIntegrationInstanceGroupProviderPresenter,
+  dashboardIntegrationInstancePresenter,
+  dashboardIntegrationInstanceProviderPresenter,
+  dashboardIntegrationPresenter,
+  dashboardIntegrationProviderPresenter,
+  dashboardIntegrationSetupSessionPresenter,
   dashboardMagicMcpServerPresenter,
   dashboardMagicMcpServerProviderPresenter,
   dashboardProviderListingPresenter,
@@ -1013,43 +1020,42 @@ export let providerAuthCredentialsPresenter = declarePresenter(providerAuthCrede
 });
 
 export let integrationPresenter = declarePresenter(integrationType, {
-  mt_2025_01_01_dashboard: v1IntegrationPresenter,
+  mt_2025_01_01_dashboard: dashboardIntegrationPresenter,
   mt_2026_01_01_magnetar: v1IntegrationPresenter
 });
 
 export let integrationProviderPresenter = declarePresenter(integrationProviderType, {
-  mt_2025_01_01_dashboard: v1IntegrationProviderPresenter,
+  mt_2025_01_01_dashboard: dashboardIntegrationProviderPresenter,
   mt_2026_01_01_magnetar: v1IntegrationProviderPresenter
 });
 
 export let integrationInstancePresenter = declarePresenter(integrationInstanceType, {
-  mt_2025_01_01_dashboard: v1IntegrationInstancePresenter,
+  mt_2025_01_01_dashboard: dashboardIntegrationInstancePresenter,
   mt_2026_01_01_magnetar: v1IntegrationInstancePresenter
 });
 
 export let integrationSetupSessionPresenter = declarePresenter(integrationSetupSessionType, {
-  mt_2025_01_01_dashboard: v1IntegrationSetupSessionPresenter,
-  mt_2026_01_01_magnetar: v1IntegrationSetupSessionPresenter,
-  mt_2026_04_01_consumer: v1IntegrationSetupSessionPresenter
+  mt_2025_01_01_dashboard: dashboardIntegrationSetupSessionPresenter,
+  mt_2026_01_01_magnetar: v1IntegrationSetupSessionPresenter
 });
 
 export let integrationInstanceProviderPresenter = declarePresenter(
   integrationInstanceProviderType,
   {
-    mt_2025_01_01_dashboard: v1IntegrationInstanceProviderPresenter,
+    mt_2025_01_01_dashboard: dashboardIntegrationInstanceProviderPresenter,
     mt_2026_01_01_magnetar: v1IntegrationInstanceProviderPresenter
   }
 );
 
 export let integrationInstanceGroupPresenter = declarePresenter(integrationInstanceGroupType, {
-  mt_2025_01_01_dashboard: v1IntegrationInstanceGroupPresenter,
+  mt_2025_01_01_dashboard: dashboardIntegrationInstanceGroupPresenter,
   mt_2026_01_01_magnetar: v1IntegrationInstanceGroupPresenter
 });
 
 export let integrationInstanceGroupProviderPresenter = declarePresenter(
   integrationInstanceGroupProviderType,
   {
-    mt_2025_01_01_dashboard: v1IntegrationInstanceGroupProviderPresenter,
+    mt_2025_01_01_dashboard: dashboardIntegrationInstanceGroupProviderPresenter,
     mt_2026_01_01_magnetar: v1IntegrationInstanceGroupProviderPresenter
   }
 );

--- a/src/backend/modules/consumer/test/consumerOAuthLinking.test.ts
+++ b/src/backend/modules/consumer/test/consumerOAuthLinking.test.ts
@@ -419,20 +419,56 @@ describe('consumer OAuth integration endpoint linking', () => {
     );
   });
 
-  it('requires plugin_id for plugin OAuth test authorization URLs', async () => {
-    await expect(
-      consumerOAuthTestAuthorizationService.createTestAuthorization({
-        instance: {
-          oid: 1n,
-          organizationOid: 2n
-        } as any,
-        input: {
-          url: 'https://api.test/connect/plugin/plugin-1/oauth/authorize?response_type=code&client_id=coaci_test&redirect_uri=http%3A%2F%2F127.0.0.1%2Fcallback',
-          consumerProfileId: 'consumer-profile-1',
-          magicMcpEndpointId: 'endpoint-1'
+  it('adds portal_id for plugin OAuth test authorization URLs when missing', async () => {
+    vi.mocked(db.consumerProfile.findFirst).mockResolvedValue({
+      oid: 30n,
+      id: 'consumer-profile-1',
+      surfaceOid: 50n,
+      surface: {
+        oid: 50n,
+        id: 'test-7',
+        instanceOid: 1n,
+        organizationOid: 2n,
+        portal: {
+          id: 'test-7',
+          slug: 'test-7'
         }
-      })
-    ).rejects.toThrow('plugin_id is required');
+      }
+    } as any);
+    vi.mocked(db.magicMcpEndpoint.findFirst).mockResolvedValue({
+      oid: 60n,
+      id: 'endpoint-1',
+      consumerProfileOid: 30n,
+      skillPluginOid: null,
+      servers: [{ magicMcpServerOid: 70n }]
+    } as any);
+    vi.mocked(db.consumerAuthClient.findFirst).mockResolvedValue({
+      oid: 10n,
+      clientId: 'coaci_test',
+      expiresAt: new Date(Date.now() + 60_000),
+      skillPluginOid: null,
+      consumerAuthClientSurfaces: []
+    } as any);
+    vi.mocked(db.consumerAuthTestAuthorization.create).mockResolvedValue({
+      id: 'coata_test',
+      expiresAt: new Date(Date.now() + 60_000),
+      createdAt: new Date()
+    } as any);
+
+    let result = await consumerOAuthTestAuthorizationService.createTestAuthorization({
+      instance: {
+        oid: 1n,
+        organizationOid: 2n
+      } as any,
+      input: {
+        url: 'https://api.test/connect/plugin/plugin-1/oauth/authorize?response_type=code&client_id=coaci_test&redirect_uri=http%3A%2F%2F127.0.0.1%2Fcallback',
+        consumerProfileId: 'consumer-profile-1',
+        magicMcpEndpointId: 'endpoint-1'
+      }
+    });
+
+    expect(result.url).toContain('portal_id=test-7');
+    expect(result.url).toContain('test_auth_id=coata_test');
   });
 
   it('rejects an already consumed test authorization', async () => {

--- a/src/systems/subspace/apps/controller/src/controllers/customProvider.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/customProvider.ts
@@ -139,7 +139,7 @@ export let customProviderController = app.controller({
         allowDeleted: v.optional(v.boolean())
       })
     )
-    .do(async ctx => customProviderPresenter(ctx.customProvider, ctx)),
+    .do(async ctx => await customProviderPresenter(ctx.customProvider, ctx)),
 
   create: tenantApp
     .handler()
@@ -179,7 +179,7 @@ export let customProviderController = app.controller({
         }
       });
 
-      return customProviderPresenter(customProvider, ctx);
+      return await customProviderPresenter(customProvider, ctx);
     }),
 
   update: customProviderApp
@@ -223,6 +223,6 @@ export let customProviderController = app.controller({
         }
       });
 
-      return customProviderPresenter(customProvider, ctx);
+      return await customProviderPresenter(customProvider, ctx);
     })
 });

--- a/src/systems/subspace/apps/controller/src/controllers/provider.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/provider.ts
@@ -70,7 +70,7 @@ export let providerController = app.controller({
         providerId: v.string()
       })
     )
-    .do(async ctx => providerPresenter(ctx.provider, ctx)),
+    .do(async ctx => await providerPresenter(ctx.provider, ctx)),
 
   update: providerApp
     .handler()
@@ -99,6 +99,6 @@ export let providerController = app.controller({
         }
       });
 
-      return providerPresenter(provider, ctx);
+      return await providerPresenter(provider, ctx);
     })
 });

--- a/src/systems/subspace/apps/controller/src/controllers/providerListing.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerListing.ts
@@ -135,5 +135,5 @@ export let providerListingController = app.controller({
         providerListingId: v.string()
       })
     )
-    .do(async ctx => providerListingPresenter(ctx.providerListing, ctx))
+    .do(async ctx => await providerListingPresenter(ctx.providerListing, ctx))
 });

--- a/src/systems/subspace/apps/public/src/api/public/oauthCallback.ts
+++ b/src/systems/subspace/apps/public/src/api/public/oauthCallback.ts
@@ -1,5 +1,5 @@
 import { createHono } from '@lowerdeck/hono';
-import { db } from '@metorial-subspace/db';
+import { parseTenantOAuthCallbackSlug } from '@metorial-subspace/db';
 
 export let oauthCallbackApp = createHono()
   .use(async (c, next) => {
@@ -15,24 +15,10 @@ export let oauthCallbackApp = createHono()
   })
   .get('/:oauthIdentifier', async c => {
     let oauthIdentifier = c.req.param('oauthIdentifier');
-    let [tenantUrlKey, providerTag, typeKey] = oauthIdentifier.split('-');
-    if (!tenantUrlKey || !providerTag || !typeKey) {
-      return c.text('Invalid oauth callback URL', 400);
-    }
+    let parsed = await parseTenantOAuthCallbackSlug(oauthIdentifier);
+    if (!parsed) return c.text('Invalid oauth callback URL', 400);
 
-    let tenant = await db.tenant.findFirst({
-      where: { urlKey: tenantUrlKey }
-    });
-    let type = await db.providerType.findFirst({
-      where: { shortKey: typeKey }
-    });
-    let provider = await db.provider.findFirst({
-      where: { tag: providerTag }
-    });
-    if (!tenant || !provider || !type) {
-      return c.text('Invalid oauth callback URL', 400);
-    }
-
+    let { tenant, provider, providerType: type } = parsed;
     if (
       type.attributes.auth.status === 'disabled' ||
       type.attributes.auth.oauth.status === 'disabled'

--- a/src/systems/subspace/db/prisma/schema/deployment/oauthCallbackUrl.prisma
+++ b/src/systems/subspace/db/prisma/schema/deployment/oauthCallbackUrl.prisma
@@ -1,0 +1,19 @@
+model TenantOAuthCallbackUrl {
+  oid BigInt @id
+  id  String @unique
+
+  slug String @unique
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  providerOid BigInt
+  provider    Provider @relation(fields: [providerOid], references: [oid])
+
+  providerTypeOid Int
+  providerType    ProviderType @relation(fields: [providerTypeOid], references: [oid])
+
+  createdAt DateTime @default(now())
+
+  @@unique([tenantOid, providerOid])
+}

--- a/src/systems/subspace/db/prisma/schema/provider/provider.prisma
+++ b/src/systems/subspace/db/prisma/schema/provider/provider.prisma
@@ -106,6 +106,7 @@ model Provider {
   skillProviders                 SkillProvider[]
   skillProviderLinks             SkillProviderLink[]
   skillTemplateItems             SkillTemplateItem[]
+  tenantOAuthCallbackUrls        TenantOAuthCallbackUrl[]
 
   @@index([status])
   @@index([access])

--- a/src/systems/subspace/db/prisma/schema/provider/type.prisma
+++ b/src/systems/subspace/db/prisma/schema/provider/type.prisma
@@ -20,7 +20,8 @@ model ProviderType {
 
   createdAt DateTime @default(now())
 
-  providers        Provider[]
-  providerVersions ProviderVersion[]
-  providerListings ProviderListing[]
+  providers               Provider[]
+  providerVersions        ProviderVersion[]
+  providerListings        ProviderListing[]
+  tenantOAuthCallbackUrls TenantOAuthCallbackUrl[]
 }

--- a/src/systems/subspace/db/prisma/schema/tenant.prisma
+++ b/src/systems/subspace/db/prisma/schema/tenant.prisma
@@ -103,6 +103,7 @@ model Tenant {
   skillEntities                            SkillEntity[]
   skillForks                               SkillFork[]
   skillTemplates                           SkillTemplate[]
+  tenantOAuthCallbackUrls                  TenantOAuthCallbackUrl[]
 }
 
 enum EnvironmentType {

--- a/src/systems/subspace/db/src/id.ts
+++ b/src/systems/subspace/db/src/id.ts
@@ -8,6 +8,7 @@ export let ID = createIdGenerator({
   backend: idType.sorted('kbe'),
   brand: idType.sorted('kbr'),
   tenantActor: idType.sorted('pact'),
+  tenantOAuthCallbackUrl: idType.sorted('cbu'),
 
   publisher: idType.sorted('pub'),
 

--- a/src/systems/subspace/db/src/utils/getOAuthCallbackUrl.ts
+++ b/src/systems/subspace/db/src/utils/getOAuthCallbackUrl.ts
@@ -1,10 +1,110 @@
 import type { Provider, ProviderType, Tenant } from '../../prisma/generated/client';
+import { db } from '../db';
 import { env } from '../env';
+import { getId } from '../id';
 
-export let getOAuthCallbackUrl = (
+export let getLegacySlug = (providerType: ProviderType, provider: Provider, tenant: Tenant) =>
+  `${tenant.urlKey}-${provider.tag}-${providerType.shortKey}`;
+
+export let getOAuthCallbackUrl = async (
   providerType: ProviderType,
   provider: Provider,
   tenant: Tenant
 ) => {
-  return `${env.service.PUBLIC_SERVICE_URL}/oauth-callback/${tenant.urlKey}-${provider.tag}-${providerType.shortKey}`;
+  let storedUrl = await db.tenantOAuthCallbackUrl.findUnique({
+    where: {
+      tenantOid_providerOid: {
+        tenantOid: tenant.oid,
+        providerOid: provider.oid
+      }
+    }
+  });
+
+  if (!storedUrl) {
+    let slug = getLegacySlug(providerType, provider, tenant);
+
+    try {
+      storedUrl = await db.tenantOAuthCallbackUrl.upsert({
+        where: {
+          tenantOid_providerOid: {
+            tenantOid: tenant.oid,
+            providerOid: provider.oid
+          }
+        },
+        create: {
+          ...getId('tenantOAuthCallbackUrl'),
+          tenantOid: tenant.oid,
+          providerOid: provider.oid,
+          providerTypeOid: providerType.oid,
+          slug
+        },
+        update: {
+          providerTypeOid: providerType.oid,
+          slug
+        }
+      });
+    } catch (e) {
+      try {
+        storedUrl = await db.tenantOAuthCallbackUrl.findUniqueOrThrow({
+          where: {
+            tenantOid_providerOid: {
+              tenantOid: tenant.oid,
+              providerOid: provider.oid
+            }
+          }
+        });
+      } catch {
+        throw e;
+      }
+    }
+  }
+
+  if (providerType.oid !== storedUrl.providerTypeOid) {
+    storedUrl = await db.tenantOAuthCallbackUrl.update({
+      where: { oid: storedUrl.oid },
+      data: { providerTypeOid: providerType.oid }
+    });
+  }
+
+  let slug = storedUrl.slug;
+  return `${env.service.PUBLIC_SERVICE_URL}/oauth-callback/${slug}`;
+};
+
+export let parseTenantOAuthCallbackSlug = async (slug: string) => {
+  let record = await db.tenantOAuthCallbackUrl.findUnique({
+    where: { slug },
+    include: {
+      tenant: true,
+      provider: true,
+      providerType: true
+    }
+  });
+
+  if (record) {
+    return {
+      tenant: record.tenant,
+      provider: record.provider,
+      providerType: record.providerType
+    };
+  }
+
+  let [tenantUrlKey, providerTag, providerTypeShortKey] = slug.split('-');
+  if (!tenantUrlKey || !providerTag || !providerTypeShortKey) return null;
+
+  let providerType = await db.providerType.findFirst({
+    where: { shortKey: providerTypeShortKey }
+  });
+  if (!providerType) return null;
+
+  let provider = await db.provider.findFirst({
+    where: { tag: providerTag, typeOid: providerType.oid }
+  });
+  if (!provider) return null;
+
+  let tenant = await db.tenant.findFirst({
+    where: { urlKey: tenantUrlKey }
+  });
+  if (!tenant) return null;
+
+  return { tenant, provider, providerType };
 };

--- a/src/systems/subspace/modules/auth/src/services/providerOAuthSetup.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerOAuthSetup.ts
@@ -204,7 +204,7 @@ class providerOAuthSetupServiceImpl {
 
       let callbackUrlOverride = isManagedCredentials
         ? null
-        : getOAuthCallbackUrl(d.provider.type, d.provider, d.tenant);
+        : await getOAuthCallbackUrl(d.provider.type, d.provider, d.tenant);
 
       let backendProviderOAuthSetup = await backend.auth.createProviderOAuthSetup({
         tenant: d.tenant,

--- a/src/systems/subspace/packages/presenters/src/customProvider.ts
+++ b/src/systems/subspace/packages/presenters/src/customProvider.ts
@@ -20,7 +20,7 @@ import { bucketPresenter } from './bucket';
 import { providerPresenter } from './provider';
 import { scmRepositoryPresenter } from './scmRepository';
 
-export let customProviderPresenter = (
+export let customProviderPresenter = async (
   customProvider: CustomProvider & {
     provider:
       | (Provider & {
@@ -70,7 +70,9 @@ export let customProviderPresenter = (
     ? bucketPresenter(customProvider.draftCodeBucket)
     : null,
 
-  provider: customProvider.provider ? providerPresenter(customProvider.provider, d) : null,
+  provider: customProvider.provider
+    ? await providerPresenter(customProvider.provider, d)
+    : null,
 
   draft: {
     containerRegistry: customProvider.containerRegistry,

--- a/src/systems/subspace/packages/presenters/src/provider.ts
+++ b/src/systems/subspace/packages/presenters/src/provider.ts
@@ -17,7 +17,7 @@ import { providerVersionPresenter } from './providerVersion';
 import { publisherPresenter } from './publisher';
 import { tenantPresenter } from './tenant';
 
-export let providerPresenter = (
+export let providerPresenter = async (
   provider: Provider & {
     entry: ProviderEntry;
     publisher: Publisher;
@@ -38,7 +38,7 @@ export let providerPresenter = (
   },
   d: { tenant: Tenant | undefined }
 ) => {
-  let type = providerTypePresenter(provider.type, {
+  let type = await providerTypePresenter(provider.type, {
     tenant: d.tenant,
     provider
   });

--- a/src/systems/subspace/packages/presenters/src/providerListing.ts
+++ b/src/systems/subspace/packages/presenters/src/providerListing.ts
@@ -17,7 +17,7 @@ import { providerListingCategoryPresenter } from './providerListingCategory';
 import { providerListingCollectionPresenter } from './providerListingCollection';
 import { providerListingGroupPresenter } from './providerListingGroup';
 
-export let providerListingPresenter = (
+export let providerListingPresenter = async (
   providerListing: Omit<ProviderListing, 'readme'> & {
     provider: Provider & {
       entry: ProviderEntry;
@@ -74,7 +74,7 @@ export let providerListingPresenter = (
   providerSessionsCount: providerListing.providerSessionsCount,
   providerMessagesCount: providerListing.providerMessagesCount,
 
-  provider: providerPresenter(providerListing.provider, d),
+  provider: await providerPresenter(providerListing.provider, d),
 
   categories: (providerListing.categories ?? []).map(category =>
     providerListingCategoryPresenter(category)

--- a/src/systems/subspace/packages/presenters/src/providerType.ts
+++ b/src/systems/subspace/packages/presenters/src/providerType.ts
@@ -5,7 +5,7 @@ import {
   type Tenant
 } from '@metorial-subspace/db';
 
-let mapAuth = (
+let mapAuth = async (
   auth: ProviderType['attributes']['auth'],
   providerType: ProviderType,
   provider: Provider,
@@ -20,14 +20,14 @@ let mapAuth = (
         ? {
             ...auth.oauth,
             oauthCallbackUrl: tenant
-              ? getOAuthCallbackUrl(providerType, provider, tenant)
+              ? await getOAuthCallbackUrl(providerType, provider, tenant)
               : null
           }
         : auth.oauth
   };
 };
 
-export let providerTypePresenter = (
+export let providerTypePresenter = async (
   providerType: ProviderType,
   d: { tenant: Tenant | undefined; provider: Provider }
 ) => ({
@@ -40,7 +40,7 @@ export let providerTypePresenter = (
 
   config: providerType.attributes.config,
   triggers: providerType.attributes.triggers,
-  auth: mapAuth(providerType.attributes.auth, providerType, d.provider, d.tenant),
+  auth: await mapAuth(providerType.attributes.auth, providerType, d.provider, d.tenant),
 
   createdAt: providerType.createdAt
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes generated client types/mappers (nullability, added IDs/timestamps, and nested object structure) which can break downstream TypeScript compile/runtime assumptions when consuming these responses.
> 
> **Overview**
> Adds a new generated endpoint `MetorialTestHelpersConsumerOauthAuthorizationsEndpoint.create()` and exports it from the dashboard client, enabling creation of single-use test authorization tokens for consumer OAuth flows.
> 
> Updates generated `integration-instance-group-providers` (`get`, `list`, `set`, `delete`) and `integration-instance-groups/create` outputs to reflect new response shapes: **adds timestamps**, introduces `integrationInstanceProviderId`, makes `integrationProviderId` nullable, and replaces several previously nested provider/auth/deployment objects with their corresponding `...Id` fields while refactoring the `mtMap` mappers accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01f35f19ccd9c3070676d731df0c424782a5409a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->