### PR TITLE
Clean up integration providers

### DIFF
--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/delete.ts
@@ -31,7 +31,6 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -196,9 +195,174 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput = {
 };
 
 export let mapDashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<DashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstanceGroupId: mtMap.objectField(
+      'integration_instance_group_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    integrationProviderId: mtMap.objectField(
+      'integration_provider_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceProviderId: mtMap.objectField(
+      'integration_instance_provider_id',
+      mtMap.passthrough()
+    ),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
+              )
+            )
+          })
+        )
+      ])
+    ),
+    isOverrideToolFilter: mtMap.objectField(
+      'is_override_tool_filter',
+      mtMap.passthrough()
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    integrationProvider: mtMap.objectField(
+      'integration_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        providerVersion: mtMap.objectField(
+          'provider_version',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            index: mtMap.objectField('index', mtMap.passthrough())
+          })
+        ),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
+                  mtMap.passthrough()
+                ),
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
+                            mtMap.passthrough()
+                          ),
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
+                          )
+                        })
+                      )
+                    ])
+                  )
+                )
+              })
+            )
+          ])
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
+          mtMap.passthrough()
+        ),
+        config: mtMap.objectField(
+          'config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    integrationInstanceProvider: mtMap.objectField(
+      'integration_instance_provider',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
@@ -207,20 +371,8 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput =
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstanceGroupId: mtMap.objectField(
-          'integration_instance_group_id',
-          mtMap.passthrough()
-        ),
         integrationInstanceId: mtMap.objectField(
           'integration_instance_id',
-          mtMap.passthrough()
-        ),
-        integrationProviderId: mtMap.objectField(
-          'integration_provider_id',
-          mtMap.passthrough()
-        ),
-        integrationInstanceProviderId: mtMap.objectField(
-          'integration_instance_provider_id',
           mtMap.passthrough()
         ),
         toolFilter: mtMap.objectField(
@@ -267,9 +419,6 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput =
           'is_override_tool_filter',
           mtMap.passthrough()
         ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date()),
         provider: mtMap.objectField(
           'provider',
           mtMap.object({
@@ -380,241 +529,38 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersDeleteOutput =
             archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
         ),
-        integrationInstanceProvider: mtMap.objectField(
-          'integration_instance_provider',
+        config: mtMap.objectField(
+          'config',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            integrationId: mtMap.objectField(
-              'integration_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceId: mtMap.objectField(
-              'integration_instance_id',
-              mtMap.passthrough()
-            ),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            isOverrideToolFilter: mtMap.objectField(
-              'is_override_tool_filter',
-              mtMap.passthrough()
-            ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            integrationProvider: mtMap.objectField(
-              'integration_provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                providerVersion: mtMap.objectField(
-                  'provider_version',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    index: mtMap.objectField('index', mtMap.passthrough())
-                  })
-                ),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            ),
-            config: mtMap.objectField(
-              'config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authConfig: mtMap.objectField(
-              'auth_config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
           })
-        )
+        ),
+        authConfig: mtMap.objectField(
+          'auth_config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
       })
     )
-  ]);
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/get.ts
@@ -31,7 +31,6 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -196,9 +195,174 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersGetOutput = {
 };
 
 export let mapDashboardInstanceIntegrationInstanceGroupProvidersGetOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<DashboardInstanceIntegrationInstanceGroupProvidersGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstanceGroupId: mtMap.objectField(
+      'integration_instance_group_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    integrationProviderId: mtMap.objectField(
+      'integration_provider_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceProviderId: mtMap.objectField(
+      'integration_instance_provider_id',
+      mtMap.passthrough()
+    ),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
+              )
+            )
+          })
+        )
+      ])
+    ),
+    isOverrideToolFilter: mtMap.objectField(
+      'is_override_tool_filter',
+      mtMap.passthrough()
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    integrationProvider: mtMap.objectField(
+      'integration_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        providerVersion: mtMap.objectField(
+          'provider_version',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            index: mtMap.objectField('index', mtMap.passthrough())
+          })
+        ),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
+                  mtMap.passthrough()
+                ),
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
+                            mtMap.passthrough()
+                          ),
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
+                          )
+                        })
+                      )
+                    ])
+                  )
+                )
+              })
+            )
+          ])
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
+          mtMap.passthrough()
+        ),
+        config: mtMap.objectField(
+          'config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    integrationInstanceProvider: mtMap.objectField(
+      'integration_instance_provider',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
@@ -207,20 +371,8 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersGetOutput =
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstanceGroupId: mtMap.objectField(
-          'integration_instance_group_id',
-          mtMap.passthrough()
-        ),
         integrationInstanceId: mtMap.objectField(
           'integration_instance_id',
-          mtMap.passthrough()
-        ),
-        integrationProviderId: mtMap.objectField(
-          'integration_provider_id',
-          mtMap.passthrough()
-        ),
-        integrationInstanceProviderId: mtMap.objectField(
-          'integration_instance_provider_id',
           mtMap.passthrough()
         ),
         toolFilter: mtMap.objectField(
@@ -267,9 +419,6 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersGetOutput =
           'is_override_tool_filter',
           mtMap.passthrough()
         ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date()),
         provider: mtMap.objectField(
           'provider',
           mtMap.object({
@@ -380,241 +529,38 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersGetOutput =
             archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
         ),
-        integrationInstanceProvider: mtMap.objectField(
-          'integration_instance_provider',
+        config: mtMap.objectField(
+          'config',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            integrationId: mtMap.objectField(
-              'integration_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceId: mtMap.objectField(
-              'integration_instance_id',
-              mtMap.passthrough()
-            ),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            isOverrideToolFilter: mtMap.objectField(
-              'is_override_tool_filter',
-              mtMap.passthrough()
-            ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            integrationProvider: mtMap.objectField(
-              'integration_provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                providerVersion: mtMap.objectField(
-                  'provider_version',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    index: mtMap.objectField('index', mtMap.passthrough())
-                  })
-                ),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            ),
-            config: mtMap.objectField(
-              'config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authConfig: mtMap.objectField(
-              'auth_config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
           })
-        )
+        ),
+        authConfig: mtMap.objectField(
+          'auth_config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
       })
     )
-  ]);
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceIntegrationInstanceGroupProvidersListOutput = {
-  items: ({
+  items: {
     object: 'integration.instance.group.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -32,7 +32,6 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
     provider: {
       object: 'provider#preview';
       id: string;
@@ -194,7 +193,7 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersListOutput = {
       updatedAt: Date;
       archivedAt: Date | null;
     };
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -203,9 +202,204 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          integrationInstanceProvider: mtMap.objectField(
+            'integration_instance_provider',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
@@ -220,20 +414,8 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersListOutput =
                 'integration_id',
                 mtMap.passthrough()
               ),
-              integrationInstanceGroupId: mtMap.objectField(
-                'integration_instance_group_id',
-                mtMap.passthrough()
-              ),
               integrationInstanceId: mtMap.objectField(
                 'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              integrationProviderId: mtMap.objectField(
-                'integration_provider_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceProviderId: mtMap.objectField(
-                'integration_instance_provider_id',
                 mtMap.passthrough()
               ),
               toolFilter: mtMap.objectField(
@@ -283,9 +465,6 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersListOutput =
                 'is_override_tool_filter',
                 mtMap.passthrough()
               ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date()),
               provider: mtMap.objectField(
                 'provider',
                 mtMap.object({
@@ -411,276 +590,58 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersListOutput =
                   archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
               ),
-              integrationInstanceProvider: mtMap.objectField(
-                'integration_instance_provider',
+              config: mtMap.objectField(
+                'config',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  integrationId: mtMap.objectField(
-                    'integration_id',
+                  providerId: mtMap.objectField(
+                    'provider_id',
                     mtMap.passthrough()
-                  ),
-                  integrationInstanceId: mtMap.objectField(
-                    'integration_instance_id',
-                    mtMap.passthrough()
-                  ),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  isOverrideToolFilter: mtMap.objectField(
-                    'is_override_tool_filter',
-                    mtMap.passthrough()
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  integrationProvider: mtMap.objectField(
-                    'integration_provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      providerVersion: mtMap.objectField(
-                        'provider_version',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          index: mtMap.objectField('index', mtMap.passthrough())
-                        })
-                      ),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      toolFilter: mtMap.objectField(
-                        'tool_filter',
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              ignoreParentFilters: mtMap.objectField(
-                                'ignore_parent_filters',
-                                mtMap.passthrough()
-                              ),
-                              filters: mtMap.objectField(
-                                'filters',
-                                mtMap.array(
-                                  mtMap.union([
-                                    mtMap.unionOption(
-                                      'object',
-                                      mtMap.object({
-                                        type: mtMap.objectField(
-                                          'type',
-                                          mtMap.passthrough()
-                                        ),
-                                        keys: mtMap.objectField(
-                                          'keys',
-                                          mtMap.array(mtMap.passthrough())
-                                        ),
-                                        pattern: mtMap.objectField(
-                                          'pattern',
-                                          mtMap.passthrough()
-                                        ),
-                                        uris: mtMap.objectField(
-                                          'uris',
-                                          mtMap.array(mtMap.passthrough())
-                                        )
-                                      })
-                                    )
-                                  ])
-                                )
-                              )
-                            })
-                          )
-                        ])
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      deploymentId: mtMap.objectField(
-                        'deployment_id',
-                        mtMap.passthrough()
-                      ),
-                      authMethodId: mtMap.objectField(
-                        'auth_method_id',
-                        mtMap.passthrough()
-                      ),
-                      authCredentialsId: mtMap.objectField(
-                        'auth_credentials_id',
-                        mtMap.passthrough()
-                      ),
-                      config: mtMap.objectField(
-                        'config',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          isDefault: mtMap.objectField(
-                            'is_default',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          ),
-                          metadata: mtMap.objectField(
-                            'metadata',
-                            mtMap.passthrough()
-                          ),
-                          providerId: mtMap.objectField(
-                            'provider_id',
-                            mtMap.passthrough()
-                          ),
-                          createdAt: mtMap.objectField(
-                            'created_at',
-                            mtMap.date()
-                          ),
-                          updatedAt: mtMap.objectField(
-                            'updated_at',
-                            mtMap.date()
-                          )
-                        })
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authConfig: mtMap.objectField(
-                    'auth_config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
                   ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
-              )
+              ),
+              authConfig: mtMap.objectField(
+                'auth_config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
           )
-        ])
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/set.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-group-providers/set.ts
@@ -31,7 +31,6 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersSetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -196,9 +195,174 @@ export type DashboardInstanceIntegrationInstanceGroupProvidersSetOutput = {
 };
 
 export let mapDashboardInstanceIntegrationInstanceGroupProvidersSetOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<DashboardInstanceIntegrationInstanceGroupProvidersSetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstanceGroupId: mtMap.objectField(
+      'integration_instance_group_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    integrationProviderId: mtMap.objectField(
+      'integration_provider_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceProviderId: mtMap.objectField(
+      'integration_instance_provider_id',
+      mtMap.passthrough()
+    ),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
+              )
+            )
+          })
+        )
+      ])
+    ),
+    isOverrideToolFilter: mtMap.objectField(
+      'is_override_tool_filter',
+      mtMap.passthrough()
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    integrationProvider: mtMap.objectField(
+      'integration_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        providerVersion: mtMap.objectField(
+          'provider_version',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            index: mtMap.objectField('index', mtMap.passthrough())
+          })
+        ),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
+                  mtMap.passthrough()
+                ),
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
+                            mtMap.passthrough()
+                          ),
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
+                          )
+                        })
+                      )
+                    ])
+                  )
+                )
+              })
+            )
+          ])
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
+          mtMap.passthrough()
+        ),
+        config: mtMap.objectField(
+          'config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    integrationInstanceProvider: mtMap.objectField(
+      'integration_instance_provider',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
@@ -207,20 +371,8 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersSetOutput =
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstanceGroupId: mtMap.objectField(
-          'integration_instance_group_id',
-          mtMap.passthrough()
-        ),
         integrationInstanceId: mtMap.objectField(
           'integration_instance_id',
-          mtMap.passthrough()
-        ),
-        integrationProviderId: mtMap.objectField(
-          'integration_provider_id',
-          mtMap.passthrough()
-        ),
-        integrationInstanceProviderId: mtMap.objectField(
-          'integration_instance_provider_id',
           mtMap.passthrough()
         ),
         toolFilter: mtMap.objectField(
@@ -267,9 +419,6 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersSetOutput =
           'is_override_tool_filter',
           mtMap.passthrough()
         ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date()),
         provider: mtMap.objectField(
           'provider',
           mtMap.object({
@@ -380,243 +529,40 @@ export let mapDashboardInstanceIntegrationInstanceGroupProvidersSetOutput =
             archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
         ),
-        integrationInstanceProvider: mtMap.objectField(
-          'integration_instance_provider',
+        config: mtMap.objectField(
+          'config',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            integrationId: mtMap.objectField(
-              'integration_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceId: mtMap.objectField(
-              'integration_instance_id',
-              mtMap.passthrough()
-            ),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            isOverrideToolFilter: mtMap.objectField(
-              'is_override_tool_filter',
-              mtMap.passthrough()
-            ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            integrationProvider: mtMap.objectField(
-              'integration_provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                providerVersion: mtMap.objectField(
-                  'provider_version',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    index: mtMap.objectField('index', mtMap.passthrough())
-                  })
-                ),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            ),
-            config: mtMap.objectField(
-              'config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authConfig: mtMap.objectField(
-              'auth_config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
           })
-        )
+        ),
+        authConfig: mtMap.objectField(
+          'auth_config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
       })
     )
-  ]);
+  });
 
 export type DashboardInstanceIntegrationInstanceGroupProvidersSetBody = {
   toolFilters?:

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/create.ts
@@ -46,154 +46,113 @@ export type DashboardInstanceIntegrationInstanceGroupsCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: {
-    object: 'integration.instance.group.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceGroupId: string;
-    integrationInstanceId: string;
-    integrationProviderId: string | null;
-    integrationInstanceProviderId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
 };
 
 export let mapDashboardInstanceIntegrationInstanceGroupsCreateOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<DashboardInstanceIntegrationInstanceGroupsCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
       mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        implementation: mtMap.objectField(
-          'implementation',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            magicMcpEndpointId: mtMap.objectField(
-              'magic_mcp_endpoint_id',
-              mtMap.passthrough()
-            )
-          })
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceGroupId: mtMap.objectField(
-                'integration_instance_group_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              integrationProviderId: mtMap.objectField(
-                'integration_provider_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceProviderId: mtMap.objectField(
-                'integration_instance_provider_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpEndpointId: mtMap.objectField(
+          'magic_mcp_endpoint_id',
+          mtMap.passthrough()
+        )
       })
-    )
-  ]);
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type DashboardInstanceIntegrationInstanceGroupsCreateBody = {
   name: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/delete.ts
@@ -46,152 +46,111 @@ export type DashboardInstanceIntegrationInstanceGroupsDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: {
-    object: 'integration.instance.group.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceGroupId: string;
-    integrationInstanceId: string;
-    integrationProviderId: string | null;
-    integrationInstanceProviderId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
 };
 
 export let mapDashboardInstanceIntegrationInstanceGroupsDeleteOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<DashboardInstanceIntegrationInstanceGroupsDeleteOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
       mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        implementation: mtMap.objectField(
-          'implementation',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            magicMcpEndpointId: mtMap.objectField(
-              'magic_mcp_endpoint_id',
-              mtMap.passthrough()
-            )
-          })
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceGroupId: mtMap.objectField(
-                'integration_instance_group_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              integrationProviderId: mtMap.objectField(
-                'integration_provider_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceProviderId: mtMap.objectField(
-                'integration_instance_provider_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpEndpointId: mtMap.objectField(
+          'magic_mcp_endpoint_id',
+          mtMap.passthrough()
+        )
       })
-    )
-  ]);
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/get.ts
@@ -46,153 +46,111 @@ export type DashboardInstanceIntegrationInstanceGroupsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: {
-    object: 'integration.instance.group.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceGroupId: string;
-    integrationInstanceId: string;
-    integrationProviderId: string | null;
-    integrationInstanceProviderId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
 };
 
-export let mapDashboardInstanceIntegrationInstanceGroupsGetOutput = mtMap.union(
-  [
-    mtMap.unionOption(
-      'object',
+export let mapDashboardInstanceIntegrationInstanceGroupsGetOutput =
+  mtMap.object<DashboardInstanceIntegrationInstanceGroupsGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
       mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        implementation: mtMap.objectField(
-          'implementation',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            magicMcpEndpointId: mtMap.objectField(
-              'magic_mcp_endpoint_id',
-              mtMap.passthrough()
-            )
-          })
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceGroupId: mtMap.objectField(
-                'integration_instance_group_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              integrationProviderId: mtMap.objectField(
-                'integration_provider_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceProviderId: mtMap.objectField(
-                'integration_instance_provider_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpEndpointId: mtMap.objectField(
+          'magic_mcp_endpoint_id',
+          mtMap.passthrough()
+        )
       })
-    )
-  ]
-);
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceIntegrationInstanceGroupsListOutput = {
-  items: ({
+  items: {
     object: 'integration.instance.group';
     id: string;
     status: 'draft' | 'active' | 'archived' | 'deleted';
@@ -47,40 +47,7 @@ export type DashboardInstanceIntegrationInstanceGroupsListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
-    providers: {
-      object: 'integration.instance.group.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceGroupId: string;
-      integrationInstanceId: string;
-      integrationProviderId: string | null;
-      integrationInstanceProviderId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    }[];
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -89,127 +56,113 @@ export let mapDashboardInstanceIntegrationInstanceGroupsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          implementation: mtMap.objectField(
+            'implementation',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              magicMcpEndpointId: mtMap.objectField(
+                'magic_mcp_endpoint_id',
                 mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              implementation: mtMap.objectField(
-                'implementation',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  magicMcpEndpointId: mtMap.objectField(
-                    'magic_mcp_endpoint_id',
-                    mtMap.passthrough()
-                  )
-                })
-              ),
-              providers: mtMap.objectField(
-                'providers',
-                mtMap.array(
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    integrationId: mtMap.objectField(
-                      'integration_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationInstanceGroupId: mtMap.objectField(
-                      'integration_instance_group_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationInstanceId: mtMap.objectField(
-                      'integration_instance_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationProviderId: mtMap.objectField(
-                      'integration_provider_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationInstanceProviderId: mtMap.objectField(
-                      'integration_instance_provider_id',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    isOverrideToolFilter: mtMap.objectField(
-                      'is_override_tool_filter',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                )
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              )
             })
-          )
-        ])
+          ),
+          providers: mtMap.objectField(
+            'providers',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceGroupId: mtMap.objectField(
+                  'integration_instance_group_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                integrationProviderId: mtMap.objectField(
+                  'integration_provider_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceProviderId: mtMap.objectField(
+                  'integration_instance_provider_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-groups/update.ts
@@ -46,154 +46,113 @@ export type DashboardInstanceIntegrationInstanceGroupsUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: {
-    object: 'integration.instance.group.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceGroupId: string;
-    integrationInstanceId: string;
-    integrationProviderId: string | null;
-    integrationInstanceProviderId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
 };
 
 export let mapDashboardInstanceIntegrationInstanceGroupsUpdateOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<DashboardInstanceIntegrationInstanceGroupsUpdateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
       mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        implementation: mtMap.objectField(
-          'implementation',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            magicMcpEndpointId: mtMap.objectField(
-              'magic_mcp_endpoint_id',
-              mtMap.passthrough()
-            )
-          })
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceGroupId: mtMap.objectField(
-                'integration_instance_group_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              integrationProviderId: mtMap.objectField(
-                'integration_provider_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceProviderId: mtMap.objectField(
-                'integration_instance_provider_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpEndpointId: mtMap.objectField(
+          'magic_mcp_endpoint_id',
+          mtMap.passthrough()
+        )
       })
-    )
-  ]);
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type DashboardInstanceIntegrationInstanceGroupsUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-providers/get.ts
@@ -105,71 +105,94 @@ export type DashboardInstanceIntegrationInstanceProvidersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  integrationProvider: {
-    object: 'integration.provider#snapshot';
-    id: string;
-    providerVersion: {
-      object: 'integration.provider.version';
-      id: string;
-      index: number;
-    };
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  };
 };
 
 export let mapDashboardInstanceIntegrationInstanceProvidersGetOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<DashboardInstanceIntegrationInstanceProvidersGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
+              )
+            )
+          })
+        )
+      ])
+    ),
+    isOverrideToolFilter: mtMap.objectField(
+      'is_override_tool_filter',
+      mtMap.passthrough()
+    ),
+    provider: mtMap.objectField(
+      'provider',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    integrationProvider: mtMap.objectField(
+      'integration_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        providerVersion: mtMap.objectField(
+          'provider_version',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            index: mtMap.objectField('index', mtMap.passthrough())
+          })
+        ),
         status: mtMap.objectField('status', mtMap.passthrough()),
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstanceId: mtMap.objectField(
-          'integration_instance_id',
-          mtMap.passthrough()
-        ),
         toolFilter: mtMap.objectField(
           'tool_filter',
           mtMap.union([
@@ -210,136 +233,15 @@ export let mapDashboardInstanceIntegrationInstanceProvidersGetOutput =
             )
           ])
         ),
-        isOverrideToolFilter: mtMap.objectField(
-          'is_override_tool_filter',
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
           mtMap.passthrough()
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        integrationProvider: mtMap.objectField(
-          'integration_provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            providerVersion: mtMap.objectField(
-              'provider_version',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                index: mtMap.objectField('index', mtMap.passthrough())
-              })
-            ),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            deploymentId: mtMap.objectField(
-              'deployment_id',
-              mtMap.passthrough()
-            ),
-            authMethodId: mtMap.objectField(
-              'auth_method_id',
-              mtMap.passthrough()
-            ),
-            authCredentialsId: mtMap.objectField(
-              'auth_credentials_id',
-              mtMap.passthrough()
-            ),
-            config: mtMap.objectField(
-              'config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
         ),
         config: mtMap.objectField(
           'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authConfig: mtMap.objectField(
-          'auth_config',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
@@ -356,6 +258,37 @@ export let mapDashboardInstanceIntegrationInstanceProvidersGetOutput =
         updatedAt: mtMap.objectField('updated_at', mtMap.date()),
         archivedAt: mtMap.objectField('archived_at', mtMap.date())
       })
-    )
-  ]);
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authConfig: mtMap.objectField(
+      'auth_config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-providers/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceIntegrationInstanceProvidersListOutput = {
-  items: ({
+  items: {
     object: 'integration.instance.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -106,54 +106,7 @@ export type DashboardInstanceIntegrationInstanceProvidersListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -162,12 +115,96 @@ export let mapDashboardInstanceIntegrationInstanceProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
               status: mtMap.objectField('status', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
@@ -175,14 +212,6 @@ export let mapDashboardInstanceIntegrationInstanceProvidersListOutput =
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
               toolFilter: mtMap.objectField(
                 'tool_filter',
                 mtMap.union([
@@ -226,160 +255,21 @@ export let mapDashboardInstanceIntegrationInstanceProvidersListOutput =
                   )
                 ])
               ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
                 mtMap.passthrough()
               ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
               ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  deploymentId: mtMap.objectField(
-                    'deployment_id',
-                    mtMap.passthrough()
-                  ),
-                  authMethodId: mtMap.objectField(
-                    'auth_method_id',
-                    mtMap.passthrough()
-                  ),
-                  authCredentialsId: mtMap.objectField(
-                    'auth_credentials_id',
-                    mtMap.passthrough()
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
               ),
               config: mtMap.objectField(
                 'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
@@ -405,8 +295,45 @@ export let mapDashboardInstanceIntegrationInstanceProvidersListOutput =
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
               archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
-          )
-        ])
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-providers/set.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instance-providers/set.ts
@@ -105,71 +105,94 @@ export type DashboardInstanceIntegrationInstanceProvidersSetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  integrationProvider: {
-    object: 'integration.provider#snapshot';
-    id: string;
-    providerVersion: {
-      object: 'integration.provider.version';
-      id: string;
-      index: number;
-    };
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  };
 };
 
 export let mapDashboardInstanceIntegrationInstanceProvidersSetOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<DashboardInstanceIntegrationInstanceProvidersSetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
+              )
+            )
+          })
+        )
+      ])
+    ),
+    isOverrideToolFilter: mtMap.objectField(
+      'is_override_tool_filter',
+      mtMap.passthrough()
+    ),
+    provider: mtMap.objectField(
+      'provider',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    integrationProvider: mtMap.objectField(
+      'integration_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        providerVersion: mtMap.objectField(
+          'provider_version',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            index: mtMap.objectField('index', mtMap.passthrough())
+          })
+        ),
         status: mtMap.objectField('status', mtMap.passthrough()),
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstanceId: mtMap.objectField(
-          'integration_instance_id',
-          mtMap.passthrough()
-        ),
         toolFilter: mtMap.objectField(
           'tool_filter',
           mtMap.union([
@@ -210,136 +233,15 @@ export let mapDashboardInstanceIntegrationInstanceProvidersSetOutput =
             )
           ])
         ),
-        isOverrideToolFilter: mtMap.objectField(
-          'is_override_tool_filter',
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
           mtMap.passthrough()
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        integrationProvider: mtMap.objectField(
-          'integration_provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            providerVersion: mtMap.objectField(
-              'provider_version',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                index: mtMap.objectField('index', mtMap.passthrough())
-              })
-            ),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            deploymentId: mtMap.objectField(
-              'deployment_id',
-              mtMap.passthrough()
-            ),
-            authMethodId: mtMap.objectField(
-              'auth_method_id',
-              mtMap.passthrough()
-            ),
-            authCredentialsId: mtMap.objectField(
-              'auth_credentials_id',
-              mtMap.passthrough()
-            ),
-            config: mtMap.objectField(
-              'config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
         ),
         config: mtMap.objectField(
           'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authConfig: mtMap.objectField(
-          'auth_config',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
@@ -356,8 +258,39 @@ export let mapDashboardInstanceIntegrationInstanceProvidersSetOutput =
         updatedAt: mtMap.objectField('updated_at', mtMap.date()),
         archivedAt: mtMap.objectField('archived_at', mtMap.date())
       })
-    )
-  ]);
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authConfig: mtMap.objectField(
+      'auth_config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type DashboardInstanceIntegrationInstanceProvidersSetBody = {
   providerDeploymentId?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/create.ts
@@ -120,302 +120,64 @@ export type DashboardInstanceIntegrationInstancesCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.instance.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authConfig: {
-      object: 'provider.auth_config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
 };
 
-export let mapDashboardInstanceIntegrationInstancesCreateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      identityActorId: mtMap.objectField(
-        'identity_actor_id',
-        mtMap.passthrough()
-      ),
-      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
+export let mapDashboardInstanceIntegrationInstancesCreateOutput =
+  mtMap.object<DashboardInstanceIntegrationInstancesCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpServerId: mtMap.objectField(
+          'magic_mcp_server_id',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpServerId: mtMap.objectField(
-            'magic_mcp_server_id',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -424,161 +186,194 @@ export let mapDashboardInstanceIntegrationInstancesCreateOutput = mtMap.union([
                               'type',
                               mtMap.passthrough()
                             ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
                               mtMap.passthrough()
                             ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
                             )
                           })
                         )
                       ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type DashboardInstanceIntegrationInstancesCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/delete.ts
@@ -120,302 +120,64 @@ export type DashboardInstanceIntegrationInstancesDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.instance.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authConfig: {
-      object: 'provider.auth_config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
 };
 
-export let mapDashboardInstanceIntegrationInstancesDeleteOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      identityActorId: mtMap.objectField(
-        'identity_actor_id',
-        mtMap.passthrough()
-      ),
-      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
+export let mapDashboardInstanceIntegrationInstancesDeleteOutput =
+  mtMap.object<DashboardInstanceIntegrationInstancesDeleteOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpServerId: mtMap.objectField(
+          'magic_mcp_server_id',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpServerId: mtMap.objectField(
-            'magic_mcp_server_id',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -424,159 +186,192 @@ export let mapDashboardInstanceIntegrationInstancesDeleteOutput = mtMap.union([
                               'type',
                               mtMap.passthrough()
                             ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
                               mtMap.passthrough()
                             ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
                             )
                           })
                         )
                       ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/get.ts
@@ -120,302 +120,64 @@ export type DashboardInstanceIntegrationInstancesGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.instance.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authConfig: {
-      object: 'provider.auth_config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
 };
 
-export let mapDashboardInstanceIntegrationInstancesGetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      identityActorId: mtMap.objectField(
-        'identity_actor_id',
-        mtMap.passthrough()
-      ),
-      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
+export let mapDashboardInstanceIntegrationInstancesGetOutput =
+  mtMap.object<DashboardInstanceIntegrationInstancesGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpServerId: mtMap.objectField(
+          'magic_mcp_server_id',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpServerId: mtMap.objectField(
-            'magic_mcp_server_id',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -424,159 +186,192 @@ export let mapDashboardInstanceIntegrationInstancesGetOutput = mtMap.union([
                               'type',
                               mtMap.passthrough()
                             ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
                               mtMap.passthrough()
                             ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
                             )
                           })
                         )
                       ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceIntegrationInstancesListOutput = {
-  items: ({
+  items: {
     object: 'integration.instance';
     id: string;
     status: 'draft' | 'active' | 'archived' | 'deleted';
@@ -124,161 +124,7 @@ export type DashboardInstanceIntegrationInstancesListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
-    providers: ({
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        providerId: string;
-        deploymentId: string;
-        authMethodId: string | null;
-        authCredentialsId: string | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } & {
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        providerId: string;
-        deploymentId: string;
-        authMethodId: string | null;
-        authCredentialsId: string | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-    })[];
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -287,52 +133,213 @@ export let mapDashboardInstanceIntegrationInstancesListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          implementation: mtMap.objectField(
+            'implementation',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              identityActorId: mtMap.objectField(
-                'identity_actor_id',
-                mtMap.passthrough()
-              ),
-              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-              implementation: mtMap.objectField(
-                'implementation',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  magicMcpServerId: mtMap.objectField(
-                    'magic_mcp_server_id',
-                    mtMap.passthrough()
-                  )
-                })
-              ),
-              providers: mtMap.objectField(
-                'providers',
-                mtMap.array(
+              )
+            })
+          ),
+          providers: mtMap.objectField(
+            'providers',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
                   mtMap.union([
                     mtMap.unionOption(
                       'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        status: mtMap.objectField(
-                          'status',
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
+                              mtMap.passthrough()
+                            ),
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
+                            )
+                          })
+                        )
+                      ])
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
                           mtMap.passthrough()
                         ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
@@ -344,351 +351,84 @@ export let mapDashboardInstanceIntegrationInstancesListOutput =
                           'metadata',
                           mtMap.passthrough()
                         ),
-                        integrationId: mtMap.objectField(
-                          'integration_id',
+                        providerId: mtMap.objectField(
+                          'provider_id',
                           mtMap.passthrough()
-                        ),
-                        integrationInstanceId: mtMap.objectField(
-                          'integration_instance_id',
-                          mtMap.passthrough()
-                        ),
-                        toolFilter: mtMap.objectField(
-                          'tool_filter',
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                ignoreParentFilters: mtMap.objectField(
-                                  'ignore_parent_filters',
-                                  mtMap.passthrough()
-                                ),
-                                filters: mtMap.objectField(
-                                  'filters',
-                                  mtMap.array(
-                                    mtMap.union([
-                                      mtMap.unionOption(
-                                        'object',
-                                        mtMap.object({
-                                          type: mtMap.objectField(
-                                            'type',
-                                            mtMap.passthrough()
-                                          ),
-                                          keys: mtMap.objectField(
-                                            'keys',
-                                            mtMap.array(mtMap.passthrough())
-                                          ),
-                                          pattern: mtMap.objectField(
-                                            'pattern',
-                                            mtMap.passthrough()
-                                          ),
-                                          uris: mtMap.objectField(
-                                            'uris',
-                                            mtMap.array(mtMap.passthrough())
-                                          )
-                                        })
-                                      )
-                                    ])
-                                  )
-                                )
-                              })
-                            )
-                          ])
-                        ),
-                        isOverrideToolFilter: mtMap.objectField(
-                          'is_override_tool_filter',
-                          mtMap.passthrough()
-                        ),
-                        provider: mtMap.objectField(
-                          'provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            slug: mtMap.objectField(
-                              'slug',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        integrationProvider: mtMap.objectField(
-                          'integration_provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            providerVersion: mtMap.objectField(
-                              'provider_version',
-                              mtMap.object({
-                                object: mtMap.objectField(
-                                  'object',
-                                  mtMap.passthrough()
-                                ),
-                                id: mtMap.objectField(
-                                  'id',
-                                  mtMap.passthrough()
-                                ),
-                                index: mtMap.objectField(
-                                  'index',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            status: mtMap.objectField(
-                              'status',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            toolFilter: mtMap.objectField(
-                              'tool_filter',
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    ignoreParentFilters: mtMap.objectField(
-                                      'ignore_parent_filters',
-                                      mtMap.passthrough()
-                                    ),
-                                    filters: mtMap.objectField(
-                                      'filters',
-                                      mtMap.array(
-                                        mtMap.union([
-                                          mtMap.unionOption(
-                                            'object',
-                                            mtMap.object({
-                                              type: mtMap.objectField(
-                                                'type',
-                                                mtMap.passthrough()
-                                              ),
-                                              keys: mtMap.objectField(
-                                                'keys',
-                                                mtMap.array(mtMap.passthrough())
-                                              ),
-                                              pattern: mtMap.objectField(
-                                                'pattern',
-                                                mtMap.passthrough()
-                                              ),
-                                              uris: mtMap.objectField(
-                                                'uris',
-                                                mtMap.array(mtMap.passthrough())
-                                              )
-                                            })
-                                          )
-                                        ])
-                                      )
-                                    )
-                                  })
-                                )
-                              ])
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            deploymentId: mtMap.objectField(
-                              'deployment_id',
-                              mtMap.passthrough()
-                            ),
-                            authMethodId: mtMap.objectField(
-                              'auth_method_id',
-                              mtMap.passthrough()
-                            ),
-                            authCredentialsId: mtMap.objectField(
-                              'auth_credentials_id',
-                              mtMap.passthrough()
-                            ),
-                            config: mtMap.objectField(
-                              'config',
-                              mtMap.object({
-                                object: mtMap.objectField(
-                                  'object',
-                                  mtMap.passthrough()
-                                ),
-                                id: mtMap.objectField(
-                                  'id',
-                                  mtMap.passthrough()
-                                ),
-                                isDefault: mtMap.objectField(
-                                  'is_default',
-                                  mtMap.passthrough()
-                                ),
-                                name: mtMap.objectField(
-                                  'name',
-                                  mtMap.passthrough()
-                                ),
-                                description: mtMap.objectField(
-                                  'description',
-                                  mtMap.passthrough()
-                                ),
-                                metadata: mtMap.objectField(
-                                  'metadata',
-                                  mtMap.passthrough()
-                                ),
-                                providerId: mtMap.objectField(
-                                  'provider_id',
-                                  mtMap.passthrough()
-                                ),
-                                createdAt: mtMap.objectField(
-                                  'created_at',
-                                  mtMap.date()
-                                ),
-                                updatedAt: mtMap.objectField(
-                                  'updated_at',
-                                  mtMap.date()
-                                )
-                              })
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            ),
-                            archivedAt: mtMap.objectField(
-                              'archived_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        config: mtMap.objectField(
-                          'config',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authConfig: mtMap.objectField(
-                          'auth_config',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',
                           mtMap.date()
                         ),
-                        updatedAt: mtMap.objectField(
-                          'updated_at',
-                          mtMap.date()
-                        ),
-                        archivedAt: mtMap.objectField(
-                          'archived_at',
-                          mtMap.date()
-                        )
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ])
-                )
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ])
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-instances/update.ts
@@ -120,302 +120,64 @@ export type DashboardInstanceIntegrationInstancesUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.instance.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authConfig: {
-      object: 'provider.auth_config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
 };
 
-export let mapDashboardInstanceIntegrationInstancesUpdateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      identityActorId: mtMap.objectField(
-        'identity_actor_id',
-        mtMap.passthrough()
-      ),
-      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
+export let mapDashboardInstanceIntegrationInstancesUpdateOutput =
+  mtMap.object<DashboardInstanceIntegrationInstancesUpdateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpServerId: mtMap.objectField(
+          'magic_mcp_server_id',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpServerId: mtMap.objectField(
-            'magic_mcp_server_id',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -424,161 +186,194 @@ export let mapDashboardInstanceIntegrationInstancesUpdateOutput = mtMap.union([
                               'type',
                               mtMap.passthrough()
                             ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
                               mtMap.passthrough()
                             ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
                             )
                           })
                         )
                       ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type DashboardInstanceIntegrationInstancesUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/create.ts
@@ -41,29 +41,6 @@ export type DashboardInstanceIntegrationProvidersCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  object: 'integration.provider';
-  id: string;
-  status: 'active' | 'archived' | 'deleted';
-  integrationId: string;
-  name: string;
-  description: string | null;
-  metadata: Record<string, any> | null;
-  toolFilter:
-    | { type: 'allow_all'; ignoreParentFilters: boolean }
-    | {
-        type: 'filter';
-        filters: (
-          | { type: 'tool_keys'; keys: string[] }
-          | { type: 'tool_regex'; pattern: string }
-          | { type: 'resource_regex'; pattern: string }
-          | { type: 'resource_uris'; uris: string[] }
-          | { type: 'prompt_keys'; keys: string[] }
-          | { type: 'prompt_regex'; pattern: string }
-        )[];
-        ignoreParentFilters: boolean;
-      }
-    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -125,176 +102,169 @@ export type DashboardInstanceIntegrationProvidersCreateOutput = {
   } | null;
 };
 
-export let mapDashboardInstanceIntegrationProvidersCreateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
+export let mapDashboardInstanceIntegrationProvidersCreateOutput =
+  mtMap.object<DashboardInstanceIntegrationProvidersCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
               )
+            )
+          })
+        )
+      ])
+    ),
+    providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+    deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+    authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+    authCredentialsId: mtMap.objectField(
+      'auth_credentials_id',
+      mtMap.passthrough()
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    deployment: mtMap.objectField(
+      'deployment',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authMethod: mtMap.objectField(
+      'auth_method',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        key: mtMap.objectField('key', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+        inputSchema: mtMap.objectField(
+          'input_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        outputSchema: mtMap.objectField(
+          'output_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        scopes: mtMap.objectField(
+          'scopes',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              scope: mtMap.objectField('scope', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField('description', mtMap.passthrough())
             })
           )
-        ])
-      ),
-      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
-      authCredentialsId: mtMap.objectField(
-        'auth_credentials_id',
-        mtMap.passthrough()
-      ),
-      config: mtMap.objectField(
-        'config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      deployment: mtMap.objectField(
-        'deployment',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authMethod: mtMap.objectField(
-        'auth_method',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          key: mtMap.objectField('key', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-          inputSchema: mtMap.objectField(
-            'input_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          outputSchema: mtMap.objectField(
-            'output_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          scopes: mtMap.objectField(
-            'scopes',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                scope: mtMap.objectField('scope', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                )
-              })
-            )
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          providerSpecificationId: mtMap.objectField(
-            'provider_specification_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authCredentials: mtMap.objectField(
-        'auth_credentials',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        providerSpecificationId: mtMap.objectField(
+          'provider_specification_id',
+          mtMap.passthrough()
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authCredentials: mtMap.objectField(
+      'auth_credentials',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    )
+  });
 
 export type DashboardInstanceIntegrationProvidersCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/delete.ts
@@ -41,29 +41,6 @@ export type DashboardInstanceIntegrationProvidersDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  object: 'integration.provider';
-  id: string;
-  status: 'active' | 'archived' | 'deleted';
-  integrationId: string;
-  name: string;
-  description: string | null;
-  metadata: Record<string, any> | null;
-  toolFilter:
-    | { type: 'allow_all'; ignoreParentFilters: boolean }
-    | {
-        type: 'filter';
-        filters: (
-          | { type: 'tool_keys'; keys: string[] }
-          | { type: 'tool_regex'; pattern: string }
-          | { type: 'resource_regex'; pattern: string }
-          | { type: 'resource_uris'; uris: string[] }
-          | { type: 'prompt_keys'; keys: string[] }
-          | { type: 'prompt_regex'; pattern: string }
-        )[];
-        ignoreParentFilters: boolean;
-      }
-    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -125,174 +102,167 @@ export type DashboardInstanceIntegrationProvidersDeleteOutput = {
   } | null;
 };
 
-export let mapDashboardInstanceIntegrationProvidersDeleteOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
+export let mapDashboardInstanceIntegrationProvidersDeleteOutput =
+  mtMap.object<DashboardInstanceIntegrationProvidersDeleteOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
               )
+            )
+          })
+        )
+      ])
+    ),
+    providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+    deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+    authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+    authCredentialsId: mtMap.objectField(
+      'auth_credentials_id',
+      mtMap.passthrough()
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    deployment: mtMap.objectField(
+      'deployment',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authMethod: mtMap.objectField(
+      'auth_method',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        key: mtMap.objectField('key', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+        inputSchema: mtMap.objectField(
+          'input_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        outputSchema: mtMap.objectField(
+          'output_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        scopes: mtMap.objectField(
+          'scopes',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              scope: mtMap.objectField('scope', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField('description', mtMap.passthrough())
             })
           )
-        ])
-      ),
-      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
-      authCredentialsId: mtMap.objectField(
-        'auth_credentials_id',
-        mtMap.passthrough()
-      ),
-      config: mtMap.objectField(
-        'config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      deployment: mtMap.objectField(
-        'deployment',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authMethod: mtMap.objectField(
-        'auth_method',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          key: mtMap.objectField('key', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-          inputSchema: mtMap.objectField(
-            'input_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          outputSchema: mtMap.objectField(
-            'output_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          scopes: mtMap.objectField(
-            'scopes',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                scope: mtMap.objectField('scope', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                )
-              })
-            )
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          providerSpecificationId: mtMap.objectField(
-            'provider_specification_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authCredentials: mtMap.objectField(
-        'auth_credentials',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        providerSpecificationId: mtMap.objectField(
+          'provider_specification_id',
+          mtMap.passthrough()
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authCredentials: mtMap.objectField(
+      'auth_credentials',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    )
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/get.ts
@@ -41,29 +41,6 @@ export type DashboardInstanceIntegrationProvidersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  object: 'integration.provider';
-  id: string;
-  status: 'active' | 'archived' | 'deleted';
-  integrationId: string;
-  name: string;
-  description: string | null;
-  metadata: Record<string, any> | null;
-  toolFilter:
-    | { type: 'allow_all'; ignoreParentFilters: boolean }
-    | {
-        type: 'filter';
-        filters: (
-          | { type: 'tool_keys'; keys: string[] }
-          | { type: 'tool_regex'; pattern: string }
-          | { type: 'resource_regex'; pattern: string }
-          | { type: 'resource_uris'; uris: string[] }
-          | { type: 'prompt_keys'; keys: string[] }
-          | { type: 'prompt_regex'; pattern: string }
-        )[];
-        ignoreParentFilters: boolean;
-      }
-    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -125,174 +102,167 @@ export type DashboardInstanceIntegrationProvidersGetOutput = {
   } | null;
 };
 
-export let mapDashboardInstanceIntegrationProvidersGetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
+export let mapDashboardInstanceIntegrationProvidersGetOutput =
+  mtMap.object<DashboardInstanceIntegrationProvidersGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
               )
+            )
+          })
+        )
+      ])
+    ),
+    providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+    deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+    authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+    authCredentialsId: mtMap.objectField(
+      'auth_credentials_id',
+      mtMap.passthrough()
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    deployment: mtMap.objectField(
+      'deployment',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authMethod: mtMap.objectField(
+      'auth_method',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        key: mtMap.objectField('key', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+        inputSchema: mtMap.objectField(
+          'input_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        outputSchema: mtMap.objectField(
+          'output_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        scopes: mtMap.objectField(
+          'scopes',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              scope: mtMap.objectField('scope', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField('description', mtMap.passthrough())
             })
           )
-        ])
-      ),
-      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
-      authCredentialsId: mtMap.objectField(
-        'auth_credentials_id',
-        mtMap.passthrough()
-      ),
-      config: mtMap.objectField(
-        'config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      deployment: mtMap.objectField(
-        'deployment',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authMethod: mtMap.objectField(
-        'auth_method',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          key: mtMap.objectField('key', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-          inputSchema: mtMap.objectField(
-            'input_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          outputSchema: mtMap.objectField(
-            'output_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          scopes: mtMap.objectField(
-            'scopes',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                scope: mtMap.objectField('scope', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                )
-              })
-            )
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          providerSpecificationId: mtMap.objectField(
-            'provider_specification_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authCredentials: mtMap.objectField(
-        'auth_credentials',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        providerSpecificationId: mtMap.objectField(
+          'provider_specification_id',
+          mtMap.passthrough()
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authCredentials: mtMap.objectField(
+      'auth_credentials',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    )
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceIntegrationProvidersListOutput = {
-  items: ({
+  items: {
     object: 'integration.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -42,29 +42,6 @@ export type DashboardInstanceIntegrationProvidersListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -124,7 +101,7 @@ export type DashboardInstanceIntegrationProvidersListOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -133,239 +110,201 @@ export let mapDashboardInstanceIntegrationProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
+            mtMap.passthrough()
+          ),
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
+            mtMap.passthrough()
+          ),
+          config: mtMap.objectField(
+            'config',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
                 'description',
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          deployment: mtMap.objectField(
+            'deployment',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authMethod: mtMap.objectField(
+            'auth_method',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              key: mtMap.objectField('key', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              capabilities: mtMap.objectField(
+                'capabilities',
+                mtMap.passthrough()
+              ),
+              inputSchema: mtMap.objectField(
+                'input_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              outputSchema: mtMap.objectField(
+                'output_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    )
+                  })
+                )
               ),
               providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              deploymentId: mtMap.objectField(
-                'deployment_id',
+              providerSpecificationId: mtMap.objectField(
+                'provider_specification_id',
                 mtMap.passthrough()
-              ),
-              authMethodId: mtMap.objectField(
-                'auth_method_id',
-                mtMap.passthrough()
-              ),
-              authCredentialsId: mtMap.objectField(
-                'auth_credentials_id',
-                mtMap.passthrough()
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authCredentials: mtMap.objectField(
+            'auth_credentials',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
               ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(mtMap.passthrough())
               ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              )
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
           )
-        ])
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-providers/update.ts
@@ -41,29 +41,6 @@ export type DashboardInstanceIntegrationProvidersUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  object: 'integration.provider';
-  id: string;
-  status: 'active' | 'archived' | 'deleted';
-  integrationId: string;
-  name: string;
-  description: string | null;
-  metadata: Record<string, any> | null;
-  toolFilter:
-    | { type: 'allow_all'; ignoreParentFilters: boolean }
-    | {
-        type: 'filter';
-        filters: (
-          | { type: 'tool_keys'; keys: string[] }
-          | { type: 'tool_regex'; pattern: string }
-          | { type: 'resource_regex'; pattern: string }
-          | { type: 'resource_uris'; uris: string[] }
-          | { type: 'prompt_keys'; keys: string[] }
-          | { type: 'prompt_regex'; pattern: string }
-        )[];
-        ignoreParentFilters: boolean;
-      }
-    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -125,176 +102,169 @@ export type DashboardInstanceIntegrationProvidersUpdateOutput = {
   } | null;
 };
 
-export let mapDashboardInstanceIntegrationProvidersUpdateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
+export let mapDashboardInstanceIntegrationProvidersUpdateOutput =
+  mtMap.object<DashboardInstanceIntegrationProvidersUpdateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
               )
+            )
+          })
+        )
+      ])
+    ),
+    providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+    deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+    authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+    authCredentialsId: mtMap.objectField(
+      'auth_credentials_id',
+      mtMap.passthrough()
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    deployment: mtMap.objectField(
+      'deployment',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authMethod: mtMap.objectField(
+      'auth_method',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        key: mtMap.objectField('key', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+        inputSchema: mtMap.objectField(
+          'input_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        outputSchema: mtMap.objectField(
+          'output_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        scopes: mtMap.objectField(
+          'scopes',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              scope: mtMap.objectField('scope', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField('description', mtMap.passthrough())
             })
           )
-        ])
-      ),
-      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
-      authCredentialsId: mtMap.objectField(
-        'auth_credentials_id',
-        mtMap.passthrough()
-      ),
-      config: mtMap.objectField(
-        'config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      deployment: mtMap.objectField(
-        'deployment',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authMethod: mtMap.objectField(
-        'auth_method',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          key: mtMap.objectField('key', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-          inputSchema: mtMap.objectField(
-            'input_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          outputSchema: mtMap.objectField(
-            'output_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          scopes: mtMap.objectField(
-            'scopes',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                scope: mtMap.objectField('scope', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                )
-              })
-            )
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          providerSpecificationId: mtMap.objectField(
-            'provider_specification_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authCredentials: mtMap.objectField(
-        'auth_credentials',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        providerSpecificationId: mtMap.objectField(
+          'provider_specification_id',
+          mtMap.passthrough()
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authCredentials: mtMap.objectField(
+      'auth_credentials',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    )
+  });
 
 export type DashboardInstanceIntegrationProvidersUpdateBody = {
   providerDeploymentId?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-setup-sessions/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-setup-sessions/create.ts
@@ -138,7 +138,6 @@ export type DashboardInstanceIntegrationSetupSessionsCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   expiresAt: Date;
-} & {
   integrationInstanceId: string;
   steps: {
     object: 'integration.setup_session.step';
@@ -170,54 +169,138 @@ export type DashboardInstanceIntegrationSetupSessionsCreateOutput = {
 };
 
 export let mapDashboardInstanceIntegrationSetupSessionsCreateOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<DashboardInstanceIntegrationSetupSessionsCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    url: mtMap.objectField('url', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField('configuration', mtMap.passthrough()),
+    redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstance: mtMap.objectField(
+      'integration_instance',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
         status: mtMap.objectField('status', mtMap.passthrough()),
-        url: mtMap.objectField('url', mtMap.passthrough()),
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        configuration: mtMap.objectField('configuration', mtMap.passthrough()),
-        redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstance: mtMap.objectField(
-          'integration_instance',
+        identityActorId: mtMap.objectField(
+          'identity_actor_id',
+          mtMap.passthrough()
+        ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        implementation: mtMap.objectField(
+          'implementation',
           mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            integrationId: mtMap.objectField(
-              'integration_id',
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
               mtMap.passthrough()
-            ),
-            identityActorId: mtMap.objectField(
-              'identity_actor_id',
-              mtMap.passthrough()
-            ),
-            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-            implementation: mtMap.objectField(
-              'implementation',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                magicMcpServerId: mtMap.objectField(
-                  'magic_mcp_server_id',
-                  mtMap.passthrough()
-                )
-              })
-            ),
-            providers: mtMap.objectField(
-              'providers',
-              mtMap.array(
+            )
+          })
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              isOverrideToolFilter: mtMap.objectField(
+                'is_override_tool_filter',
+                mtMap.passthrough()
+              ),
+              provider: mtMap.objectField(
+                'provider',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              integrationProvider: mtMap.objectField(
+                'integration_provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  providerVersion: mtMap.objectField(
+                    'provider_version',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      index: mtMap.objectField('index', mtMap.passthrough())
+                    })
+                  ),
                   status: mtMap.objectField('status', mtMap.passthrough()),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
@@ -225,14 +308,6 @@ export let mapDashboardInstanceIntegrationSetupSessionsCreateOutput =
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  integrationId: mtMap.objectField(
-                    'integration_id',
-                    mtMap.passthrough()
-                  ),
-                  integrationInstanceId: mtMap.objectField(
-                    'integration_instance_id',
-                    mtMap.passthrough()
-                  ),
                   toolFilter: mtMap.objectField(
                     'tool_filter',
                     mtMap.union([
@@ -276,181 +351,24 @@ export let mapDashboardInstanceIntegrationSetupSessionsCreateOutput =
                       )
                     ])
                   ),
-                  isOverrideToolFilter: mtMap.objectField(
-                    'is_override_tool_filter',
+                  providerId: mtMap.objectField(
+                    'provider_id',
                     mtMap.passthrough()
                   ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  deploymentId: mtMap.objectField(
+                    'deployment_id',
+                    mtMap.passthrough()
                   ),
-                  integrationProvider: mtMap.objectField(
-                    'integration_provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      providerVersion: mtMap.objectField(
-                        'provider_version',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          index: mtMap.objectField('index', mtMap.passthrough())
-                        })
-                      ),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      toolFilter: mtMap.objectField(
-                        'tool_filter',
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              ignoreParentFilters: mtMap.objectField(
-                                'ignore_parent_filters',
-                                mtMap.passthrough()
-                              ),
-                              filters: mtMap.objectField(
-                                'filters',
-                                mtMap.array(
-                                  mtMap.union([
-                                    mtMap.unionOption(
-                                      'object',
-                                      mtMap.object({
-                                        type: mtMap.objectField(
-                                          'type',
-                                          mtMap.passthrough()
-                                        ),
-                                        keys: mtMap.objectField(
-                                          'keys',
-                                          mtMap.array(mtMap.passthrough())
-                                        ),
-                                        pattern: mtMap.objectField(
-                                          'pattern',
-                                          mtMap.passthrough()
-                                        ),
-                                        uris: mtMap.objectField(
-                                          'uris',
-                                          mtMap.array(mtMap.passthrough())
-                                        )
-                                      })
-                                    )
-                                  ])
-                                )
-                              )
-                            })
-                          )
-                        ])
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      deploymentId: mtMap.objectField(
-                        'deployment_id',
-                        mtMap.passthrough()
-                      ),
-                      authMethodId: mtMap.objectField(
-                        'auth_method_id',
-                        mtMap.passthrough()
-                      ),
-                      authCredentialsId: mtMap.objectField(
-                        'auth_credentials_id',
-                        mtMap.passthrough()
-                      ),
-                      config: mtMap.objectField(
-                        'config',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          isDefault: mtMap.objectField(
-                            'is_default',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          ),
-                          metadata: mtMap.objectField(
-                            'metadata',
-                            mtMap.passthrough()
-                          ),
-                          providerId: mtMap.objectField(
-                            'provider_id',
-                            mtMap.passthrough()
-                          ),
-                          createdAt: mtMap.objectField(
-                            'created_at',
-                            mtMap.date()
-                          ),
-                          updatedAt: mtMap.objectField(
-                            'updated_at',
-                            mtMap.date()
-                          )
-                        })
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                    })
+                  authMethodId: mtMap.objectField(
+                    'auth_method_id',
+                    mtMap.passthrough()
+                  ),
+                  authCredentialsId: mtMap.objectField(
+                    'auth_credentials_id',
+                    mtMap.passthrough()
                   ),
                   config: mtMap.objectField(
                     'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authConfig: mtMap.objectField(
-                    'auth_config',
                     mtMap.object({
                       object: mtMap.objectField('object', mtMap.passthrough()),
                       id: mtMap.objectField('id', mtMap.passthrough()),
@@ -479,63 +397,112 @@ export let mapDashboardInstanceIntegrationSetupSessionsCreateOutput =
                   updatedAt: mtMap.objectField('updated_at', mtMap.date()),
                   archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
-              )
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        expiresAt: mtMap.objectField('expires_at', mtMap.date()),
-        integrationInstanceId: mtMap.objectField(
-          'integration_instance_id',
-          mtMap.passthrough()
-        ),
-        steps: mtMap.objectField(
-          'steps',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              url: mtMap.objectField('url', mtMap.passthrough()),
-              integrationProviderId: mtMap.objectField(
-                'integration_provider_id',
-                mtMap.passthrough()
               ),
-              provider: mtMap.objectField(
-                'provider',
+              config: mtMap.objectField(
+                'config',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
                   ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
               ),
-              providerSetupSessionId: mtMap.objectField(
-                'provider_setup_session_id',
+              authConfig: mtMap.objectField(
+                'auth_config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    steps: mtMap.objectField(
+      'steps',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          url: mtMap.objectField('url', mtMap.passthrough()),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              integrationInstanceProviderId: mtMap.objectField(
-                'integration_instance_provider_id',
-                mtMap.passthrough()
-              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          )
-        )
-      })
+          ),
+          providerSetupSessionId: mtMap.objectField(
+            'provider_setup_session_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
     )
-  ]);
+  });
 
 export type DashboardInstanceIntegrationSetupSessionsCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-setup-sessions/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-setup-sessions/get.ts
@@ -138,7 +138,6 @@ export type DashboardInstanceIntegrationSetupSessionsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   expiresAt: Date;
-} & {
   integrationInstanceId: string;
   steps: {
     object: 'integration.setup_session.step';
@@ -169,367 +168,339 @@ export type DashboardInstanceIntegrationSetupSessionsGetOutput = {
   }[];
 };
 
-export let mapDashboardInstanceIntegrationSetupSessionsGetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      url: mtMap.objectField('url', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField('configuration', mtMap.passthrough()),
-      redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      integrationInstance: mtMap.objectField(
-        'integration_instance',
+export let mapDashboardInstanceIntegrationSetupSessionsGetOutput =
+  mtMap.object<DashboardInstanceIntegrationSetupSessionsGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    url: mtMap.objectField('url', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField('configuration', mtMap.passthrough()),
+    redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstance: mtMap.objectField(
+      'integration_instance',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        identityActorId: mtMap.objectField(
+          'identity_actor_id',
+          mtMap.passthrough()
+        ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        implementation: mtMap.objectField(
+          'implementation',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
+              mtMap.passthrough()
+            )
+          })
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              isOverrideToolFilter: mtMap.objectField(
+                'is_override_tool_filter',
+                mtMap.passthrough()
+              ),
+              provider: mtMap.objectField(
+                'provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              integrationProvider: mtMap.objectField(
+                'integration_provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  providerVersion: mtMap.objectField(
+                    'provider_version',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      index: mtMap.objectField('index', mtMap.passthrough())
+                    })
+                  ),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  toolFilter: mtMap.objectField(
+                    'tool_filter',
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          ignoreParentFilters: mtMap.objectField(
+                            'ignore_parent_filters',
+                            mtMap.passthrough()
+                          ),
+                          filters: mtMap.objectField(
+                            'filters',
+                            mtMap.array(
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    keys: mtMap.objectField(
+                                      'keys',
+                                      mtMap.array(mtMap.passthrough())
+                                    ),
+                                    pattern: mtMap.objectField(
+                                      'pattern',
+                                      mtMap.passthrough()
+                                    ),
+                                    uris: mtMap.objectField(
+                                      'uris',
+                                      mtMap.array(mtMap.passthrough())
+                                    )
+                                  })
+                                )
+                              ])
+                            )
+                          )
+                        })
+                      )
+                    ])
+                  ),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  deploymentId: mtMap.objectField(
+                    'deployment_id',
+                    mtMap.passthrough()
+                  ),
+                  authMethodId: mtMap.objectField(
+                    'auth_method_id',
+                    mtMap.passthrough()
+                  ),
+                  authCredentialsId: mtMap.objectField(
+                    'auth_credentials_id',
+                    mtMap.passthrough()
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                })
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              authConfig: mtMap.objectField(
+                'auth_config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    steps: mtMap.objectField(
+      'steps',
+      mtMap.array(
         mtMap.object({
           object: mtMap.objectField('object', mtMap.passthrough()),
           id: mtMap.objectField('id', mtMap.passthrough()),
           status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          url: mtMap.objectField('url', mtMap.passthrough()),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
             mtMap.passthrough()
           ),
-          identityActorId: mtMap.objectField(
-            'identity_actor_id',
-            mtMap.passthrough()
-          ),
-          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-          implementation: mtMap.objectField(
-            'implementation',
+          provider: mtMap.objectField(
+            'provider',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
-              )
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
           ),
-          providers: mtMap.objectField(
-            'providers',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
+          providerSetupSessionId: mtMap.objectField(
+            'provider_setup_session_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
           ),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
         })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      expiresAt: mtMap.objectField('expires_at', mtMap.date()),
-      integrationInstanceId: mtMap.objectField(
-        'integration_instance_id',
-        mtMap.passthrough()
-      ),
-      steps: mtMap.objectField(
-        'steps',
-        mtMap.array(
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            url: mtMap.objectField('url', mtMap.passthrough()),
-            integrationProviderId: mtMap.objectField(
-              'integration_provider_id',
-              mtMap.passthrough()
-            ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            providerSetupSessionId: mtMap.objectField(
-              'provider_setup_session_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceProviderId: mtMap.objectField(
-              'integration_instance_provider_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        )
       )
-    })
-  )
-]);
+    )
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-setup-sessions/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integration-setup-sessions/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceIntegrationSetupSessionsListOutput = {
-  items: ({
+  items: {
     object: 'integration.setup_session';
     id: string;
     status: 'pending' | 'successful' | 'expired' | 'archived' | 'deleted';
@@ -139,7 +139,6 @@ export type DashboardInstanceIntegrationSetupSessionsListOutput = {
     createdAt: Date;
     updatedAt: Date;
     expiresAt: Date;
-  } & {
     integrationInstanceId: string;
     steps: {
       object: 'integration.setup_session.step';
@@ -168,7 +167,7 @@ export type DashboardInstanceIntegrationSetupSessionsListOutput = {
       createdAt: Date;
       updatedAt: Date;
     }[];
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -177,75 +176,171 @@ export let mapDashboardInstanceIntegrationSetupSessionsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          url: mtMap.objectField('url', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          configuration: mtMap.objectField(
+            'configuration',
+            mtMap.passthrough()
+          ),
+          redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstance: mtMap.objectField(
+            'integration_instance',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
               status: mtMap.objectField('status', mtMap.passthrough()),
-              url: mtMap.objectField('url', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
                 'description',
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              configuration: mtMap.objectField(
-                'configuration',
-                mtMap.passthrough()
-              ),
-              redirectUrl: mtMap.objectField(
-                'redirect_url',
-                mtMap.passthrough()
-              ),
               integrationId: mtMap.objectField(
                 'integration_id',
                 mtMap.passthrough()
               ),
-              integrationInstance: mtMap.objectField(
-                'integration_instance',
+              identityActorId: mtMap.objectField(
+                'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              implementation: mtMap.objectField(
+                'implementation',
                 mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  magicMcpServerId: mtMap.objectField(
+                    'magic_mcp_server_id',
                     mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  integrationId: mtMap.objectField(
-                    'integration_id',
-                    mtMap.passthrough()
-                  ),
-                  identityActorId: mtMap.objectField(
-                    'identity_actor_id',
-                    mtMap.passthrough()
-                  ),
-                  identityId: mtMap.objectField(
-                    'identity_id',
-                    mtMap.passthrough()
-                  ),
-                  implementation: mtMap.objectField(
-                    'implementation',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      magicMcpServerId: mtMap.objectField(
-                        'magic_mcp_server_id',
-                        mtMap.passthrough()
-                      )
-                    })
-                  ),
-                  providers: mtMap.objectField(
-                    'providers',
-                    mtMap.array(
+                  )
+                })
+              ),
+              providers: mtMap.objectField(
+                'providers',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    integrationId: mtMap.objectField(
+                      'integration_id',
+                      mtMap.passthrough()
+                    ),
+                    integrationInstanceId: mtMap.objectField(
+                      'integration_instance_id',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
+                              mtMap.passthrough()
+                            ),
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
+                            )
+                          })
+                        )
+                      ])
+                    ),
+                    isOverrideToolFilter: mtMap.objectField(
+                      'is_override_tool_filter',
+                      mtMap.passthrough()
+                    ),
+                    provider: mtMap.objectField(
+                      'provider',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        ),
+                        slug: mtMap.objectField('slug', mtMap.passthrough()),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    ),
+                    integrationProvider: mtMap.objectField(
+                      'integration_provider',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        providerVersion: mtMap.objectField(
+                          'provider_version',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            index: mtMap.objectField(
+                              'index',
+                              mtMap.passthrough()
+                            )
+                          })
+                        ),
                         status: mtMap.objectField(
                           'status',
                           mtMap.passthrough()
@@ -257,14 +352,6 @@ export let mapDashboardInstanceIntegrationSetupSessionsListOutput =
                         ),
                         metadata: mtMap.objectField(
                           'metadata',
-                          mtMap.passthrough()
-                        ),
-                        integrationId: mtMap.objectField(
-                          'integration_id',
-                          mtMap.passthrough()
-                        ),
-                        integrationInstanceId: mtMap.objectField(
-                          'integration_instance_id',
                           mtMap.passthrough()
                         ),
                         toolFilter: mtMap.objectField(
@@ -313,238 +400,24 @@ export let mapDashboardInstanceIntegrationSetupSessionsListOutput =
                             )
                           ])
                         ),
-                        isOverrideToolFilter: mtMap.objectField(
-                          'is_override_tool_filter',
+                        providerId: mtMap.objectField(
+                          'provider_id',
                           mtMap.passthrough()
                         ),
-                        provider: mtMap.objectField(
-                          'provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            slug: mtMap.objectField(
-                              'slug',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
+                        deploymentId: mtMap.objectField(
+                          'deployment_id',
+                          mtMap.passthrough()
                         ),
-                        integrationProvider: mtMap.objectField(
-                          'integration_provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            providerVersion: mtMap.objectField(
-                              'provider_version',
-                              mtMap.object({
-                                object: mtMap.objectField(
-                                  'object',
-                                  mtMap.passthrough()
-                                ),
-                                id: mtMap.objectField(
-                                  'id',
-                                  mtMap.passthrough()
-                                ),
-                                index: mtMap.objectField(
-                                  'index',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            status: mtMap.objectField(
-                              'status',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            toolFilter: mtMap.objectField(
-                              'tool_filter',
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    ignoreParentFilters: mtMap.objectField(
-                                      'ignore_parent_filters',
-                                      mtMap.passthrough()
-                                    ),
-                                    filters: mtMap.objectField(
-                                      'filters',
-                                      mtMap.array(
-                                        mtMap.union([
-                                          mtMap.unionOption(
-                                            'object',
-                                            mtMap.object({
-                                              type: mtMap.objectField(
-                                                'type',
-                                                mtMap.passthrough()
-                                              ),
-                                              keys: mtMap.objectField(
-                                                'keys',
-                                                mtMap.array(mtMap.passthrough())
-                                              ),
-                                              pattern: mtMap.objectField(
-                                                'pattern',
-                                                mtMap.passthrough()
-                                              ),
-                                              uris: mtMap.objectField(
-                                                'uris',
-                                                mtMap.array(mtMap.passthrough())
-                                              )
-                                            })
-                                          )
-                                        ])
-                                      )
-                                    )
-                                  })
-                                )
-                              ])
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            deploymentId: mtMap.objectField(
-                              'deployment_id',
-                              mtMap.passthrough()
-                            ),
-                            authMethodId: mtMap.objectField(
-                              'auth_method_id',
-                              mtMap.passthrough()
-                            ),
-                            authCredentialsId: mtMap.objectField(
-                              'auth_credentials_id',
-                              mtMap.passthrough()
-                            ),
-                            config: mtMap.objectField(
-                              'config',
-                              mtMap.object({
-                                object: mtMap.objectField(
-                                  'object',
-                                  mtMap.passthrough()
-                                ),
-                                id: mtMap.objectField(
-                                  'id',
-                                  mtMap.passthrough()
-                                ),
-                                isDefault: mtMap.objectField(
-                                  'is_default',
-                                  mtMap.passthrough()
-                                ),
-                                name: mtMap.objectField(
-                                  'name',
-                                  mtMap.passthrough()
-                                ),
-                                description: mtMap.objectField(
-                                  'description',
-                                  mtMap.passthrough()
-                                ),
-                                metadata: mtMap.objectField(
-                                  'metadata',
-                                  mtMap.passthrough()
-                                ),
-                                providerId: mtMap.objectField(
-                                  'provider_id',
-                                  mtMap.passthrough()
-                                ),
-                                createdAt: mtMap.objectField(
-                                  'created_at',
-                                  mtMap.date()
-                                ),
-                                updatedAt: mtMap.objectField(
-                                  'updated_at',
-                                  mtMap.date()
-                                )
-                              })
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            ),
-                            archivedAt: mtMap.objectField(
-                              'archived_at',
-                              mtMap.date()
-                            )
-                          })
+                        authMethodId: mtMap.objectField(
+                          'auth_method_id',
+                          mtMap.passthrough()
+                        ),
+                        authCredentialsId: mtMap.objectField(
+                          'auth_credentials_id',
+                          mtMap.passthrough()
                         ),
                         config: mtMap.objectField(
                           'config',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authConfig: mtMap.objectField(
-                          'auth_config',
                           mtMap.object({
                             object: mtMap.objectField(
                               'object',
@@ -594,46 +467,32 @@ export let mapDashboardInstanceIntegrationSetupSessionsListOutput =
                           mtMap.date()
                         )
                       })
-                    )
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              expiresAt: mtMap.objectField('expires_at', mtMap.date()),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              steps: mtMap.objectField(
-                'steps',
-                mtMap.array(
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    url: mtMap.objectField('url', mtMap.passthrough()),
-                    integrationProviderId: mtMap.objectField(
-                      'integration_provider_id',
-                      mtMap.passthrough()
                     ),
-                    provider: mtMap.objectField(
-                      'provider',
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
                         ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
                         createdAt: mtMap.objectField(
                           'created_at',
                           mtMap.date()
@@ -641,22 +500,97 @@ export let mapDashboardInstanceIntegrationSetupSessionsListOutput =
                         updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
                     ),
-                    providerSetupSessionId: mtMap.objectField(
-                      'provider_setup_session_id',
+                    authConfig: mtMap.objectField(
+                      'auth_config',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                )
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          steps: mtMap.objectField(
+            'steps',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough()),
+                integrationProviderId: mtMap.objectField(
+                  'integration_provider_id',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
                       mtMap.passthrough()
                     ),
-                    integrationInstanceProviderId: mtMap.objectField(
-                      'integration_instance_provider_id',
-                      mtMap.passthrough()
-                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
                     createdAt: mtMap.objectField('created_at', mtMap.date()),
                     updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
-                )
-              )
-            })
+                ),
+                providerSetupSessionId: mtMap.objectField(
+                  'provider_setup_session_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceProviderId: mtMap.objectField(
+                  'integration_instance_provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            )
           )
-        ])
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/create.ts
@@ -58,75 +58,6 @@ export type DashboardInstanceIntegrationsCreateOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -186,315 +117,261 @@ export type DashboardInstanceIntegrationsCreateOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
 };
 
-export let mapDashboardInstanceIntegrationsCreateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      slug: mtMap.objectField('slug', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField(
-        'configuration',
+export let mapDashboardInstanceIntegrationsCreateOutput =
+  mtMap.object<DashboardInstanceIntegrationsCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    slug: mtMap.objectField('slug', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField(
+      'configuration',
+      mtMap.object({
+        canAttachCustomToolFilters: mtMap.objectField(
+          'can_attach_custom_tool_filters',
+          mtMap.passthrough()
+        ),
+        canAttachCustomProviderConfig: mtMap.objectField(
+          'can_attach_custom_provider_config',
+          mtMap.passthrough()
+        ),
+        canOverrideToolFilters: mtMap.objectField(
+          'can_override_tool_filters',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            providerTemplateId: mtMap.objectField(
+              'provider_template_id',
+              mtMap.passthrough()
+            ),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
+              mtMap.passthrough()
+            )
+          })
+        )
+      ])
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          canAttachCustomToolFilters: mtMap.objectField(
-            'can_attach_custom_tool_filters',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
           ),
-          canAttachCustomProviderConfig: mtMap.objectField(
-            'can_attach_custom_provider_config',
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
             mtMap.passthrough()
           ),
-          canOverrideToolFilters: mtMap.objectField(
-            'can_override_tool_filters',
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+          ),
+          config: mtMap.objectField(
+            'config',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              providerTemplateId: mtMap.objectField(
-                'provider_template_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
-                mtMap.passthrough()
-              )
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          )
-        ])
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          deployment: mtMap.objectField(
+            'deployment',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authMethod: mtMap.objectField(
+            'auth_method',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              key: mtMap.objectField('key', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              capabilities: mtMap.objectField(
+                'capabilities',
+                mtMap.passthrough()
+              ),
+              inputSchema: mtMap.objectField(
+                'input_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              outputSchema: mtMap.objectField(
+                'output_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
                     )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                deployment: mtMap.objectField(
-                  'deployment',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authMethod: mtMap.objectField(
-                  'auth_method',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    key: mtMap.objectField('key', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    capabilities: mtMap.objectField(
-                      'capabilities',
-                      mtMap.passthrough()
-                    ),
-                    inputSchema: mtMap.objectField(
-                      'input_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    outputSchema: mtMap.objectField(
-                      'output_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          scope: mtMap.objectField(
-                            'scope',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          )
-                        })
-                      )
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    providerSpecificationId: mtMap.objectField(
-                      'provider_specification_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authCredentials: mtMap.objectField(
-                  'auth_credentials',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    isManaged: mtMap.objectField(
-                      'is_managed',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(mtMap.passthrough())
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              providerSpecificationId: mtMap.objectField(
+                'provider_specification_id',
+                mtMap.passthrough()
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authCredentials: mtMap.objectField(
+            'auth_credentials',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(mtMap.passthrough())
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          )
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type DashboardInstanceIntegrationsCreateBody = {
   name: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/delete.ts
@@ -58,75 +58,6 @@ export type DashboardInstanceIntegrationsDeleteOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -186,313 +117,259 @@ export type DashboardInstanceIntegrationsDeleteOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
 };
 
-export let mapDashboardInstanceIntegrationsDeleteOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      slug: mtMap.objectField('slug', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField(
-        'configuration',
+export let mapDashboardInstanceIntegrationsDeleteOutput =
+  mtMap.object<DashboardInstanceIntegrationsDeleteOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    slug: mtMap.objectField('slug', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField(
+      'configuration',
+      mtMap.object({
+        canAttachCustomToolFilters: mtMap.objectField(
+          'can_attach_custom_tool_filters',
+          mtMap.passthrough()
+        ),
+        canAttachCustomProviderConfig: mtMap.objectField(
+          'can_attach_custom_provider_config',
+          mtMap.passthrough()
+        ),
+        canOverrideToolFilters: mtMap.objectField(
+          'can_override_tool_filters',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            providerTemplateId: mtMap.objectField(
+              'provider_template_id',
+              mtMap.passthrough()
+            ),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
+              mtMap.passthrough()
+            )
+          })
+        )
+      ])
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          canAttachCustomToolFilters: mtMap.objectField(
-            'can_attach_custom_tool_filters',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
           ),
-          canAttachCustomProviderConfig: mtMap.objectField(
-            'can_attach_custom_provider_config',
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
             mtMap.passthrough()
           ),
-          canOverrideToolFilters: mtMap.objectField(
-            'can_override_tool_filters',
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+          ),
+          config: mtMap.objectField(
+            'config',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              providerTemplateId: mtMap.objectField(
-                'provider_template_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
-                mtMap.passthrough()
-              )
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          )
-        ])
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          deployment: mtMap.objectField(
+            'deployment',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authMethod: mtMap.objectField(
+            'auth_method',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              key: mtMap.objectField('key', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              capabilities: mtMap.objectField(
+                'capabilities',
+                mtMap.passthrough()
+              ),
+              inputSchema: mtMap.objectField(
+                'input_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              outputSchema: mtMap.objectField(
+                'output_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
                     )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                deployment: mtMap.objectField(
-                  'deployment',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authMethod: mtMap.objectField(
-                  'auth_method',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    key: mtMap.objectField('key', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    capabilities: mtMap.objectField(
-                      'capabilities',
-                      mtMap.passthrough()
-                    ),
-                    inputSchema: mtMap.objectField(
-                      'input_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    outputSchema: mtMap.objectField(
-                      'output_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          scope: mtMap.objectField(
-                            'scope',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          )
-                        })
-                      )
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    providerSpecificationId: mtMap.objectField(
-                      'provider_specification_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authCredentials: mtMap.objectField(
-                  'auth_credentials',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    isManaged: mtMap.objectField(
-                      'is_managed',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(mtMap.passthrough())
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              providerSpecificationId: mtMap.objectField(
+                'provider_specification_id',
+                mtMap.passthrough()
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authCredentials: mtMap.objectField(
+            'auth_credentials',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(mtMap.passthrough())
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          )
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/get.ts
@@ -58,75 +58,6 @@ export type DashboardInstanceIntegrationsGetOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -186,313 +117,259 @@ export type DashboardInstanceIntegrationsGetOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
 };
 
-export let mapDashboardInstanceIntegrationsGetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      slug: mtMap.objectField('slug', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField(
-        'configuration',
+export let mapDashboardInstanceIntegrationsGetOutput =
+  mtMap.object<DashboardInstanceIntegrationsGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    slug: mtMap.objectField('slug', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField(
+      'configuration',
+      mtMap.object({
+        canAttachCustomToolFilters: mtMap.objectField(
+          'can_attach_custom_tool_filters',
+          mtMap.passthrough()
+        ),
+        canAttachCustomProviderConfig: mtMap.objectField(
+          'can_attach_custom_provider_config',
+          mtMap.passthrough()
+        ),
+        canOverrideToolFilters: mtMap.objectField(
+          'can_override_tool_filters',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            providerTemplateId: mtMap.objectField(
+              'provider_template_id',
+              mtMap.passthrough()
+            ),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
+              mtMap.passthrough()
+            )
+          })
+        )
+      ])
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          canAttachCustomToolFilters: mtMap.objectField(
-            'can_attach_custom_tool_filters',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
           ),
-          canAttachCustomProviderConfig: mtMap.objectField(
-            'can_attach_custom_provider_config',
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
             mtMap.passthrough()
           ),
-          canOverrideToolFilters: mtMap.objectField(
-            'can_override_tool_filters',
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+          ),
+          config: mtMap.objectField(
+            'config',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              providerTemplateId: mtMap.objectField(
-                'provider_template_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
-                mtMap.passthrough()
-              )
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          )
-        ])
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          deployment: mtMap.objectField(
+            'deployment',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authMethod: mtMap.objectField(
+            'auth_method',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              key: mtMap.objectField('key', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              capabilities: mtMap.objectField(
+                'capabilities',
+                mtMap.passthrough()
+              ),
+              inputSchema: mtMap.objectField(
+                'input_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              outputSchema: mtMap.objectField(
+                'output_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
                     )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                deployment: mtMap.objectField(
-                  'deployment',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authMethod: mtMap.objectField(
-                  'auth_method',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    key: mtMap.objectField('key', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    capabilities: mtMap.objectField(
-                      'capabilities',
-                      mtMap.passthrough()
-                    ),
-                    inputSchema: mtMap.objectField(
-                      'input_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    outputSchema: mtMap.objectField(
-                      'output_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          scope: mtMap.objectField(
-                            'scope',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          )
-                        })
-                      )
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    providerSpecificationId: mtMap.objectField(
-                      'provider_specification_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authCredentials: mtMap.objectField(
-                  'auth_credentials',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    isManaged: mtMap.objectField(
-                      'is_managed',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(mtMap.passthrough())
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              providerSpecificationId: mtMap.objectField(
+                'provider_specification_id',
+                mtMap.passthrough()
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authCredentials: mtMap.objectField(
+            'auth_credentials',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(mtMap.passthrough())
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          )
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceIntegrationsListOutput = {
-  items: ({
+  items: {
     object: 'integration';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -59,75 +59,6 @@ export type DashboardInstanceIntegrationsListOutput = {
       createdAt: Date;
       updatedAt: Date;
       archivedAt: Date | null;
-    }[];
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    providers: ({
-      object: 'integration.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      integrationId: string;
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } & {
-      object: 'integration.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      integrationId: string;
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
       provider: {
         object: 'provider#preview';
         id: string;
@@ -193,8 +124,11 @@ export type DashboardInstanceIntegrationsListOutput = {
         createdAt: Date;
         updatedAt: Date;
       } | null;
-    })[];
-  })[];
+    }[];
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -203,426 +137,302 @@ export let mapDashboardInstanceIntegrationsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          configuration: mtMap.objectField(
+            'configuration',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              canAttachCustomToolFilters: mtMap.objectField(
+                'can_attach_custom_tool_filters',
                 mtMap.passthrough()
               ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              configuration: mtMap.objectField(
-                'configuration',
+              canAttachCustomProviderConfig: mtMap.objectField(
+                'can_attach_custom_provider_config',
+                mtMap.passthrough()
+              ),
+              canOverrideToolFilters: mtMap.objectField(
+                'can_override_tool_filters',
+                mtMap.passthrough()
+              )
+            })
+          ),
+          implementation: mtMap.objectField(
+            'implementation',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
                 mtMap.object({
-                  canAttachCustomToolFilters: mtMap.objectField(
-                    'can_attach_custom_tool_filters',
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  providerTemplateId: mtMap.objectField(
+                    'provider_template_id',
                     mtMap.passthrough()
                   ),
-                  canAttachCustomProviderConfig: mtMap.objectField(
-                    'can_attach_custom_provider_config',
-                    mtMap.passthrough()
-                  ),
-                  canOverrideToolFilters: mtMap.objectField(
-                    'can_override_tool_filters',
+                  magicMcpServerId: mtMap.objectField(
+                    'magic_mcp_server_id',
                     mtMap.passthrough()
                   )
                 })
-              ),
-              implementation: mtMap.objectField(
-                'implementation',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      providerTemplateId: mtMap.objectField(
-                        'provider_template_id',
-                        mtMap.passthrough()
-                      ),
-                      magicMcpServerId: mtMap.objectField(
-                        'magic_mcp_server_id',
-                        mtMap.passthrough()
-                      )
-                    })
-                  )
-                ])
-              ),
-              providers: mtMap.objectField(
-                'providers',
-                mtMap.array(
+              )
+            ])
+          ),
+          providers: mtMap.objectField(
+            'providers',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
                   mtMap.union([
                     mtMap.unionOption(
                       'object',
                       mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
                           mtMap.passthrough()
                         ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        status: mtMap.objectField(
-                          'status',
-                          mtMap.passthrough()
-                        ),
-                        integrationId: mtMap.objectField(
-                          'integration_id',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        toolFilter: mtMap.objectField(
-                          'tool_filter',
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                ignoreParentFilters: mtMap.objectField(
-                                  'ignore_parent_filters',
-                                  mtMap.passthrough()
-                                ),
-                                filters: mtMap.objectField(
-                                  'filters',
-                                  mtMap.array(
-                                    mtMap.union([
-                                      mtMap.unionOption(
-                                        'object',
-                                        mtMap.object({
-                                          type: mtMap.objectField(
-                                            'type',
-                                            mtMap.passthrough()
-                                          ),
-                                          keys: mtMap.objectField(
-                                            'keys',
-                                            mtMap.array(mtMap.passthrough())
-                                          ),
-                                          pattern: mtMap.objectField(
-                                            'pattern',
-                                            mtMap.passthrough()
-                                          ),
-                                          uris: mtMap.objectField(
-                                            'uris',
-                                            mtMap.array(mtMap.passthrough())
-                                          )
-                                        })
-                                      )
-                                    ])
-                                  )
-                                )
-                              })
-                            )
-                          ])
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        deploymentId: mtMap.objectField(
-                          'deployment_id',
-                          mtMap.passthrough()
-                        ),
-                        authMethodId: mtMap.objectField(
-                          'auth_method_id',
-                          mtMap.passthrough()
-                        ),
-                        authCredentialsId: mtMap.objectField(
-                          'auth_credentials_id',
-                          mtMap.passthrough()
-                        ),
-                        config: mtMap.objectField(
-                          'config',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField(
-                          'updated_at',
-                          mtMap.date()
-                        ),
-                        archivedAt: mtMap.objectField(
-                          'archived_at',
-                          mtMap.date()
-                        ),
-                        provider: mtMap.objectField(
-                          'provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            slug: mtMap.objectField(
-                              'slug',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        deployment: mtMap.objectField(
-                          'deployment',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authMethod: mtMap.objectField(
-                          'auth_method',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            key: mtMap.objectField('key', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            capabilities: mtMap.objectField(
-                              'capabilities',
-                              mtMap.passthrough()
-                            ),
-                            inputSchema: mtMap.objectField(
-                              'input_schema',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                schema: mtMap.objectField(
-                                  'schema',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            outputSchema: mtMap.objectField(
-                              'output_schema',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                schema: mtMap.objectField(
-                                  'schema',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
                                 mtMap.object({
-                                  object: mtMap.objectField(
-                                    'object',
+                                  type: mtMap.objectField(
+                                    'type',
                                     mtMap.passthrough()
                                   ),
-                                  id: mtMap.objectField(
-                                    'id',
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
                                     mtMap.passthrough()
                                   ),
-                                  scope: mtMap.objectField(
-                                    'scope',
-                                    mtMap.passthrough()
-                                  ),
-                                  name: mtMap.objectField(
-                                    'name',
-                                    mtMap.passthrough()
-                                  ),
-                                  description: mtMap.objectField(
-                                    'description',
-                                    mtMap.passthrough()
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
                                   )
                                 })
                               )
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            providerSpecificationId: mtMap.objectField(
-                              'provider_specification_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authCredentials: mtMap.objectField(
-                          'auth_credentials',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            status: mtMap.objectField(
-                              'status',
-                              mtMap.passthrough()
-                            ),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            isManaged: mtMap.objectField(
-                              'is_managed',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
+                            ])
+                          )
                         )
                       })
                     )
                   ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                deployment: mtMap.objectField(
+                  'deployment',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authMethod: mtMap.objectField(
+                  'auth_method',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    key: mtMap.objectField('key', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    capabilities: mtMap.objectField(
+                      'capabilities',
+                      mtMap.passthrough()
+                    ),
+                    inputSchema: mtMap.objectField(
+                      'input_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    outputSchema: mtMap.objectField(
+                      'output_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          scope: mtMap.objectField(
+                            'scope',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          )
+                        })
+                      )
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    providerSpecificationId: mtMap.objectField(
+                      'provider_specification_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authCredentials: mtMap.objectField(
+                  'auth_credentials',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    isManaged: mtMap.objectField(
+                      'is_managed',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(mtMap.passthrough())
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
                 )
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ])
+              })
+            )
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/update.ts
@@ -58,75 +58,6 @@ export type DashboardInstanceIntegrationsUpdateOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -186,315 +117,261 @@ export type DashboardInstanceIntegrationsUpdateOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
 };
 
-export let mapDashboardInstanceIntegrationsUpdateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      slug: mtMap.objectField('slug', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField(
-        'configuration',
+export let mapDashboardInstanceIntegrationsUpdateOutput =
+  mtMap.object<DashboardInstanceIntegrationsUpdateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    slug: mtMap.objectField('slug', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField(
+      'configuration',
+      mtMap.object({
+        canAttachCustomToolFilters: mtMap.objectField(
+          'can_attach_custom_tool_filters',
+          mtMap.passthrough()
+        ),
+        canAttachCustomProviderConfig: mtMap.objectField(
+          'can_attach_custom_provider_config',
+          mtMap.passthrough()
+        ),
+        canOverrideToolFilters: mtMap.objectField(
+          'can_override_tool_filters',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            providerTemplateId: mtMap.objectField(
+              'provider_template_id',
+              mtMap.passthrough()
+            ),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
+              mtMap.passthrough()
+            )
+          })
+        )
+      ])
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          canAttachCustomToolFilters: mtMap.objectField(
-            'can_attach_custom_tool_filters',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
           ),
-          canAttachCustomProviderConfig: mtMap.objectField(
-            'can_attach_custom_provider_config',
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
             mtMap.passthrough()
           ),
-          canOverrideToolFilters: mtMap.objectField(
-            'can_override_tool_filters',
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+          ),
+          config: mtMap.objectField(
+            'config',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              providerTemplateId: mtMap.objectField(
-                'provider_template_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
-                mtMap.passthrough()
-              )
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          )
-        ])
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          deployment: mtMap.objectField(
+            'deployment',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authMethod: mtMap.objectField(
+            'auth_method',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              key: mtMap.objectField('key', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              capabilities: mtMap.objectField(
+                'capabilities',
+                mtMap.passthrough()
+              ),
+              inputSchema: mtMap.objectField(
+                'input_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              outputSchema: mtMap.objectField(
+                'output_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
                     )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                deployment: mtMap.objectField(
-                  'deployment',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authMethod: mtMap.objectField(
-                  'auth_method',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    key: mtMap.objectField('key', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    capabilities: mtMap.objectField(
-                      'capabilities',
-                      mtMap.passthrough()
-                    ),
-                    inputSchema: mtMap.objectField(
-                      'input_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    outputSchema: mtMap.objectField(
-                      'output_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          scope: mtMap.objectField(
-                            'scope',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          )
-                        })
-                      )
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    providerSpecificationId: mtMap.objectField(
-                      'provider_specification_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authCredentials: mtMap.objectField(
-                  'auth_credentials',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    isManaged: mtMap.objectField(
-                      'is_managed',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(mtMap.passthrough())
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              providerSpecificationId: mtMap.objectField(
+                'provider_specification_id',
+                mtMap.passthrough()
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authCredentials: mtMap.objectField(
+            'auth_credentials',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(mtMap.passthrough())
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          )
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type DashboardInstanceIntegrationsUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/delete.ts
@@ -31,7 +31,6 @@ export type IntegrationInstanceGroupProvidersDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -195,407 +194,373 @@ export type IntegrationInstanceGroupProvidersDeleteOutput = {
   };
 };
 
-export let mapIntegrationInstanceGroupProvidersDeleteOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      integrationInstanceGroupId: mtMap.objectField(
-        'integration_instance_group_id',
-        mtMap.passthrough()
-      ),
-      integrationInstanceId: mtMap.objectField(
-        'integration_instance_id',
-        mtMap.passthrough()
-      ),
-      integrationProviderId: mtMap.objectField(
-        'integration_provider_id',
-        mtMap.passthrough()
-      ),
-      integrationInstanceProviderId: mtMap.objectField(
-        'integration_instance_provider_id',
-        mtMap.passthrough()
-      ),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
-              )
-            })
-          )
-        ])
-      ),
-      isOverrideToolFilter: mtMap.objectField(
-        'is_override_tool_filter',
-        mtMap.passthrough()
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      integrationProvider: mtMap.objectField(
-        'integration_provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          providerVersion: mtMap.objectField(
-            'provider_version',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              index: mtMap.objectField('index', mtMap.passthrough())
-            })
-          ),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-          authMethodId: mtMap.objectField(
-            'auth_method_id',
-            mtMap.passthrough()
-          ),
-          authCredentialsId: mtMap.objectField(
-            'auth_credentials_id',
-            mtMap.passthrough()
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      ),
-      integrationInstanceProvider: mtMap.objectField(
-        'integration_instance_provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
+export let mapIntegrationInstanceGroupProvidersDeleteOutput =
+  mtMap.object<IntegrationInstanceGroupProvidersDeleteOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstanceGroupId: mtMap.objectField(
+      'integration_instance_group_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    integrationProviderId: mtMap.objectField(
+      'integration_provider_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceProviderId: mtMap.objectField(
+      'integration_instance_provider_id',
+      mtMap.passthrough()
+    ),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
                 mtMap.union([
                   mtMap.unionOption(
                     'object',
                     mtMap.object({
                       type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
                         mtMap.passthrough()
                       ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
                       )
                     })
                   )
                 ])
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              deploymentId: mtMap.objectField(
-                'deployment_id',
-                mtMap.passthrough()
-              ),
-              authMethodId: mtMap.objectField(
-                'auth_method_id',
-                mtMap.passthrough()
-              ),
-              authCredentialsId: mtMap.objectField(
-                'auth_credentials_id',
-                mtMap.passthrough()
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+              )
+            )
+          })
+        )
+      ])
+    ),
+    isOverrideToolFilter: mtMap.objectField(
+      'is_override_tool_filter',
+      mtMap.passthrough()
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    integrationProvider: mtMap.objectField(
+      'integration_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        providerVersion: mtMap.objectField(
+          'provider_version',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            index: mtMap.objectField('index', mtMap.passthrough())
+          })
+        ),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
+                  mtMap.passthrough()
+                ),
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
+                            mtMap.passthrough()
+                          ),
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
+                          )
+                        })
+                      )
+                    ])
+                  )
+                )
+              })
+            )
+          ])
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
+          mtMap.passthrough()
+        ),
+        config: mtMap.objectField(
+          'config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    integrationInstanceProvider: mtMap.objectField(
+      'integration_instance_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        integrationInstanceId: mtMap.objectField(
+          'integration_instance_id',
+          mtMap.passthrough()
+        ),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
+                  mtMap.passthrough()
+                ),
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
+                            mtMap.passthrough()
+                          ),
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
+                          )
+                        })
+                      )
+                    ])
+                  )
+                )
+              })
+            )
+          ])
+        ),
+        isOverrideToolFilter: mtMap.objectField(
+          'is_override_tool_filter',
+          mtMap.passthrough()
+        ),
+        provider: mtMap.objectField(
+          'provider',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            slug: mtMap.objectField('slug', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        integrationProvider: mtMap.objectField(
+          'integration_provider',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            providerVersion: mtMap.objectField(
+              'provider_version',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                index: mtMap.objectField('index', mtMap.passthrough())
+              })
+            ),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
+            ),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            deploymentId: mtMap.objectField(
+              'deployment_id',
+              mtMap.passthrough()
+            ),
+            authMethodId: mtMap.objectField(
+              'auth_method_id',
+              mtMap.passthrough()
+            ),
+            authCredentialsId: mtMap.objectField(
+              'auth_credentials_id',
+              mtMap.passthrough()
+            ),
+            config: mtMap.objectField(
+              'config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          })
+        ),
+        config: mtMap.objectField(
+          'config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        authConfig: mtMap.objectField(
+          'auth_config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    )
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/get.ts
@@ -31,7 +31,6 @@ export type IntegrationInstanceGroupProvidersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -195,407 +194,373 @@ export type IntegrationInstanceGroupProvidersGetOutput = {
   };
 };
 
-export let mapIntegrationInstanceGroupProvidersGetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      integrationInstanceGroupId: mtMap.objectField(
-        'integration_instance_group_id',
-        mtMap.passthrough()
-      ),
-      integrationInstanceId: mtMap.objectField(
-        'integration_instance_id',
-        mtMap.passthrough()
-      ),
-      integrationProviderId: mtMap.objectField(
-        'integration_provider_id',
-        mtMap.passthrough()
-      ),
-      integrationInstanceProviderId: mtMap.objectField(
-        'integration_instance_provider_id',
-        mtMap.passthrough()
-      ),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
-              )
-            })
-          )
-        ])
-      ),
-      isOverrideToolFilter: mtMap.objectField(
-        'is_override_tool_filter',
-        mtMap.passthrough()
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      integrationProvider: mtMap.objectField(
-        'integration_provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          providerVersion: mtMap.objectField(
-            'provider_version',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              index: mtMap.objectField('index', mtMap.passthrough())
-            })
-          ),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-          authMethodId: mtMap.objectField(
-            'auth_method_id',
-            mtMap.passthrough()
-          ),
-          authCredentialsId: mtMap.objectField(
-            'auth_credentials_id',
-            mtMap.passthrough()
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      ),
-      integrationInstanceProvider: mtMap.objectField(
-        'integration_instance_provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
+export let mapIntegrationInstanceGroupProvidersGetOutput =
+  mtMap.object<IntegrationInstanceGroupProvidersGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstanceGroupId: mtMap.objectField(
+      'integration_instance_group_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    integrationProviderId: mtMap.objectField(
+      'integration_provider_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceProviderId: mtMap.objectField(
+      'integration_instance_provider_id',
+      mtMap.passthrough()
+    ),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
                 mtMap.union([
                   mtMap.unionOption(
                     'object',
                     mtMap.object({
                       type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
                         mtMap.passthrough()
                       ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
                       )
                     })
                   )
                 ])
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              deploymentId: mtMap.objectField(
-                'deployment_id',
-                mtMap.passthrough()
-              ),
-              authMethodId: mtMap.objectField(
-                'auth_method_id',
-                mtMap.passthrough()
-              ),
-              authCredentialsId: mtMap.objectField(
-                'auth_credentials_id',
-                mtMap.passthrough()
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+              )
+            )
+          })
+        )
+      ])
+    ),
+    isOverrideToolFilter: mtMap.objectField(
+      'is_override_tool_filter',
+      mtMap.passthrough()
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    integrationProvider: mtMap.objectField(
+      'integration_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        providerVersion: mtMap.objectField(
+          'provider_version',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            index: mtMap.objectField('index', mtMap.passthrough())
+          })
+        ),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
+                  mtMap.passthrough()
+                ),
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
+                            mtMap.passthrough()
+                          ),
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
+                          )
+                        })
+                      )
+                    ])
+                  )
+                )
+              })
+            )
+          ])
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
+          mtMap.passthrough()
+        ),
+        config: mtMap.objectField(
+          'config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    integrationInstanceProvider: mtMap.objectField(
+      'integration_instance_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        integrationInstanceId: mtMap.objectField(
+          'integration_instance_id',
+          mtMap.passthrough()
+        ),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
+                  mtMap.passthrough()
+                ),
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
+                            mtMap.passthrough()
+                          ),
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
+                          )
+                        })
+                      )
+                    ])
+                  )
+                )
+              })
+            )
+          ])
+        ),
+        isOverrideToolFilter: mtMap.objectField(
+          'is_override_tool_filter',
+          mtMap.passthrough()
+        ),
+        provider: mtMap.objectField(
+          'provider',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            slug: mtMap.objectField('slug', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        integrationProvider: mtMap.objectField(
+          'integration_provider',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            providerVersion: mtMap.objectField(
+              'provider_version',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                index: mtMap.objectField('index', mtMap.passthrough())
+              })
+            ),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
+            ),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            deploymentId: mtMap.objectField(
+              'deployment_id',
+              mtMap.passthrough()
+            ),
+            authMethodId: mtMap.objectField(
+              'auth_method_id',
+              mtMap.passthrough()
+            ),
+            authCredentialsId: mtMap.objectField(
+              'auth_credentials_id',
+              mtMap.passthrough()
+            ),
+            config: mtMap.objectField(
+              'config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          })
+        ),
+        config: mtMap.objectField(
+          'config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        authConfig: mtMap.objectField(
+          'auth_config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    )
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type IntegrationInstanceGroupProvidersListOutput = {
-  items: ({
+  items: {
     object: 'integration.instance.group.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -32,7 +32,6 @@ export type IntegrationInstanceGroupProvidersListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
     provider: {
       object: 'provider#preview';
       id: string;
@@ -194,7 +193,7 @@ export type IntegrationInstanceGroupProvidersListOutput = {
       updatedAt: Date;
       archivedAt: Date | null;
     };
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -203,9 +202,204 @@ export let mapIntegrationInstanceGroupProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          integrationInstanceProvider: mtMap.objectField(
+            'integration_instance_provider',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
@@ -220,20 +414,8 @@ export let mapIntegrationInstanceGroupProvidersListOutput =
                 'integration_id',
                 mtMap.passthrough()
               ),
-              integrationInstanceGroupId: mtMap.objectField(
-                'integration_instance_group_id',
-                mtMap.passthrough()
-              ),
               integrationInstanceId: mtMap.objectField(
                 'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              integrationProviderId: mtMap.objectField(
-                'integration_provider_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceProviderId: mtMap.objectField(
-                'integration_instance_provider_id',
                 mtMap.passthrough()
               ),
               toolFilter: mtMap.objectField(
@@ -283,9 +465,6 @@ export let mapIntegrationInstanceGroupProvidersListOutput =
                 'is_override_tool_filter',
                 mtMap.passthrough()
               ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date()),
               provider: mtMap.objectField(
                 'provider',
                 mtMap.object({
@@ -411,276 +590,58 @@ export let mapIntegrationInstanceGroupProvidersListOutput =
                   archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
               ),
-              integrationInstanceProvider: mtMap.objectField(
-                'integration_instance_provider',
+              config: mtMap.objectField(
+                'config',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  integrationId: mtMap.objectField(
-                    'integration_id',
+                  providerId: mtMap.objectField(
+                    'provider_id',
                     mtMap.passthrough()
-                  ),
-                  integrationInstanceId: mtMap.objectField(
-                    'integration_instance_id',
-                    mtMap.passthrough()
-                  ),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  isOverrideToolFilter: mtMap.objectField(
-                    'is_override_tool_filter',
-                    mtMap.passthrough()
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  integrationProvider: mtMap.objectField(
-                    'integration_provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      providerVersion: mtMap.objectField(
-                        'provider_version',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          index: mtMap.objectField('index', mtMap.passthrough())
-                        })
-                      ),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      toolFilter: mtMap.objectField(
-                        'tool_filter',
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              ignoreParentFilters: mtMap.objectField(
-                                'ignore_parent_filters',
-                                mtMap.passthrough()
-                              ),
-                              filters: mtMap.objectField(
-                                'filters',
-                                mtMap.array(
-                                  mtMap.union([
-                                    mtMap.unionOption(
-                                      'object',
-                                      mtMap.object({
-                                        type: mtMap.objectField(
-                                          'type',
-                                          mtMap.passthrough()
-                                        ),
-                                        keys: mtMap.objectField(
-                                          'keys',
-                                          mtMap.array(mtMap.passthrough())
-                                        ),
-                                        pattern: mtMap.objectField(
-                                          'pattern',
-                                          mtMap.passthrough()
-                                        ),
-                                        uris: mtMap.objectField(
-                                          'uris',
-                                          mtMap.array(mtMap.passthrough())
-                                        )
-                                      })
-                                    )
-                                  ])
-                                )
-                              )
-                            })
-                          )
-                        ])
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      deploymentId: mtMap.objectField(
-                        'deployment_id',
-                        mtMap.passthrough()
-                      ),
-                      authMethodId: mtMap.objectField(
-                        'auth_method_id',
-                        mtMap.passthrough()
-                      ),
-                      authCredentialsId: mtMap.objectField(
-                        'auth_credentials_id',
-                        mtMap.passthrough()
-                      ),
-                      config: mtMap.objectField(
-                        'config',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          isDefault: mtMap.objectField(
-                            'is_default',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          ),
-                          metadata: mtMap.objectField(
-                            'metadata',
-                            mtMap.passthrough()
-                          ),
-                          providerId: mtMap.objectField(
-                            'provider_id',
-                            mtMap.passthrough()
-                          ),
-                          createdAt: mtMap.objectField(
-                            'created_at',
-                            mtMap.date()
-                          ),
-                          updatedAt: mtMap.objectField(
-                            'updated_at',
-                            mtMap.date()
-                          )
-                        })
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authConfig: mtMap.objectField(
-                    'auth_config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
                   ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
-              )
+              ),
+              authConfig: mtMap.objectField(
+                'auth_config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
           )
-        ])
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/set.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-group-providers/set.ts
@@ -31,7 +31,6 @@ export type IntegrationInstanceGroupProvidersSetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -195,409 +194,375 @@ export type IntegrationInstanceGroupProvidersSetOutput = {
   };
 };
 
-export let mapIntegrationInstanceGroupProvidersSetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      integrationInstanceGroupId: mtMap.objectField(
-        'integration_instance_group_id',
-        mtMap.passthrough()
-      ),
-      integrationInstanceId: mtMap.objectField(
-        'integration_instance_id',
-        mtMap.passthrough()
-      ),
-      integrationProviderId: mtMap.objectField(
-        'integration_provider_id',
-        mtMap.passthrough()
-      ),
-      integrationInstanceProviderId: mtMap.objectField(
-        'integration_instance_provider_id',
-        mtMap.passthrough()
-      ),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
-              )
-            })
-          )
-        ])
-      ),
-      isOverrideToolFilter: mtMap.objectField(
-        'is_override_tool_filter',
-        mtMap.passthrough()
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      integrationProvider: mtMap.objectField(
-        'integration_provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          providerVersion: mtMap.objectField(
-            'provider_version',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              index: mtMap.objectField('index', mtMap.passthrough())
-            })
-          ),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-          authMethodId: mtMap.objectField(
-            'auth_method_id',
-            mtMap.passthrough()
-          ),
-          authCredentialsId: mtMap.objectField(
-            'auth_credentials_id',
-            mtMap.passthrough()
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      ),
-      integrationInstanceProvider: mtMap.objectField(
-        'integration_instance_provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
-            mtMap.passthrough()
-          ),
-          integrationInstanceId: mtMap.objectField(
-            'integration_instance_id',
-            mtMap.passthrough()
-          ),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
-                  )
-                })
-              )
-            ])
-          ),
-          isOverrideToolFilter: mtMap.objectField(
-            'is_override_tool_filter',
-            mtMap.passthrough()
-          ),
-          provider: mtMap.objectField(
-            'provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          integrationProvider: mtMap.objectField(
-            'integration_provider',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              providerVersion: mtMap.objectField(
-                'provider_version',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  index: mtMap.objectField('index', mtMap.passthrough())
-                })
-              ),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
+export let mapIntegrationInstanceGroupProvidersSetOutput =
+  mtMap.object<IntegrationInstanceGroupProvidersSetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstanceGroupId: mtMap.objectField(
+      'integration_instance_group_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    integrationProviderId: mtMap.objectField(
+      'integration_provider_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceProviderId: mtMap.objectField(
+      'integration_instance_provider_id',
+      mtMap.passthrough()
+    ),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
                 mtMap.union([
                   mtMap.unionOption(
                     'object',
                     mtMap.object({
                       type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
                         mtMap.passthrough()
                       ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
                       )
                     })
                   )
                 ])
-              ),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              deploymentId: mtMap.objectField(
-                'deployment_id',
-                mtMap.passthrough()
-              ),
-              authMethodId: mtMap.objectField(
-                'auth_method_id',
-                mtMap.passthrough()
-              ),
-              authCredentialsId: mtMap.objectField(
-                'auth_credentials_id',
-                mtMap.passthrough()
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          authConfig: mtMap.objectField(
-            'auth_config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+              )
+            )
+          })
+        )
+      ])
+    ),
+    isOverrideToolFilter: mtMap.objectField(
+      'is_override_tool_filter',
+      mtMap.passthrough()
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    integrationProvider: mtMap.objectField(
+      'integration_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        providerVersion: mtMap.objectField(
+          'provider_version',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            index: mtMap.objectField('index', mtMap.passthrough())
+          })
+        ),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
+                  mtMap.passthrough()
+                ),
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
+                            mtMap.passthrough()
+                          ),
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
+                          )
+                        })
+                      )
+                    ])
+                  )
+                )
+              })
+            )
+          ])
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
+          mtMap.passthrough()
+        ),
+        config: mtMap.objectField(
+          'config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    integrationInstanceProvider: mtMap.objectField(
+      'integration_instance_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        integrationInstanceId: mtMap.objectField(
+          'integration_instance_id',
+          mtMap.passthrough()
+        ),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
+                  mtMap.passthrough()
+                ),
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
+                            mtMap.passthrough()
+                          ),
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
+                          )
+                        })
+                      )
+                    ])
+                  )
+                )
+              })
+            )
+          ])
+        ),
+        isOverrideToolFilter: mtMap.objectField(
+          'is_override_tool_filter',
+          mtMap.passthrough()
+        ),
+        provider: mtMap.objectField(
+          'provider',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            slug: mtMap.objectField('slug', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        integrationProvider: mtMap.objectField(
+          'integration_provider',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            providerVersion: mtMap.objectField(
+              'provider_version',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                index: mtMap.objectField('index', mtMap.passthrough())
+              })
+            ),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            toolFilter: mtMap.objectField(
+              'tool_filter',
+              mtMap.union([
+                mtMap.unionOption(
+                  'object',
+                  mtMap.object({
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    ignoreParentFilters: mtMap.objectField(
+                      'ignore_parent_filters',
+                      mtMap.passthrough()
+                    ),
+                    filters: mtMap.objectField(
+                      'filters',
+                      mtMap.array(
+                        mtMap.union([
+                          mtMap.unionOption(
+                            'object',
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              keys: mtMap.objectField(
+                                'keys',
+                                mtMap.array(mtMap.passthrough())
+                              ),
+                              pattern: mtMap.objectField(
+                                'pattern',
+                                mtMap.passthrough()
+                              ),
+                              uris: mtMap.objectField(
+                                'uris',
+                                mtMap.array(mtMap.passthrough())
+                              )
+                            })
+                          )
+                        ])
+                      )
+                    )
+                  })
+                )
+              ])
+            ),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            deploymentId: mtMap.objectField(
+              'deployment_id',
+              mtMap.passthrough()
+            ),
+            authMethodId: mtMap.objectField(
+              'auth_method_id',
+              mtMap.passthrough()
+            ),
+            authCredentialsId: mtMap.objectField(
+              'auth_credentials_id',
+              mtMap.passthrough()
+            ),
+            config: mtMap.objectField(
+              'config',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          })
+        ),
+        config: mtMap.objectField(
+          'config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        authConfig: mtMap.objectField(
+          'auth_config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    )
+  });
 
 export type IntegrationInstanceGroupProvidersSetBody = {
   toolFilters?:

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/create.ts
@@ -46,150 +46,113 @@ export type IntegrationInstanceGroupsCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: {
-    object: 'integration.instance.group.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceGroupId: string;
-    integrationInstanceId: string;
-    integrationProviderId: string | null;
-    integrationInstanceProviderId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
 };
 
-export let mapIntegrationInstanceGroupsCreateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpEndpointId: mtMap.objectField(
-            'magic_mcp_endpoint_id',
-            mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            integrationId: mtMap.objectField(
-              'integration_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceGroupId: mtMap.objectField(
-              'integration_instance_group_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceId: mtMap.objectField(
-              'integration_instance_id',
-              mtMap.passthrough()
-            ),
-            integrationProviderId: mtMap.objectField(
-              'integration_provider_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceProviderId: mtMap.objectField(
-              'integration_instance_provider_id',
-              mtMap.passthrough()
-            ),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            isOverrideToolFilter: mtMap.objectField(
-              'is_override_tool_filter',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
+export let mapIntegrationInstanceGroupsCreateOutput =
+  mtMap.object<IntegrationInstanceGroupsCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpEndpointId: mtMap.objectField(
+          'magic_mcp_endpoint_id',
+          mtMap.passthrough()
         )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type IntegrationInstanceGroupsCreateBody = {
   name: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/delete.ts
@@ -46,148 +46,111 @@ export type IntegrationInstanceGroupsDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: {
-    object: 'integration.instance.group.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceGroupId: string;
-    integrationInstanceId: string;
-    integrationProviderId: string | null;
-    integrationInstanceProviderId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
 };
 
-export let mapIntegrationInstanceGroupsDeleteOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpEndpointId: mtMap.objectField(
-            'magic_mcp_endpoint_id',
-            mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            integrationId: mtMap.objectField(
-              'integration_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceGroupId: mtMap.objectField(
-              'integration_instance_group_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceId: mtMap.objectField(
-              'integration_instance_id',
-              mtMap.passthrough()
-            ),
-            integrationProviderId: mtMap.objectField(
-              'integration_provider_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceProviderId: mtMap.objectField(
-              'integration_instance_provider_id',
-              mtMap.passthrough()
-            ),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            isOverrideToolFilter: mtMap.objectField(
-              'is_override_tool_filter',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
+export let mapIntegrationInstanceGroupsDeleteOutput =
+  mtMap.object<IntegrationInstanceGroupsDeleteOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpEndpointId: mtMap.objectField(
+          'magic_mcp_endpoint_id',
+          mtMap.passthrough()
         )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/get.ts
@@ -46,148 +46,111 @@ export type IntegrationInstanceGroupsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: {
-    object: 'integration.instance.group.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceGroupId: string;
-    integrationInstanceId: string;
-    integrationProviderId: string | null;
-    integrationInstanceProviderId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
 };
 
-export let mapIntegrationInstanceGroupsGetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpEndpointId: mtMap.objectField(
-            'magic_mcp_endpoint_id',
-            mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            integrationId: mtMap.objectField(
-              'integration_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceGroupId: mtMap.objectField(
-              'integration_instance_group_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceId: mtMap.objectField(
-              'integration_instance_id',
-              mtMap.passthrough()
-            ),
-            integrationProviderId: mtMap.objectField(
-              'integration_provider_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceProviderId: mtMap.objectField(
-              'integration_instance_provider_id',
-              mtMap.passthrough()
-            ),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            isOverrideToolFilter: mtMap.objectField(
-              'is_override_tool_filter',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
+export let mapIntegrationInstanceGroupsGetOutput =
+  mtMap.object<IntegrationInstanceGroupsGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpEndpointId: mtMap.objectField(
+          'magic_mcp_endpoint_id',
+          mtMap.passthrough()
         )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type IntegrationInstanceGroupsListOutput = {
-  items: ({
+  items: {
     object: 'integration.instance.group';
     id: string;
     status: 'draft' | 'active' | 'archived' | 'deleted';
@@ -47,40 +47,7 @@ export type IntegrationInstanceGroupsListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
-    providers: {
-      object: 'integration.instance.group.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceGroupId: string;
-      integrationInstanceId: string;
-      integrationProviderId: string | null;
-      integrationInstanceProviderId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    }[];
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -89,127 +56,113 @@ export let mapIntegrationInstanceGroupsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          implementation: mtMap.objectField(
+            'implementation',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              magicMcpEndpointId: mtMap.objectField(
+                'magic_mcp_endpoint_id',
                 mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              implementation: mtMap.objectField(
-                'implementation',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  magicMcpEndpointId: mtMap.objectField(
-                    'magic_mcp_endpoint_id',
-                    mtMap.passthrough()
-                  )
-                })
-              ),
-              providers: mtMap.objectField(
-                'providers',
-                mtMap.array(
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    integrationId: mtMap.objectField(
-                      'integration_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationInstanceGroupId: mtMap.objectField(
-                      'integration_instance_group_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationInstanceId: mtMap.objectField(
-                      'integration_instance_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationProviderId: mtMap.objectField(
-                      'integration_provider_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationInstanceProviderId: mtMap.objectField(
-                      'integration_instance_provider_id',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    isOverrideToolFilter: mtMap.objectField(
-                      'is_override_tool_filter',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                )
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              )
             })
-          )
-        ])
+          ),
+          providers: mtMap.objectField(
+            'providers',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceGroupId: mtMap.objectField(
+                  'integration_instance_group_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                integrationProviderId: mtMap.objectField(
+                  'integration_provider_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceProviderId: mtMap.objectField(
+                  'integration_instance_provider_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-groups/update.ts
@@ -46,150 +46,113 @@ export type IntegrationInstanceGroupsUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: {
-    object: 'integration.instance.group.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceGroupId: string;
-    integrationInstanceId: string;
-    integrationProviderId: string | null;
-    integrationInstanceProviderId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
 };
 
-export let mapIntegrationInstanceGroupsUpdateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpEndpointId: mtMap.objectField(
-            'magic_mcp_endpoint_id',
-            mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            integrationId: mtMap.objectField(
-              'integration_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceGroupId: mtMap.objectField(
-              'integration_instance_group_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceId: mtMap.objectField(
-              'integration_instance_id',
-              mtMap.passthrough()
-            ),
-            integrationProviderId: mtMap.objectField(
-              'integration_provider_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceProviderId: mtMap.objectField(
-              'integration_instance_provider_id',
-              mtMap.passthrough()
-            ),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            isOverrideToolFilter: mtMap.objectField(
-              'is_override_tool_filter',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
+export let mapIntegrationInstanceGroupsUpdateOutput =
+  mtMap.object<IntegrationInstanceGroupsUpdateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpEndpointId: mtMap.objectField(
+          'magic_mcp_endpoint_id',
+          mtMap.passthrough()
         )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type IntegrationInstanceGroupsUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-providers/get.ts
@@ -105,250 +105,190 @@ export type IntegrationInstanceProvidersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  integrationProvider: {
-    object: 'integration.provider#snapshot';
-    id: string;
-    providerVersion: {
-      object: 'integration.provider.version';
-      id: string;
-      index: number;
-    };
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  };
 };
 
-export let mapIntegrationInstanceProvidersGetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      integrationInstanceId: mtMap.objectField(
-        'integration_instance_id',
-        mtMap.passthrough()
-      ),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
-              )
-            })
-          )
-        ])
-      ),
-      isOverrideToolFilter: mtMap.objectField(
-        'is_override_tool_filter',
-        mtMap.passthrough()
-      ),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      integrationProvider: mtMap.objectField(
-        'integration_provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          providerVersion: mtMap.objectField(
-            'provider_version',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              index: mtMap.objectField('index', mtMap.passthrough())
-            })
-          ),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
+export let mapIntegrationInstanceProvidersGetOutput =
+  mtMap.object<IntegrationInstanceProvidersGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
                   )
-                })
+                ])
               )
-            ])
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-          authMethodId: mtMap.objectField(
-            'auth_method_id',
-            mtMap.passthrough()
-          ),
-          authCredentialsId: mtMap.objectField(
-            'auth_credentials_id',
-            mtMap.passthrough()
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      ),
-      config: mtMap.objectField(
-        'config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authConfig: mtMap.objectField(
-        'auth_config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+            )
+          })
+        )
+      ])
+    ),
+    isOverrideToolFilter: mtMap.objectField(
+      'is_override_tool_filter',
+      mtMap.passthrough()
+    ),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    integrationProvider: mtMap.objectField(
+      'integration_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        providerVersion: mtMap.objectField(
+          'provider_version',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            index: mtMap.objectField('index', mtMap.passthrough())
+          })
+        ),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
+                  mtMap.passthrough()
+                ),
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
+                            mtMap.passthrough()
+                          ),
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
+                          )
+                        })
+                      )
+                    ])
+                  )
+                )
+              })
+            )
+          ])
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
+          mtMap.passthrough()
+        ),
+        config: mtMap.objectField(
+          'config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authConfig: mtMap.objectField(
+      'auth_config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-providers/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type IntegrationInstanceProvidersListOutput = {
-  items: ({
+  items: {
     object: 'integration.instance.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -106,54 +106,7 @@ export type IntegrationInstanceProvidersListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -162,12 +115,96 @@ export let mapIntegrationInstanceProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
               status: mtMap.objectField('status', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
@@ -175,14 +212,6 @@ export let mapIntegrationInstanceProvidersListOutput =
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
               toolFilter: mtMap.objectField(
                 'tool_filter',
                 mtMap.union([
@@ -226,160 +255,21 @@ export let mapIntegrationInstanceProvidersListOutput =
                   )
                 ])
               ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
                 mtMap.passthrough()
               ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
               ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  deploymentId: mtMap.objectField(
-                    'deployment_id',
-                    mtMap.passthrough()
-                  ),
-                  authMethodId: mtMap.objectField(
-                    'auth_method_id',
-                    mtMap.passthrough()
-                  ),
-                  authCredentialsId: mtMap.objectField(
-                    'auth_credentials_id',
-                    mtMap.passthrough()
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
               ),
               config: mtMap.objectField(
                 'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
@@ -405,8 +295,45 @@ export let mapIntegrationInstanceProvidersListOutput =
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
               archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
-          )
-        ])
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-providers/set.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instance-providers/set.ts
@@ -105,252 +105,192 @@ export type IntegrationInstanceProvidersSetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  integrationProvider: {
-    object: 'integration.provider#snapshot';
-    id: string;
-    providerVersion: {
-      object: 'integration.provider.version';
-      id: string;
-      index: number;
-    };
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  };
 };
 
-export let mapIntegrationInstanceProvidersSetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      integrationInstanceId: mtMap.objectField(
-        'integration_instance_id',
-        mtMap.passthrough()
-      ),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
-              )
-            })
-          )
-        ])
-      ),
-      isOverrideToolFilter: mtMap.objectField(
-        'is_override_tool_filter',
-        mtMap.passthrough()
-      ),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      integrationProvider: mtMap.objectField(
-        'integration_provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          providerVersion: mtMap.objectField(
-            'provider_version',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              index: mtMap.objectField('index', mtMap.passthrough())
-            })
-          ),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          toolFilter: mtMap.objectField(
-            'tool_filter',
-            mtMap.union([
-              mtMap.unionOption(
-                'object',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  ignoreParentFilters: mtMap.objectField(
-                    'ignore_parent_filters',
-                    mtMap.passthrough()
-                  ),
-                  filters: mtMap.objectField(
-                    'filters',
-                    mtMap.array(
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            keys: mtMap.objectField(
-                              'keys',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            pattern: mtMap.objectField(
-                              'pattern',
-                              mtMap.passthrough()
-                            ),
-                            uris: mtMap.objectField(
-                              'uris',
-                              mtMap.array(mtMap.passthrough())
-                            )
-                          })
-                        )
-                      ])
-                    )
+export let mapIntegrationInstanceProvidersSetOutput =
+  mtMap.object<IntegrationInstanceProvidersSetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
                   )
-                })
+                ])
               )
-            ])
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-          authMethodId: mtMap.objectField(
-            'auth_method_id',
-            mtMap.passthrough()
-          ),
-          authCredentialsId: mtMap.objectField(
-            'auth_credentials_id',
-            mtMap.passthrough()
-          ),
-          config: mtMap.objectField(
-            'config',
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
-            })
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
-        })
-      ),
-      config: mtMap.objectField(
-        'config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authConfig: mtMap.objectField(
-        'auth_config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+            )
+          })
+        )
+      ])
+    ),
+    isOverrideToolFilter: mtMap.objectField(
+      'is_override_tool_filter',
+      mtMap.passthrough()
+    ),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    integrationProvider: mtMap.objectField(
+      'integration_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        providerVersion: mtMap.objectField(
+          'provider_version',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            index: mtMap.objectField('index', mtMap.passthrough())
+          })
+        ),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
+                  mtMap.passthrough()
+                ),
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
+                            mtMap.passthrough()
+                          ),
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
+                          )
+                        })
+                      )
+                    ])
+                  )
+                )
+              })
+            )
+          ])
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
+          mtMap.passthrough()
+        ),
+        config: mtMap.objectField(
+          'config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authConfig: mtMap.objectField(
+      'auth_config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type IntegrationInstanceProvidersSetBody = {
   providerDeploymentId?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/create.ts
@@ -120,302 +120,64 @@ export type IntegrationInstancesCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.instance.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authConfig: {
-      object: 'provider.auth_config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
 };
 
-export let mapIntegrationInstancesCreateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      identityActorId: mtMap.objectField(
-        'identity_actor_id',
-        mtMap.passthrough()
-      ),
-      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
+export let mapIntegrationInstancesCreateOutput =
+  mtMap.object<IntegrationInstancesCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpServerId: mtMap.objectField(
+          'magic_mcp_server_id',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpServerId: mtMap.objectField(
-            'magic_mcp_server_id',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -424,161 +186,194 @@ export let mapIntegrationInstancesCreateOutput = mtMap.union([
                               'type',
                               mtMap.passthrough()
                             ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
                               mtMap.passthrough()
                             ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
                             )
                           })
                         )
                       ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type IntegrationInstancesCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/delete.ts
@@ -120,302 +120,64 @@ export type IntegrationInstancesDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.instance.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authConfig: {
-      object: 'provider.auth_config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
 };
 
-export let mapIntegrationInstancesDeleteOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      identityActorId: mtMap.objectField(
-        'identity_actor_id',
-        mtMap.passthrough()
-      ),
-      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
+export let mapIntegrationInstancesDeleteOutput =
+  mtMap.object<IntegrationInstancesDeleteOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpServerId: mtMap.objectField(
+          'magic_mcp_server_id',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpServerId: mtMap.objectField(
-            'magic_mcp_server_id',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -424,159 +186,192 @@ export let mapIntegrationInstancesDeleteOutput = mtMap.union([
                               'type',
                               mtMap.passthrough()
                             ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
                               mtMap.passthrough()
                             ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
                             )
                           })
                         )
                       ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/get.ts
@@ -120,302 +120,64 @@ export type IntegrationInstancesGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.instance.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authConfig: {
-      object: 'provider.auth_config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
 };
 
-export let mapIntegrationInstancesGetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      identityActorId: mtMap.objectField(
-        'identity_actor_id',
-        mtMap.passthrough()
-      ),
-      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
+export let mapIntegrationInstancesGetOutput =
+  mtMap.object<IntegrationInstancesGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpServerId: mtMap.objectField(
+          'magic_mcp_server_id',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpServerId: mtMap.objectField(
-            'magic_mcp_server_id',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -424,159 +186,192 @@ export let mapIntegrationInstancesGetOutput = mtMap.union([
                               'type',
                               mtMap.passthrough()
                             ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
                               mtMap.passthrough()
                             ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
                             )
                           })
                         )
                       ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type IntegrationInstancesListOutput = {
-  items: ({
+  items: {
     object: 'integration.instance';
     id: string;
     status: 'draft' | 'active' | 'archived' | 'deleted';
@@ -124,161 +124,7 @@ export type IntegrationInstancesListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
-    providers: ({
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        providerId: string;
-        deploymentId: string;
-        authMethodId: string | null;
-        authCredentialsId: string | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } & {
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        providerId: string;
-        deploymentId: string;
-        authMethodId: string | null;
-        authCredentialsId: string | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-    })[];
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -287,52 +133,213 @@ export let mapIntegrationInstancesListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          implementation: mtMap.objectField(
+            'implementation',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              identityActorId: mtMap.objectField(
-                'identity_actor_id',
-                mtMap.passthrough()
-              ),
-              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-              implementation: mtMap.objectField(
-                'implementation',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  magicMcpServerId: mtMap.objectField(
-                    'magic_mcp_server_id',
-                    mtMap.passthrough()
-                  )
-                })
-              ),
-              providers: mtMap.objectField(
-                'providers',
-                mtMap.array(
+              )
+            })
+          ),
+          providers: mtMap.objectField(
+            'providers',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
                   mtMap.union([
                     mtMap.unionOption(
                       'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        status: mtMap.objectField(
-                          'status',
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
+                              mtMap.passthrough()
+                            ),
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
+                            )
+                          })
+                        )
+                      ])
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
                           mtMap.passthrough()
                         ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
@@ -344,351 +351,84 @@ export let mapIntegrationInstancesListOutput =
                           'metadata',
                           mtMap.passthrough()
                         ),
-                        integrationId: mtMap.objectField(
-                          'integration_id',
+                        providerId: mtMap.objectField(
+                          'provider_id',
                           mtMap.passthrough()
-                        ),
-                        integrationInstanceId: mtMap.objectField(
-                          'integration_instance_id',
-                          mtMap.passthrough()
-                        ),
-                        toolFilter: mtMap.objectField(
-                          'tool_filter',
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                ignoreParentFilters: mtMap.objectField(
-                                  'ignore_parent_filters',
-                                  mtMap.passthrough()
-                                ),
-                                filters: mtMap.objectField(
-                                  'filters',
-                                  mtMap.array(
-                                    mtMap.union([
-                                      mtMap.unionOption(
-                                        'object',
-                                        mtMap.object({
-                                          type: mtMap.objectField(
-                                            'type',
-                                            mtMap.passthrough()
-                                          ),
-                                          keys: mtMap.objectField(
-                                            'keys',
-                                            mtMap.array(mtMap.passthrough())
-                                          ),
-                                          pattern: mtMap.objectField(
-                                            'pattern',
-                                            mtMap.passthrough()
-                                          ),
-                                          uris: mtMap.objectField(
-                                            'uris',
-                                            mtMap.array(mtMap.passthrough())
-                                          )
-                                        })
-                                      )
-                                    ])
-                                  )
-                                )
-                              })
-                            )
-                          ])
-                        ),
-                        isOverrideToolFilter: mtMap.objectField(
-                          'is_override_tool_filter',
-                          mtMap.passthrough()
-                        ),
-                        provider: mtMap.objectField(
-                          'provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            slug: mtMap.objectField(
-                              'slug',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        integrationProvider: mtMap.objectField(
-                          'integration_provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            providerVersion: mtMap.objectField(
-                              'provider_version',
-                              mtMap.object({
-                                object: mtMap.objectField(
-                                  'object',
-                                  mtMap.passthrough()
-                                ),
-                                id: mtMap.objectField(
-                                  'id',
-                                  mtMap.passthrough()
-                                ),
-                                index: mtMap.objectField(
-                                  'index',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            status: mtMap.objectField(
-                              'status',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            toolFilter: mtMap.objectField(
-                              'tool_filter',
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    ignoreParentFilters: mtMap.objectField(
-                                      'ignore_parent_filters',
-                                      mtMap.passthrough()
-                                    ),
-                                    filters: mtMap.objectField(
-                                      'filters',
-                                      mtMap.array(
-                                        mtMap.union([
-                                          mtMap.unionOption(
-                                            'object',
-                                            mtMap.object({
-                                              type: mtMap.objectField(
-                                                'type',
-                                                mtMap.passthrough()
-                                              ),
-                                              keys: mtMap.objectField(
-                                                'keys',
-                                                mtMap.array(mtMap.passthrough())
-                                              ),
-                                              pattern: mtMap.objectField(
-                                                'pattern',
-                                                mtMap.passthrough()
-                                              ),
-                                              uris: mtMap.objectField(
-                                                'uris',
-                                                mtMap.array(mtMap.passthrough())
-                                              )
-                                            })
-                                          )
-                                        ])
-                                      )
-                                    )
-                                  })
-                                )
-                              ])
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            deploymentId: mtMap.objectField(
-                              'deployment_id',
-                              mtMap.passthrough()
-                            ),
-                            authMethodId: mtMap.objectField(
-                              'auth_method_id',
-                              mtMap.passthrough()
-                            ),
-                            authCredentialsId: mtMap.objectField(
-                              'auth_credentials_id',
-                              mtMap.passthrough()
-                            ),
-                            config: mtMap.objectField(
-                              'config',
-                              mtMap.object({
-                                object: mtMap.objectField(
-                                  'object',
-                                  mtMap.passthrough()
-                                ),
-                                id: mtMap.objectField(
-                                  'id',
-                                  mtMap.passthrough()
-                                ),
-                                isDefault: mtMap.objectField(
-                                  'is_default',
-                                  mtMap.passthrough()
-                                ),
-                                name: mtMap.objectField(
-                                  'name',
-                                  mtMap.passthrough()
-                                ),
-                                description: mtMap.objectField(
-                                  'description',
-                                  mtMap.passthrough()
-                                ),
-                                metadata: mtMap.objectField(
-                                  'metadata',
-                                  mtMap.passthrough()
-                                ),
-                                providerId: mtMap.objectField(
-                                  'provider_id',
-                                  mtMap.passthrough()
-                                ),
-                                createdAt: mtMap.objectField(
-                                  'created_at',
-                                  mtMap.date()
-                                ),
-                                updatedAt: mtMap.objectField(
-                                  'updated_at',
-                                  mtMap.date()
-                                )
-                              })
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            ),
-                            archivedAt: mtMap.objectField(
-                              'archived_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        config: mtMap.objectField(
-                          'config',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authConfig: mtMap.objectField(
-                          'auth_config',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',
                           mtMap.date()
                         ),
-                        updatedAt: mtMap.objectField(
-                          'updated_at',
-                          mtMap.date()
-                        ),
-                        archivedAt: mtMap.objectField(
-                          'archived_at',
-                          mtMap.date()
-                        )
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ])
-                )
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ])
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-instances/update.ts
@@ -120,302 +120,64 @@ export type IntegrationInstancesUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.instance.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authConfig: {
-      object: 'provider.auth_config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
 };
 
-export let mapIntegrationInstancesUpdateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      identityActorId: mtMap.objectField(
-        'identity_actor_id',
-        mtMap.passthrough()
-      ),
-      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
+export let mapIntegrationInstancesUpdateOutput =
+  mtMap.object<IntegrationInstancesUpdateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpServerId: mtMap.objectField(
+          'magic_mcp_server_id',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpServerId: mtMap.objectField(
-            'magic_mcp_server_id',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -424,161 +186,194 @@ export let mapIntegrationInstancesUpdateOutput = mtMap.union([
                               'type',
                               mtMap.passthrough()
                             ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
                               mtMap.passthrough()
                             ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
                             )
                           })
                         )
                       ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type IntegrationInstancesUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/create.ts
@@ -41,29 +41,6 @@ export type IntegrationProvidersCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  object: 'integration.provider';
-  id: string;
-  status: 'active' | 'archived' | 'deleted';
-  integrationId: string;
-  name: string;
-  description: string | null;
-  metadata: Record<string, any> | null;
-  toolFilter:
-    | { type: 'allow_all'; ignoreParentFilters: boolean }
-    | {
-        type: 'filter';
-        filters: (
-          | { type: 'tool_keys'; keys: string[] }
-          | { type: 'tool_regex'; pattern: string }
-          | { type: 'resource_regex'; pattern: string }
-          | { type: 'resource_uris'; uris: string[] }
-          | { type: 'prompt_keys'; keys: string[] }
-          | { type: 'prompt_regex'; pattern: string }
-        )[];
-        ignoreParentFilters: boolean;
-      }
-    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -125,176 +102,169 @@ export type IntegrationProvidersCreateOutput = {
   } | null;
 };
 
-export let mapIntegrationProvidersCreateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
+export let mapIntegrationProvidersCreateOutput =
+  mtMap.object<IntegrationProvidersCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
               )
+            )
+          })
+        )
+      ])
+    ),
+    providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+    deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+    authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+    authCredentialsId: mtMap.objectField(
+      'auth_credentials_id',
+      mtMap.passthrough()
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    deployment: mtMap.objectField(
+      'deployment',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authMethod: mtMap.objectField(
+      'auth_method',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        key: mtMap.objectField('key', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+        inputSchema: mtMap.objectField(
+          'input_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        outputSchema: mtMap.objectField(
+          'output_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        scopes: mtMap.objectField(
+          'scopes',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              scope: mtMap.objectField('scope', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField('description', mtMap.passthrough())
             })
           )
-        ])
-      ),
-      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
-      authCredentialsId: mtMap.objectField(
-        'auth_credentials_id',
-        mtMap.passthrough()
-      ),
-      config: mtMap.objectField(
-        'config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      deployment: mtMap.objectField(
-        'deployment',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authMethod: mtMap.objectField(
-        'auth_method',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          key: mtMap.objectField('key', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-          inputSchema: mtMap.objectField(
-            'input_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          outputSchema: mtMap.objectField(
-            'output_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          scopes: mtMap.objectField(
-            'scopes',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                scope: mtMap.objectField('scope', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                )
-              })
-            )
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          providerSpecificationId: mtMap.objectField(
-            'provider_specification_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authCredentials: mtMap.objectField(
-        'auth_credentials',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        providerSpecificationId: mtMap.objectField(
+          'provider_specification_id',
+          mtMap.passthrough()
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authCredentials: mtMap.objectField(
+      'auth_credentials',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    )
+  });
 
 export type IntegrationProvidersCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/delete.ts
@@ -41,29 +41,6 @@ export type IntegrationProvidersDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  object: 'integration.provider';
-  id: string;
-  status: 'active' | 'archived' | 'deleted';
-  integrationId: string;
-  name: string;
-  description: string | null;
-  metadata: Record<string, any> | null;
-  toolFilter:
-    | { type: 'allow_all'; ignoreParentFilters: boolean }
-    | {
-        type: 'filter';
-        filters: (
-          | { type: 'tool_keys'; keys: string[] }
-          | { type: 'tool_regex'; pattern: string }
-          | { type: 'resource_regex'; pattern: string }
-          | { type: 'resource_uris'; uris: string[] }
-          | { type: 'prompt_keys'; keys: string[] }
-          | { type: 'prompt_regex'; pattern: string }
-        )[];
-        ignoreParentFilters: boolean;
-      }
-    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -125,174 +102,167 @@ export type IntegrationProvidersDeleteOutput = {
   } | null;
 };
 
-export let mapIntegrationProvidersDeleteOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
+export let mapIntegrationProvidersDeleteOutput =
+  mtMap.object<IntegrationProvidersDeleteOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
               )
+            )
+          })
+        )
+      ])
+    ),
+    providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+    deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+    authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+    authCredentialsId: mtMap.objectField(
+      'auth_credentials_id',
+      mtMap.passthrough()
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    deployment: mtMap.objectField(
+      'deployment',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authMethod: mtMap.objectField(
+      'auth_method',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        key: mtMap.objectField('key', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+        inputSchema: mtMap.objectField(
+          'input_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        outputSchema: mtMap.objectField(
+          'output_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        scopes: mtMap.objectField(
+          'scopes',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              scope: mtMap.objectField('scope', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField('description', mtMap.passthrough())
             })
           )
-        ])
-      ),
-      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
-      authCredentialsId: mtMap.objectField(
-        'auth_credentials_id',
-        mtMap.passthrough()
-      ),
-      config: mtMap.objectField(
-        'config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      deployment: mtMap.objectField(
-        'deployment',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authMethod: mtMap.objectField(
-        'auth_method',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          key: mtMap.objectField('key', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-          inputSchema: mtMap.objectField(
-            'input_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          outputSchema: mtMap.objectField(
-            'output_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          scopes: mtMap.objectField(
-            'scopes',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                scope: mtMap.objectField('scope', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                )
-              })
-            )
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          providerSpecificationId: mtMap.objectField(
-            'provider_specification_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authCredentials: mtMap.objectField(
-        'auth_credentials',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        providerSpecificationId: mtMap.objectField(
+          'provider_specification_id',
+          mtMap.passthrough()
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authCredentials: mtMap.objectField(
+      'auth_credentials',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    )
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/get.ts
@@ -41,29 +41,6 @@ export type IntegrationProvidersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  object: 'integration.provider';
-  id: string;
-  status: 'active' | 'archived' | 'deleted';
-  integrationId: string;
-  name: string;
-  description: string | null;
-  metadata: Record<string, any> | null;
-  toolFilter:
-    | { type: 'allow_all'; ignoreParentFilters: boolean }
-    | {
-        type: 'filter';
-        filters: (
-          | { type: 'tool_keys'; keys: string[] }
-          | { type: 'tool_regex'; pattern: string }
-          | { type: 'resource_regex'; pattern: string }
-          | { type: 'resource_uris'; uris: string[] }
-          | { type: 'prompt_keys'; keys: string[] }
-          | { type: 'prompt_regex'; pattern: string }
-        )[];
-        ignoreParentFilters: boolean;
-      }
-    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -125,174 +102,167 @@ export type IntegrationProvidersGetOutput = {
   } | null;
 };
 
-export let mapIntegrationProvidersGetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
+export let mapIntegrationProvidersGetOutput =
+  mtMap.object<IntegrationProvidersGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
               )
+            )
+          })
+        )
+      ])
+    ),
+    providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+    deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+    authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+    authCredentialsId: mtMap.objectField(
+      'auth_credentials_id',
+      mtMap.passthrough()
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    deployment: mtMap.objectField(
+      'deployment',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authMethod: mtMap.objectField(
+      'auth_method',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        key: mtMap.objectField('key', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+        inputSchema: mtMap.objectField(
+          'input_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        outputSchema: mtMap.objectField(
+          'output_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        scopes: mtMap.objectField(
+          'scopes',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              scope: mtMap.objectField('scope', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField('description', mtMap.passthrough())
             })
           )
-        ])
-      ),
-      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
-      authCredentialsId: mtMap.objectField(
-        'auth_credentials_id',
-        mtMap.passthrough()
-      ),
-      config: mtMap.objectField(
-        'config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      deployment: mtMap.objectField(
-        'deployment',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authMethod: mtMap.objectField(
-        'auth_method',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          key: mtMap.objectField('key', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-          inputSchema: mtMap.objectField(
-            'input_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          outputSchema: mtMap.objectField(
-            'output_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          scopes: mtMap.objectField(
-            'scopes',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                scope: mtMap.objectField('scope', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                )
-              })
-            )
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          providerSpecificationId: mtMap.objectField(
-            'provider_specification_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authCredentials: mtMap.objectField(
-        'auth_credentials',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        providerSpecificationId: mtMap.objectField(
+          'provider_specification_id',
+          mtMap.passthrough()
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authCredentials: mtMap.objectField(
+      'auth_credentials',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    )
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type IntegrationProvidersListOutput = {
-  items: ({
+  items: {
     object: 'integration.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -42,29 +42,6 @@ export type IntegrationProvidersListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -124,7 +101,7 @@ export type IntegrationProvidersListOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -133,239 +110,201 @@ export let mapIntegrationProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
+            mtMap.passthrough()
+          ),
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
+            mtMap.passthrough()
+          ),
+          config: mtMap.objectField(
+            'config',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
                 'description',
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          deployment: mtMap.objectField(
+            'deployment',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authMethod: mtMap.objectField(
+            'auth_method',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              key: mtMap.objectField('key', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              capabilities: mtMap.objectField(
+                'capabilities',
+                mtMap.passthrough()
+              ),
+              inputSchema: mtMap.objectField(
+                'input_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              outputSchema: mtMap.objectField(
+                'output_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    )
+                  })
+                )
               ),
               providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              deploymentId: mtMap.objectField(
-                'deployment_id',
+              providerSpecificationId: mtMap.objectField(
+                'provider_specification_id',
                 mtMap.passthrough()
-              ),
-              authMethodId: mtMap.objectField(
-                'auth_method_id',
-                mtMap.passthrough()
-              ),
-              authCredentialsId: mtMap.objectField(
-                'auth_credentials_id',
-                mtMap.passthrough()
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authCredentials: mtMap.objectField(
+            'auth_credentials',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
               ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(mtMap.passthrough())
               ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              )
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
           )
-        ])
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-providers/update.ts
@@ -41,29 +41,6 @@ export type IntegrationProvidersUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  object: 'integration.provider';
-  id: string;
-  status: 'active' | 'archived' | 'deleted';
-  integrationId: string;
-  name: string;
-  description: string | null;
-  metadata: Record<string, any> | null;
-  toolFilter:
-    | { type: 'allow_all'; ignoreParentFilters: boolean }
-    | {
-        type: 'filter';
-        filters: (
-          | { type: 'tool_keys'; keys: string[] }
-          | { type: 'tool_regex'; pattern: string }
-          | { type: 'resource_regex'; pattern: string }
-          | { type: 'resource_uris'; uris: string[] }
-          | { type: 'prompt_keys'; keys: string[] }
-          | { type: 'prompt_regex'; pattern: string }
-        )[];
-        ignoreParentFilters: boolean;
-      }
-    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -125,176 +102,169 @@ export type IntegrationProvidersUpdateOutput = {
   } | null;
 };
 
-export let mapIntegrationProvidersUpdateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
+export let mapIntegrationProvidersUpdateOutput =
+  mtMap.object<IntegrationProvidersUpdateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
               )
+            )
+          })
+        )
+      ])
+    ),
+    providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+    deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+    authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+    authCredentialsId: mtMap.objectField(
+      'auth_credentials_id',
+      mtMap.passthrough()
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    deployment: mtMap.objectField(
+      'deployment',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authMethod: mtMap.objectField(
+      'auth_method',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        key: mtMap.objectField('key', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+        inputSchema: mtMap.objectField(
+          'input_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        outputSchema: mtMap.objectField(
+          'output_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        scopes: mtMap.objectField(
+          'scopes',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              scope: mtMap.objectField('scope', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField('description', mtMap.passthrough())
             })
           )
-        ])
-      ),
-      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
-      authCredentialsId: mtMap.objectField(
-        'auth_credentials_id',
-        mtMap.passthrough()
-      ),
-      config: mtMap.objectField(
-        'config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      deployment: mtMap.objectField(
-        'deployment',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authMethod: mtMap.objectField(
-        'auth_method',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          key: mtMap.objectField('key', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-          inputSchema: mtMap.objectField(
-            'input_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          outputSchema: mtMap.objectField(
-            'output_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          scopes: mtMap.objectField(
-            'scopes',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                scope: mtMap.objectField('scope', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                )
-              })
-            )
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          providerSpecificationId: mtMap.objectField(
-            'provider_specification_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authCredentials: mtMap.objectField(
-        'auth_credentials',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        providerSpecificationId: mtMap.objectField(
+          'provider_specification_id',
+          mtMap.passthrough()
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authCredentials: mtMap.objectField(
+      'auth_credentials',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    )
+  });
 
 export type IntegrationProvidersUpdateBody = {
   providerDeploymentId?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-setup-sessions/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-setup-sessions/create.ts
@@ -138,7 +138,6 @@ export type IntegrationSetupSessionsCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   expiresAt: Date;
-} & {
   integrationInstanceId: string;
   steps: {
     object: 'integration.setup_session.step';
@@ -169,369 +168,341 @@ export type IntegrationSetupSessionsCreateOutput = {
   }[];
 };
 
-export let mapIntegrationSetupSessionsCreateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      url: mtMap.objectField('url', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField('configuration', mtMap.passthrough()),
-      redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      integrationInstance: mtMap.objectField(
-        'integration_instance',
+export let mapIntegrationSetupSessionsCreateOutput =
+  mtMap.object<IntegrationSetupSessionsCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    url: mtMap.objectField('url', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField('configuration', mtMap.passthrough()),
+    redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstance: mtMap.objectField(
+      'integration_instance',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        identityActorId: mtMap.objectField(
+          'identity_actor_id',
+          mtMap.passthrough()
+        ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        implementation: mtMap.objectField(
+          'implementation',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
+              mtMap.passthrough()
+            )
+          })
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              isOverrideToolFilter: mtMap.objectField(
+                'is_override_tool_filter',
+                mtMap.passthrough()
+              ),
+              provider: mtMap.objectField(
+                'provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              integrationProvider: mtMap.objectField(
+                'integration_provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  providerVersion: mtMap.objectField(
+                    'provider_version',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      index: mtMap.objectField('index', mtMap.passthrough())
+                    })
+                  ),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  toolFilter: mtMap.objectField(
+                    'tool_filter',
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          ignoreParentFilters: mtMap.objectField(
+                            'ignore_parent_filters',
+                            mtMap.passthrough()
+                          ),
+                          filters: mtMap.objectField(
+                            'filters',
+                            mtMap.array(
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    keys: mtMap.objectField(
+                                      'keys',
+                                      mtMap.array(mtMap.passthrough())
+                                    ),
+                                    pattern: mtMap.objectField(
+                                      'pattern',
+                                      mtMap.passthrough()
+                                    ),
+                                    uris: mtMap.objectField(
+                                      'uris',
+                                      mtMap.array(mtMap.passthrough())
+                                    )
+                                  })
+                                )
+                              ])
+                            )
+                          )
+                        })
+                      )
+                    ])
+                  ),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  deploymentId: mtMap.objectField(
+                    'deployment_id',
+                    mtMap.passthrough()
+                  ),
+                  authMethodId: mtMap.objectField(
+                    'auth_method_id',
+                    mtMap.passthrough()
+                  ),
+                  authCredentialsId: mtMap.objectField(
+                    'auth_credentials_id',
+                    mtMap.passthrough()
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                })
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              authConfig: mtMap.objectField(
+                'auth_config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    steps: mtMap.objectField(
+      'steps',
+      mtMap.array(
         mtMap.object({
           object: mtMap.objectField('object', mtMap.passthrough()),
           id: mtMap.objectField('id', mtMap.passthrough()),
           status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          url: mtMap.objectField('url', mtMap.passthrough()),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
             mtMap.passthrough()
           ),
-          identityActorId: mtMap.objectField(
-            'identity_actor_id',
-            mtMap.passthrough()
-          ),
-          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-          implementation: mtMap.objectField(
-            'implementation',
+          provider: mtMap.objectField(
+            'provider',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
-              )
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
           ),
-          providers: mtMap.objectField(
-            'providers',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
+          providerSetupSessionId: mtMap.objectField(
+            'provider_setup_session_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
           ),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
         })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      expiresAt: mtMap.objectField('expires_at', mtMap.date()),
-      integrationInstanceId: mtMap.objectField(
-        'integration_instance_id',
-        mtMap.passthrough()
-      ),
-      steps: mtMap.objectField(
-        'steps',
-        mtMap.array(
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            url: mtMap.objectField('url', mtMap.passthrough()),
-            integrationProviderId: mtMap.objectField(
-              'integration_provider_id',
-              mtMap.passthrough()
-            ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            providerSetupSessionId: mtMap.objectField(
-              'provider_setup_session_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceProviderId: mtMap.objectField(
-              'integration_instance_provider_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        )
       )
-    })
-  )
-]);
+    )
+  });
 
 export type IntegrationSetupSessionsCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-setup-sessions/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-setup-sessions/get.ts
@@ -138,7 +138,6 @@ export type IntegrationSetupSessionsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   expiresAt: Date;
-} & {
   integrationInstanceId: string;
   steps: {
     object: 'integration.setup_session.step';
@@ -169,367 +168,339 @@ export type IntegrationSetupSessionsGetOutput = {
   }[];
 };
 
-export let mapIntegrationSetupSessionsGetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      url: mtMap.objectField('url', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField('configuration', mtMap.passthrough()),
-      redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      integrationInstance: mtMap.objectField(
-        'integration_instance',
+export let mapIntegrationSetupSessionsGetOutput =
+  mtMap.object<IntegrationSetupSessionsGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    url: mtMap.objectField('url', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField('configuration', mtMap.passthrough()),
+    redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstance: mtMap.objectField(
+      'integration_instance',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        identityActorId: mtMap.objectField(
+          'identity_actor_id',
+          mtMap.passthrough()
+        ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        implementation: mtMap.objectField(
+          'implementation',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
+              mtMap.passthrough()
+            )
+          })
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              isOverrideToolFilter: mtMap.objectField(
+                'is_override_tool_filter',
+                mtMap.passthrough()
+              ),
+              provider: mtMap.objectField(
+                'provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              integrationProvider: mtMap.objectField(
+                'integration_provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  providerVersion: mtMap.objectField(
+                    'provider_version',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      index: mtMap.objectField('index', mtMap.passthrough())
+                    })
+                  ),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  toolFilter: mtMap.objectField(
+                    'tool_filter',
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          ignoreParentFilters: mtMap.objectField(
+                            'ignore_parent_filters',
+                            mtMap.passthrough()
+                          ),
+                          filters: mtMap.objectField(
+                            'filters',
+                            mtMap.array(
+                              mtMap.union([
+                                mtMap.unionOption(
+                                  'object',
+                                  mtMap.object({
+                                    type: mtMap.objectField(
+                                      'type',
+                                      mtMap.passthrough()
+                                    ),
+                                    keys: mtMap.objectField(
+                                      'keys',
+                                      mtMap.array(mtMap.passthrough())
+                                    ),
+                                    pattern: mtMap.objectField(
+                                      'pattern',
+                                      mtMap.passthrough()
+                                    ),
+                                    uris: mtMap.objectField(
+                                      'uris',
+                                      mtMap.array(mtMap.passthrough())
+                                    )
+                                  })
+                                )
+                              ])
+                            )
+                          )
+                        })
+                      )
+                    ])
+                  ),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  deploymentId: mtMap.objectField(
+                    'deployment_id',
+                    mtMap.passthrough()
+                  ),
+                  authMethodId: mtMap.objectField(
+                    'auth_method_id',
+                    mtMap.passthrough()
+                  ),
+                  authCredentialsId: mtMap.objectField(
+                    'auth_credentials_id',
+                    mtMap.passthrough()
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      isDefault: mtMap.objectField(
+                        'is_default',
+                        mtMap.passthrough()
+                      ),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      description: mtMap.objectField(
+                        'description',
+                        mtMap.passthrough()
+                      ),
+                      metadata: mtMap.objectField(
+                        'metadata',
+                        mtMap.passthrough()
+                      ),
+                      providerId: mtMap.objectField(
+                        'provider_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                })
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              authConfig: mtMap.objectField(
+                'auth_config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    steps: mtMap.objectField(
+      'steps',
+      mtMap.array(
         mtMap.object({
           object: mtMap.objectField('object', mtMap.passthrough()),
           id: mtMap.objectField('id', mtMap.passthrough()),
           status: mtMap.objectField('status', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          integrationId: mtMap.objectField(
-            'integration_id',
+          url: mtMap.objectField('url', mtMap.passthrough()),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
             mtMap.passthrough()
           ),
-          identityActorId: mtMap.objectField(
-            'identity_actor_id',
-            mtMap.passthrough()
-          ),
-          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-          implementation: mtMap.objectField(
-            'implementation',
+          provider: mtMap.objectField(
+            'provider',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
-              )
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
           ),
-          providers: mtMap.objectField(
-            'providers',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
+          providerSetupSessionId: mtMap.objectField(
+            'provider_setup_session_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
           ),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
         })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      expiresAt: mtMap.objectField('expires_at', mtMap.date()),
-      integrationInstanceId: mtMap.objectField(
-        'integration_instance_id',
-        mtMap.passthrough()
-      ),
-      steps: mtMap.objectField(
-        'steps',
-        mtMap.array(
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            url: mtMap.objectField('url', mtMap.passthrough()),
-            integrationProviderId: mtMap.objectField(
-              'integration_provider_id',
-              mtMap.passthrough()
-            ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            providerSetupSessionId: mtMap.objectField(
-              'provider_setup_session_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceProviderId: mtMap.objectField(
-              'integration_instance_provider_id',
-              mtMap.passthrough()
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        )
       )
-    })
-  )
-]);
+    )
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-setup-sessions/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integration-setup-sessions/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type IntegrationSetupSessionsListOutput = {
-  items: ({
+  items: {
     object: 'integration.setup_session';
     id: string;
     status: 'pending' | 'successful' | 'expired' | 'archived' | 'deleted';
@@ -139,7 +139,6 @@ export type IntegrationSetupSessionsListOutput = {
     createdAt: Date;
     updatedAt: Date;
     expiresAt: Date;
-  } & {
     integrationInstanceId: string;
     steps: {
       object: 'integration.setup_session.step';
@@ -168,7 +167,7 @@ export type IntegrationSetupSessionsListOutput = {
       createdAt: Date;
       updatedAt: Date;
     }[];
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -177,75 +176,171 @@ export let mapIntegrationSetupSessionsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          url: mtMap.objectField('url', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          configuration: mtMap.objectField(
+            'configuration',
+            mtMap.passthrough()
+          ),
+          redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstance: mtMap.objectField(
+            'integration_instance',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
               status: mtMap.objectField('status', mtMap.passthrough()),
-              url: mtMap.objectField('url', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
                 'description',
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              configuration: mtMap.objectField(
-                'configuration',
-                mtMap.passthrough()
-              ),
-              redirectUrl: mtMap.objectField(
-                'redirect_url',
-                mtMap.passthrough()
-              ),
               integrationId: mtMap.objectField(
                 'integration_id',
                 mtMap.passthrough()
               ),
-              integrationInstance: mtMap.objectField(
-                'integration_instance',
+              identityActorId: mtMap.objectField(
+                'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              implementation: mtMap.objectField(
+                'implementation',
                 mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  magicMcpServerId: mtMap.objectField(
+                    'magic_mcp_server_id',
                     mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  integrationId: mtMap.objectField(
-                    'integration_id',
-                    mtMap.passthrough()
-                  ),
-                  identityActorId: mtMap.objectField(
-                    'identity_actor_id',
-                    mtMap.passthrough()
-                  ),
-                  identityId: mtMap.objectField(
-                    'identity_id',
-                    mtMap.passthrough()
-                  ),
-                  implementation: mtMap.objectField(
-                    'implementation',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      magicMcpServerId: mtMap.objectField(
-                        'magic_mcp_server_id',
-                        mtMap.passthrough()
-                      )
-                    })
-                  ),
-                  providers: mtMap.objectField(
-                    'providers',
-                    mtMap.array(
+                  )
+                })
+              ),
+              providers: mtMap.objectField(
+                'providers',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    integrationId: mtMap.objectField(
+                      'integration_id',
+                      mtMap.passthrough()
+                    ),
+                    integrationInstanceId: mtMap.objectField(
+                      'integration_instance_id',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
+                              mtMap.passthrough()
+                            ),
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
+                            )
+                          })
+                        )
+                      ])
+                    ),
+                    isOverrideToolFilter: mtMap.objectField(
+                      'is_override_tool_filter',
+                      mtMap.passthrough()
+                    ),
+                    provider: mtMap.objectField(
+                      'provider',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        ),
+                        slug: mtMap.objectField('slug', mtMap.passthrough()),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    ),
+                    integrationProvider: mtMap.objectField(
+                      'integration_provider',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        providerVersion: mtMap.objectField(
+                          'provider_version',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            index: mtMap.objectField(
+                              'index',
+                              mtMap.passthrough()
+                            )
+                          })
+                        ),
                         status: mtMap.objectField(
                           'status',
                           mtMap.passthrough()
@@ -257,14 +352,6 @@ export let mapIntegrationSetupSessionsListOutput =
                         ),
                         metadata: mtMap.objectField(
                           'metadata',
-                          mtMap.passthrough()
-                        ),
-                        integrationId: mtMap.objectField(
-                          'integration_id',
-                          mtMap.passthrough()
-                        ),
-                        integrationInstanceId: mtMap.objectField(
-                          'integration_instance_id',
                           mtMap.passthrough()
                         ),
                         toolFilter: mtMap.objectField(
@@ -313,238 +400,24 @@ export let mapIntegrationSetupSessionsListOutput =
                             )
                           ])
                         ),
-                        isOverrideToolFilter: mtMap.objectField(
-                          'is_override_tool_filter',
+                        providerId: mtMap.objectField(
+                          'provider_id',
                           mtMap.passthrough()
                         ),
-                        provider: mtMap.objectField(
-                          'provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            slug: mtMap.objectField(
-                              'slug',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
+                        deploymentId: mtMap.objectField(
+                          'deployment_id',
+                          mtMap.passthrough()
                         ),
-                        integrationProvider: mtMap.objectField(
-                          'integration_provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            providerVersion: mtMap.objectField(
-                              'provider_version',
-                              mtMap.object({
-                                object: mtMap.objectField(
-                                  'object',
-                                  mtMap.passthrough()
-                                ),
-                                id: mtMap.objectField(
-                                  'id',
-                                  mtMap.passthrough()
-                                ),
-                                index: mtMap.objectField(
-                                  'index',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            status: mtMap.objectField(
-                              'status',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            toolFilter: mtMap.objectField(
-                              'tool_filter',
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    ignoreParentFilters: mtMap.objectField(
-                                      'ignore_parent_filters',
-                                      mtMap.passthrough()
-                                    ),
-                                    filters: mtMap.objectField(
-                                      'filters',
-                                      mtMap.array(
-                                        mtMap.union([
-                                          mtMap.unionOption(
-                                            'object',
-                                            mtMap.object({
-                                              type: mtMap.objectField(
-                                                'type',
-                                                mtMap.passthrough()
-                                              ),
-                                              keys: mtMap.objectField(
-                                                'keys',
-                                                mtMap.array(mtMap.passthrough())
-                                              ),
-                                              pattern: mtMap.objectField(
-                                                'pattern',
-                                                mtMap.passthrough()
-                                              ),
-                                              uris: mtMap.objectField(
-                                                'uris',
-                                                mtMap.array(mtMap.passthrough())
-                                              )
-                                            })
-                                          )
-                                        ])
-                                      )
-                                    )
-                                  })
-                                )
-                              ])
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            deploymentId: mtMap.objectField(
-                              'deployment_id',
-                              mtMap.passthrough()
-                            ),
-                            authMethodId: mtMap.objectField(
-                              'auth_method_id',
-                              mtMap.passthrough()
-                            ),
-                            authCredentialsId: mtMap.objectField(
-                              'auth_credentials_id',
-                              mtMap.passthrough()
-                            ),
-                            config: mtMap.objectField(
-                              'config',
-                              mtMap.object({
-                                object: mtMap.objectField(
-                                  'object',
-                                  mtMap.passthrough()
-                                ),
-                                id: mtMap.objectField(
-                                  'id',
-                                  mtMap.passthrough()
-                                ),
-                                isDefault: mtMap.objectField(
-                                  'is_default',
-                                  mtMap.passthrough()
-                                ),
-                                name: mtMap.objectField(
-                                  'name',
-                                  mtMap.passthrough()
-                                ),
-                                description: mtMap.objectField(
-                                  'description',
-                                  mtMap.passthrough()
-                                ),
-                                metadata: mtMap.objectField(
-                                  'metadata',
-                                  mtMap.passthrough()
-                                ),
-                                providerId: mtMap.objectField(
-                                  'provider_id',
-                                  mtMap.passthrough()
-                                ),
-                                createdAt: mtMap.objectField(
-                                  'created_at',
-                                  mtMap.date()
-                                ),
-                                updatedAt: mtMap.objectField(
-                                  'updated_at',
-                                  mtMap.date()
-                                )
-                              })
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            ),
-                            archivedAt: mtMap.objectField(
-                              'archived_at',
-                              mtMap.date()
-                            )
-                          })
+                        authMethodId: mtMap.objectField(
+                          'auth_method_id',
+                          mtMap.passthrough()
+                        ),
+                        authCredentialsId: mtMap.objectField(
+                          'auth_credentials_id',
+                          mtMap.passthrough()
                         ),
                         config: mtMap.objectField(
                           'config',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authConfig: mtMap.objectField(
-                          'auth_config',
                           mtMap.object({
                             object: mtMap.objectField(
                               'object',
@@ -594,46 +467,32 @@ export let mapIntegrationSetupSessionsListOutput =
                           mtMap.date()
                         )
                       })
-                    )
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              expiresAt: mtMap.objectField('expires_at', mtMap.date()),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              steps: mtMap.objectField(
-                'steps',
-                mtMap.array(
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    url: mtMap.objectField('url', mtMap.passthrough()),
-                    integrationProviderId: mtMap.objectField(
-                      'integration_provider_id',
-                      mtMap.passthrough()
                     ),
-                    provider: mtMap.objectField(
-                      'provider',
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
                         ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
                         createdAt: mtMap.objectField(
                           'created_at',
                           mtMap.date()
@@ -641,22 +500,97 @@ export let mapIntegrationSetupSessionsListOutput =
                         updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
                     ),
-                    providerSetupSessionId: mtMap.objectField(
-                      'provider_setup_session_id',
+                    authConfig: mtMap.objectField(
+                      'auth_config',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                )
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          steps: mtMap.objectField(
+            'steps',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough()),
+                integrationProviderId: mtMap.objectField(
+                  'integration_provider_id',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
                       mtMap.passthrough()
                     ),
-                    integrationInstanceProviderId: mtMap.objectField(
-                      'integration_instance_provider_id',
-                      mtMap.passthrough()
-                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
                     createdAt: mtMap.objectField('created_at', mtMap.date()),
                     updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
-                )
-              )
-            })
+                ),
+                providerSetupSessionId: mtMap.objectField(
+                  'provider_setup_session_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceProviderId: mtMap.objectField(
+                  'integration_instance_provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            )
           )
-        ])
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/create.ts
@@ -58,75 +58,6 @@ export type IntegrationsCreateOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -186,315 +117,262 @@ export type IntegrationsCreateOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
 };
 
-export let mapIntegrationsCreateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      slug: mtMap.objectField('slug', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField(
-        'configuration',
+export let mapIntegrationsCreateOutput = mtMap.object<IntegrationsCreateOutput>(
+  {
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    slug: mtMap.objectField('slug', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField(
+      'configuration',
+      mtMap.object({
+        canAttachCustomToolFilters: mtMap.objectField(
+          'can_attach_custom_tool_filters',
+          mtMap.passthrough()
+        ),
+        canAttachCustomProviderConfig: mtMap.objectField(
+          'can_attach_custom_provider_config',
+          mtMap.passthrough()
+        ),
+        canOverrideToolFilters: mtMap.objectField(
+          'can_override_tool_filters',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            providerTemplateId: mtMap.objectField(
+              'provider_template_id',
+              mtMap.passthrough()
+            ),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
+              mtMap.passthrough()
+            )
+          })
+        )
+      ])
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          canAttachCustomToolFilters: mtMap.objectField(
-            'can_attach_custom_tool_filters',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
           ),
-          canAttachCustomProviderConfig: mtMap.objectField(
-            'can_attach_custom_provider_config',
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
             mtMap.passthrough()
           ),
-          canOverrideToolFilters: mtMap.objectField(
-            'can_override_tool_filters',
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+          ),
+          config: mtMap.objectField(
+            'config',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              providerTemplateId: mtMap.objectField(
-                'provider_template_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
-                mtMap.passthrough()
-              )
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          )
-        ])
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          deployment: mtMap.objectField(
+            'deployment',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authMethod: mtMap.objectField(
+            'auth_method',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              key: mtMap.objectField('key', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              capabilities: mtMap.objectField(
+                'capabilities',
+                mtMap.passthrough()
+              ),
+              inputSchema: mtMap.objectField(
+                'input_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              outputSchema: mtMap.objectField(
+                'output_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
                     )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                deployment: mtMap.objectField(
-                  'deployment',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authMethod: mtMap.objectField(
-                  'auth_method',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    key: mtMap.objectField('key', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    capabilities: mtMap.objectField(
-                      'capabilities',
-                      mtMap.passthrough()
-                    ),
-                    inputSchema: mtMap.objectField(
-                      'input_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    outputSchema: mtMap.objectField(
-                      'output_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          scope: mtMap.objectField(
-                            'scope',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          )
-                        })
-                      )
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    providerSpecificationId: mtMap.objectField(
-                      'provider_specification_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authCredentials: mtMap.objectField(
-                  'auth_credentials',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    isManaged: mtMap.objectField(
-                      'is_managed',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(mtMap.passthrough())
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              providerSpecificationId: mtMap.objectField(
+                'provider_specification_id',
+                mtMap.passthrough()
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authCredentials: mtMap.objectField(
+            'auth_credentials',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(mtMap.passthrough())
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          )
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  }
+);
 
 export type IntegrationsCreateBody = {
   name: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/delete.ts
@@ -58,75 +58,6 @@ export type IntegrationsDeleteOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -186,313 +117,260 @@ export type IntegrationsDeleteOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
 };
 
-export let mapIntegrationsDeleteOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      slug: mtMap.objectField('slug', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField(
-        'configuration',
+export let mapIntegrationsDeleteOutput = mtMap.object<IntegrationsDeleteOutput>(
+  {
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    slug: mtMap.objectField('slug', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField(
+      'configuration',
+      mtMap.object({
+        canAttachCustomToolFilters: mtMap.objectField(
+          'can_attach_custom_tool_filters',
+          mtMap.passthrough()
+        ),
+        canAttachCustomProviderConfig: mtMap.objectField(
+          'can_attach_custom_provider_config',
+          mtMap.passthrough()
+        ),
+        canOverrideToolFilters: mtMap.objectField(
+          'can_override_tool_filters',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            providerTemplateId: mtMap.objectField(
+              'provider_template_id',
+              mtMap.passthrough()
+            ),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
+              mtMap.passthrough()
+            )
+          })
+        )
+      ])
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          canAttachCustomToolFilters: mtMap.objectField(
-            'can_attach_custom_tool_filters',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
           ),
-          canAttachCustomProviderConfig: mtMap.objectField(
-            'can_attach_custom_provider_config',
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
             mtMap.passthrough()
           ),
-          canOverrideToolFilters: mtMap.objectField(
-            'can_override_tool_filters',
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+          ),
+          config: mtMap.objectField(
+            'config',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              providerTemplateId: mtMap.objectField(
-                'provider_template_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
-                mtMap.passthrough()
-              )
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          )
-        ])
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          deployment: mtMap.objectField(
+            'deployment',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authMethod: mtMap.objectField(
+            'auth_method',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              key: mtMap.objectField('key', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              capabilities: mtMap.objectField(
+                'capabilities',
+                mtMap.passthrough()
+              ),
+              inputSchema: mtMap.objectField(
+                'input_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              outputSchema: mtMap.objectField(
+                'output_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
                     )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                deployment: mtMap.objectField(
-                  'deployment',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authMethod: mtMap.objectField(
-                  'auth_method',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    key: mtMap.objectField('key', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    capabilities: mtMap.objectField(
-                      'capabilities',
-                      mtMap.passthrough()
-                    ),
-                    inputSchema: mtMap.objectField(
-                      'input_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    outputSchema: mtMap.objectField(
-                      'output_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          scope: mtMap.objectField(
-                            'scope',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          )
-                        })
-                      )
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    providerSpecificationId: mtMap.objectField(
-                      'provider_specification_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authCredentials: mtMap.objectField(
-                  'auth_credentials',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    isManaged: mtMap.objectField(
-                      'is_managed',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(mtMap.passthrough())
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              providerSpecificationId: mtMap.objectField(
+                'provider_specification_id',
+                mtMap.passthrough()
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authCredentials: mtMap.objectField(
+            'auth_credentials',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(mtMap.passthrough())
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          )
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  }
+);
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/get.ts
@@ -58,75 +58,6 @@ export type IntegrationsGetOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -186,313 +117,234 @@ export type IntegrationsGetOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
 };
 
-export let mapIntegrationsGetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
+export let mapIntegrationsGetOutput = mtMap.object<IntegrationsGetOutput>({
+  object: mtMap.objectField('object', mtMap.passthrough()),
+  id: mtMap.objectField('id', mtMap.passthrough()),
+  status: mtMap.objectField('status', mtMap.passthrough()),
+  slug: mtMap.objectField('slug', mtMap.passthrough()),
+  name: mtMap.objectField('name', mtMap.passthrough()),
+  description: mtMap.objectField('description', mtMap.passthrough()),
+  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+  configuration: mtMap.objectField(
+    'configuration',
     mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      slug: mtMap.objectField('slug', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField(
-        'configuration',
+      canAttachCustomToolFilters: mtMap.objectField(
+        'can_attach_custom_tool_filters',
+        mtMap.passthrough()
+      ),
+      canAttachCustomProviderConfig: mtMap.objectField(
+        'can_attach_custom_provider_config',
+        mtMap.passthrough()
+      ),
+      canOverrideToolFilters: mtMap.objectField(
+        'can_override_tool_filters',
+        mtMap.passthrough()
+      )
+    })
+  ),
+  implementation: mtMap.objectField(
+    'implementation',
+    mtMap.union([
+      mtMap.unionOption(
+        'object',
         mtMap.object({
-          canAttachCustomToolFilters: mtMap.objectField(
-            'can_attach_custom_tool_filters',
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          providerTemplateId: mtMap.objectField(
+            'provider_template_id',
             mtMap.passthrough()
           ),
-          canAttachCustomProviderConfig: mtMap.objectField(
-            'can_attach_custom_provider_config',
-            mtMap.passthrough()
-          ),
-          canOverrideToolFilters: mtMap.objectField(
-            'can_override_tool_filters',
+          magicMcpServerId: mtMap.objectField(
+            'magic_mcp_server_id',
             mtMap.passthrough()
           )
         })
-      ),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              providerTemplateId: mtMap.objectField(
-                'provider_template_id',
-                mtMap.passthrough()
-              ),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
-                mtMap.passthrough()
-              )
-            })
-          )
-        ])
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
+      )
+    ])
+  ),
+  providers: mtMap.objectField(
+    'providers',
+    mtMap.array(
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
           mtMap.union([
             mtMap.unionOption(
               'object',
               mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
                   mtMap.passthrough()
                 ),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                deployment: mtMap.objectField(
-                  'deployment',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authMethod: mtMap.objectField(
-                  'auth_method',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    key: mtMap.objectField('key', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    capabilities: mtMap.objectField(
-                      'capabilities',
-                      mtMap.passthrough()
-                    ),
-                    inputSchema: mtMap.objectField(
-                      'input_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    outputSchema: mtMap.objectField(
-                      'output_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
                         mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
                             mtMap.passthrough()
                           ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          scope: mtMap.objectField(
-                            'scope',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
                           )
                         })
                       )
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    providerSpecificationId: mtMap.objectField(
-                      'provider_specification_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authCredentials: mtMap.objectField(
-                  'auth_credentials',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    isManaged: mtMap.objectField(
-                      'is_managed',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(mtMap.passthrough())
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
+                    ])
+                  )
                 )
               })
             )
           ])
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
+          mtMap.passthrough()
+        ),
+        config: mtMap.objectField(
+          'config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+        provider: mtMap.objectField(
+          'provider',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            slug: mtMap.objectField('slug', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        deployment: mtMap.objectField(
+          'deployment',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        authMethod: mtMap.objectField(
+          'auth_method',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            key: mtMap.objectField('key', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            capabilities: mtMap.objectField(
+              'capabilities',
+              mtMap.passthrough()
+            ),
+            inputSchema: mtMap.objectField(
+              'input_schema',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                schema: mtMap.objectField('schema', mtMap.passthrough())
+              })
+            ),
+            outputSchema: mtMap.objectField(
+              'output_schema',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                schema: mtMap.objectField('schema', mtMap.passthrough())
+              })
+            ),
+            scopes: mtMap.objectField(
+              'scopes',
+              mtMap.array(
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  scope: mtMap.objectField('scope', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  )
+                })
+              )
+            ),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            providerSpecificationId: mtMap.objectField(
+              'provider_specification_id',
+              mtMap.passthrough()
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        authCredentials: mtMap.objectField(
+          'auth_credentials',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            status: mtMap.objectField('status', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            scopes: mtMap.objectField(
+              'scopes',
+              mtMap.array(mtMap.passthrough())
+            ),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
         )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+      })
+    )
+  ),
+  createdAt: mtMap.objectField('created_at', mtMap.date()),
+  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+  archivedAt: mtMap.objectField('archived_at', mtMap.date())
+});
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type IntegrationsListOutput = {
-  items: ({
+  items: {
     object: 'integration';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -59,75 +59,6 @@ export type IntegrationsListOutput = {
       createdAt: Date;
       updatedAt: Date;
       archivedAt: Date | null;
-    }[];
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    providers: ({
-      object: 'integration.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      integrationId: string;
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } & {
-      object: 'integration.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      integrationId: string;
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
       provider: {
         object: 'provider#preview';
         id: string;
@@ -193,8 +124,11 @@ export type IntegrationsListOutput = {
         createdAt: Date;
         updatedAt: Date;
       } | null;
-    })[];
-  })[];
+    }[];
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -202,387 +136,287 @@ export let mapIntegrationsListOutput = mtMap.object<IntegrationsListOutput>({
   items: mtMap.objectField(
     'items',
     mtMap.array(
-      mtMap.union([
-        mtMap.unionOption(
-          'object',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        configuration: mtMap.objectField(
+          'configuration',
           mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            configuration: mtMap.objectField(
-              'configuration',
+            canAttachCustomToolFilters: mtMap.objectField(
+              'can_attach_custom_tool_filters',
+              mtMap.passthrough()
+            ),
+            canAttachCustomProviderConfig: mtMap.objectField(
+              'can_attach_custom_provider_config',
+              mtMap.passthrough()
+            ),
+            canOverrideToolFilters: mtMap.objectField(
+              'can_override_tool_filters',
+              mtMap.passthrough()
+            )
+          })
+        ),
+        implementation: mtMap.objectField(
+          'implementation',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
               mtMap.object({
-                canAttachCustomToolFilters: mtMap.objectField(
-                  'can_attach_custom_tool_filters',
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                providerTemplateId: mtMap.objectField(
+                  'provider_template_id',
                   mtMap.passthrough()
                 ),
-                canAttachCustomProviderConfig: mtMap.objectField(
-                  'can_attach_custom_provider_config',
-                  mtMap.passthrough()
-                ),
-                canOverrideToolFilters: mtMap.objectField(
-                  'can_override_tool_filters',
+                magicMcpServerId: mtMap.objectField(
+                  'magic_mcp_server_id',
                   mtMap.passthrough()
                 )
               })
-            ),
-            implementation: mtMap.objectField(
-              'implementation',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    providerTemplateId: mtMap.objectField(
-                      'provider_template_id',
-                      mtMap.passthrough()
-                    ),
-                    magicMcpServerId: mtMap.objectField(
-                      'magic_mcp_server_id',
-                      mtMap.passthrough()
-                    )
-                  })
-                )
-              ])
-            ),
-            providers: mtMap.objectField(
-              'providers',
-              mtMap.array(
+            )
+          ])
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
                 mtMap.union([
                   mtMap.unionOption(
                     'object',
                     mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      integrationId: mtMap.objectField(
-                        'integration_id',
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
                         mtMap.passthrough()
                       ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      toolFilter: mtMap.objectField(
-                        'tool_filter',
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              ignoreParentFilters: mtMap.objectField(
-                                'ignore_parent_filters',
-                                mtMap.passthrough()
-                              ),
-                              filters: mtMap.objectField(
-                                'filters',
-                                mtMap.array(
-                                  mtMap.union([
-                                    mtMap.unionOption(
-                                      'object',
-                                      mtMap.object({
-                                        type: mtMap.objectField(
-                                          'type',
-                                          mtMap.passthrough()
-                                        ),
-                                        keys: mtMap.objectField(
-                                          'keys',
-                                          mtMap.array(mtMap.passthrough())
-                                        ),
-                                        pattern: mtMap.objectField(
-                                          'pattern',
-                                          mtMap.passthrough()
-                                        ),
-                                        uris: mtMap.objectField(
-                                          'uris',
-                                          mtMap.array(mtMap.passthrough())
-                                        )
-                                      })
-                                    )
-                                  ])
-                                )
-                              )
-                            })
-                          )
-                        ])
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      deploymentId: mtMap.objectField(
-                        'deployment_id',
-                        mtMap.passthrough()
-                      ),
-                      authMethodId: mtMap.objectField(
-                        'auth_method_id',
-                        mtMap.passthrough()
-                      ),
-                      authCredentialsId: mtMap.objectField(
-                        'auth_credentials_id',
-                        mtMap.passthrough()
-                      ),
-                      config: mtMap.objectField(
-                        'config',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          isDefault: mtMap.objectField(
-                            'is_default',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          ),
-                          metadata: mtMap.objectField(
-                            'metadata',
-                            mtMap.passthrough()
-                          ),
-                          providerId: mtMap.objectField(
-                            'provider_id',
-                            mtMap.passthrough()
-                          ),
-                          createdAt: mtMap.objectField(
-                            'created_at',
-                            mtMap.date()
-                          ),
-                          updatedAt: mtMap.objectField(
-                            'updated_at',
-                            mtMap.date()
-                          )
-                        })
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                      archivedAt: mtMap.objectField(
-                        'archived_at',
-                        mtMap.date()
-                      ),
-                      provider: mtMap.objectField(
-                        'provider',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          ),
-                          slug: mtMap.objectField('slug', mtMap.passthrough()),
-                          createdAt: mtMap.objectField(
-                            'created_at',
-                            mtMap.date()
-                          ),
-                          updatedAt: mtMap.objectField(
-                            'updated_at',
-                            mtMap.date()
-                          )
-                        })
-                      ),
-                      deployment: mtMap.objectField(
-                        'deployment',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          isDefault: mtMap.objectField(
-                            'is_default',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          ),
-                          metadata: mtMap.objectField(
-                            'metadata',
-                            mtMap.passthrough()
-                          ),
-                          providerId: mtMap.objectField(
-                            'provider_id',
-                            mtMap.passthrough()
-                          ),
-                          createdAt: mtMap.objectField(
-                            'created_at',
-                            mtMap.date()
-                          ),
-                          updatedAt: mtMap.objectField(
-                            'updated_at',
-                            mtMap.date()
-                          )
-                        })
-                      ),
-                      authMethod: mtMap.objectField(
-                        'auth_method',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          key: mtMap.objectField('key', mtMap.passthrough()),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          ),
-                          capabilities: mtMap.objectField(
-                            'capabilities',
-                            mtMap.passthrough()
-                          ),
-                          inputSchema: mtMap.objectField(
-                            'input_schema',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              schema: mtMap.objectField(
-                                'schema',
-                                mtMap.passthrough()
-                              )
-                            })
-                          ),
-                          outputSchema: mtMap.objectField(
-                            'output_schema',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              schema: mtMap.objectField(
-                                'schema',
-                                mtMap.passthrough()
-                              )
-                            })
-                          ),
-                          scopes: mtMap.objectField(
-                            'scopes',
-                            mtMap.array(
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
                               mtMap.object({
-                                object: mtMap.objectField(
-                                  'object',
+                                type: mtMap.objectField(
+                                  'type',
                                   mtMap.passthrough()
                                 ),
-                                id: mtMap.objectField(
-                                  'id',
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
                                   mtMap.passthrough()
                                 ),
-                                scope: mtMap.objectField(
-                                  'scope',
-                                  mtMap.passthrough()
-                                ),
-                                name: mtMap.objectField(
-                                  'name',
-                                  mtMap.passthrough()
-                                ),
-                                description: mtMap.objectField(
-                                  'description',
-                                  mtMap.passthrough()
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
                                 )
                               })
                             )
-                          ),
-                          providerId: mtMap.objectField(
-                            'provider_id',
-                            mtMap.passthrough()
-                          ),
-                          providerSpecificationId: mtMap.objectField(
-                            'provider_specification_id',
-                            mtMap.passthrough()
-                          ),
-                          createdAt: mtMap.objectField(
-                            'created_at',
-                            mtMap.date()
-                          ),
-                          updatedAt: mtMap.objectField(
-                            'updated_at',
-                            mtMap.date()
-                          )
-                        })
-                      ),
-                      authCredentials: mtMap.objectField(
-                        'auth_credentials',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          status: mtMap.objectField(
-                            'status',
-                            mtMap.passthrough()
-                          ),
-                          isDefault: mtMap.objectField(
-                            'is_default',
-                            mtMap.passthrough()
-                          ),
-                          isManaged: mtMap.objectField(
-                            'is_managed',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          ),
-                          metadata: mtMap.objectField(
-                            'metadata',
-                            mtMap.passthrough()
-                          ),
-                          scopes: mtMap.objectField(
-                            'scopes',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          providerId: mtMap.objectField(
-                            'provider_id',
-                            mtMap.passthrough()
-                          ),
-                          createdAt: mtMap.objectField(
-                            'created_at',
-                            mtMap.date()
-                          ),
-                          updatedAt: mtMap.objectField(
-                            'updated_at',
-                            mtMap.date()
-                          )
-                        })
+                          ])
+                        )
                       )
                     })
                   )
                 ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+              provider: mtMap.objectField(
+                'provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              deployment: mtMap.objectField(
+                'deployment',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              authMethod: mtMap.objectField(
+                'auth_method',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  key: mtMap.objectField('key', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  capabilities: mtMap.objectField(
+                    'capabilities',
+                    mtMap.passthrough()
+                  ),
+                  inputSchema: mtMap.objectField(
+                    'input_schema',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      schema: mtMap.objectField('schema', mtMap.passthrough())
+                    })
+                  ),
+                  outputSchema: mtMap.objectField(
+                    'output_schema',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      schema: mtMap.objectField('schema', mtMap.passthrough())
+                    })
+                  ),
+                  scopes: mtMap.objectField(
+                    'scopes',
+                    mtMap.array(
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        scope: mtMap.objectField('scope', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        )
+                      })
+                    )
+                  ),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  providerSpecificationId: mtMap.objectField(
+                    'provider_specification_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              authCredentials: mtMap.objectField(
+                'auth_credentials',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  isManaged: mtMap.objectField(
+                    'is_managed',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  scopes: mtMap.objectField(
+                    'scopes',
+                    mtMap.array(mtMap.passthrough())
+                  ),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
               )
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
-        )
-      ])
+            })
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
     )
   ),
   pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/update.ts
@@ -58,75 +58,6 @@ export type IntegrationsUpdateOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -186,315 +117,262 @@ export type IntegrationsUpdateOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
 };
 
-export let mapIntegrationsUpdateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      slug: mtMap.objectField('slug', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField(
-        'configuration',
+export let mapIntegrationsUpdateOutput = mtMap.object<IntegrationsUpdateOutput>(
+  {
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    slug: mtMap.objectField('slug', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField(
+      'configuration',
+      mtMap.object({
+        canAttachCustomToolFilters: mtMap.objectField(
+          'can_attach_custom_tool_filters',
+          mtMap.passthrough()
+        ),
+        canAttachCustomProviderConfig: mtMap.objectField(
+          'can_attach_custom_provider_config',
+          mtMap.passthrough()
+        ),
+        canOverrideToolFilters: mtMap.objectField(
+          'can_override_tool_filters',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            providerTemplateId: mtMap.objectField(
+              'provider_template_id',
+              mtMap.passthrough()
+            ),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
+              mtMap.passthrough()
+            )
+          })
+        )
+      ])
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          canAttachCustomToolFilters: mtMap.objectField(
-            'can_attach_custom_tool_filters',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
           ),
-          canAttachCustomProviderConfig: mtMap.objectField(
-            'can_attach_custom_provider_config',
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
             mtMap.passthrough()
           ),
-          canOverrideToolFilters: mtMap.objectField(
-            'can_override_tool_filters',
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+          ),
+          config: mtMap.objectField(
+            'config',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              providerTemplateId: mtMap.objectField(
-                'provider_template_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
-                mtMap.passthrough()
-              )
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          )
-        ])
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          deployment: mtMap.objectField(
+            'deployment',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authMethod: mtMap.objectField(
+            'auth_method',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              key: mtMap.objectField('key', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              capabilities: mtMap.objectField(
+                'capabilities',
+                mtMap.passthrough()
+              ),
+              inputSchema: mtMap.objectField(
+                'input_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              outputSchema: mtMap.objectField(
+                'output_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
                     )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                deployment: mtMap.objectField(
-                  'deployment',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authMethod: mtMap.objectField(
-                  'auth_method',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    key: mtMap.objectField('key', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    capabilities: mtMap.objectField(
-                      'capabilities',
-                      mtMap.passthrough()
-                    ),
-                    inputSchema: mtMap.objectField(
-                      'input_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    outputSchema: mtMap.objectField(
-                      'output_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          scope: mtMap.objectField(
-                            'scope',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          )
-                        })
-                      )
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    providerSpecificationId: mtMap.objectField(
-                      'provider_specification_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authCredentials: mtMap.objectField(
-                  'auth_credentials',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    isManaged: mtMap.objectField(
-                      'is_managed',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(mtMap.passthrough())
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              providerSpecificationId: mtMap.objectField(
+                'provider_specification_id',
+                mtMap.passthrough()
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authCredentials: mtMap.objectField(
+            'auth_credentials',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(mtMap.passthrough())
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          )
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  }
+);
 
 export type IntegrationsUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/delete.ts
@@ -31,7 +31,6 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -196,425 +195,404 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersDeleteOutput = {
 };
 
 export let mapManagementInstanceIntegrationInstanceGroupProvidersDeleteOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
-      mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstanceGroupId: mtMap.objectField(
-          'integration_instance_group_id',
-          mtMap.passthrough()
-        ),
-        integrationInstanceId: mtMap.objectField(
-          'integration_instance_id',
-          mtMap.passthrough()
-        ),
-        integrationProviderId: mtMap.objectField(
-          'integration_provider_id',
-          mtMap.passthrough()
-        ),
-        integrationInstanceProviderId: mtMap.objectField(
-          'integration_instance_provider_id',
-          mtMap.passthrough()
-        ),
-        toolFilter: mtMap.objectField(
-          'tool_filter',
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                ignoreParentFilters: mtMap.objectField(
-                  'ignore_parent_filters',
-                  mtMap.passthrough()
-                ),
-                filters: mtMap.objectField(
-                  'filters',
-                  mtMap.array(
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          keys: mtMap.objectField(
-                            'keys',
-                            mtMap.array(mtMap.passthrough())
-                          ),
-                          pattern: mtMap.objectField(
-                            'pattern',
-                            mtMap.passthrough()
-                          ),
-                          uris: mtMap.objectField(
-                            'uris',
-                            mtMap.array(mtMap.passthrough())
-                          )
-                        })
-                      )
-                    ])
-                  )
-                )
-              })
-            )
-          ])
-        ),
-        isOverrideToolFilter: mtMap.objectField(
-          'is_override_tool_filter',
-          mtMap.passthrough()
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        integrationProvider: mtMap.objectField(
-          'integration_provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            providerVersion: mtMap.objectField(
-              'provider_version',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                index: mtMap.objectField('index', mtMap.passthrough())
-              })
-            ),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            deploymentId: mtMap.objectField(
-              'deployment_id',
-              mtMap.passthrough()
-            ),
-            authMethodId: mtMap.objectField(
-              'auth_method_id',
-              mtMap.passthrough()
-            ),
-            authCredentialsId: mtMap.objectField(
-              'auth_credentials_id',
-              mtMap.passthrough()
-            ),
-            config: mtMap.objectField(
-              'config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
-        ),
-        integrationInstanceProvider: mtMap.objectField(
-          'integration_instance_provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            integrationId: mtMap.objectField(
-              'integration_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceId: mtMap.objectField(
-              'integration_instance_id',
-              mtMap.passthrough()
-            ),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            isOverrideToolFilter: mtMap.objectField(
-              'is_override_tool_filter',
-              mtMap.passthrough()
-            ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            integrationProvider: mtMap.objectField(
-              'integration_provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                providerVersion: mtMap.objectField(
-                  'provider_version',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    index: mtMap.objectField('index', mtMap.passthrough())
-                  })
-                ),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
+  mtMap.object<ManagementInstanceIntegrationInstanceGroupProvidersDeleteOutput>(
+    {
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      description: mtMap.objectField('description', mtMap.passthrough()),
+      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceGroupId: mtMap.objectField(
+        'integration_instance_group_id',
+        mtMap.passthrough()
+      ),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      integrationProviderId: mtMap.objectField(
+        'integration_provider_id',
+        mtMap.passthrough()
+      ),
+      integrationInstanceProviderId: mtMap.objectField(
+        'integration_instance_provider_id',
+        mtMap.passthrough()
+      ),
+      toolFilter: mtMap.objectField(
+        'tool_filter',
+        mtMap.union([
+          mtMap.unionOption(
+            'object',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              ignoreParentFilters: mtMap.objectField(
+                'ignore_parent_filters',
+                mtMap.passthrough()
+              ),
+              filters: mtMap.objectField(
+                'filters',
+                mtMap.array(
                   mtMap.union([
                     mtMap.unionOption(
                       'object',
                       mtMap.object({
                         type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
+                        keys: mtMap.objectField(
+                          'keys',
+                          mtMap.array(mtMap.passthrough())
+                        ),
+                        pattern: mtMap.objectField(
+                          'pattern',
                           mtMap.passthrough()
                         ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
+                        uris: mtMap.objectField(
+                          'uris',
+                          mtMap.array(mtMap.passthrough())
                         )
                       })
                     )
                   ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            ),
-            config: mtMap.objectField(
-              'config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authConfig: mtMap.objectField(
-              'auth_config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
-        )
-      })
-    )
-  ]);
+                )
+              )
+            })
+          )
+        ])
+      ),
+      isOverrideToolFilter: mtMap.objectField(
+        'is_override_tool_filter',
+        mtMap.passthrough()
+      ),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+      provider: mtMap.objectField(
+        'provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      ),
+      integrationProvider: mtMap.objectField(
+        'integration_provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          providerVersion: mtMap.objectField(
+            'provider_version',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              index: mtMap.objectField('index', mtMap.passthrough())
+            })
+          ),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
+            mtMap.passthrough()
+          ),
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
+            mtMap.passthrough()
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      ),
+      integrationInstanceProvider: mtMap.objectField(
+        'integration_instance_provider',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    }
+  );
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/get.ts
@@ -31,7 +31,6 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -196,9 +195,174 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersGetOutput = {
 };
 
 export let mapManagementInstanceIntegrationInstanceGroupProvidersGetOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<ManagementInstanceIntegrationInstanceGroupProvidersGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstanceGroupId: mtMap.objectField(
+      'integration_instance_group_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    integrationProviderId: mtMap.objectField(
+      'integration_provider_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceProviderId: mtMap.objectField(
+      'integration_instance_provider_id',
+      mtMap.passthrough()
+    ),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
+              )
+            )
+          })
+        )
+      ])
+    ),
+    isOverrideToolFilter: mtMap.objectField(
+      'is_override_tool_filter',
+      mtMap.passthrough()
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    integrationProvider: mtMap.objectField(
+      'integration_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        providerVersion: mtMap.objectField(
+          'provider_version',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            index: mtMap.objectField('index', mtMap.passthrough())
+          })
+        ),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
+                  mtMap.passthrough()
+                ),
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
+                            mtMap.passthrough()
+                          ),
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
+                          )
+                        })
+                      )
+                    ])
+                  )
+                )
+              })
+            )
+          ])
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
+          mtMap.passthrough()
+        ),
+        config: mtMap.objectField(
+          'config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    integrationInstanceProvider: mtMap.objectField(
+      'integration_instance_provider',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
@@ -207,20 +371,8 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersGetOutput =
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstanceGroupId: mtMap.objectField(
-          'integration_instance_group_id',
-          mtMap.passthrough()
-        ),
         integrationInstanceId: mtMap.objectField(
           'integration_instance_id',
-          mtMap.passthrough()
-        ),
-        integrationProviderId: mtMap.objectField(
-          'integration_provider_id',
-          mtMap.passthrough()
-        ),
-        integrationInstanceProviderId: mtMap.objectField(
-          'integration_instance_provider_id',
           mtMap.passthrough()
         ),
         toolFilter: mtMap.objectField(
@@ -267,9 +419,6 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersGetOutput =
           'is_override_tool_filter',
           mtMap.passthrough()
         ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date()),
         provider: mtMap.objectField(
           'provider',
           mtMap.object({
@@ -380,241 +529,38 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersGetOutput =
             archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
         ),
-        integrationInstanceProvider: mtMap.objectField(
-          'integration_instance_provider',
+        config: mtMap.objectField(
+          'config',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            integrationId: mtMap.objectField(
-              'integration_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceId: mtMap.objectField(
-              'integration_instance_id',
-              mtMap.passthrough()
-            ),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            isOverrideToolFilter: mtMap.objectField(
-              'is_override_tool_filter',
-              mtMap.passthrough()
-            ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            integrationProvider: mtMap.objectField(
-              'integration_provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                providerVersion: mtMap.objectField(
-                  'provider_version',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    index: mtMap.objectField('index', mtMap.passthrough())
-                  })
-                ),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            ),
-            config: mtMap.objectField(
-              'config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authConfig: mtMap.objectField(
-              'auth_config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
           })
-        )
+        ),
+        authConfig: mtMap.objectField(
+          'auth_config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
       })
     )
-  ]);
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceIntegrationInstanceGroupProvidersListOutput = {
-  items: ({
+  items: {
     object: 'integration.instance.group.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -32,7 +32,6 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
     provider: {
       object: 'provider#preview';
       id: string;
@@ -194,7 +193,7 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersListOutput = {
       updatedAt: Date;
       archivedAt: Date | null;
     };
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -203,9 +202,204 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          integrationInstanceProvider: mtMap.objectField(
+            'integration_instance_provider',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
@@ -220,20 +414,8 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersListOutput =
                 'integration_id',
                 mtMap.passthrough()
               ),
-              integrationInstanceGroupId: mtMap.objectField(
-                'integration_instance_group_id',
-                mtMap.passthrough()
-              ),
               integrationInstanceId: mtMap.objectField(
                 'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              integrationProviderId: mtMap.objectField(
-                'integration_provider_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceProviderId: mtMap.objectField(
-                'integration_instance_provider_id',
                 mtMap.passthrough()
               ),
               toolFilter: mtMap.objectField(
@@ -283,9 +465,6 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersListOutput =
                 'is_override_tool_filter',
                 mtMap.passthrough()
               ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date()),
               provider: mtMap.objectField(
                 'provider',
                 mtMap.object({
@@ -411,276 +590,58 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersListOutput =
                   archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
               ),
-              integrationInstanceProvider: mtMap.objectField(
-                'integration_instance_provider',
+              config: mtMap.objectField(
+                'config',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  integrationId: mtMap.objectField(
-                    'integration_id',
+                  providerId: mtMap.objectField(
+                    'provider_id',
                     mtMap.passthrough()
-                  ),
-                  integrationInstanceId: mtMap.objectField(
-                    'integration_instance_id',
-                    mtMap.passthrough()
-                  ),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  isOverrideToolFilter: mtMap.objectField(
-                    'is_override_tool_filter',
-                    mtMap.passthrough()
-                  ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  integrationProvider: mtMap.objectField(
-                    'integration_provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      providerVersion: mtMap.objectField(
-                        'provider_version',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          index: mtMap.objectField('index', mtMap.passthrough())
-                        })
-                      ),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      toolFilter: mtMap.objectField(
-                        'tool_filter',
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              ignoreParentFilters: mtMap.objectField(
-                                'ignore_parent_filters',
-                                mtMap.passthrough()
-                              ),
-                              filters: mtMap.objectField(
-                                'filters',
-                                mtMap.array(
-                                  mtMap.union([
-                                    mtMap.unionOption(
-                                      'object',
-                                      mtMap.object({
-                                        type: mtMap.objectField(
-                                          'type',
-                                          mtMap.passthrough()
-                                        ),
-                                        keys: mtMap.objectField(
-                                          'keys',
-                                          mtMap.array(mtMap.passthrough())
-                                        ),
-                                        pattern: mtMap.objectField(
-                                          'pattern',
-                                          mtMap.passthrough()
-                                        ),
-                                        uris: mtMap.objectField(
-                                          'uris',
-                                          mtMap.array(mtMap.passthrough())
-                                        )
-                                      })
-                                    )
-                                  ])
-                                )
-                              )
-                            })
-                          )
-                        ])
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      deploymentId: mtMap.objectField(
-                        'deployment_id',
-                        mtMap.passthrough()
-                      ),
-                      authMethodId: mtMap.objectField(
-                        'auth_method_id',
-                        mtMap.passthrough()
-                      ),
-                      authCredentialsId: mtMap.objectField(
-                        'auth_credentials_id',
-                        mtMap.passthrough()
-                      ),
-                      config: mtMap.objectField(
-                        'config',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          isDefault: mtMap.objectField(
-                            'is_default',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          ),
-                          metadata: mtMap.objectField(
-                            'metadata',
-                            mtMap.passthrough()
-                          ),
-                          providerId: mtMap.objectField(
-                            'provider_id',
-                            mtMap.passthrough()
-                          ),
-                          createdAt: mtMap.objectField(
-                            'created_at',
-                            mtMap.date()
-                          ),
-                          updatedAt: mtMap.objectField(
-                            'updated_at',
-                            mtMap.date()
-                          )
-                        })
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                    })
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authConfig: mtMap.objectField(
-                    'auth_config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
                   ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
-              )
+              ),
+              authConfig: mtMap.objectField(
+                'auth_config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
           )
-        ])
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/set.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-group-providers/set.ts
@@ -31,7 +31,6 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersSetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
   provider: {
     object: 'provider#preview';
     id: string;
@@ -196,9 +195,174 @@ export type ManagementInstanceIntegrationInstanceGroupProvidersSetOutput = {
 };
 
 export let mapManagementInstanceIntegrationInstanceGroupProvidersSetOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<ManagementInstanceIntegrationInstanceGroupProvidersSetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstanceGroupId: mtMap.objectField(
+      'integration_instance_group_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    integrationProviderId: mtMap.objectField(
+      'integration_provider_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceProviderId: mtMap.objectField(
+      'integration_instance_provider_id',
+      mtMap.passthrough()
+    ),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
+              )
+            )
+          })
+        )
+      ])
+    ),
+    isOverrideToolFilter: mtMap.objectField(
+      'is_override_tool_filter',
+      mtMap.passthrough()
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    integrationProvider: mtMap.objectField(
+      'integration_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        providerVersion: mtMap.objectField(
+          'provider_version',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            index: mtMap.objectField('index', mtMap.passthrough())
+          })
+        ),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        toolFilter: mtMap.objectField(
+          'tool_filter',
+          mtMap.union([
+            mtMap.unionOption(
+              'object',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                ignoreParentFilters: mtMap.objectField(
+                  'ignore_parent_filters',
+                  mtMap.passthrough()
+                ),
+                filters: mtMap.objectField(
+                  'filters',
+                  mtMap.array(
+                    mtMap.union([
+                      mtMap.unionOption(
+                        'object',
+                        mtMap.object({
+                          type: mtMap.objectField('type', mtMap.passthrough()),
+                          keys: mtMap.objectField(
+                            'keys',
+                            mtMap.array(mtMap.passthrough())
+                          ),
+                          pattern: mtMap.objectField(
+                            'pattern',
+                            mtMap.passthrough()
+                          ),
+                          uris: mtMap.objectField(
+                            'uris',
+                            mtMap.array(mtMap.passthrough())
+                          )
+                        })
+                      )
+                    ])
+                  )
+                )
+              })
+            )
+          ])
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
+          mtMap.passthrough()
+        ),
+        config: mtMap.objectField(
+          'config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    integrationInstanceProvider: mtMap.objectField(
+      'integration_instance_provider',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
@@ -207,20 +371,8 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersSetOutput =
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstanceGroupId: mtMap.objectField(
-          'integration_instance_group_id',
-          mtMap.passthrough()
-        ),
         integrationInstanceId: mtMap.objectField(
           'integration_instance_id',
-          mtMap.passthrough()
-        ),
-        integrationProviderId: mtMap.objectField(
-          'integration_provider_id',
-          mtMap.passthrough()
-        ),
-        integrationInstanceProviderId: mtMap.objectField(
-          'integration_instance_provider_id',
           mtMap.passthrough()
         ),
         toolFilter: mtMap.objectField(
@@ -267,9 +419,6 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersSetOutput =
           'is_override_tool_filter',
           mtMap.passthrough()
         ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date()),
         provider: mtMap.objectField(
           'provider',
           mtMap.object({
@@ -380,243 +529,40 @@ export let mapManagementInstanceIntegrationInstanceGroupProvidersSetOutput =
             archivedAt: mtMap.objectField('archived_at', mtMap.date())
           })
         ),
-        integrationInstanceProvider: mtMap.objectField(
-          'integration_instance_provider',
+        config: mtMap.objectField(
+          'config',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            integrationId: mtMap.objectField(
-              'integration_id',
-              mtMap.passthrough()
-            ),
-            integrationInstanceId: mtMap.objectField(
-              'integration_instance_id',
-              mtMap.passthrough()
-            ),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            isOverrideToolFilter: mtMap.objectField(
-              'is_override_tool_filter',
-              mtMap.passthrough()
-            ),
-            provider: mtMap.objectField(
-              'provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                slug: mtMap.objectField('slug', mtMap.passthrough()),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            integrationProvider: mtMap.objectField(
-              'integration_provider',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                providerVersion: mtMap.objectField(
-                  'provider_version',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    index: mtMap.objectField('index', mtMap.passthrough())
-                  })
-                ),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            ),
-            config: mtMap.objectField(
-              'config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            authConfig: mtMap.objectField(
-              'auth_config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
           })
-        )
+        ),
+        authConfig: mtMap.objectField(
+          'auth_config',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
       })
     )
-  ]);
+  });
 
 export type ManagementInstanceIntegrationInstanceGroupProvidersSetBody = {
   toolFilters?:

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/create.ts
@@ -46,154 +46,113 @@ export type ManagementInstanceIntegrationInstanceGroupsCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: {
-    object: 'integration.instance.group.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceGroupId: string;
-    integrationInstanceId: string;
-    integrationProviderId: string | null;
-    integrationInstanceProviderId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
 };
 
 export let mapManagementInstanceIntegrationInstanceGroupsCreateOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<ManagementInstanceIntegrationInstanceGroupsCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
       mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        implementation: mtMap.objectField(
-          'implementation',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            magicMcpEndpointId: mtMap.objectField(
-              'magic_mcp_endpoint_id',
-              mtMap.passthrough()
-            )
-          })
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceGroupId: mtMap.objectField(
-                'integration_instance_group_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              integrationProviderId: mtMap.objectField(
-                'integration_provider_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceProviderId: mtMap.objectField(
-                'integration_instance_provider_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpEndpointId: mtMap.objectField(
+          'magic_mcp_endpoint_id',
+          mtMap.passthrough()
+        )
       })
-    )
-  ]);
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type ManagementInstanceIntegrationInstanceGroupsCreateBody = {
   name: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/delete.ts
@@ -46,152 +46,111 @@ export type ManagementInstanceIntegrationInstanceGroupsDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: {
-    object: 'integration.instance.group.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceGroupId: string;
-    integrationInstanceId: string;
-    integrationProviderId: string | null;
-    integrationInstanceProviderId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
 };
 
 export let mapManagementInstanceIntegrationInstanceGroupsDeleteOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<ManagementInstanceIntegrationInstanceGroupsDeleteOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
       mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        implementation: mtMap.objectField(
-          'implementation',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            magicMcpEndpointId: mtMap.objectField(
-              'magic_mcp_endpoint_id',
-              mtMap.passthrough()
-            )
-          })
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceGroupId: mtMap.objectField(
-                'integration_instance_group_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              integrationProviderId: mtMap.objectField(
-                'integration_provider_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceProviderId: mtMap.objectField(
-                'integration_instance_provider_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpEndpointId: mtMap.objectField(
+          'magic_mcp_endpoint_id',
+          mtMap.passthrough()
+        )
       })
-    )
-  ]);
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/get.ts
@@ -46,152 +46,111 @@ export type ManagementInstanceIntegrationInstanceGroupsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: {
-    object: 'integration.instance.group.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceGroupId: string;
-    integrationInstanceId: string;
-    integrationProviderId: string | null;
-    integrationInstanceProviderId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
 };
 
 export let mapManagementInstanceIntegrationInstanceGroupsGetOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<ManagementInstanceIntegrationInstanceGroupsGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
       mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        implementation: mtMap.objectField(
-          'implementation',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            magicMcpEndpointId: mtMap.objectField(
-              'magic_mcp_endpoint_id',
-              mtMap.passthrough()
-            )
-          })
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceGroupId: mtMap.objectField(
-                'integration_instance_group_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              integrationProviderId: mtMap.objectField(
-                'integration_provider_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceProviderId: mtMap.objectField(
-                'integration_instance_provider_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpEndpointId: mtMap.objectField(
+          'magic_mcp_endpoint_id',
+          mtMap.passthrough()
+        )
       })
-    )
-  ]);
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceIntegrationInstanceGroupsListOutput = {
-  items: ({
+  items: {
     object: 'integration.instance.group';
     id: string;
     status: 'draft' | 'active' | 'archived' | 'deleted';
@@ -47,40 +47,7 @@ export type ManagementInstanceIntegrationInstanceGroupsListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
-    providers: {
-      object: 'integration.instance.group.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceGroupId: string;
-      integrationInstanceId: string;
-      integrationProviderId: string | null;
-      integrationInstanceProviderId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    }[];
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -89,127 +56,113 @@ export let mapManagementInstanceIntegrationInstanceGroupsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          implementation: mtMap.objectField(
+            'implementation',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              magicMcpEndpointId: mtMap.objectField(
+                'magic_mcp_endpoint_id',
                 mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              implementation: mtMap.objectField(
-                'implementation',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  magicMcpEndpointId: mtMap.objectField(
-                    'magic_mcp_endpoint_id',
-                    mtMap.passthrough()
-                  )
-                })
-              ),
-              providers: mtMap.objectField(
-                'providers',
-                mtMap.array(
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    integrationId: mtMap.objectField(
-                      'integration_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationInstanceGroupId: mtMap.objectField(
-                      'integration_instance_group_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationInstanceId: mtMap.objectField(
-                      'integration_instance_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationProviderId: mtMap.objectField(
-                      'integration_provider_id',
-                      mtMap.passthrough()
-                    ),
-                    integrationInstanceProviderId: mtMap.objectField(
-                      'integration_instance_provider_id',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
-                      mtMap.union([
-                        mtMap.unionOption(
-                          'object',
-                          mtMap.object({
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
-                              mtMap.passthrough()
-                            ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
-                            )
-                          })
-                        )
-                      ])
-                    ),
-                    isOverrideToolFilter: mtMap.objectField(
-                      'is_override_tool_filter',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                )
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              )
             })
-          )
-        ])
+          ),
+          providers: mtMap.objectField(
+            'providers',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceGroupId: mtMap.objectField(
+                  'integration_instance_group_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                integrationProviderId: mtMap.objectField(
+                  'integration_provider_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceProviderId: mtMap.objectField(
+                  'integration_instance_provider_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
+                  mtMap.union([
+                    mtMap.unionOption(
+                      'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-groups/update.ts
@@ -46,154 +46,113 @@ export type ManagementInstanceIntegrationInstanceGroupsUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: {
-    object: 'integration.instance.group.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceGroupId: string;
-    integrationInstanceId: string;
-    integrationProviderId: string | null;
-    integrationInstanceProviderId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  }[];
 };
 
 export let mapManagementInstanceIntegrationInstanceGroupsUpdateOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<ManagementInstanceIntegrationInstanceGroupsUpdateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
       mtMap.object({
-        object: mtMap.objectField('object', mtMap.passthrough()),
-        id: mtMap.objectField('id', mtMap.passthrough()),
-        status: mtMap.objectField('status', mtMap.passthrough()),
-        name: mtMap.objectField('name', mtMap.passthrough()),
-        description: mtMap.objectField('description', mtMap.passthrough()),
-        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        implementation: mtMap.objectField(
-          'implementation',
-          mtMap.object({
-            type: mtMap.objectField('type', mtMap.passthrough()),
-            magicMcpEndpointId: mtMap.objectField(
-              'magic_mcp_endpoint_id',
-              mtMap.passthrough()
-            )
-          })
-        ),
-        providers: mtMap.objectField(
-          'providers',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
-                mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceGroupId: mtMap.objectField(
-                'integration_instance_group_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              integrationProviderId: mtMap.objectField(
-                'integration_provider_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceProviderId: mtMap.objectField(
-                'integration_instance_provider_id',
-                mtMap.passthrough()
-              ),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
-              ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
-                mtMap.passthrough()
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpEndpointId: mtMap.objectField(
+          'magic_mcp_endpoint_id',
+          mtMap.passthrough()
+        )
       })
-    )
-  ]);
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceGroupId: mtMap.objectField(
+            'integration_instance_group_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type ManagementInstanceIntegrationInstanceGroupsUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-providers/get.ts
@@ -105,71 +105,94 @@ export type ManagementInstanceIntegrationInstanceProvidersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  integrationProvider: {
-    object: 'integration.provider#snapshot';
-    id: string;
-    providerVersion: {
-      object: 'integration.provider.version';
-      id: string;
-      index: number;
-    };
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  };
 };
 
 export let mapManagementInstanceIntegrationInstanceProvidersGetOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<ManagementInstanceIntegrationInstanceProvidersGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
+              )
+            )
+          })
+        )
+      ])
+    ),
+    isOverrideToolFilter: mtMap.objectField(
+      'is_override_tool_filter',
+      mtMap.passthrough()
+    ),
+    provider: mtMap.objectField(
+      'provider',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    integrationProvider: mtMap.objectField(
+      'integration_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        providerVersion: mtMap.objectField(
+          'provider_version',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            index: mtMap.objectField('index', mtMap.passthrough())
+          })
+        ),
         status: mtMap.objectField('status', mtMap.passthrough()),
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstanceId: mtMap.objectField(
-          'integration_instance_id',
-          mtMap.passthrough()
-        ),
         toolFilter: mtMap.objectField(
           'tool_filter',
           mtMap.union([
@@ -210,136 +233,15 @@ export let mapManagementInstanceIntegrationInstanceProvidersGetOutput =
             )
           ])
         ),
-        isOverrideToolFilter: mtMap.objectField(
-          'is_override_tool_filter',
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
           mtMap.passthrough()
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        integrationProvider: mtMap.objectField(
-          'integration_provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            providerVersion: mtMap.objectField(
-              'provider_version',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                index: mtMap.objectField('index', mtMap.passthrough())
-              })
-            ),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            deploymentId: mtMap.objectField(
-              'deployment_id',
-              mtMap.passthrough()
-            ),
-            authMethodId: mtMap.objectField(
-              'auth_method_id',
-              mtMap.passthrough()
-            ),
-            authCredentialsId: mtMap.objectField(
-              'auth_credentials_id',
-              mtMap.passthrough()
-            ),
-            config: mtMap.objectField(
-              'config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
         ),
         config: mtMap.objectField(
           'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authConfig: mtMap.objectField(
-          'auth_config',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
@@ -356,6 +258,37 @@ export let mapManagementInstanceIntegrationInstanceProvidersGetOutput =
         updatedAt: mtMap.objectField('updated_at', mtMap.date()),
         archivedAt: mtMap.objectField('archived_at', mtMap.date())
       })
-    )
-  ]);
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authConfig: mtMap.objectField(
+      'auth_config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-providers/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceIntegrationInstanceProvidersListOutput = {
-  items: ({
+  items: {
     object: 'integration.instance.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -106,54 +106,7 @@ export type ManagementInstanceIntegrationInstanceProvidersListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -162,12 +115,96 @@ export let mapManagementInstanceIntegrationInstanceProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
               status: mtMap.objectField('status', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
@@ -175,14 +212,6 @@ export let mapManagementInstanceIntegrationInstanceProvidersListOutput =
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
               toolFilter: mtMap.objectField(
                 'tool_filter',
                 mtMap.union([
@@ -226,160 +255,21 @@ export let mapManagementInstanceIntegrationInstanceProvidersListOutput =
                   )
                 ])
               ),
-              isOverrideToolFilter: mtMap.objectField(
-                'is_override_tool_filter',
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
                 mtMap.passthrough()
               ),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
               ),
-              integrationProvider: mtMap.objectField(
-                'integration_provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  providerVersion: mtMap.objectField(
-                    'provider_version',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      index: mtMap.objectField('index', mtMap.passthrough())
-                    })
-                  ),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  toolFilter: mtMap.objectField(
-                    'tool_filter',
-                    mtMap.union([
-                      mtMap.unionOption(
-                        'object',
-                        mtMap.object({
-                          type: mtMap.objectField('type', mtMap.passthrough()),
-                          ignoreParentFilters: mtMap.objectField(
-                            'ignore_parent_filters',
-                            mtMap.passthrough()
-                          ),
-                          filters: mtMap.objectField(
-                            'filters',
-                            mtMap.array(
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    keys: mtMap.objectField(
-                                      'keys',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
-                                    pattern: mtMap.objectField(
-                                      'pattern',
-                                      mtMap.passthrough()
-                                    ),
-                                    uris: mtMap.objectField(
-                                      'uris',
-                                      mtMap.array(mtMap.passthrough())
-                                    )
-                                  })
-                                )
-                              ])
-                            )
-                          )
-                        })
-                      )
-                    ])
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  deploymentId: mtMap.objectField(
-                    'deployment_id',
-                    mtMap.passthrough()
-                  ),
-                  authMethodId: mtMap.objectField(
-                    'auth_method_id',
-                    mtMap.passthrough()
-                  ),
-                  authCredentialsId: mtMap.objectField(
-                    'auth_credentials_id',
-                    mtMap.passthrough()
-                  ),
-                  config: mtMap.objectField(
-                    'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
               ),
               config: mtMap.objectField(
                 'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authConfig: mtMap.objectField(
-                'auth_config',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
@@ -405,8 +295,45 @@ export let mapManagementInstanceIntegrationInstanceProvidersListOutput =
               updatedAt: mtMap.objectField('updated_at', mtMap.date()),
               archivedAt: mtMap.objectField('archived_at', mtMap.date())
             })
-          )
-        ])
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-providers/set.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instance-providers/set.ts
@@ -105,71 +105,94 @@ export type ManagementInstanceIntegrationInstanceProvidersSetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  integrationProvider: {
-    object: 'integration.provider#snapshot';
-    id: string;
-    providerVersion: {
-      object: 'integration.provider.version';
-      id: string;
-      index: number;
-    };
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  };
 };
 
 export let mapManagementInstanceIntegrationInstanceProvidersSetOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<ManagementInstanceIntegrationInstanceProvidersSetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
+              )
+            )
+          })
+        )
+      ])
+    ),
+    isOverrideToolFilter: mtMap.objectField(
+      'is_override_tool_filter',
+      mtMap.passthrough()
+    ),
+    provider: mtMap.objectField(
+      'provider',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    integrationProvider: mtMap.objectField(
+      'integration_provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        providerVersion: mtMap.objectField(
+          'provider_version',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            index: mtMap.objectField('index', mtMap.passthrough())
+          })
+        ),
         status: mtMap.objectField('status', mtMap.passthrough()),
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstanceId: mtMap.objectField(
-          'integration_instance_id',
-          mtMap.passthrough()
-        ),
         toolFilter: mtMap.objectField(
           'tool_filter',
           mtMap.union([
@@ -210,136 +233,15 @@ export let mapManagementInstanceIntegrationInstanceProvidersSetOutput =
             )
           ])
         ),
-        isOverrideToolFilter: mtMap.objectField(
-          'is_override_tool_filter',
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+        authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+        authCredentialsId: mtMap.objectField(
+          'auth_credentials_id',
           mtMap.passthrough()
-        ),
-        provider: mtMap.objectField(
-          'provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            slug: mtMap.objectField('slug', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        integrationProvider: mtMap.objectField(
-          'integration_provider',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            providerVersion: mtMap.objectField(
-              'provider_version',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                index: mtMap.objectField('index', mtMap.passthrough())
-              })
-            ),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            toolFilter: mtMap.objectField(
-              'tool_filter',
-              mtMap.union([
-                mtMap.unionOption(
-                  'object',
-                  mtMap.object({
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    ignoreParentFilters: mtMap.objectField(
-                      'ignore_parent_filters',
-                      mtMap.passthrough()
-                    ),
-                    filters: mtMap.objectField(
-                      'filters',
-                      mtMap.array(
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              keys: mtMap.objectField(
-                                'keys',
-                                mtMap.array(mtMap.passthrough())
-                              ),
-                              pattern: mtMap.objectField(
-                                'pattern',
-                                mtMap.passthrough()
-                              ),
-                              uris: mtMap.objectField(
-                                'uris',
-                                mtMap.array(mtMap.passthrough())
-                              )
-                            })
-                          )
-                        ])
-                      )
-                    )
-                  })
-                )
-              ])
-            ),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            deploymentId: mtMap.objectField(
-              'deployment_id',
-              mtMap.passthrough()
-            ),
-            authMethodId: mtMap.objectField(
-              'auth_method_id',
-              mtMap.passthrough()
-            ),
-            authCredentialsId: mtMap.objectField(
-              'auth_credentials_id',
-              mtMap.passthrough()
-            ),
-            config: mtMap.objectField(
-              'config',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date())
-              })
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
         ),
         config: mtMap.objectField(
           'config',
-          mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date())
-          })
-        ),
-        authConfig: mtMap.objectField(
-          'auth_config',
           mtMap.object({
             object: mtMap.objectField('object', mtMap.passthrough()),
             id: mtMap.objectField('id', mtMap.passthrough()),
@@ -356,8 +258,39 @@ export let mapManagementInstanceIntegrationInstanceProvidersSetOutput =
         updatedAt: mtMap.objectField('updated_at', mtMap.date()),
         archivedAt: mtMap.objectField('archived_at', mtMap.date())
       })
-    )
-  ]);
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authConfig: mtMap.objectField(
+      'auth_config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type ManagementInstanceIntegrationInstanceProvidersSetBody = {
   providerDeploymentId?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/create.ts
@@ -120,302 +120,64 @@ export type ManagementInstanceIntegrationInstancesCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.instance.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authConfig: {
-      object: 'provider.auth_config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
 };
 
-export let mapManagementInstanceIntegrationInstancesCreateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      identityActorId: mtMap.objectField(
-        'identity_actor_id',
-        mtMap.passthrough()
-      ),
-      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
+export let mapManagementInstanceIntegrationInstancesCreateOutput =
+  mtMap.object<ManagementInstanceIntegrationInstancesCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpServerId: mtMap.objectField(
+          'magic_mcp_server_id',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpServerId: mtMap.objectField(
-            'magic_mcp_server_id',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -424,161 +186,194 @@ export let mapManagementInstanceIntegrationInstancesCreateOutput = mtMap.union([
                               'type',
                               mtMap.passthrough()
                             ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
                               mtMap.passthrough()
                             ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
                             )
                           })
                         )
                       ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type ManagementInstanceIntegrationInstancesCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/delete.ts
@@ -120,302 +120,64 @@ export type ManagementInstanceIntegrationInstancesDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.instance.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authConfig: {
-      object: 'provider.auth_config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
 };
 
-export let mapManagementInstanceIntegrationInstancesDeleteOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      identityActorId: mtMap.objectField(
-        'identity_actor_id',
-        mtMap.passthrough()
-      ),
-      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
+export let mapManagementInstanceIntegrationInstancesDeleteOutput =
+  mtMap.object<ManagementInstanceIntegrationInstancesDeleteOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpServerId: mtMap.objectField(
+          'magic_mcp_server_id',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpServerId: mtMap.objectField(
-            'magic_mcp_server_id',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -424,159 +186,192 @@ export let mapManagementInstanceIntegrationInstancesDeleteOutput = mtMap.union([
                               'type',
                               mtMap.passthrough()
                             ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
                               mtMap.passthrough()
                             ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
                             )
                           })
                         )
                       ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/get.ts
@@ -120,302 +120,64 @@ export type ManagementInstanceIntegrationInstancesGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.instance.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authConfig: {
-      object: 'provider.auth_config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
 };
 
-export let mapManagementInstanceIntegrationInstancesGetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      identityActorId: mtMap.objectField(
-        'identity_actor_id',
-        mtMap.passthrough()
-      ),
-      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
+export let mapManagementInstanceIntegrationInstancesGetOutput =
+  mtMap.object<ManagementInstanceIntegrationInstancesGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpServerId: mtMap.objectField(
+          'magic_mcp_server_id',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpServerId: mtMap.objectField(
-            'magic_mcp_server_id',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -424,159 +186,192 @@ export let mapManagementInstanceIntegrationInstancesGetOutput = mtMap.union([
                               'type',
                               mtMap.passthrough()
                             ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
                               mtMap.passthrough()
                             ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
                             )
                           })
                         )
                       ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceIntegrationInstancesListOutput = {
-  items: ({
+  items: {
     object: 'integration.instance';
     id: string;
     status: 'draft' | 'active' | 'archived' | 'deleted';
@@ -124,161 +124,7 @@ export type ManagementInstanceIntegrationInstancesListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
-    providers: ({
-      object: 'integration.instance.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      integrationId: string;
-      integrationInstanceId: string;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      isOverrideToolFilter: boolean;
-      provider: {
-        object: 'provider#preview';
-        id: string;
-        name: string;
-        description: string | null;
-        slug: string;
-        createdAt: Date;
-        updatedAt: Date;
-      };
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        providerId: string;
-        deploymentId: string;
-        authMethodId: string | null;
-        authCredentialsId: string | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      authConfig: {
-        object: 'provider.auth_config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } & {
-      integrationProvider: {
-        object: 'integration.provider#snapshot';
-        id: string;
-        providerVersion: {
-          object: 'integration.provider.version';
-          id: string;
-          index: number;
-        };
-        status: 'active' | 'archived' | 'deleted';
-        name: string;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        toolFilter:
-          | { type: 'allow_all'; ignoreParentFilters: boolean }
-          | {
-              type: 'filter';
-              filters: (
-                | { type: 'tool_keys'; keys: string[] }
-                | { type: 'tool_regex'; pattern: string }
-                | { type: 'resource_regex'; pattern: string }
-                | { type: 'resource_uris'; uris: string[] }
-                | { type: 'prompt_keys'; keys: string[] }
-                | { type: 'prompt_regex'; pattern: string }
-              )[];
-              ignoreParentFilters: boolean;
-            }
-          | null;
-        providerId: string;
-        deploymentId: string;
-        authMethodId: string | null;
-        authCredentialsId: string | null;
-        config: {
-          object: 'provider.config#preview';
-          id: string;
-          isDefault: boolean;
-          name: string | null;
-          description: string | null;
-          metadata: Record<string, any> | null;
-          providerId: string;
-          createdAt: Date;
-          updatedAt: Date;
-        } | null;
-        createdAt: Date;
-        updatedAt: Date;
-        archivedAt: Date | null;
-      };
-    })[];
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -287,52 +133,213 @@ export let mapManagementInstanceIntegrationInstancesListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          implementation: mtMap.objectField(
+            'implementation',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              magicMcpServerId: mtMap.objectField(
+                'magic_mcp_server_id',
                 mtMap.passthrough()
-              ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
-              identityActorId: mtMap.objectField(
-                'identity_actor_id',
-                mtMap.passthrough()
-              ),
-              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-              implementation: mtMap.objectField(
-                'implementation',
-                mtMap.object({
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  magicMcpServerId: mtMap.objectField(
-                    'magic_mcp_server_id',
-                    mtMap.passthrough()
-                  )
-                })
-              ),
-              providers: mtMap.objectField(
-                'providers',
-                mtMap.array(
+              )
+            })
+          ),
+          providers: mtMap.objectField(
+            'providers',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceId: mtMap.objectField(
+                  'integration_instance_id',
+                  mtMap.passthrough()
+                ),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
                   mtMap.union([
                     mtMap.unionOption(
                       'object',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
+                          mtMap.passthrough()
+                        ),
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
+                                mtMap.object({
+                                  type: mtMap.objectField(
+                                    'type',
+                                    mtMap.passthrough()
+                                  ),
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
+                                    mtMap.passthrough()
+                                  ),
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
+                                  )
+                                })
+                              )
+                            ])
+                          )
+                        )
+                      })
+                    )
+                  ])
+                ),
+                isOverrideToolFilter: mtMap.objectField(
+                  'is_override_tool_filter',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                integrationProvider: mtMap.objectField(
+                  'integration_provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    providerVersion: mtMap.objectField(
+                      'provider_version',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
-                        status: mtMap.objectField(
-                          'status',
+                        index: mtMap.objectField('index', mtMap.passthrough())
+                      })
+                    ),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
+                              mtMap.passthrough()
+                            ),
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
+                            )
+                          })
+                        )
+                      ])
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    deploymentId: mtMap.objectField(
+                      'deployment_id',
+                      mtMap.passthrough()
+                    ),
+                    authMethodId: mtMap.objectField(
+                      'auth_method_id',
+                      mtMap.passthrough()
+                    ),
+                    authCredentialsId: mtMap.objectField(
+                      'auth_credentials_id',
+                      mtMap.passthrough()
+                    ),
+                    config: mtMap.objectField(
+                      'config',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
                           mtMap.passthrough()
                         ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
@@ -344,351 +351,84 @@ export let mapManagementInstanceIntegrationInstancesListOutput =
                           'metadata',
                           mtMap.passthrough()
                         ),
-                        integrationId: mtMap.objectField(
-                          'integration_id',
+                        providerId: mtMap.objectField(
+                          'provider_id',
                           mtMap.passthrough()
-                        ),
-                        integrationInstanceId: mtMap.objectField(
-                          'integration_instance_id',
-                          mtMap.passthrough()
-                        ),
-                        toolFilter: mtMap.objectField(
-                          'tool_filter',
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                ignoreParentFilters: mtMap.objectField(
-                                  'ignore_parent_filters',
-                                  mtMap.passthrough()
-                                ),
-                                filters: mtMap.objectField(
-                                  'filters',
-                                  mtMap.array(
-                                    mtMap.union([
-                                      mtMap.unionOption(
-                                        'object',
-                                        mtMap.object({
-                                          type: mtMap.objectField(
-                                            'type',
-                                            mtMap.passthrough()
-                                          ),
-                                          keys: mtMap.objectField(
-                                            'keys',
-                                            mtMap.array(mtMap.passthrough())
-                                          ),
-                                          pattern: mtMap.objectField(
-                                            'pattern',
-                                            mtMap.passthrough()
-                                          ),
-                                          uris: mtMap.objectField(
-                                            'uris',
-                                            mtMap.array(mtMap.passthrough())
-                                          )
-                                        })
-                                      )
-                                    ])
-                                  )
-                                )
-                              })
-                            )
-                          ])
-                        ),
-                        isOverrideToolFilter: mtMap.objectField(
-                          'is_override_tool_filter',
-                          mtMap.passthrough()
-                        ),
-                        provider: mtMap.objectField(
-                          'provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            slug: mtMap.objectField(
-                              'slug',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        integrationProvider: mtMap.objectField(
-                          'integration_provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            providerVersion: mtMap.objectField(
-                              'provider_version',
-                              mtMap.object({
-                                object: mtMap.objectField(
-                                  'object',
-                                  mtMap.passthrough()
-                                ),
-                                id: mtMap.objectField(
-                                  'id',
-                                  mtMap.passthrough()
-                                ),
-                                index: mtMap.objectField(
-                                  'index',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            status: mtMap.objectField(
-                              'status',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            toolFilter: mtMap.objectField(
-                              'tool_filter',
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    ignoreParentFilters: mtMap.objectField(
-                                      'ignore_parent_filters',
-                                      mtMap.passthrough()
-                                    ),
-                                    filters: mtMap.objectField(
-                                      'filters',
-                                      mtMap.array(
-                                        mtMap.union([
-                                          mtMap.unionOption(
-                                            'object',
-                                            mtMap.object({
-                                              type: mtMap.objectField(
-                                                'type',
-                                                mtMap.passthrough()
-                                              ),
-                                              keys: mtMap.objectField(
-                                                'keys',
-                                                mtMap.array(mtMap.passthrough())
-                                              ),
-                                              pattern: mtMap.objectField(
-                                                'pattern',
-                                                mtMap.passthrough()
-                                              ),
-                                              uris: mtMap.objectField(
-                                                'uris',
-                                                mtMap.array(mtMap.passthrough())
-                                              )
-                                            })
-                                          )
-                                        ])
-                                      )
-                                    )
-                                  })
-                                )
-                              ])
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            deploymentId: mtMap.objectField(
-                              'deployment_id',
-                              mtMap.passthrough()
-                            ),
-                            authMethodId: mtMap.objectField(
-                              'auth_method_id',
-                              mtMap.passthrough()
-                            ),
-                            authCredentialsId: mtMap.objectField(
-                              'auth_credentials_id',
-                              mtMap.passthrough()
-                            ),
-                            config: mtMap.objectField(
-                              'config',
-                              mtMap.object({
-                                object: mtMap.objectField(
-                                  'object',
-                                  mtMap.passthrough()
-                                ),
-                                id: mtMap.objectField(
-                                  'id',
-                                  mtMap.passthrough()
-                                ),
-                                isDefault: mtMap.objectField(
-                                  'is_default',
-                                  mtMap.passthrough()
-                                ),
-                                name: mtMap.objectField(
-                                  'name',
-                                  mtMap.passthrough()
-                                ),
-                                description: mtMap.objectField(
-                                  'description',
-                                  mtMap.passthrough()
-                                ),
-                                metadata: mtMap.objectField(
-                                  'metadata',
-                                  mtMap.passthrough()
-                                ),
-                                providerId: mtMap.objectField(
-                                  'provider_id',
-                                  mtMap.passthrough()
-                                ),
-                                createdAt: mtMap.objectField(
-                                  'created_at',
-                                  mtMap.date()
-                                ),
-                                updatedAt: mtMap.objectField(
-                                  'updated_at',
-                                  mtMap.date()
-                                )
-                              })
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            ),
-                            archivedAt: mtMap.objectField(
-                              'archived_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        config: mtMap.objectField(
-                          'config',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authConfig: mtMap.objectField(
-                          'auth_config',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',
                           mtMap.date()
                         ),
-                        updatedAt: mtMap.objectField(
-                          'updated_at',
-                          mtMap.date()
-                        ),
-                        archivedAt: mtMap.objectField(
-                          'archived_at',
-                          mtMap.date()
-                        )
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
-                    )
-                  ])
-                )
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ])
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authConfig: mtMap.objectField(
+                  'auth_config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date())
+              })
+            )
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-instances/update.ts
@@ -120,302 +120,64 @@ export type ManagementInstanceIntegrationInstancesUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.instance.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    integrationId: string;
-    integrationInstanceId: string;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    isOverrideToolFilter: boolean;
-    provider: {
-      object: 'provider#preview';
-      id: string;
-      name: string;
-      description: string | null;
-      slug: string;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    authConfig: {
-      object: 'provider.auth_config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    integrationProvider: {
-      object: 'integration.provider#snapshot';
-      id: string;
-      providerVersion: {
-        object: 'integration.provider.version';
-        id: string;
-        index: number;
-      };
-      status: 'active' | 'archived' | 'deleted';
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    };
-  })[];
 };
 
-export let mapManagementInstanceIntegrationInstancesUpdateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      identityActorId: mtMap.objectField(
-        'identity_actor_id',
-        mtMap.passthrough()
-      ),
-      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-      implementation: mtMap.objectField(
-        'implementation',
+export let mapManagementInstanceIntegrationInstancesUpdateOutput =
+  mtMap.object<ManagementInstanceIntegrationInstancesUpdateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.object({
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        magicMcpServerId: mtMap.objectField(
+          'magic_mcp_server_id',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          magicMcpServerId: mtMap.objectField(
-            'magic_mcp_server_id',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                integrationInstanceId: mtMap.objectField(
-                  'integration_instance_id',
-                  mtMap.passthrough()
-                ),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
-                    )
-                  ])
-                ),
-                isOverrideToolFilter: mtMap.objectField(
-                  'is_override_tool_filter',
-                  mtMap.passthrough()
-                ),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                integrationProvider: mtMap.objectField(
-                  'integration_provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    providerVersion: mtMap.objectField(
-                      'provider_version',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        index: mtMap.objectField('index', mtMap.passthrough())
-                      })
-                    ),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    toolFilter: mtMap.objectField(
-                      'tool_filter',
+          ),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
                       mtMap.union([
                         mtMap.unionOption(
                           'object',
@@ -424,161 +186,194 @@ export let mapManagementInstanceIntegrationInstancesUpdateOutput = mtMap.union([
                               'type',
                               mtMap.passthrough()
                             ),
-                            ignoreParentFilters: mtMap.objectField(
-                              'ignore_parent_filters',
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
                               mtMap.passthrough()
                             ),
-                            filters: mtMap.objectField(
-                              'filters',
-                              mtMap.array(
-                                mtMap.union([
-                                  mtMap.unionOption(
-                                    'object',
-                                    mtMap.object({
-                                      type: mtMap.objectField(
-                                        'type',
-                                        mtMap.passthrough()
-                                      ),
-                                      keys: mtMap.objectField(
-                                        'keys',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
-                                      pattern: mtMap.objectField(
-                                        'pattern',
-                                        mtMap.passthrough()
-                                      ),
-                                      uris: mtMap.objectField(
-                                        'uris',
-                                        mtMap.array(mtMap.passthrough())
-                                      )
-                                    })
-                                  )
-                                ])
-                              )
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
                             )
                           })
                         )
                       ])
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    deploymentId: mtMap.objectField(
-                      'deployment_id',
-                      mtMap.passthrough()
-                    ),
-                    authMethodId: mtMap.objectField(
-                      'auth_method_id',
-                      mtMap.passthrough()
-                    ),
-                    authCredentialsId: mtMap.objectField(
-                      'auth_credentials_id',
-                      mtMap.passthrough()
-                    ),
-                    config: mtMap.objectField(
-                      'config',
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        isDefault: mtMap.objectField(
-                          'is_default',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                      })
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                  })
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authConfig: mtMap.objectField(
-                  'auth_config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date())
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          isOverrideToolFilter: mtMap.objectField(
+            'is_override_tool_filter',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          integrationProvider: mtMap.objectField(
+            'integration_provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              providerVersion: mtMap.objectField(
+                'provider_version',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  index: mtMap.objectField('index', mtMap.passthrough())
+                })
+              ),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              deploymentId: mtMap.objectField(
+                'deployment_id',
+                mtMap.passthrough()
+              ),
+              authMethodId: mtMap.objectField(
+                'auth_method_id',
+                mtMap.passthrough()
+              ),
+              authCredentialsId: mtMap.objectField(
+                'auth_credentials_id',
+                mtMap.passthrough()
+              ),
+              config: mtMap.objectField(
+                'config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authConfig: mtMap.objectField(
+            'auth_config',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type ManagementInstanceIntegrationInstancesUpdateBody = {
   name?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/create.ts
@@ -41,29 +41,6 @@ export type ManagementInstanceIntegrationProvidersCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  object: 'integration.provider';
-  id: string;
-  status: 'active' | 'archived' | 'deleted';
-  integrationId: string;
-  name: string;
-  description: string | null;
-  metadata: Record<string, any> | null;
-  toolFilter:
-    | { type: 'allow_all'; ignoreParentFilters: boolean }
-    | {
-        type: 'filter';
-        filters: (
-          | { type: 'tool_keys'; keys: string[] }
-          | { type: 'tool_regex'; pattern: string }
-          | { type: 'resource_regex'; pattern: string }
-          | { type: 'resource_uris'; uris: string[] }
-          | { type: 'prompt_keys'; keys: string[] }
-          | { type: 'prompt_regex'; pattern: string }
-        )[];
-        ignoreParentFilters: boolean;
-      }
-    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -125,176 +102,169 @@ export type ManagementInstanceIntegrationProvidersCreateOutput = {
   } | null;
 };
 
-export let mapManagementInstanceIntegrationProvidersCreateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
+export let mapManagementInstanceIntegrationProvidersCreateOutput =
+  mtMap.object<ManagementInstanceIntegrationProvidersCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
               )
+            )
+          })
+        )
+      ])
+    ),
+    providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+    deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+    authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+    authCredentialsId: mtMap.objectField(
+      'auth_credentials_id',
+      mtMap.passthrough()
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    deployment: mtMap.objectField(
+      'deployment',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authMethod: mtMap.objectField(
+      'auth_method',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        key: mtMap.objectField('key', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+        inputSchema: mtMap.objectField(
+          'input_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        outputSchema: mtMap.objectField(
+          'output_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        scopes: mtMap.objectField(
+          'scopes',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              scope: mtMap.objectField('scope', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField('description', mtMap.passthrough())
             })
           )
-        ])
-      ),
-      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
-      authCredentialsId: mtMap.objectField(
-        'auth_credentials_id',
-        mtMap.passthrough()
-      ),
-      config: mtMap.objectField(
-        'config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      deployment: mtMap.objectField(
-        'deployment',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authMethod: mtMap.objectField(
-        'auth_method',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          key: mtMap.objectField('key', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-          inputSchema: mtMap.objectField(
-            'input_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          outputSchema: mtMap.objectField(
-            'output_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          scopes: mtMap.objectField(
-            'scopes',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                scope: mtMap.objectField('scope', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                )
-              })
-            )
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          providerSpecificationId: mtMap.objectField(
-            'provider_specification_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authCredentials: mtMap.objectField(
-        'auth_credentials',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        providerSpecificationId: mtMap.objectField(
+          'provider_specification_id',
+          mtMap.passthrough()
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authCredentials: mtMap.objectField(
+      'auth_credentials',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    )
+  });
 
 export type ManagementInstanceIntegrationProvidersCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/delete.ts
@@ -41,29 +41,6 @@ export type ManagementInstanceIntegrationProvidersDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  object: 'integration.provider';
-  id: string;
-  status: 'active' | 'archived' | 'deleted';
-  integrationId: string;
-  name: string;
-  description: string | null;
-  metadata: Record<string, any> | null;
-  toolFilter:
-    | { type: 'allow_all'; ignoreParentFilters: boolean }
-    | {
-        type: 'filter';
-        filters: (
-          | { type: 'tool_keys'; keys: string[] }
-          | { type: 'tool_regex'; pattern: string }
-          | { type: 'resource_regex'; pattern: string }
-          | { type: 'resource_uris'; uris: string[] }
-          | { type: 'prompt_keys'; keys: string[] }
-          | { type: 'prompt_regex'; pattern: string }
-        )[];
-        ignoreParentFilters: boolean;
-      }
-    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -125,174 +102,167 @@ export type ManagementInstanceIntegrationProvidersDeleteOutput = {
   } | null;
 };
 
-export let mapManagementInstanceIntegrationProvidersDeleteOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
+export let mapManagementInstanceIntegrationProvidersDeleteOutput =
+  mtMap.object<ManagementInstanceIntegrationProvidersDeleteOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
               )
+            )
+          })
+        )
+      ])
+    ),
+    providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+    deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+    authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+    authCredentialsId: mtMap.objectField(
+      'auth_credentials_id',
+      mtMap.passthrough()
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    deployment: mtMap.objectField(
+      'deployment',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authMethod: mtMap.objectField(
+      'auth_method',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        key: mtMap.objectField('key', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+        inputSchema: mtMap.objectField(
+          'input_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        outputSchema: mtMap.objectField(
+          'output_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        scopes: mtMap.objectField(
+          'scopes',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              scope: mtMap.objectField('scope', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField('description', mtMap.passthrough())
             })
           )
-        ])
-      ),
-      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
-      authCredentialsId: mtMap.objectField(
-        'auth_credentials_id',
-        mtMap.passthrough()
-      ),
-      config: mtMap.objectField(
-        'config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      deployment: mtMap.objectField(
-        'deployment',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authMethod: mtMap.objectField(
-        'auth_method',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          key: mtMap.objectField('key', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-          inputSchema: mtMap.objectField(
-            'input_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          outputSchema: mtMap.objectField(
-            'output_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          scopes: mtMap.objectField(
-            'scopes',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                scope: mtMap.objectField('scope', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                )
-              })
-            )
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          providerSpecificationId: mtMap.objectField(
-            'provider_specification_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authCredentials: mtMap.objectField(
-        'auth_credentials',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        providerSpecificationId: mtMap.objectField(
+          'provider_specification_id',
+          mtMap.passthrough()
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authCredentials: mtMap.objectField(
+      'auth_credentials',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    )
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/get.ts
@@ -41,29 +41,6 @@ export type ManagementInstanceIntegrationProvidersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  object: 'integration.provider';
-  id: string;
-  status: 'active' | 'archived' | 'deleted';
-  integrationId: string;
-  name: string;
-  description: string | null;
-  metadata: Record<string, any> | null;
-  toolFilter:
-    | { type: 'allow_all'; ignoreParentFilters: boolean }
-    | {
-        type: 'filter';
-        filters: (
-          | { type: 'tool_keys'; keys: string[] }
-          | { type: 'tool_regex'; pattern: string }
-          | { type: 'resource_regex'; pattern: string }
-          | { type: 'resource_uris'; uris: string[] }
-          | { type: 'prompt_keys'; keys: string[] }
-          | { type: 'prompt_regex'; pattern: string }
-        )[];
-        ignoreParentFilters: boolean;
-      }
-    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -125,174 +102,167 @@ export type ManagementInstanceIntegrationProvidersGetOutput = {
   } | null;
 };
 
-export let mapManagementInstanceIntegrationProvidersGetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
+export let mapManagementInstanceIntegrationProvidersGetOutput =
+  mtMap.object<ManagementInstanceIntegrationProvidersGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
               )
+            )
+          })
+        )
+      ])
+    ),
+    providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+    deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+    authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+    authCredentialsId: mtMap.objectField(
+      'auth_credentials_id',
+      mtMap.passthrough()
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    deployment: mtMap.objectField(
+      'deployment',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authMethod: mtMap.objectField(
+      'auth_method',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        key: mtMap.objectField('key', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+        inputSchema: mtMap.objectField(
+          'input_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        outputSchema: mtMap.objectField(
+          'output_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        scopes: mtMap.objectField(
+          'scopes',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              scope: mtMap.objectField('scope', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField('description', mtMap.passthrough())
             })
           )
-        ])
-      ),
-      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
-      authCredentialsId: mtMap.objectField(
-        'auth_credentials_id',
-        mtMap.passthrough()
-      ),
-      config: mtMap.objectField(
-        'config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      deployment: mtMap.objectField(
-        'deployment',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authMethod: mtMap.objectField(
-        'auth_method',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          key: mtMap.objectField('key', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-          inputSchema: mtMap.objectField(
-            'input_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          outputSchema: mtMap.objectField(
-            'output_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          scopes: mtMap.objectField(
-            'scopes',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                scope: mtMap.objectField('scope', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                )
-              })
-            )
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          providerSpecificationId: mtMap.objectField(
-            'provider_specification_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authCredentials: mtMap.objectField(
-        'auth_credentials',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        providerSpecificationId: mtMap.objectField(
+          'provider_specification_id',
+          mtMap.passthrough()
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authCredentials: mtMap.objectField(
+      'auth_credentials',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    )
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceIntegrationProvidersListOutput = {
-  items: ({
+  items: {
     object: 'integration.provider';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -42,29 +42,6 @@ export type ManagementInstanceIntegrationProvidersListOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -124,7 +101,7 @@ export type ManagementInstanceIntegrationProvidersListOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -133,239 +110,201 @@ export let mapManagementInstanceIntegrationProvidersListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
+            mtMap.passthrough()
+          ),
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
+            mtMap.passthrough()
+          ),
+          config: mtMap.objectField(
+            'config',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              integrationId: mtMap.objectField(
-                'integration_id',
-                mtMap.passthrough()
-              ),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
                 'description',
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              toolFilter: mtMap.objectField(
-                'tool_filter',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      ignoreParentFilters: mtMap.objectField(
-                        'ignore_parent_filters',
-                        mtMap.passthrough()
-                      ),
-                      filters: mtMap.objectField(
-                        'filters',
-                        mtMap.array(
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                keys: mtMap.objectField(
-                                  'keys',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
-                                pattern: mtMap.objectField(
-                                  'pattern',
-                                  mtMap.passthrough()
-                                ),
-                                uris: mtMap.objectField(
-                                  'uris',
-                                  mtMap.array(mtMap.passthrough())
-                                )
-                              })
-                            )
-                          ])
-                        )
-                      )
-                    })
-                  )
-                ])
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          deployment: mtMap.objectField(
+            'deployment',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authMethod: mtMap.objectField(
+            'auth_method',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              key: mtMap.objectField('key', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              capabilities: mtMap.objectField(
+                'capabilities',
+                mtMap.passthrough()
+              ),
+              inputSchema: mtMap.objectField(
+                'input_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              outputSchema: mtMap.objectField(
+                'output_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    )
+                  })
+                )
               ),
               providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-              deploymentId: mtMap.objectField(
-                'deployment_id',
+              providerSpecificationId: mtMap.objectField(
+                'provider_specification_id',
                 mtMap.passthrough()
-              ),
-              authMethodId: mtMap.objectField(
-                'auth_method_id',
-                mtMap.passthrough()
-              ),
-              authCredentialsId: mtMap.objectField(
-                'auth_credentials_id',
-                mtMap.passthrough()
-              ),
-              config: mtMap.objectField(
-                'config',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-              provider: mtMap.objectField(
-                'provider',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authCredentials: mtMap.objectField(
+            'auth_credentials',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
               ),
-              deployment: mtMap.objectField(
-                'deployment',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(mtMap.passthrough())
               ),
-              authMethod: mtMap.objectField(
-                'auth_method',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  key: mtMap.objectField('key', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  capabilities: mtMap.objectField(
-                    'capabilities',
-                    mtMap.passthrough()
-                  ),
-                  inputSchema: mtMap.objectField(
-                    'input_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  outputSchema: mtMap.objectField(
-                    'output_schema',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      schema: mtMap.objectField('schema', mtMap.passthrough())
-                    })
-                  ),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(
-                      mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
-                          mtMap.passthrough()
-                        ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        scope: mtMap.objectField('scope', mtMap.passthrough()),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        )
-                      })
-                    )
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  providerSpecificationId: mtMap.objectField(
-                    'provider_specification_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              ),
-              authCredentials: mtMap.objectField(
-                'auth_credentials',
-                mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  type: mtMap.objectField('type', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  isDefault: mtMap.objectField(
-                    'is_default',
-                    mtMap.passthrough()
-                  ),
-                  isManaged: mtMap.objectField(
-                    'is_managed',
-                    mtMap.passthrough()
-                  ),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
-                    mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  scopes: mtMap.objectField(
-                    'scopes',
-                    mtMap.array(mtMap.passthrough())
-                  ),
-                  providerId: mtMap.objectField(
-                    'provider_id',
-                    mtMap.passthrough()
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                })
-              )
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
           )
-        ])
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-providers/update.ts
@@ -41,29 +41,6 @@ export type ManagementInstanceIntegrationProvidersUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date | null;
-} & {
-  object: 'integration.provider';
-  id: string;
-  status: 'active' | 'archived' | 'deleted';
-  integrationId: string;
-  name: string;
-  description: string | null;
-  metadata: Record<string, any> | null;
-  toolFilter:
-    | { type: 'allow_all'; ignoreParentFilters: boolean }
-    | {
-        type: 'filter';
-        filters: (
-          | { type: 'tool_keys'; keys: string[] }
-          | { type: 'tool_regex'; pattern: string }
-          | { type: 'resource_regex'; pattern: string }
-          | { type: 'resource_uris'; uris: string[] }
-          | { type: 'prompt_keys'; keys: string[] }
-          | { type: 'prompt_regex'; pattern: string }
-        )[];
-        ignoreParentFilters: boolean;
-      }
-    | null;
   provider: {
     object: 'provider#preview';
     id: string;
@@ -125,176 +102,169 @@ export type ManagementInstanceIntegrationProvidersUpdateOutput = {
   } | null;
 };
 
-export let mapManagementInstanceIntegrationProvidersUpdateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      toolFilter: mtMap.objectField(
-        'tool_filter',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              ignoreParentFilters: mtMap.objectField(
-                'ignore_parent_filters',
-                mtMap.passthrough()
-              ),
-              filters: mtMap.objectField(
-                'filters',
-                mtMap.array(
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        keys: mtMap.objectField(
-                          'keys',
-                          mtMap.array(mtMap.passthrough())
-                        ),
-                        pattern: mtMap.objectField(
-                          'pattern',
-                          mtMap.passthrough()
-                        ),
-                        uris: mtMap.objectField(
-                          'uris',
-                          mtMap.array(mtMap.passthrough())
-                        )
-                      })
-                    )
-                  ])
-                )
+export let mapManagementInstanceIntegrationProvidersUpdateOutput =
+  mtMap.object<ManagementInstanceIntegrationProvidersUpdateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    toolFilter: mtMap.objectField(
+      'tool_filter',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            ignoreParentFilters: mtMap.objectField(
+              'ignore_parent_filters',
+              mtMap.passthrough()
+            ),
+            filters: mtMap.objectField(
+              'filters',
+              mtMap.array(
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      keys: mtMap.objectField(
+                        'keys',
+                        mtMap.array(mtMap.passthrough())
+                      ),
+                      pattern: mtMap.objectField(
+                        'pattern',
+                        mtMap.passthrough()
+                      ),
+                      uris: mtMap.objectField(
+                        'uris',
+                        mtMap.array(mtMap.passthrough())
+                      )
+                    })
+                  )
+                ])
               )
+            )
+          })
+        )
+      ])
+    ),
+    providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+    deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+    authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
+    authCredentialsId: mtMap.objectField(
+      'auth_credentials_id',
+      mtMap.passthrough()
+    ),
+    config: mtMap.objectField(
+      'config',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+    provider: mtMap.objectField(
+      'provider',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    deployment: mtMap.objectField(
+      'deployment',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authMethod: mtMap.objectField(
+      'auth_method',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        key: mtMap.objectField('key', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
+        inputSchema: mtMap.objectField(
+          'input_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        outputSchema: mtMap.objectField(
+          'output_schema',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            schema: mtMap.objectField('schema', mtMap.passthrough())
+          })
+        ),
+        scopes: mtMap.objectField(
+          'scopes',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              scope: mtMap.objectField('scope', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField('description', mtMap.passthrough())
             })
           )
-        ])
-      ),
-      providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-      deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
-      authMethodId: mtMap.objectField('auth_method_id', mtMap.passthrough()),
-      authCredentialsId: mtMap.objectField(
-        'auth_credentials_id',
-        mtMap.passthrough()
-      ),
-      config: mtMap.objectField(
-        'config',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-      provider: mtMap.objectField(
-        'provider',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          slug: mtMap.objectField('slug', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      deployment: mtMap.objectField(
-        'deployment',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authMethod: mtMap.objectField(
-        'auth_method',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          key: mtMap.objectField('key', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          capabilities: mtMap.objectField('capabilities', mtMap.passthrough()),
-          inputSchema: mtMap.objectField(
-            'input_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          outputSchema: mtMap.objectField(
-            'output_schema',
-            mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              schema: mtMap.objectField('schema', mtMap.passthrough())
-            })
-          ),
-          scopes: mtMap.objectField(
-            'scopes',
-            mtMap.array(
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                scope: mtMap.objectField('scope', mtMap.passthrough()),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                )
-              })
-            )
-          ),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          providerSpecificationId: mtMap.objectField(
-            'provider_specification_id',
-            mtMap.passthrough()
-          ),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      ),
-      authCredentials: mtMap.objectField(
-        'auth_credentials',
-        mtMap.object({
-          object: mtMap.objectField('object', mtMap.passthrough()),
-          id: mtMap.objectField('id', mtMap.passthrough()),
-          type: mtMap.objectField('type', mtMap.passthrough()),
-          status: mtMap.objectField('status', mtMap.passthrough()),
-          isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
-          name: mtMap.objectField('name', mtMap.passthrough()),
-          description: mtMap.objectField('description', mtMap.passthrough()),
-          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-          scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
-          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
-          createdAt: mtMap.objectField('created_at', mtMap.date()),
-          updatedAt: mtMap.objectField('updated_at', mtMap.date())
-        })
-      )
-    })
-  )
-]);
+        ),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        providerSpecificationId: mtMap.objectField(
+          'provider_specification_id',
+          mtMap.passthrough()
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    ),
+    authCredentials: mtMap.objectField(
+      'auth_credentials',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+        isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough())),
+        providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    )
+  });
 
 export type ManagementInstanceIntegrationProvidersUpdateBody = {
   providerDeploymentId?: string | undefined;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-setup-sessions/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-setup-sessions/create.ts
@@ -138,7 +138,6 @@ export type ManagementInstanceIntegrationSetupSessionsCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
   expiresAt: Date;
-} & {
   integrationInstanceId: string;
   steps: {
     object: 'integration.setup_session.step';
@@ -170,54 +169,138 @@ export type ManagementInstanceIntegrationSetupSessionsCreateOutput = {
 };
 
 export let mapManagementInstanceIntegrationSetupSessionsCreateOutput =
-  mtMap.union([
-    mtMap.unionOption(
-      'object',
+  mtMap.object<ManagementInstanceIntegrationSetupSessionsCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    url: mtMap.objectField('url', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField('configuration', mtMap.passthrough()),
+    redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstance: mtMap.objectField(
+      'integration_instance',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
         status: mtMap.objectField('status', mtMap.passthrough()),
-        url: mtMap.objectField('url', mtMap.passthrough()),
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        configuration: mtMap.objectField('configuration', mtMap.passthrough()),
-        redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstance: mtMap.objectField(
-          'integration_instance',
+        identityActorId: mtMap.objectField(
+          'identity_actor_id',
+          mtMap.passthrough()
+        ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        implementation: mtMap.objectField(
+          'implementation',
           mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            integrationId: mtMap.objectField(
-              'integration_id',
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
               mtMap.passthrough()
-            ),
-            identityActorId: mtMap.objectField(
-              'identity_actor_id',
-              mtMap.passthrough()
-            ),
-            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-            implementation: mtMap.objectField(
-              'implementation',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                magicMcpServerId: mtMap.objectField(
-                  'magic_mcp_server_id',
-                  mtMap.passthrough()
-                )
-              })
-            ),
-            providers: mtMap.objectField(
-              'providers',
-              mtMap.array(
+            )
+          })
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              isOverrideToolFilter: mtMap.objectField(
+                'is_override_tool_filter',
+                mtMap.passthrough()
+              ),
+              provider: mtMap.objectField(
+                'provider',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              integrationProvider: mtMap.objectField(
+                'integration_provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  providerVersion: mtMap.objectField(
+                    'provider_version',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      index: mtMap.objectField('index', mtMap.passthrough())
+                    })
+                  ),
                   status: mtMap.objectField('status', mtMap.passthrough()),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
@@ -225,14 +308,6 @@ export let mapManagementInstanceIntegrationSetupSessionsCreateOutput =
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  integrationId: mtMap.objectField(
-                    'integration_id',
-                    mtMap.passthrough()
-                  ),
-                  integrationInstanceId: mtMap.objectField(
-                    'integration_instance_id',
-                    mtMap.passthrough()
-                  ),
                   toolFilter: mtMap.objectField(
                     'tool_filter',
                     mtMap.union([
@@ -276,181 +351,24 @@ export let mapManagementInstanceIntegrationSetupSessionsCreateOutput =
                       )
                     ])
                   ),
-                  isOverrideToolFilter: mtMap.objectField(
-                    'is_override_tool_filter',
+                  providerId: mtMap.objectField(
+                    'provider_id',
                     mtMap.passthrough()
                   ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  deploymentId: mtMap.objectField(
+                    'deployment_id',
+                    mtMap.passthrough()
                   ),
-                  integrationProvider: mtMap.objectField(
-                    'integration_provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      providerVersion: mtMap.objectField(
-                        'provider_version',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          index: mtMap.objectField('index', mtMap.passthrough())
-                        })
-                      ),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      toolFilter: mtMap.objectField(
-                        'tool_filter',
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              ignoreParentFilters: mtMap.objectField(
-                                'ignore_parent_filters',
-                                mtMap.passthrough()
-                              ),
-                              filters: mtMap.objectField(
-                                'filters',
-                                mtMap.array(
-                                  mtMap.union([
-                                    mtMap.unionOption(
-                                      'object',
-                                      mtMap.object({
-                                        type: mtMap.objectField(
-                                          'type',
-                                          mtMap.passthrough()
-                                        ),
-                                        keys: mtMap.objectField(
-                                          'keys',
-                                          mtMap.array(mtMap.passthrough())
-                                        ),
-                                        pattern: mtMap.objectField(
-                                          'pattern',
-                                          mtMap.passthrough()
-                                        ),
-                                        uris: mtMap.objectField(
-                                          'uris',
-                                          mtMap.array(mtMap.passthrough())
-                                        )
-                                      })
-                                    )
-                                  ])
-                                )
-                              )
-                            })
-                          )
-                        ])
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      deploymentId: mtMap.objectField(
-                        'deployment_id',
-                        mtMap.passthrough()
-                      ),
-                      authMethodId: mtMap.objectField(
-                        'auth_method_id',
-                        mtMap.passthrough()
-                      ),
-                      authCredentialsId: mtMap.objectField(
-                        'auth_credentials_id',
-                        mtMap.passthrough()
-                      ),
-                      config: mtMap.objectField(
-                        'config',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          isDefault: mtMap.objectField(
-                            'is_default',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          ),
-                          metadata: mtMap.objectField(
-                            'metadata',
-                            mtMap.passthrough()
-                          ),
-                          providerId: mtMap.objectField(
-                            'provider_id',
-                            mtMap.passthrough()
-                          ),
-                          createdAt: mtMap.objectField(
-                            'created_at',
-                            mtMap.date()
-                          ),
-                          updatedAt: mtMap.objectField(
-                            'updated_at',
-                            mtMap.date()
-                          )
-                        })
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                    })
+                  authMethodId: mtMap.objectField(
+                    'auth_method_id',
+                    mtMap.passthrough()
+                  ),
+                  authCredentialsId: mtMap.objectField(
+                    'auth_credentials_id',
+                    mtMap.passthrough()
                   ),
                   config: mtMap.objectField(
                     'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authConfig: mtMap.objectField(
-                    'auth_config',
                     mtMap.object({
                       object: mtMap.objectField('object', mtMap.passthrough()),
                       id: mtMap.objectField('id', mtMap.passthrough()),
@@ -479,63 +397,112 @@ export let mapManagementInstanceIntegrationSetupSessionsCreateOutput =
                   updatedAt: mtMap.objectField('updated_at', mtMap.date()),
                   archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
-              )
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        expiresAt: mtMap.objectField('expires_at', mtMap.date()),
-        integrationInstanceId: mtMap.objectField(
-          'integration_instance_id',
-          mtMap.passthrough()
-        ),
-        steps: mtMap.objectField(
-          'steps',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              url: mtMap.objectField('url', mtMap.passthrough()),
-              integrationProviderId: mtMap.objectField(
-                'integration_provider_id',
-                mtMap.passthrough()
               ),
-              provider: mtMap.objectField(
-                'provider',
+              config: mtMap.objectField(
+                'config',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
                   ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
               ),
-              providerSetupSessionId: mtMap.objectField(
-                'provider_setup_session_id',
+              authConfig: mtMap.objectField(
+                'auth_config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    steps: mtMap.objectField(
+      'steps',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          url: mtMap.objectField('url', mtMap.passthrough()),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              integrationInstanceProviderId: mtMap.objectField(
-                'integration_instance_provider_id',
-                mtMap.passthrough()
-              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          )
-        )
-      })
+          ),
+          providerSetupSessionId: mtMap.objectField(
+            'provider_setup_session_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
     )
-  ]);
+  });
 
 export type ManagementInstanceIntegrationSetupSessionsCreateBody = {
   integrationId: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-setup-sessions/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-setup-sessions/get.ts
@@ -138,7 +138,6 @@ export type ManagementInstanceIntegrationSetupSessionsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
   expiresAt: Date;
-} & {
   integrationInstanceId: string;
   steps: {
     object: 'integration.setup_session.step';
@@ -169,55 +168,139 @@ export type ManagementInstanceIntegrationSetupSessionsGetOutput = {
   }[];
 };
 
-export let mapManagementInstanceIntegrationSetupSessionsGetOutput = mtMap.union(
-  [
-    mtMap.unionOption(
-      'object',
+export let mapManagementInstanceIntegrationSetupSessionsGetOutput =
+  mtMap.object<ManagementInstanceIntegrationSetupSessionsGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    url: mtMap.objectField('url', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField('configuration', mtMap.passthrough()),
+    redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+    integrationInstance: mtMap.objectField(
+      'integration_instance',
       mtMap.object({
         object: mtMap.objectField('object', mtMap.passthrough()),
         id: mtMap.objectField('id', mtMap.passthrough()),
         status: mtMap.objectField('status', mtMap.passthrough()),
-        url: mtMap.objectField('url', mtMap.passthrough()),
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-        configuration: mtMap.objectField('configuration', mtMap.passthrough()),
-        redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
         integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
-        integrationInstance: mtMap.objectField(
-          'integration_instance',
+        identityActorId: mtMap.objectField(
+          'identity_actor_id',
+          mtMap.passthrough()
+        ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        implementation: mtMap.objectField(
+          'implementation',
           mtMap.object({
-            object: mtMap.objectField('object', mtMap.passthrough()),
-            id: mtMap.objectField('id', mtMap.passthrough()),
-            status: mtMap.objectField('status', mtMap.passthrough()),
-            name: mtMap.objectField('name', mtMap.passthrough()),
-            description: mtMap.objectField('description', mtMap.passthrough()),
-            metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-            integrationId: mtMap.objectField(
-              'integration_id',
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
               mtMap.passthrough()
-            ),
-            identityActorId: mtMap.objectField(
-              'identity_actor_id',
-              mtMap.passthrough()
-            ),
-            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
-            implementation: mtMap.objectField(
-              'implementation',
-              mtMap.object({
-                type: mtMap.objectField('type', mtMap.passthrough()),
-                magicMcpServerId: mtMap.objectField(
-                  'magic_mcp_server_id',
-                  mtMap.passthrough()
-                )
-              })
-            ),
-            providers: mtMap.objectField(
-              'providers',
-              mtMap.array(
+            )
+          })
+        ),
+        providers: mtMap.objectField(
+          'providers',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              toolFilter: mtMap.objectField(
+                'tool_filter',
+                mtMap.union([
+                  mtMap.unionOption(
+                    'object',
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      ignoreParentFilters: mtMap.objectField(
+                        'ignore_parent_filters',
+                        mtMap.passthrough()
+                      ),
+                      filters: mtMap.objectField(
+                        'filters',
+                        mtMap.array(
+                          mtMap.union([
+                            mtMap.unionOption(
+                              'object',
+                              mtMap.object({
+                                type: mtMap.objectField(
+                                  'type',
+                                  mtMap.passthrough()
+                                ),
+                                keys: mtMap.objectField(
+                                  'keys',
+                                  mtMap.array(mtMap.passthrough())
+                                ),
+                                pattern: mtMap.objectField(
+                                  'pattern',
+                                  mtMap.passthrough()
+                                ),
+                                uris: mtMap.objectField(
+                                  'uris',
+                                  mtMap.array(mtMap.passthrough())
+                                )
+                              })
+                            )
+                          ])
+                        )
+                      )
+                    })
+                  )
+                ])
+              ),
+              isOverrideToolFilter: mtMap.objectField(
+                'is_override_tool_filter',
+                mtMap.passthrough()
+              ),
+              provider: mtMap.objectField(
+                'provider',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              integrationProvider: mtMap.objectField(
+                'integration_provider',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  providerVersion: mtMap.objectField(
+                    'provider_version',
+                    mtMap.object({
+                      object: mtMap.objectField('object', mtMap.passthrough()),
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      index: mtMap.objectField('index', mtMap.passthrough())
+                    })
+                  ),
                   status: mtMap.objectField('status', mtMap.passthrough()),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
@@ -225,14 +308,6 @@ export let mapManagementInstanceIntegrationSetupSessionsGetOutput = mtMap.union(
                     mtMap.passthrough()
                   ),
                   metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  integrationId: mtMap.objectField(
-                    'integration_id',
-                    mtMap.passthrough()
-                  ),
-                  integrationInstanceId: mtMap.objectField(
-                    'integration_instance_id',
-                    mtMap.passthrough()
-                  ),
                   toolFilter: mtMap.objectField(
                     'tool_filter',
                     mtMap.union([
@@ -276,181 +351,24 @@ export let mapManagementInstanceIntegrationSetupSessionsGetOutput = mtMap.union(
                       )
                     ])
                   ),
-                  isOverrideToolFilter: mtMap.objectField(
-                    'is_override_tool_filter',
+                  providerId: mtMap.objectField(
+                    'provider_id',
                     mtMap.passthrough()
                   ),
-                  provider: mtMap.objectField(
-                    'provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      slug: mtMap.objectField('slug', mtMap.passthrough()),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
+                  deploymentId: mtMap.objectField(
+                    'deployment_id',
+                    mtMap.passthrough()
                   ),
-                  integrationProvider: mtMap.objectField(
-                    'integration_provider',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      providerVersion: mtMap.objectField(
-                        'provider_version',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          index: mtMap.objectField('index', mtMap.passthrough())
-                        })
-                      ),
-                      status: mtMap.objectField('status', mtMap.passthrough()),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      toolFilter: mtMap.objectField(
-                        'tool_filter',
-                        mtMap.union([
-                          mtMap.unionOption(
-                            'object',
-                            mtMap.object({
-                              type: mtMap.objectField(
-                                'type',
-                                mtMap.passthrough()
-                              ),
-                              ignoreParentFilters: mtMap.objectField(
-                                'ignore_parent_filters',
-                                mtMap.passthrough()
-                              ),
-                              filters: mtMap.objectField(
-                                'filters',
-                                mtMap.array(
-                                  mtMap.union([
-                                    mtMap.unionOption(
-                                      'object',
-                                      mtMap.object({
-                                        type: mtMap.objectField(
-                                          'type',
-                                          mtMap.passthrough()
-                                        ),
-                                        keys: mtMap.objectField(
-                                          'keys',
-                                          mtMap.array(mtMap.passthrough())
-                                        ),
-                                        pattern: mtMap.objectField(
-                                          'pattern',
-                                          mtMap.passthrough()
-                                        ),
-                                        uris: mtMap.objectField(
-                                          'uris',
-                                          mtMap.array(mtMap.passthrough())
-                                        )
-                                      })
-                                    )
-                                  ])
-                                )
-                              )
-                            })
-                          )
-                        ])
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      deploymentId: mtMap.objectField(
-                        'deployment_id',
-                        mtMap.passthrough()
-                      ),
-                      authMethodId: mtMap.objectField(
-                        'auth_method_id',
-                        mtMap.passthrough()
-                      ),
-                      authCredentialsId: mtMap.objectField(
-                        'auth_credentials_id',
-                        mtMap.passthrough()
-                      ),
-                      config: mtMap.objectField(
-                        'config',
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          isDefault: mtMap.objectField(
-                            'is_default',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          ),
-                          metadata: mtMap.objectField(
-                            'metadata',
-                            mtMap.passthrough()
-                          ),
-                          providerId: mtMap.objectField(
-                            'provider_id',
-                            mtMap.passthrough()
-                          ),
-                          createdAt: mtMap.objectField(
-                            'created_at',
-                            mtMap.date()
-                          ),
-                          updatedAt: mtMap.objectField(
-                            'updated_at',
-                            mtMap.date()
-                          )
-                        })
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                    })
+                  authMethodId: mtMap.objectField(
+                    'auth_method_id',
+                    mtMap.passthrough()
+                  ),
+                  authCredentialsId: mtMap.objectField(
+                    'auth_credentials_id',
+                    mtMap.passthrough()
                   ),
                   config: mtMap.objectField(
                     'config',
-                    mtMap.object({
-                      object: mtMap.objectField('object', mtMap.passthrough()),
-                      id: mtMap.objectField('id', mtMap.passthrough()),
-                      isDefault: mtMap.objectField(
-                        'is_default',
-                        mtMap.passthrough()
-                      ),
-                      name: mtMap.objectField('name', mtMap.passthrough()),
-                      description: mtMap.objectField(
-                        'description',
-                        mtMap.passthrough()
-                      ),
-                      metadata: mtMap.objectField(
-                        'metadata',
-                        mtMap.passthrough()
-                      ),
-                      providerId: mtMap.objectField(
-                        'provider_id',
-                        mtMap.passthrough()
-                      ),
-                      createdAt: mtMap.objectField('created_at', mtMap.date()),
-                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                    })
-                  ),
-                  authConfig: mtMap.objectField(
-                    'auth_config',
                     mtMap.object({
                       object: mtMap.objectField('object', mtMap.passthrough()),
                       id: mtMap.objectField('id', mtMap.passthrough()),
@@ -479,62 +397,110 @@ export let mapManagementInstanceIntegrationSetupSessionsGetOutput = mtMap.union(
                   updatedAt: mtMap.objectField('updated_at', mtMap.date()),
                   archivedAt: mtMap.objectField('archived_at', mtMap.date())
                 })
-              )
-            ),
-            createdAt: mtMap.objectField('created_at', mtMap.date()),
-            updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-            archivedAt: mtMap.objectField('archived_at', mtMap.date())
-          })
-        ),
-        createdAt: mtMap.objectField('created_at', mtMap.date()),
-        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-        expiresAt: mtMap.objectField('expires_at', mtMap.date()),
-        integrationInstanceId: mtMap.objectField(
-          'integration_instance_id',
-          mtMap.passthrough()
-        ),
-        steps: mtMap.objectField(
-          'steps',
-          mtMap.array(
-            mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              url: mtMap.objectField('url', mtMap.passthrough()),
-              integrationProviderId: mtMap.objectField(
-                'integration_provider_id',
-                mtMap.passthrough()
               ),
-              provider: mtMap.objectField(
-                'provider',
+              config: mtMap.objectField(
+                'config',
                 mtMap.object({
                   object: mtMap.objectField('object', mtMap.passthrough()),
                   id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
                   name: mtMap.objectField('name', mtMap.passthrough()),
                   description: mtMap.objectField(
                     'description',
                     mtMap.passthrough()
                   ),
-                  slug: mtMap.objectField('slug', mtMap.passthrough()),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())
                 })
               ),
-              providerSetupSessionId: mtMap.objectField(
-                'provider_setup_session_id',
+              authConfig: mtMap.objectField(
+                'auth_config',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                  providerId: mtMap.objectField(
+                    'provider_id',
+                    mtMap.passthrough()
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          )
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
+      mtMap.passthrough()
+    ),
+    steps: mtMap.objectField(
+      'steps',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          url: mtMap.objectField('url', mtMap.passthrough()),
+          integrationProviderId: mtMap.objectField(
+            'integration_provider_id',
+            mtMap.passthrough()
+          ),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              integrationInstanceProviderId: mtMap.objectField(
-                'integration_instance_provider_id',
-                mtMap.passthrough()
-              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          )
-        )
-      })
+          ),
+          providerSetupSessionId: mtMap.objectField(
+            'provider_setup_session_id',
+            mtMap.passthrough()
+          ),
+          integrationInstanceProviderId: mtMap.objectField(
+            'integration_instance_provider_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
     )
-  ]
-);
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-setup-sessions/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integration-setup-sessions/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceIntegrationSetupSessionsListOutput = {
-  items: ({
+  items: {
     object: 'integration.setup_session';
     id: string;
     status: 'pending' | 'successful' | 'expired' | 'archived' | 'deleted';
@@ -139,7 +139,6 @@ export type ManagementInstanceIntegrationSetupSessionsListOutput = {
     createdAt: Date;
     updatedAt: Date;
     expiresAt: Date;
-  } & {
     integrationInstanceId: string;
     steps: {
       object: 'integration.setup_session.step';
@@ -168,7 +167,7 @@ export type ManagementInstanceIntegrationSetupSessionsListOutput = {
       createdAt: Date;
       updatedAt: Date;
     }[];
-  })[];
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -177,75 +176,171 @@ export let mapManagementInstanceIntegrationSetupSessionsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          url: mtMap.objectField('url', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          configuration: mtMap.objectField(
+            'configuration',
+            mtMap.passthrough()
+          ),
+          redirectUrl: mtMap.objectField('redirect_url', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
+            mtMap.passthrough()
+          ),
+          integrationInstance: mtMap.objectField(
+            'integration_instance',
             mtMap.object({
               object: mtMap.objectField('object', mtMap.passthrough()),
               id: mtMap.objectField('id', mtMap.passthrough()),
               status: mtMap.objectField('status', mtMap.passthrough()),
-              url: mtMap.objectField('url', mtMap.passthrough()),
               name: mtMap.objectField('name', mtMap.passthrough()),
               description: mtMap.objectField(
                 'description',
                 mtMap.passthrough()
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              configuration: mtMap.objectField(
-                'configuration',
-                mtMap.passthrough()
-              ),
-              redirectUrl: mtMap.objectField(
-                'redirect_url',
-                mtMap.passthrough()
-              ),
               integrationId: mtMap.objectField(
                 'integration_id',
                 mtMap.passthrough()
               ),
-              integrationInstance: mtMap.objectField(
-                'integration_instance',
+              identityActorId: mtMap.objectField(
+                'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              implementation: mtMap.objectField(
+                'implementation',
                 mtMap.object({
-                  object: mtMap.objectField('object', mtMap.passthrough()),
-                  id: mtMap.objectField('id', mtMap.passthrough()),
-                  status: mtMap.objectField('status', mtMap.passthrough()),
-                  name: mtMap.objectField('name', mtMap.passthrough()),
-                  description: mtMap.objectField(
-                    'description',
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  magicMcpServerId: mtMap.objectField(
+                    'magic_mcp_server_id',
                     mtMap.passthrough()
-                  ),
-                  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                  integrationId: mtMap.objectField(
-                    'integration_id',
-                    mtMap.passthrough()
-                  ),
-                  identityActorId: mtMap.objectField(
-                    'identity_actor_id',
-                    mtMap.passthrough()
-                  ),
-                  identityId: mtMap.objectField(
-                    'identity_id',
-                    mtMap.passthrough()
-                  ),
-                  implementation: mtMap.objectField(
-                    'implementation',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      magicMcpServerId: mtMap.objectField(
-                        'magic_mcp_server_id',
-                        mtMap.passthrough()
-                      )
-                    })
-                  ),
-                  providers: mtMap.objectField(
-                    'providers',
-                    mtMap.array(
+                  )
+                })
+              ),
+              providers: mtMap.objectField(
+                'providers',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    integrationId: mtMap.objectField(
+                      'integration_id',
+                      mtMap.passthrough()
+                    ),
+                    integrationInstanceId: mtMap.objectField(
+                      'integration_instance_id',
+                      mtMap.passthrough()
+                    ),
+                    toolFilter: mtMap.objectField(
+                      'tool_filter',
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            ignoreParentFilters: mtMap.objectField(
+                              'ignore_parent_filters',
+                              mtMap.passthrough()
+                            ),
+                            filters: mtMap.objectField(
+                              'filters',
+                              mtMap.array(
+                                mtMap.union([
+                                  mtMap.unionOption(
+                                    'object',
+                                    mtMap.object({
+                                      type: mtMap.objectField(
+                                        'type',
+                                        mtMap.passthrough()
+                                      ),
+                                      keys: mtMap.objectField(
+                                        'keys',
+                                        mtMap.array(mtMap.passthrough())
+                                      ),
+                                      pattern: mtMap.objectField(
+                                        'pattern',
+                                        mtMap.passthrough()
+                                      ),
+                                      uris: mtMap.objectField(
+                                        'uris',
+                                        mtMap.array(mtMap.passthrough())
+                                      )
+                                    })
+                                  )
+                                ])
+                              )
+                            )
+                          })
+                        )
+                      ])
+                    ),
+                    isOverrideToolFilter: mtMap.objectField(
+                      'is_override_tool_filter',
+                      mtMap.passthrough()
+                    ),
+                    provider: mtMap.objectField(
+                      'provider',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        ),
+                        slug: mtMap.objectField('slug', mtMap.passthrough()),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    ),
+                    integrationProvider: mtMap.objectField(
+                      'integration_provider',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        providerVersion: mtMap.objectField(
+                          'provider_version',
+                          mtMap.object({
+                            object: mtMap.objectField(
+                              'object',
+                              mtMap.passthrough()
+                            ),
+                            id: mtMap.objectField('id', mtMap.passthrough()),
+                            index: mtMap.objectField(
+                              'index',
+                              mtMap.passthrough()
+                            )
+                          })
+                        ),
                         status: mtMap.objectField(
                           'status',
                           mtMap.passthrough()
@@ -257,14 +352,6 @@ export let mapManagementInstanceIntegrationSetupSessionsListOutput =
                         ),
                         metadata: mtMap.objectField(
                           'metadata',
-                          mtMap.passthrough()
-                        ),
-                        integrationId: mtMap.objectField(
-                          'integration_id',
-                          mtMap.passthrough()
-                        ),
-                        integrationInstanceId: mtMap.objectField(
-                          'integration_instance_id',
                           mtMap.passthrough()
                         ),
                         toolFilter: mtMap.objectField(
@@ -313,238 +400,24 @@ export let mapManagementInstanceIntegrationSetupSessionsListOutput =
                             )
                           ])
                         ),
-                        isOverrideToolFilter: mtMap.objectField(
-                          'is_override_tool_filter',
+                        providerId: mtMap.objectField(
+                          'provider_id',
                           mtMap.passthrough()
                         ),
-                        provider: mtMap.objectField(
-                          'provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            slug: mtMap.objectField(
-                              'slug',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
+                        deploymentId: mtMap.objectField(
+                          'deployment_id',
+                          mtMap.passthrough()
                         ),
-                        integrationProvider: mtMap.objectField(
-                          'integration_provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            providerVersion: mtMap.objectField(
-                              'provider_version',
-                              mtMap.object({
-                                object: mtMap.objectField(
-                                  'object',
-                                  mtMap.passthrough()
-                                ),
-                                id: mtMap.objectField(
-                                  'id',
-                                  mtMap.passthrough()
-                                ),
-                                index: mtMap.objectField(
-                                  'index',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            status: mtMap.objectField(
-                              'status',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            toolFilter: mtMap.objectField(
-                              'tool_filter',
-                              mtMap.union([
-                                mtMap.unionOption(
-                                  'object',
-                                  mtMap.object({
-                                    type: mtMap.objectField(
-                                      'type',
-                                      mtMap.passthrough()
-                                    ),
-                                    ignoreParentFilters: mtMap.objectField(
-                                      'ignore_parent_filters',
-                                      mtMap.passthrough()
-                                    ),
-                                    filters: mtMap.objectField(
-                                      'filters',
-                                      mtMap.array(
-                                        mtMap.union([
-                                          mtMap.unionOption(
-                                            'object',
-                                            mtMap.object({
-                                              type: mtMap.objectField(
-                                                'type',
-                                                mtMap.passthrough()
-                                              ),
-                                              keys: mtMap.objectField(
-                                                'keys',
-                                                mtMap.array(mtMap.passthrough())
-                                              ),
-                                              pattern: mtMap.objectField(
-                                                'pattern',
-                                                mtMap.passthrough()
-                                              ),
-                                              uris: mtMap.objectField(
-                                                'uris',
-                                                mtMap.array(mtMap.passthrough())
-                                              )
-                                            })
-                                          )
-                                        ])
-                                      )
-                                    )
-                                  })
-                                )
-                              ])
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            deploymentId: mtMap.objectField(
-                              'deployment_id',
-                              mtMap.passthrough()
-                            ),
-                            authMethodId: mtMap.objectField(
-                              'auth_method_id',
-                              mtMap.passthrough()
-                            ),
-                            authCredentialsId: mtMap.objectField(
-                              'auth_credentials_id',
-                              mtMap.passthrough()
-                            ),
-                            config: mtMap.objectField(
-                              'config',
-                              mtMap.object({
-                                object: mtMap.objectField(
-                                  'object',
-                                  mtMap.passthrough()
-                                ),
-                                id: mtMap.objectField(
-                                  'id',
-                                  mtMap.passthrough()
-                                ),
-                                isDefault: mtMap.objectField(
-                                  'is_default',
-                                  mtMap.passthrough()
-                                ),
-                                name: mtMap.objectField(
-                                  'name',
-                                  mtMap.passthrough()
-                                ),
-                                description: mtMap.objectField(
-                                  'description',
-                                  mtMap.passthrough()
-                                ),
-                                metadata: mtMap.objectField(
-                                  'metadata',
-                                  mtMap.passthrough()
-                                ),
-                                providerId: mtMap.objectField(
-                                  'provider_id',
-                                  mtMap.passthrough()
-                                ),
-                                createdAt: mtMap.objectField(
-                                  'created_at',
-                                  mtMap.date()
-                                ),
-                                updatedAt: mtMap.objectField(
-                                  'updated_at',
-                                  mtMap.date()
-                                )
-                              })
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            ),
-                            archivedAt: mtMap.objectField(
-                              'archived_at',
-                              mtMap.date()
-                            )
-                          })
+                        authMethodId: mtMap.objectField(
+                          'auth_method_id',
+                          mtMap.passthrough()
+                        ),
+                        authCredentialsId: mtMap.objectField(
+                          'auth_credentials_id',
+                          mtMap.passthrough()
                         ),
                         config: mtMap.objectField(
                           'config',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authConfig: mtMap.objectField(
-                          'auth_config',
                           mtMap.object({
                             object: mtMap.objectField(
                               'object',
@@ -594,46 +467,32 @@ export let mapManagementInstanceIntegrationSetupSessionsListOutput =
                           mtMap.date()
                         )
                       })
-                    )
-                  ),
-                  createdAt: mtMap.objectField('created_at', mtMap.date()),
-                  updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                  archivedAt: mtMap.objectField('archived_at', mtMap.date())
-                })
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              expiresAt: mtMap.objectField('expires_at', mtMap.date()),
-              integrationInstanceId: mtMap.objectField(
-                'integration_instance_id',
-                mtMap.passthrough()
-              ),
-              steps: mtMap.objectField(
-                'steps',
-                mtMap.array(
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    url: mtMap.objectField('url', mtMap.passthrough()),
-                    integrationProviderId: mtMap.objectField(
-                      'integration_provider_id',
-                      mtMap.passthrough()
                     ),
-                    provider: mtMap.objectField(
-                      'provider',
+                    config: mtMap.objectField(
+                      'config',
                       mtMap.object({
                         object: mtMap.objectField(
                           'object',
                           mtMap.passthrough()
                         ),
                         id: mtMap.objectField('id', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
                         name: mtMap.objectField('name', mtMap.passthrough()),
                         description: mtMap.objectField(
                           'description',
                           mtMap.passthrough()
                         ),
-                        slug: mtMap.objectField('slug', mtMap.passthrough()),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
                         createdAt: mtMap.objectField(
                           'created_at',
                           mtMap.date()
@@ -641,22 +500,97 @@ export let mapManagementInstanceIntegrationSetupSessionsListOutput =
                         updatedAt: mtMap.objectField('updated_at', mtMap.date())
                       })
                     ),
-                    providerSetupSessionId: mtMap.objectField(
-                      'provider_setup_session_id',
+                    authConfig: mtMap.objectField(
+                      'auth_config',
+                      mtMap.object({
+                        object: mtMap.objectField(
+                          'object',
+                          mtMap.passthrough()
+                        ),
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        isDefault: mtMap.objectField(
+                          'is_default',
+                          mtMap.passthrough()
+                        ),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        description: mtMap.objectField(
+                          'description',
+                          mtMap.passthrough()
+                        ),
+                        metadata: mtMap.objectField(
+                          'metadata',
+                          mtMap.passthrough()
+                        ),
+                        providerId: mtMap.objectField(
+                          'provider_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+                  })
+                )
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              archivedAt: mtMap.objectField('archived_at', mtMap.date())
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          expiresAt: mtMap.objectField('expires_at', mtMap.date()),
+          integrationInstanceId: mtMap.objectField(
+            'integration_instance_id',
+            mtMap.passthrough()
+          ),
+          steps: mtMap.objectField(
+            'steps',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough()),
+                integrationProviderId: mtMap.objectField(
+                  'integration_provider_id',
+                  mtMap.passthrough()
+                ),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
                       mtMap.passthrough()
                     ),
-                    integrationInstanceProviderId: mtMap.objectField(
-                      'integration_instance_provider_id',
-                      mtMap.passthrough()
-                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
                     createdAt: mtMap.objectField('created_at', mtMap.date()),
                     updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
-                )
-              )
-            })
+                ),
+                providerSetupSessionId: mtMap.objectField(
+                  'provider_setup_session_id',
+                  mtMap.passthrough()
+                ),
+                integrationInstanceProviderId: mtMap.objectField(
+                  'integration_instance_provider_id',
+                  mtMap.passthrough()
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            )
           )
-        ])
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/create.ts
@@ -58,75 +58,6 @@ export type ManagementInstanceIntegrationsCreateOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -186,315 +117,261 @@ export type ManagementInstanceIntegrationsCreateOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
 };
 
-export let mapManagementInstanceIntegrationsCreateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      slug: mtMap.objectField('slug', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField(
-        'configuration',
+export let mapManagementInstanceIntegrationsCreateOutput =
+  mtMap.object<ManagementInstanceIntegrationsCreateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    slug: mtMap.objectField('slug', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField(
+      'configuration',
+      mtMap.object({
+        canAttachCustomToolFilters: mtMap.objectField(
+          'can_attach_custom_tool_filters',
+          mtMap.passthrough()
+        ),
+        canAttachCustomProviderConfig: mtMap.objectField(
+          'can_attach_custom_provider_config',
+          mtMap.passthrough()
+        ),
+        canOverrideToolFilters: mtMap.objectField(
+          'can_override_tool_filters',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            providerTemplateId: mtMap.objectField(
+              'provider_template_id',
+              mtMap.passthrough()
+            ),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
+              mtMap.passthrough()
+            )
+          })
+        )
+      ])
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          canAttachCustomToolFilters: mtMap.objectField(
-            'can_attach_custom_tool_filters',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
           ),
-          canAttachCustomProviderConfig: mtMap.objectField(
-            'can_attach_custom_provider_config',
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
             mtMap.passthrough()
           ),
-          canOverrideToolFilters: mtMap.objectField(
-            'can_override_tool_filters',
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+          ),
+          config: mtMap.objectField(
+            'config',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              providerTemplateId: mtMap.objectField(
-                'provider_template_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
-                mtMap.passthrough()
-              )
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          )
-        ])
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          deployment: mtMap.objectField(
+            'deployment',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authMethod: mtMap.objectField(
+            'auth_method',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              key: mtMap.objectField('key', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              capabilities: mtMap.objectField(
+                'capabilities',
+                mtMap.passthrough()
+              ),
+              inputSchema: mtMap.objectField(
+                'input_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              outputSchema: mtMap.objectField(
+                'output_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
                     )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                deployment: mtMap.objectField(
-                  'deployment',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authMethod: mtMap.objectField(
-                  'auth_method',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    key: mtMap.objectField('key', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    capabilities: mtMap.objectField(
-                      'capabilities',
-                      mtMap.passthrough()
-                    ),
-                    inputSchema: mtMap.objectField(
-                      'input_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    outputSchema: mtMap.objectField(
-                      'output_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          scope: mtMap.objectField(
-                            'scope',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          )
-                        })
-                      )
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    providerSpecificationId: mtMap.objectField(
-                      'provider_specification_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authCredentials: mtMap.objectField(
-                  'auth_credentials',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    isManaged: mtMap.objectField(
-                      'is_managed',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(mtMap.passthrough())
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              providerSpecificationId: mtMap.objectField(
+                'provider_specification_id',
+                mtMap.passthrough()
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authCredentials: mtMap.objectField(
+            'auth_credentials',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(mtMap.passthrough())
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          )
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type ManagementInstanceIntegrationsCreateBody = {
   name: string;

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/delete.ts
@@ -58,75 +58,6 @@ export type ManagementInstanceIntegrationsDeleteOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -186,313 +117,259 @@ export type ManagementInstanceIntegrationsDeleteOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
 };
 
-export let mapManagementInstanceIntegrationsDeleteOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      slug: mtMap.objectField('slug', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField(
-        'configuration',
+export let mapManagementInstanceIntegrationsDeleteOutput =
+  mtMap.object<ManagementInstanceIntegrationsDeleteOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    slug: mtMap.objectField('slug', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField(
+      'configuration',
+      mtMap.object({
+        canAttachCustomToolFilters: mtMap.objectField(
+          'can_attach_custom_tool_filters',
+          mtMap.passthrough()
+        ),
+        canAttachCustomProviderConfig: mtMap.objectField(
+          'can_attach_custom_provider_config',
+          mtMap.passthrough()
+        ),
+        canOverrideToolFilters: mtMap.objectField(
+          'can_override_tool_filters',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            providerTemplateId: mtMap.objectField(
+              'provider_template_id',
+              mtMap.passthrough()
+            ),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
+              mtMap.passthrough()
+            )
+          })
+        )
+      ])
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          canAttachCustomToolFilters: mtMap.objectField(
-            'can_attach_custom_tool_filters',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
           ),
-          canAttachCustomProviderConfig: mtMap.objectField(
-            'can_attach_custom_provider_config',
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
             mtMap.passthrough()
           ),
-          canOverrideToolFilters: mtMap.objectField(
-            'can_override_tool_filters',
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+          ),
+          config: mtMap.objectField(
+            'config',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              providerTemplateId: mtMap.objectField(
-                'provider_template_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
-                mtMap.passthrough()
-              )
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          )
-        ])
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          deployment: mtMap.objectField(
+            'deployment',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authMethod: mtMap.objectField(
+            'auth_method',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              key: mtMap.objectField('key', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              capabilities: mtMap.objectField(
+                'capabilities',
+                mtMap.passthrough()
+              ),
+              inputSchema: mtMap.objectField(
+                'input_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              outputSchema: mtMap.objectField(
+                'output_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
                     )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                deployment: mtMap.objectField(
-                  'deployment',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authMethod: mtMap.objectField(
-                  'auth_method',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    key: mtMap.objectField('key', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    capabilities: mtMap.objectField(
-                      'capabilities',
-                      mtMap.passthrough()
-                    ),
-                    inputSchema: mtMap.objectField(
-                      'input_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    outputSchema: mtMap.objectField(
-                      'output_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          scope: mtMap.objectField(
-                            'scope',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          )
-                        })
-                      )
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    providerSpecificationId: mtMap.objectField(
-                      'provider_specification_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authCredentials: mtMap.objectField(
-                  'auth_credentials',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    isManaged: mtMap.objectField(
-                      'is_managed',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(mtMap.passthrough())
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              providerSpecificationId: mtMap.objectField(
+                'provider_specification_id',
+                mtMap.passthrough()
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authCredentials: mtMap.objectField(
+            'auth_credentials',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(mtMap.passthrough())
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          )
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/get.ts
@@ -58,75 +58,6 @@ export type ManagementInstanceIntegrationsGetOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -186,313 +117,259 @@ export type ManagementInstanceIntegrationsGetOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
 };
 
-export let mapManagementInstanceIntegrationsGetOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      slug: mtMap.objectField('slug', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField(
-        'configuration',
+export let mapManagementInstanceIntegrationsGetOutput =
+  mtMap.object<ManagementInstanceIntegrationsGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    slug: mtMap.objectField('slug', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField(
+      'configuration',
+      mtMap.object({
+        canAttachCustomToolFilters: mtMap.objectField(
+          'can_attach_custom_tool_filters',
+          mtMap.passthrough()
+        ),
+        canAttachCustomProviderConfig: mtMap.objectField(
+          'can_attach_custom_provider_config',
+          mtMap.passthrough()
+        ),
+        canOverrideToolFilters: mtMap.objectField(
+          'can_override_tool_filters',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            providerTemplateId: mtMap.objectField(
+              'provider_template_id',
+              mtMap.passthrough()
+            ),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
+              mtMap.passthrough()
+            )
+          })
+        )
+      ])
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          canAttachCustomToolFilters: mtMap.objectField(
-            'can_attach_custom_tool_filters',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
           ),
-          canAttachCustomProviderConfig: mtMap.objectField(
-            'can_attach_custom_provider_config',
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
             mtMap.passthrough()
           ),
-          canOverrideToolFilters: mtMap.objectField(
-            'can_override_tool_filters',
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+          ),
+          config: mtMap.objectField(
+            'config',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              providerTemplateId: mtMap.objectField(
-                'provider_template_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
-                mtMap.passthrough()
-              )
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          )
-        ])
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          deployment: mtMap.objectField(
+            'deployment',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authMethod: mtMap.objectField(
+            'auth_method',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              key: mtMap.objectField('key', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              capabilities: mtMap.objectField(
+                'capabilities',
+                mtMap.passthrough()
+              ),
+              inputSchema: mtMap.objectField(
+                'input_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              outputSchema: mtMap.objectField(
+                'output_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
                     )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                deployment: mtMap.objectField(
-                  'deployment',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authMethod: mtMap.objectField(
-                  'auth_method',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    key: mtMap.objectField('key', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    capabilities: mtMap.objectField(
-                      'capabilities',
-                      mtMap.passthrough()
-                    ),
-                    inputSchema: mtMap.objectField(
-                      'input_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    outputSchema: mtMap.objectField(
-                      'output_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          scope: mtMap.objectField(
-                            'scope',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          )
-                        })
-                      )
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    providerSpecificationId: mtMap.objectField(
-                      'provider_specification_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authCredentials: mtMap.objectField(
-                  'auth_credentials',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    isManaged: mtMap.objectField(
-                      'is_managed',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(mtMap.passthrough())
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              providerSpecificationId: mtMap.objectField(
+                'provider_specification_id',
+                mtMap.passthrough()
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authCredentials: mtMap.objectField(
+            'auth_credentials',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(mtMap.passthrough())
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          )
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/list.ts
@@ -1,7 +1,7 @@
 import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceIntegrationsListOutput = {
-  items: ({
+  items: {
     object: 'integration';
     id: string;
     status: 'active' | 'archived' | 'deleted';
@@ -59,75 +59,6 @@ export type ManagementInstanceIntegrationsListOutput = {
       createdAt: Date;
       updatedAt: Date;
       archivedAt: Date | null;
-    }[];
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    providers: ({
-      object: 'integration.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      integrationId: string;
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
-      providerId: string;
-      deploymentId: string;
-      authMethodId: string | null;
-      authCredentialsId: string | null;
-      config: {
-        object: 'provider.config#preview';
-        id: string;
-        isDefault: boolean;
-        name: string | null;
-        description: string | null;
-        metadata: Record<string, any> | null;
-        providerId: string;
-        createdAt: Date;
-        updatedAt: Date;
-      } | null;
-      createdAt: Date;
-      updatedAt: Date;
-      archivedAt: Date | null;
-    } & {
-      object: 'integration.provider';
-      id: string;
-      status: 'active' | 'archived' | 'deleted';
-      integrationId: string;
-      name: string;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      toolFilter:
-        | { type: 'allow_all'; ignoreParentFilters: boolean }
-        | {
-            type: 'filter';
-            filters: (
-              | { type: 'tool_keys'; keys: string[] }
-              | { type: 'tool_regex'; pattern: string }
-              | { type: 'resource_regex'; pattern: string }
-              | { type: 'resource_uris'; uris: string[] }
-              | { type: 'prompt_keys'; keys: string[] }
-              | { type: 'prompt_regex'; pattern: string }
-            )[];
-            ignoreParentFilters: boolean;
-          }
-        | null;
       provider: {
         object: 'provider#preview';
         id: string;
@@ -193,8 +124,11 @@ export type ManagementInstanceIntegrationsListOutput = {
         createdAt: Date;
         updatedAt: Date;
       } | null;
-    })[];
-  })[];
+    }[];
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
   pagination: { hasMoreBefore: boolean; hasMoreAfter: boolean };
 };
 
@@ -203,426 +137,302 @@ export let mapManagementInstanceIntegrationsListOutput =
     items: mtMap.objectField(
       'items',
       mtMap.array(
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          configuration: mtMap.objectField(
+            'configuration',
             mtMap.object({
-              object: mtMap.objectField('object', mtMap.passthrough()),
-              id: mtMap.objectField('id', mtMap.passthrough()),
-              status: mtMap.objectField('status', mtMap.passthrough()),
-              slug: mtMap.objectField('slug', mtMap.passthrough()),
-              name: mtMap.objectField('name', mtMap.passthrough()),
-              description: mtMap.objectField(
-                'description',
+              canAttachCustomToolFilters: mtMap.objectField(
+                'can_attach_custom_tool_filters',
                 mtMap.passthrough()
               ),
-              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-              configuration: mtMap.objectField(
-                'configuration',
+              canAttachCustomProviderConfig: mtMap.objectField(
+                'can_attach_custom_provider_config',
+                mtMap.passthrough()
+              ),
+              canOverrideToolFilters: mtMap.objectField(
+                'can_override_tool_filters',
+                mtMap.passthrough()
+              )
+            })
+          ),
+          implementation: mtMap.objectField(
+            'implementation',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
                 mtMap.object({
-                  canAttachCustomToolFilters: mtMap.objectField(
-                    'can_attach_custom_tool_filters',
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  providerTemplateId: mtMap.objectField(
+                    'provider_template_id',
                     mtMap.passthrough()
                   ),
-                  canAttachCustomProviderConfig: mtMap.objectField(
-                    'can_attach_custom_provider_config',
-                    mtMap.passthrough()
-                  ),
-                  canOverrideToolFilters: mtMap.objectField(
-                    'can_override_tool_filters',
+                  magicMcpServerId: mtMap.objectField(
+                    'magic_mcp_server_id',
                     mtMap.passthrough()
                   )
                 })
-              ),
-              implementation: mtMap.objectField(
-                'implementation',
-                mtMap.union([
-                  mtMap.unionOption(
-                    'object',
-                    mtMap.object({
-                      type: mtMap.objectField('type', mtMap.passthrough()),
-                      providerTemplateId: mtMap.objectField(
-                        'provider_template_id',
-                        mtMap.passthrough()
-                      ),
-                      magicMcpServerId: mtMap.objectField(
-                        'magic_mcp_server_id',
-                        mtMap.passthrough()
-                      )
-                    })
-                  )
-                ])
-              ),
-              providers: mtMap.objectField(
-                'providers',
-                mtMap.array(
+              )
+            ])
+          ),
+          providers: mtMap.objectField(
+            'providers',
+            mtMap.array(
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                integrationId: mtMap.objectField(
+                  'integration_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+                toolFilter: mtMap.objectField(
+                  'tool_filter',
                   mtMap.union([
                     mtMap.unionOption(
                       'object',
                       mtMap.object({
-                        object: mtMap.objectField(
-                          'object',
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        ignoreParentFilters: mtMap.objectField(
+                          'ignore_parent_filters',
                           mtMap.passthrough()
                         ),
-                        id: mtMap.objectField('id', mtMap.passthrough()),
-                        status: mtMap.objectField(
-                          'status',
-                          mtMap.passthrough()
-                        ),
-                        integrationId: mtMap.objectField(
-                          'integration_id',
-                          mtMap.passthrough()
-                        ),
-                        name: mtMap.objectField('name', mtMap.passthrough()),
-                        description: mtMap.objectField(
-                          'description',
-                          mtMap.passthrough()
-                        ),
-                        metadata: mtMap.objectField(
-                          'metadata',
-                          mtMap.passthrough()
-                        ),
-                        toolFilter: mtMap.objectField(
-                          'tool_filter',
-                          mtMap.union([
-                            mtMap.unionOption(
-                              'object',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                ignoreParentFilters: mtMap.objectField(
-                                  'ignore_parent_filters',
-                                  mtMap.passthrough()
-                                ),
-                                filters: mtMap.objectField(
-                                  'filters',
-                                  mtMap.array(
-                                    mtMap.union([
-                                      mtMap.unionOption(
-                                        'object',
-                                        mtMap.object({
-                                          type: mtMap.objectField(
-                                            'type',
-                                            mtMap.passthrough()
-                                          ),
-                                          keys: mtMap.objectField(
-                                            'keys',
-                                            mtMap.array(mtMap.passthrough())
-                                          ),
-                                          pattern: mtMap.objectField(
-                                            'pattern',
-                                            mtMap.passthrough()
-                                          ),
-                                          uris: mtMap.objectField(
-                                            'uris',
-                                            mtMap.array(mtMap.passthrough())
-                                          )
-                                        })
-                                      )
-                                    ])
-                                  )
-                                )
-                              })
-                            )
-                          ])
-                        ),
-                        providerId: mtMap.objectField(
-                          'provider_id',
-                          mtMap.passthrough()
-                        ),
-                        deploymentId: mtMap.objectField(
-                          'deployment_id',
-                          mtMap.passthrough()
-                        ),
-                        authMethodId: mtMap.objectField(
-                          'auth_method_id',
-                          mtMap.passthrough()
-                        ),
-                        authCredentialsId: mtMap.objectField(
-                          'auth_credentials_id',
-                          mtMap.passthrough()
-                        ),
-                        config: mtMap.objectField(
-                          'config',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        createdAt: mtMap.objectField(
-                          'created_at',
-                          mtMap.date()
-                        ),
-                        updatedAt: mtMap.objectField(
-                          'updated_at',
-                          mtMap.date()
-                        ),
-                        archivedAt: mtMap.objectField(
-                          'archived_at',
-                          mtMap.date()
-                        ),
-                        provider: mtMap.objectField(
-                          'provider',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            slug: mtMap.objectField(
-                              'slug',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        deployment: mtMap.objectField(
-                          'deployment',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authMethod: mtMap.objectField(
-                          'auth_method',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            key: mtMap.objectField('key', mtMap.passthrough()),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            capabilities: mtMap.objectField(
-                              'capabilities',
-                              mtMap.passthrough()
-                            ),
-                            inputSchema: mtMap.objectField(
-                              'input_schema',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                schema: mtMap.objectField(
-                                  'schema',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            outputSchema: mtMap.objectField(
-                              'output_schema',
-                              mtMap.object({
-                                type: mtMap.objectField(
-                                  'type',
-                                  mtMap.passthrough()
-                                ),
-                                schema: mtMap.objectField(
-                                  'schema',
-                                  mtMap.passthrough()
-                                )
-                              })
-                            ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(
+                        filters: mtMap.objectField(
+                          'filters',
+                          mtMap.array(
+                            mtMap.union([
+                              mtMap.unionOption(
+                                'object',
                                 mtMap.object({
-                                  object: mtMap.objectField(
-                                    'object',
+                                  type: mtMap.objectField(
+                                    'type',
                                     mtMap.passthrough()
                                   ),
-                                  id: mtMap.objectField(
-                                    'id',
+                                  keys: mtMap.objectField(
+                                    'keys',
+                                    mtMap.array(mtMap.passthrough())
+                                  ),
+                                  pattern: mtMap.objectField(
+                                    'pattern',
                                     mtMap.passthrough()
                                   ),
-                                  scope: mtMap.objectField(
-                                    'scope',
-                                    mtMap.passthrough()
-                                  ),
-                                  name: mtMap.objectField(
-                                    'name',
-                                    mtMap.passthrough()
-                                  ),
-                                  description: mtMap.objectField(
-                                    'description',
-                                    mtMap.passthrough()
+                                  uris: mtMap.objectField(
+                                    'uris',
+                                    mtMap.array(mtMap.passthrough())
                                   )
                                 })
                               )
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            providerSpecificationId: mtMap.objectField(
-                              'provider_specification_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
-                        ),
-                        authCredentials: mtMap.objectField(
-                          'auth_credentials',
-                          mtMap.object({
-                            object: mtMap.objectField(
-                              'object',
-                              mtMap.passthrough()
-                            ),
-                            id: mtMap.objectField('id', mtMap.passthrough()),
-                            type: mtMap.objectField(
-                              'type',
-                              mtMap.passthrough()
-                            ),
-                            status: mtMap.objectField(
-                              'status',
-                              mtMap.passthrough()
-                            ),
-                            isDefault: mtMap.objectField(
-                              'is_default',
-                              mtMap.passthrough()
-                            ),
-                            isManaged: mtMap.objectField(
-                              'is_managed',
-                              mtMap.passthrough()
-                            ),
-                            name: mtMap.objectField(
-                              'name',
-                              mtMap.passthrough()
-                            ),
-                            description: mtMap.objectField(
-                              'description',
-                              mtMap.passthrough()
-                            ),
-                            metadata: mtMap.objectField(
-                              'metadata',
-                              mtMap.passthrough()
-                            ),
-                            scopes: mtMap.objectField(
-                              'scopes',
-                              mtMap.array(mtMap.passthrough())
-                            ),
-                            providerId: mtMap.objectField(
-                              'provider_id',
-                              mtMap.passthrough()
-                            ),
-                            createdAt: mtMap.objectField(
-                              'created_at',
-                              mtMap.date()
-                            ),
-                            updatedAt: mtMap.objectField(
-                              'updated_at',
-                              mtMap.date()
-                            )
-                          })
+                            ])
+                          )
                         )
                       })
                     )
                   ])
+                ),
+                providerId: mtMap.objectField(
+                  'provider_id',
+                  mtMap.passthrough()
+                ),
+                deploymentId: mtMap.objectField(
+                  'deployment_id',
+                  mtMap.passthrough()
+                ),
+                authMethodId: mtMap.objectField(
+                  'auth_method_id',
+                  mtMap.passthrough()
+                ),
+                authCredentialsId: mtMap.objectField(
+                  'auth_credentials_id',
+                  mtMap.passthrough()
+                ),
+                config: mtMap.objectField(
+                  'config',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+                provider: mtMap.objectField(
+                  'provider',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                deployment: mtMap.objectField(
+                  'deployment',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authMethod: mtMap.objectField(
+                  'auth_method',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    key: mtMap.objectField('key', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    capabilities: mtMap.objectField(
+                      'capabilities',
+                      mtMap.passthrough()
+                    ),
+                    inputSchema: mtMap.objectField(
+                      'input_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    outputSchema: mtMap.objectField(
+                      'output_schema',
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        schema: mtMap.objectField('schema', mtMap.passthrough())
+                      })
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(
+                        mtMap.object({
+                          object: mtMap.objectField(
+                            'object',
+                            mtMap.passthrough()
+                          ),
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          scope: mtMap.objectField(
+                            'scope',
+                            mtMap.passthrough()
+                          ),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          description: mtMap.objectField(
+                            'description',
+                            mtMap.passthrough()
+                          )
+                        })
+                      )
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    providerSpecificationId: mtMap.objectField(
+                      'provider_specification_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                authCredentials: mtMap.objectField(
+                  'auth_credentials',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    status: mtMap.objectField('status', mtMap.passthrough()),
+                    isDefault: mtMap.objectField(
+                      'is_default',
+                      mtMap.passthrough()
+                    ),
+                    isManaged: mtMap.objectField(
+                      'is_managed',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
+                    ),
+                    metadata: mtMap.objectField(
+                      'metadata',
+                      mtMap.passthrough()
+                    ),
+                    scopes: mtMap.objectField(
+                      'scopes',
+                      mtMap.array(mtMap.passthrough())
+                    ),
+                    providerId: mtMap.objectField(
+                      'provider_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
                 )
-              ),
-              createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-              archivedAt: mtMap.objectField('archived_at', mtMap.date())
-            })
-          )
-        ])
+              })
+            )
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
       )
     ),
     pagination: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/update.ts
@@ -58,75 +58,6 @@ export type ManagementInstanceIntegrationsUpdateOutput = {
     createdAt: Date;
     updatedAt: Date;
     archivedAt: Date | null;
-  }[];
-  createdAt: Date;
-  updatedAt: Date;
-  archivedAt: Date | null;
-} & {
-  providers: ({
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
-    providerId: string;
-    deploymentId: string;
-    authMethodId: string | null;
-    authCredentialsId: string | null;
-    config: {
-      object: 'provider.config#preview';
-      id: string;
-      isDefault: boolean;
-      name: string | null;
-      description: string | null;
-      metadata: Record<string, any> | null;
-      providerId: string;
-      createdAt: Date;
-      updatedAt: Date;
-    } | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-  } & {
-    object: 'integration.provider';
-    id: string;
-    status: 'active' | 'archived' | 'deleted';
-    integrationId: string;
-    name: string;
-    description: string | null;
-    metadata: Record<string, any> | null;
-    toolFilter:
-      | { type: 'allow_all'; ignoreParentFilters: boolean }
-      | {
-          type: 'filter';
-          filters: (
-            | { type: 'tool_keys'; keys: string[] }
-            | { type: 'tool_regex'; pattern: string }
-            | { type: 'resource_regex'; pattern: string }
-            | { type: 'resource_uris'; uris: string[] }
-            | { type: 'prompt_keys'; keys: string[] }
-            | { type: 'prompt_regex'; pattern: string }
-          )[];
-          ignoreParentFilters: boolean;
-        }
-      | null;
     provider: {
       object: 'provider#preview';
       id: string;
@@ -186,315 +117,261 @@ export type ManagementInstanceIntegrationsUpdateOutput = {
       createdAt: Date;
       updatedAt: Date;
     } | null;
-  })[];
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
 };
 
-export let mapManagementInstanceIntegrationsUpdateOutput = mtMap.union([
-  mtMap.unionOption(
-    'object',
-    mtMap.object({
-      object: mtMap.objectField('object', mtMap.passthrough()),
-      id: mtMap.objectField('id', mtMap.passthrough()),
-      status: mtMap.objectField('status', mtMap.passthrough()),
-      slug: mtMap.objectField('slug', mtMap.passthrough()),
-      name: mtMap.objectField('name', mtMap.passthrough()),
-      description: mtMap.objectField('description', mtMap.passthrough()),
-      metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-      configuration: mtMap.objectField(
-        'configuration',
+export let mapManagementInstanceIntegrationsUpdateOutput =
+  mtMap.object<ManagementInstanceIntegrationsUpdateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    slug: mtMap.objectField('slug', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    configuration: mtMap.objectField(
+      'configuration',
+      mtMap.object({
+        canAttachCustomToolFilters: mtMap.objectField(
+          'can_attach_custom_tool_filters',
+          mtMap.passthrough()
+        ),
+        canAttachCustomProviderConfig: mtMap.objectField(
+          'can_attach_custom_provider_config',
+          mtMap.passthrough()
+        ),
+        canOverrideToolFilters: mtMap.objectField(
+          'can_override_tool_filters',
+          mtMap.passthrough()
+        )
+      })
+    ),
+    implementation: mtMap.objectField(
+      'implementation',
+      mtMap.union([
+        mtMap.unionOption(
+          'object',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            providerTemplateId: mtMap.objectField(
+              'provider_template_id',
+              mtMap.passthrough()
+            ),
+            magicMcpServerId: mtMap.objectField(
+              'magic_mcp_server_id',
+              mtMap.passthrough()
+            )
+          })
+        )
+      ])
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
         mtMap.object({
-          canAttachCustomToolFilters: mtMap.objectField(
-            'can_attach_custom_tool_filters',
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          integrationId: mtMap.objectField(
+            'integration_id',
             mtMap.passthrough()
           ),
-          canAttachCustomProviderConfig: mtMap.objectField(
-            'can_attach_custom_provider_config',
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          toolFilter: mtMap.objectField(
+            'tool_filter',
+            mtMap.union([
+              mtMap.unionOption(
+                'object',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  ignoreParentFilters: mtMap.objectField(
+                    'ignore_parent_filters',
+                    mtMap.passthrough()
+                  ),
+                  filters: mtMap.objectField(
+                    'filters',
+                    mtMap.array(
+                      mtMap.union([
+                        mtMap.unionOption(
+                          'object',
+                          mtMap.object({
+                            type: mtMap.objectField(
+                              'type',
+                              mtMap.passthrough()
+                            ),
+                            keys: mtMap.objectField(
+                              'keys',
+                              mtMap.array(mtMap.passthrough())
+                            ),
+                            pattern: mtMap.objectField(
+                              'pattern',
+                              mtMap.passthrough()
+                            ),
+                            uris: mtMap.objectField(
+                              'uris',
+                              mtMap.array(mtMap.passthrough())
+                            )
+                          })
+                        )
+                      ])
+                    )
+                  )
+                })
+              )
+            ])
+          ),
+          providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+          deploymentId: mtMap.objectField('deployment_id', mtMap.passthrough()),
+          authMethodId: mtMap.objectField(
+            'auth_method_id',
             mtMap.passthrough()
           ),
-          canOverrideToolFilters: mtMap.objectField(
-            'can_override_tool_filters',
+          authCredentialsId: mtMap.objectField(
+            'auth_credentials_id',
             mtMap.passthrough()
-          )
-        })
-      ),
-      implementation: mtMap.objectField(
-        'implementation',
-        mtMap.union([
-          mtMap.unionOption(
-            'object',
+          ),
+          config: mtMap.objectField(
+            'config',
             mtMap.object({
-              type: mtMap.objectField('type', mtMap.passthrough()),
-              providerTemplateId: mtMap.objectField(
-                'provider_template_id',
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
                 mtMap.passthrough()
               ),
-              magicMcpServerId: mtMap.objectField(
-                'magic_mcp_server_id',
-                mtMap.passthrough()
-              )
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })
-          )
-        ])
-      ),
-      providers: mtMap.objectField(
-        'providers',
-        mtMap.array(
-          mtMap.union([
-            mtMap.unionOption(
-              'object',
-              mtMap.object({
-                object: mtMap.objectField('object', mtMap.passthrough()),
-                id: mtMap.objectField('id', mtMap.passthrough()),
-                status: mtMap.objectField('status', mtMap.passthrough()),
-                integrationId: mtMap.objectField(
-                  'integration_id',
-                  mtMap.passthrough()
-                ),
-                name: mtMap.objectField('name', mtMap.passthrough()),
-                description: mtMap.objectField(
-                  'description',
-                  mtMap.passthrough()
-                ),
-                metadata: mtMap.objectField('metadata', mtMap.passthrough()),
-                toolFilter: mtMap.objectField(
-                  'tool_filter',
-                  mtMap.union([
-                    mtMap.unionOption(
-                      'object',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        ignoreParentFilters: mtMap.objectField(
-                          'ignore_parent_filters',
-                          mtMap.passthrough()
-                        ),
-                        filters: mtMap.objectField(
-                          'filters',
-                          mtMap.array(
-                            mtMap.union([
-                              mtMap.unionOption(
-                                'object',
-                                mtMap.object({
-                                  type: mtMap.objectField(
-                                    'type',
-                                    mtMap.passthrough()
-                                  ),
-                                  keys: mtMap.objectField(
-                                    'keys',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
-                                  pattern: mtMap.objectField(
-                                    'pattern',
-                                    mtMap.passthrough()
-                                  ),
-                                  uris: mtMap.objectField(
-                                    'uris',
-                                    mtMap.array(mtMap.passthrough())
-                                  )
-                                })
-                              )
-                            ])
-                          )
-                        )
-                      })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date()),
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              slug: mtMap.objectField('slug', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          deployment: mtMap.objectField(
+            'deployment',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authMethod: mtMap.objectField(
+            'auth_method',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              key: mtMap.objectField('key', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              capabilities: mtMap.objectField(
+                'capabilities',
+                mtMap.passthrough()
+              ),
+              inputSchema: mtMap.objectField(
+                'input_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              outputSchema: mtMap.objectField(
+                'output_schema',
+                mtMap.object({
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  schema: mtMap.objectField('schema', mtMap.passthrough())
+                })
+              ),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    scope: mtMap.objectField('scope', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    description: mtMap.objectField(
+                      'description',
+                      mtMap.passthrough()
                     )
-                  ])
-                ),
-                providerId: mtMap.objectField(
-                  'provider_id',
-                  mtMap.passthrough()
-                ),
-                deploymentId: mtMap.objectField(
-                  'deployment_id',
-                  mtMap.passthrough()
-                ),
-                authMethodId: mtMap.objectField(
-                  'auth_method_id',
-                  mtMap.passthrough()
-                ),
-                authCredentialsId: mtMap.objectField(
-                  'auth_credentials_id',
-                  mtMap.passthrough()
-                ),
-                config: mtMap.objectField(
-                  'config',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                createdAt: mtMap.objectField('created_at', mtMap.date()),
-                updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-                archivedAt: mtMap.objectField('archived_at', mtMap.date()),
-                provider: mtMap.objectField(
-                  'provider',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    slug: mtMap.objectField('slug', mtMap.passthrough()),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                deployment: mtMap.objectField(
-                  'deployment',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authMethod: mtMap.objectField(
-                  'auth_method',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    key: mtMap.objectField('key', mtMap.passthrough()),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    capabilities: mtMap.objectField(
-                      'capabilities',
-                      mtMap.passthrough()
-                    ),
-                    inputSchema: mtMap.objectField(
-                      'input_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    outputSchema: mtMap.objectField(
-                      'output_schema',
-                      mtMap.object({
-                        type: mtMap.objectField('type', mtMap.passthrough()),
-                        schema: mtMap.objectField('schema', mtMap.passthrough())
-                      })
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(
-                        mtMap.object({
-                          object: mtMap.objectField(
-                            'object',
-                            mtMap.passthrough()
-                          ),
-                          id: mtMap.objectField('id', mtMap.passthrough()),
-                          scope: mtMap.objectField(
-                            'scope',
-                            mtMap.passthrough()
-                          ),
-                          name: mtMap.objectField('name', mtMap.passthrough()),
-                          description: mtMap.objectField(
-                            'description',
-                            mtMap.passthrough()
-                          )
-                        })
-                      )
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    providerSpecificationId: mtMap.objectField(
-                      'provider_specification_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
-                  })
-                ),
-                authCredentials: mtMap.objectField(
-                  'auth_credentials',
-                  mtMap.object({
-                    object: mtMap.objectField('object', mtMap.passthrough()),
-                    id: mtMap.objectField('id', mtMap.passthrough()),
-                    type: mtMap.objectField('type', mtMap.passthrough()),
-                    status: mtMap.objectField('status', mtMap.passthrough()),
-                    isDefault: mtMap.objectField(
-                      'is_default',
-                      mtMap.passthrough()
-                    ),
-                    isManaged: mtMap.objectField(
-                      'is_managed',
-                      mtMap.passthrough()
-                    ),
-                    name: mtMap.objectField('name', mtMap.passthrough()),
-                    description: mtMap.objectField(
-                      'description',
-                      mtMap.passthrough()
-                    ),
-                    metadata: mtMap.objectField(
-                      'metadata',
-                      mtMap.passthrough()
-                    ),
-                    scopes: mtMap.objectField(
-                      'scopes',
-                      mtMap.array(mtMap.passthrough())
-                    ),
-                    providerId: mtMap.objectField(
-                      'provider_id',
-                      mtMap.passthrough()
-                    ),
-                    createdAt: mtMap.objectField('created_at', mtMap.date()),
-                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
                   })
                 )
-              })
-            )
-          ])
-        )
-      ),
-      createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
-      archivedAt: mtMap.objectField('archived_at', mtMap.date())
-    })
-  )
-]);
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              providerSpecificationId: mtMap.objectField(
+                'provider_specification_id',
+                mtMap.passthrough()
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          authCredentials: mtMap.objectField(
+            'auth_credentials',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              status: mtMap.objectField('status', mtMap.passthrough()),
+              isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+              isManaged: mtMap.objectField('is_managed', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              description: mtMap.objectField(
+                'description',
+                mtMap.passthrough()
+              ),
+              metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+              scopes: mtMap.objectField(
+                'scopes',
+                mtMap.array(mtMap.passthrough())
+              ),
+              providerId: mtMap.objectField('provider_id', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          )
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+    archivedAt: mtMap.objectField('archived_at', mtMap.date())
+  });
 
 export type ManagementInstanceIntegrationsUpdateBody = {
   name?: string | undefined;

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integration.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integration.ts
@@ -129,11 +129,9 @@ export let dashboardIntegrationPresenter = Presenter.create(integrationType)
     };
   })
   .schema(
-    v.intersection([
-      v1IntegrationPresenter.schema,
-      v.object({
-        providers: v.array(dashboardIntegrationProviderPresenter.schema)
-      })
-    ])
+    v.object({
+      ...v1IntegrationPresenter.schema.properties,
+      providers: v.array(dashboardIntegrationProviderPresenter.schema)
+    }) as any
   )
   .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstance.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstance.ts
@@ -77,11 +77,9 @@ export let dashboardIntegrationInstancePresenter = Presenter.create(integrationI
     };
   })
   .schema(
-    v.intersection([
-      v1IntegrationInstancePresenter.schema,
-      v.object({
-        providers: v.array(dashboardIntegrationInstanceProviderPresenter.schema)
-      })
-    ])
+    v.object({
+      ...v1IntegrationInstancePresenter.schema.properties,
+      providers: v.array(dashboardIntegrationInstanceProviderPresenter.schema)
+    }) as any
   )
   .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstanceGroup.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstanceGroup.ts
@@ -70,11 +70,9 @@ export let dashboardIntegrationInstanceGroupPresenter = Presenter.create(
     };
   })
   .schema(
-    v.intersection([
-      v1IntegrationInstanceGroupPresenter.schema,
-      v.object({
-        providers: v.array(v1IntegrationInstanceGroupProviderPresenter.schema)
-      })
-    ])
+    v.object({
+      ...v1IntegrationInstanceGroupPresenter.schema.properties,
+      providers: v.array(v1IntegrationInstanceGroupProviderPresenter.schema)
+    }) as any
   )
   .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstanceGroupProvider.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstanceGroupProvider.ts
@@ -92,13 +92,11 @@ export let dashboardIntegrationInstanceGroupProviderPresenter = Presenter.create
     };
   })
   .schema(
-    v.intersection([
-      v1IntegrationInstanceGroupProviderPresenter.schema,
-      v.object({
-        provider: v1ProviderPreview.schema,
-        integration_provider: v.nullable(v1IntegrationProviderSnapshot.schema),
-        integration_instance_provider: v1IntegrationInstanceProviderPresenter.schema
-      })
-    ])
+    v.object({
+      ...v1IntegrationInstanceGroupProviderPresenter.schema.properties,
+      provider: v1ProviderPreview.schema,
+      integration_provider: v.nullable(v1IntegrationProviderSnapshot.schema),
+      integration_instance_provider: v1IntegrationInstanceProviderPresenter.schema
+    }) as any
   )
   .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstanceProvider.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationInstanceProvider.ts
@@ -86,11 +86,9 @@ export let dashboardIntegrationInstanceProviderPresenter = Presenter.create(
     };
   })
   .schema(
-    v.intersection([
-      v1IntegrationInstanceProviderPresenter.schema,
-      v.object({
-        integration_provider: v1IntegrationProviderSnapshot.schema
-      })
-    ])
+    v.object({
+      ...v1IntegrationInstanceProviderPresenter.schema.properties,
+      integration_provider: v1IntegrationProviderSnapshot.schema
+    }) as any
   )
   .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationProvider.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationProvider.ts
@@ -94,15 +94,13 @@ export let dashboardIntegrationProviderSnapshot = Object.assign(
     };
   },
   {
-    schema: v.intersection([
-      v1IntegrationProviderSnapshot.schema,
-      v.object({
-        provider: v1ProviderPreview.schema,
-        deployment: v1ProviderDeploymentPreviewPresenter.schema,
-        auth_method: v.nullable(v1ProviderAuthMethodPresenter.schema),
-        auth_credentials: v.nullable(v1ProviderAuthCredentialsPresenter.schema)
-      })
-    ])
+    schema: v.object({
+      ...v1IntegrationProviderSnapshot.schema.properties,
+      provider: v1ProviderPreview.schema,
+      deployment: v1ProviderDeploymentPreviewPresenter.schema,
+      auth_method: v.nullable(v1ProviderAuthMethodPresenter.schema),
+      auth_credentials: v.nullable(v1ProviderAuthCredentialsPresenter.schema)
+    }) as any
   }
 );
 
@@ -176,22 +174,20 @@ export let dashboardIntegrationProviderPresenter = Presenter.create(integrationP
     };
   })
   .schema(
-    v.intersection([
-      v1IntegrationProviderPresenter.schema,
-      v.object({
-        object: v.literal('integration.provider'),
-        id: v.string(),
-        status: v.enumOf(['active', 'archived', 'deleted']),
-        integration_id: v.string(),
-        name: v.string(),
-        description: v.nullable(v.string()),
-        metadata: v.nullable(v.record(v.any())),
-        tool_filter: v.nullable(toolFilterPresenter.schema),
-        provider: v1ProviderPreview.schema,
-        deployment: v1ProviderDeploymentPreviewPresenter.schema,
-        auth_method: v.nullable(v1ProviderAuthMethodPresenter.schema),
-        auth_credentials: v.nullable(v1ProviderAuthCredentialsPresenter.schema)
-      })
-    ])
+    v.object({
+      ...v1IntegrationProviderPresenter.schema.properties,
+      object: v.literal('integration.provider'),
+      id: v.string(),
+      status: v.enumOf(['active', 'archived', 'deleted']),
+      integration_id: v.string(),
+      name: v.string(),
+      description: v.nullable(v.string()),
+      metadata: v.nullable(v.record(v.any())),
+      tool_filter: v.nullable(toolFilterPresenter.schema),
+      provider: v1ProviderPreview.schema,
+      deployment: v1ProviderDeploymentPreviewPresenter.schema,
+      auth_method: v.nullable(v1ProviderAuthMethodPresenter.schema),
+      auth_credentials: v.nullable(v1ProviderAuthCredentialsPresenter.schema)
+    }) as any
   )
   .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationSetupSession.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationSetupSession.ts
@@ -107,33 +107,31 @@ export let dashboardIntegrationSetupSessionPresenter = Presenter.create(
     };
   })
   .schema(
-    v.intersection([
-      v1IntegrationSetupSessionPresenter.schema,
-      v.object({
-        integration_instance_id: v.string(),
-        steps: v.array(
-          v.object({
-            object: v.literal('integration.setup_session.step'),
-            id: v.string(),
-            status: v.enumOf([
-              'configured',
-              'pending',
-              'failed',
-              'completed',
-              'expired',
-              'archived',
-              'deleted'
-            ]),
-            url: v.string(),
-            integration_provider_id: v.string(),
-            provider: v1ProviderPreview.schema,
-            provider_setup_session_id: v.nullable(v.string()),
-            integration_instance_provider_id: v.nullable(v.string()),
-            created_at: v.date(),
-            updated_at: v.date()
-          })
-        )
-      })
-    ])
+    v.object({
+      ...v1IntegrationSetupSessionPresenter.schema.properties,
+      integration_instance_id: v.string(),
+      steps: v.array(
+        v.object({
+          object: v.literal('integration.setup_session.step'),
+          id: v.string(),
+          status: v.enumOf([
+            'configured',
+            'pending',
+            'failed',
+            'completed',
+            'expired',
+            'archived',
+            'deleted'
+          ]),
+          url: v.string(),
+          integration_provider_id: v.string(),
+          provider: v1ProviderPreview.schema,
+          provider_setup_session_id: v.nullable(v.string()),
+          integration_instance_provider_id: v.nullable(v.string()),
+          created_at: v.date(),
+          updated_at: v.date()
+        })
+      )
+    }) as any
   )
   .build();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches generated response mappers/types for multiple integration provider and group endpoints; incorrect field mapping or nullability could break client deserialization at runtime. No direct business logic changes, but it impacts many API surfaces.
> 
> **Overview**
> Refactors the generated dashboard client for integration instance *providers*, *instance group providers*, and *instance groups* to use explicit `mtMap.object` mappings instead of `mtMap.union` wrappers, and updates list types from intersection-based `({..} & {..})[]` shapes to plain object arrays.
> 
> Response shapes are expanded/realigned: nested `integrationProvider` mappings now include `providerVersion`, IDs (`provider_id`, `deployment_id`, `auth_*`), and `config`; `config`/`authConfig` are also mapped explicitly where returned, and several timestamp fields are moved/normalized in the mapped output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87f0fd3304e2fe123a27595c7fab9c034bacce0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->