### PR TITLE
Prioritise built files for deployment

### DIFF
--- a/src/systems/slates/apps/hub/src/queues/deployment/packageFiles.test.ts
+++ b/src/systems/slates/apps/hub/src/queues/deployment/packageFiles.test.ts
@@ -106,4 +106,43 @@ describe('buildSlateDeploymentFiles', () => {
       '"file":"index.js"'
     );
   });
+
+  it('uses packed dist output instead of rebuilding a source main', () => {
+    let result = buildSlateDeploymentFiles([
+      {
+        path: 'package.json',
+        buffer: Buffer.from(
+          JSON.stringify({
+            name: '@scope/prebuilt-slate-with-source-main',
+            version: '3.0.0',
+            main: 'src/index.ts',
+            scripts: {
+              build: 'bunx @vercel/ncc build src/index.ts -o dist -m -s'
+            }
+          })
+        )
+      },
+      {
+        path: 'src/index.ts',
+        buffer: Buffer.from('export let provider = "source";')
+      },
+      {
+        path: 'dist/index.js',
+        buffer: Buffer.from('export let provider = "dist";')
+      }
+    ]);
+
+    expect(result.slateEntrypoint).toBe('dist/index.js');
+    expect(getFile(result.files, 'slates_entry_point.js').content).toContain(
+      "import { provider } from './dist/index.js';"
+    );
+
+    let functionBayJson = JSON.parse(getFile(result.files, 'function-bay.json').content);
+    expect(functionBayJson).toMatchObject({
+      entrypoint: 'slates_entry_point.js',
+      scripts: {
+        build: expect.stringContaining('Skipping slate build')
+      }
+    });
+  });
 });

--- a/src/systems/slates/apps/hub/src/queues/deployment/packageFiles.ts
+++ b/src/systems/slates/apps/hub/src/queues/deployment/packageFiles.ts
@@ -11,12 +11,13 @@ let wrapperDependencies = {
   '@lowerdeck/serialize': 'latest'
 };
 let entrypointExtensions = ['.ts', '.js', '.cjs', '.mjs'];
+let prebuiltEntrypoints = ['dist/index.js', 'dist/index.cjs', 'dist/index.mjs'];
 let fallbackEntrypoints = [
+  ...prebuiltEntrypoints,
   'src/index.ts',
   'src/index.js',
   'index.ts',
-  'index.js',
-  'dist/index.js'
+  'index.js'
 ];
 
 let getArchiveFile = (files: DeploymentArchiveFile[], path: string) =>
@@ -47,7 +48,15 @@ let getSlateEntrypoint = (
 ): string => {
   if (packageJson?.main) {
     for (let candidate of getEntrypointCandidates(packageJson.main)) {
-      if (getArchiveFile(files, candidate)) return candidate;
+      if (getArchiveFile(files, candidate)) {
+        if (candidate.startsWith('src/') || candidate.endsWith('.ts')) {
+          for (let prebuiltEntrypoint of prebuiltEntrypoints) {
+            if (getArchiveFile(files, prebuiltEntrypoint)) return prebuiltEntrypoint;
+          }
+        }
+
+        return candidate;
+      }
     }
   }
 


### PR DESCRIPTION
Prioritise built files for deployment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes deployment entrypoint selection logic; mis-detection could cause the wrong module to be executed or skip an expected build step for some packages.
> 
> **Overview**
> **Deployment packaging now prioritizes prebuilt outputs.** When `package.json` `main` points at a source (`src/*` or `.ts`) entrypoint but a `dist/index.(js|cjs|mjs)` file is present, the deployment builder selects the `dist/*` entrypoint instead.
> 
> This extends the fallback entrypoint search to include `dist/index.(js|cjs|mjs)` and adds a new test ensuring packed `dist` output is used (and the build is skipped) even when `main` references source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3045f873f442afbc0cdb7a4729b7de072109fe9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->