### PR TITLE
Enforce retention in lists

### DIFF
--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_projects_configure_retention.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_projects_configure_retention.ts
@@ -1,0 +1,102 @@
+import {
+  BaseMetorialEndpoint,
+  MetorialEndpointManager
+} from '@metorial/util-endpoint';
+
+import {
+  mapDashboardProjectsConfigureRetentionGetOutput,
+  mapDashboardProjectsConfigureRetentionUpdateBody,
+  mapDashboardProjectsConfigureRetentionUpdateOutput,
+  type DashboardProjectsConfigureRetentionGetOutput,
+  type DashboardProjectsConfigureRetentionUpdateBody,
+  type DashboardProjectsConfigureRetentionUpdateOutput
+} from '../resources';
+
+/**
+ * @name Project configuration controller
+ * @description Configure project-level settings
+ *
+ * @see https://metorial.com/api
+ * @see https://metorial.com/docs
+ */
+export class MetorialDashboardProjectsConfigureRetentionEndpoint {
+  constructor(private readonly _manager: MetorialEndpointManager<any>) {}
+
+  // thin proxies so method bodies stay unchanged
+  private _get(request: any) {
+    return this._manager._get(request);
+  }
+  private _post(request: any) {
+    return this._manager._post(request);
+  }
+  private _put(request: any) {
+    return this._manager._put(request);
+  }
+  private _patch(request: any) {
+    return this._manager._patch(request);
+  }
+  private _delete(request: any) {
+    return this._manager._delete(request);
+  }
+
+  /**
+   * @name Get project retention configuration
+   * @description Get log retention settings for a project
+   *
+   * @param `organizationId` - string
+   * @param `projectId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardProjectsConfigureRetentionGetOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  get(
+    organizationId: string,
+    projectId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardProjectsConfigureRetentionGetOutput> {
+    let path = `dashboard/organizations/${organizationId}/projects/${projectId}/configure/retention`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardProjectsConfigureRetentionGetOutput
+    );
+  }
+
+  /**
+   * @name Update project retention configuration
+   * @description Update log retention settings for a project
+   *
+   * @param `organizationId` - string
+   * @param `projectId` - string
+   * @param `body` - DashboardProjectsConfigureRetentionUpdateBody
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardProjectsConfigureRetentionUpdateOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  update(
+    organizationId: string,
+    projectId: string,
+    body: DashboardProjectsConfigureRetentionUpdateBody,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardProjectsConfigureRetentionUpdateOutput> {
+    let path = `dashboard/organizations/${organizationId}/projects/${projectId}/configure/retention`;
+
+    let request = {
+      path,
+      body: mapDashboardProjectsConfigureRetentionUpdateBody.transformTo(body),
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._patch(request).transform(
+      mapDashboardProjectsConfigureRetentionUpdateOutput
+    );
+  }
+}

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/index.ts
@@ -164,6 +164,7 @@ export * from './dashboard_organizations_service-accounts_policies';
 export * from './dashboard_organizations_teams';
 export * from './dashboard_organizations_teams_members';
 export * from './dashboard_organizations_teams_policies';
+export * from './dashboard_projects_configure_retention';
 export * from './dashboard_usage';
 export * from './documents';
 export * from './documents_participants';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/index.ts
@@ -2,4 +2,5 @@ export * from './boot';
 export * from './instance';
 export * from './oauth';
 export * from './organizations';
+export * from './projects';
 export * from './usage';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/index.ts
@@ -1,0 +1,1 @@
+export * from './retention';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/retention/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/retention/get.ts
@@ -1,0 +1,25 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type DashboardProjectsConfigureRetentionGetOutput = {
+  object: 'organization.project.retention_configuration';
+  projectId: string;
+  logRetentionInDays: number;
+  enforceSessionExpiry: boolean;
+  updatedAt: Date;
+};
+
+export let mapDashboardProjectsConfigureRetentionGetOutput =
+  mtMap.object<DashboardProjectsConfigureRetentionGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    projectId: mtMap.objectField('project_id', mtMap.passthrough()),
+    logRetentionInDays: mtMap.objectField(
+      'log_retention_in_days',
+      mtMap.passthrough()
+    ),
+    enforceSessionExpiry: mtMap.objectField(
+      'enforce_session_expiry',
+      mtMap.passthrough()
+    ),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+  });
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/retention/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/retention/index.ts
@@ -1,0 +1,2 @@
+export * from './get';
+export * from './update';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/retention/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/retention/update.ts
@@ -1,0 +1,42 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type DashboardProjectsConfigureRetentionUpdateOutput = {
+  object: 'organization.project.retention_configuration';
+  projectId: string;
+  logRetentionInDays: number;
+  enforceSessionExpiry: boolean;
+  updatedAt: Date;
+};
+
+export let mapDashboardProjectsConfigureRetentionUpdateOutput =
+  mtMap.object<DashboardProjectsConfigureRetentionUpdateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    projectId: mtMap.objectField('project_id', mtMap.passthrough()),
+    logRetentionInDays: mtMap.objectField(
+      'log_retention_in_days',
+      mtMap.passthrough()
+    ),
+    enforceSessionExpiry: mtMap.objectField(
+      'enforce_session_expiry',
+      mtMap.passthrough()
+    ),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+  });
+
+export type DashboardProjectsConfigureRetentionUpdateBody = {
+  logRetentionInDays?: number | undefined;
+  enforceSessionExpiry?: boolean | undefined;
+};
+
+export let mapDashboardProjectsConfigureRetentionUpdateBody =
+  mtMap.object<DashboardProjectsConfigureRetentionUpdateBody>({
+    logRetentionInDays: mtMap.objectField(
+      'log_retention_in_days',
+      mtMap.passthrough()
+    ),
+    enforceSessionExpiry: mtMap.objectField(
+      'enforce_session_expiry',
+      mtMap.passthrough()
+    )
+  });
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/index.ts
@@ -1,0 +1,1 @@
+export * from './configure';

--- a/clients/metorial-dashboard/src/sdk.ts
+++ b/clients/metorial-dashboard/src/sdk.ts
@@ -151,6 +151,7 @@ import {
   MetorialDashboardOrganizationsTeamsEndpoint,
   MetorialDashboardOrganizationsTeamsMembersEndpoint,
   MetorialDashboardOrganizationsTeamsPoliciesEndpoint,
+  MetorialDashboardProjectsConfigureRetentionEndpoint,
   MetorialDashboardUsageEndpoint,
   MetorialManagementUserEndpoint,
   MetorialOrganizationsFlagsEndpoint,
@@ -429,7 +430,8 @@ export let createMetorialDashboardSDK = sdkBuilder.build(
 
   instances: new MetorialDashboardOrganizationsInstancesEndpoint(manager),
   projects: Object.assign(new MetorialDashboardOrganizationsProjectsEndpoint(manager), {
-    branding: new MetorialDashboardOrganizationsProjectsBrandingEndpoint(manager)
+    branding: new MetorialDashboardOrganizationsProjectsBrandingEndpoint(manager),
+    configureRetention: new MetorialDashboardProjectsConfigureRetentionEndpoint(manager)
   }),
   user: new MetorialManagementUserEndpoint(manager),
 

--- a/src/backend/apis/core/src/controllers/dashboard/index.ts
+++ b/src/backend/apis/core/src/controllers/dashboard/index.ts
@@ -4,6 +4,7 @@ export * from './flags';
 export * from './oauthAuthorizationRequest';
 export * from './organization';
 export * from './organizationInvite';
+export * from './projectConfiguration';
 export * from './profile';
 export * from './usage';
 export * from './user';

--- a/src/backend/apis/core/src/controllers/dashboard/projectConfiguration.ts
+++ b/src/backend/apis/core/src/controllers/dashboard/projectConfiguration.ts
@@ -1,0 +1,118 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { v } from '@lowerdeck/validation';
+import { accessService } from '@metorial/module-access';
+import { projectRetentionService, projectService } from '@metorial/module-organization';
+import { Controller, Path } from '@metorial/rest';
+import { checkAccess } from '../../middleware/checkAccess';
+import { isDashboardGroup } from '../../middleware/isDashboard';
+import { organizationGroup } from '../../middleware/organizationGroup';
+import { projectRetentionPresenter } from '../../presenters';
+
+let logRetentionInDaysValidator = v.optional(
+  v.number({ modifiers: [v.positive(), v.integer(), v.minValue(1), v.maxValue(365)] })
+);
+
+export let dashboardProjectConfigurationController = Controller.create(
+  {
+    name: 'Project configuration',
+    description: 'Configure project-level settings'
+  },
+  {
+    getRetention: organizationGroup
+      .use(isDashboardGroup())
+      .get(
+        Path(
+          '/dashboard/organizations/:organizationId/projects/:projectId/configure/retention',
+          'dashboard.projects.configure.retention.get'
+        ),
+        {
+          name: 'Get project retention configuration',
+          description: 'Get log retention settings for a project'
+        }
+      )
+      .use(checkAccess({ possibleScopes: ['organization.project:read'] }))
+      .output(projectRetentionPresenter)
+      .do(async ctx => {
+        let project = await projectService.getProjectById({
+          organization: ctx.organization,
+          projectId: ctx.params.projectId,
+          member: ctx.member,
+          actor: ctx.actor
+        });
+
+        await accessService.checkTargetAccess({
+          authInfo: ctx.auth,
+          organization: ctx.organization,
+          member: ctx.member,
+          project,
+          possibleScopes: ['organization.project:read']
+        });
+
+        await projectRetentionService.getProjectRetention({ project });
+
+        return projectRetentionPresenter.present({ project });
+      }),
+
+    updateRetention: organizationGroup
+      .use(isDashboardGroup())
+      .patch(
+        Path(
+          '/dashboard/organizations/:organizationId/projects/:projectId/configure/retention',
+          'dashboard.projects.configure.retention.update'
+        ),
+        {
+          name: 'Update project retention configuration',
+          description: 'Update log retention settings for a project'
+        }
+      )
+      .use(checkAccess({ possibleScopes: ['organization.project:write'] }))
+      .body(
+        'default',
+        v.object({
+          log_retention_in_days: logRetentionInDaysValidator,
+          enforce_session_expiry: v.optional(v.boolean())
+        })
+      )
+      .output(projectRetentionPresenter)
+      .do(async ctx => {
+        if (
+          ctx.body.log_retention_in_days === undefined &&
+          ctx.body.enforce_session_expiry === undefined
+        ) {
+          throw new ServiceError(
+            badRequestError({
+              message: 'At least one retention field must be provided'
+            })
+          );
+        }
+
+        let project = await projectService.getProjectById({
+          organization: ctx.organization,
+          projectId: ctx.params.projectId,
+          member: ctx.member,
+          actor: ctx.actor
+        });
+
+        await accessService.checkTargetAccess({
+          authInfo: ctx.auth,
+          organization: ctx.organization,
+          member: ctx.member,
+          project,
+          possibleScopes: ['organization.project:write']
+        });
+
+        project = await projectRetentionService.updateProjectRetention({
+          project,
+          organization: ctx.organization,
+          performedBy: ctx.actor,
+          context: ctx.context,
+          input: {
+            logRetentionInDays: ctx.body.log_retention_in_days,
+            enforceSessionExpiry: ctx.body.enforce_session_expiry
+          }
+        });
+
+        return projectRetentionPresenter.present({ project });
+      })
+  }
+);

--- a/src/backend/apis/core/src/controllers/index.ts
+++ b/src/backend/apis/core/src/controllers/index.ts
@@ -19,6 +19,7 @@ import {
   dashboardOAuthAuthorizationRequestController,
   dashboardOrganizationController,
   dashboardOrganizationInviteController,
+  dashboardProjectConfigurationController,
   dashboardUsageController,
   dashboardUserController,
   flagsController,
@@ -506,6 +507,7 @@ export let dashboardController = Controller.create<any>(
   {
     dashboardOrganizationController,
     dashboardOrganizationInviteController,
+    dashboardProjectConfigurationController,
     dashboardOAuthAuthorizationRequestController,
     dashboardBootController,
     testHelperConsumerOAuthController,
@@ -676,6 +678,7 @@ export let fullDashboardController = Controller.create<any>(dashboardController.
 
   dashboardOrganizationController,
   dashboardOrganizationInviteController,
+  dashboardProjectConfigurationController,
   dashboardOAuthAuthorizationRequestController,
   dashboardBootController,
   testHelperConsumerOAuthController,

--- a/src/backend/apis/core/src/presenters/implementation/organization/index.ts
+++ b/src/backend/apis/core/src/presenters/implementation/organization/index.ts
@@ -6,5 +6,6 @@ export * from './organizationMember';
 export * from './profile';
 export * from './project';
 export * from './projectBrand';
+export * from './projectRetention';
 export * from './team';
 export * from './user';

--- a/src/backend/apis/core/src/presenters/implementation/organization/projectRetention.ts
+++ b/src/backend/apis/core/src/presenters/implementation/organization/projectRetention.ts
@@ -1,0 +1,23 @@
+import { v } from '@lowerdeck/validation';
+import { Presenter } from '@metorial/presenter';
+import { projectRetentionType } from '../../types';
+
+export let v1ProjectRetentionPresenter = Presenter.create(projectRetentionType)
+  .presenter(async ({ project }) => ({
+    object: 'organization.project.retention_configuration' as const,
+
+    project_id: project.id,
+    log_retention_in_days: project.logRetentionInDays,
+    enforce_session_expiry: project.enforceSessionExpiry,
+    updated_at: project.updatedAt
+  }))
+  .schema(
+    v.object({
+      object: v.literal('organization.project.retention_configuration'),
+      project_id: v.string(),
+      log_retention_in_days: v.number(),
+      enforce_session_expiry: v.boolean(),
+      updated_at: v.date()
+    })
+  )
+  .build();

--- a/src/backend/apis/core/src/presenters/index.ts
+++ b/src/backend/apis/core/src/presenters/index.ts
@@ -111,6 +111,7 @@ import {
   v1ProfilePresenter,
   v1ProjectBrandPresenter,
   v1ProjectPresenter,
+  v1ProjectRetentionPresenter,
   v1ProviderAuthConfigErrorGroupPresenter,
   v1ProviderAuthConfigErrorPresenter,
   v1ProviderAuthConfigEventPresenter,
@@ -287,6 +288,7 @@ import {
   portalType,
   profileType,
   projectBrandType,
+  projectRetentionType,
   projectType,
   providerAuthConfigErrorGroupType,
   providerAuthConfigErrorType,
@@ -512,6 +514,11 @@ export let projectPresenter = declarePresenter(projectType, {
 export let projectBrandPresenter = declarePresenter(projectBrandType, {
   mt_2025_01_01_dashboard: v1ProjectBrandPresenter,
   mt_2026_01_01_magnetar: v1ProjectBrandPresenter
+});
+
+export let projectRetentionPresenter = declarePresenter(projectRetentionType, {
+  mt_2025_01_01_dashboard: v1ProjectRetentionPresenter,
+  mt_2026_01_01_magnetar: v1ProjectRetentionPresenter
 });
 
 export let userPresenter = declarePresenter(userType, {

--- a/src/backend/apis/core/src/presenters/types.ts
+++ b/src/backend/apis/core/src/presenters/types.ts
@@ -237,6 +237,10 @@ export let projectType = PresentableType.create<{
   project: Project & { organization: Organization };
 }>()('project');
 
+export let projectRetentionType = PresentableType.create<{
+  project: Project;
+}>()('project_retention');
+
 export let tokenType = PresentableType.create<{
   token: {
     type:

--- a/src/backend/db/prisma/schema/organization/instance.prisma
+++ b/src/backend/db/prisma/schema/organization/instance.prisma
@@ -18,8 +18,6 @@ model Instance {
   slug String @unique
   name String
 
-  defaultCallbackPollingIntervalSeconds Int @default(1800)
-
   projectOid BigInt
   project    Project @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
 

--- a/src/backend/db/prisma/schema/organization/project.prisma
+++ b/src/backend/db/prisma/schema/organization/project.prisma
@@ -15,6 +15,9 @@ model Project {
   onlyAllowTrustedProviders      Boolean @default(false)
   magicMcpSessionDurationMinutes Int     @default(1440)
 
+  logRetentionInDays     Int     @default(30)
+  enforceSessionExpiry Boolean @default(false)
+
   organizationOid BigInt
   organization    Organization @relation(fields: [organizationOid], references: [oid], onDelete: Cascade)
 

--- a/src/backend/modules/organization/package.json
+++ b/src/backend/modules/organization/package.json
@@ -9,6 +9,7 @@
     "lint": "prettier src/**/*.ts --check"
   },
   "dependencies": {
+    "@metorial/cron": "^1.0.0",
     "@metorial/config": "^1.0.0",
     "@metorial/context": "^1.0.0",
     "@metorial/db": "^1.0.0",

--- a/src/backend/modules/organization/src/index.ts
+++ b/src/backend/modules/organization/src/index.ts
@@ -6,7 +6,8 @@ import {
   syncBrandQueueProcessor
 } from './queues/syncBrand';
 import { syncProfileQueueProcessor } from './queues/syncProfile';
-import { syncSubspaceTenantQueueProcessor } from './queues/syncSubspaceTenant';
+import { syncSubspaceTenantProcessors } from './queues/syncSubspaceTenant';
+export { syncSubspaceTenantQueue } from './queues/syncSubspaceTenant';
 
 export * from './services';
 
@@ -19,5 +20,5 @@ export let organizationQueueProcessor = combineQueueProcessors([
   reconcileAuthVersionProcessors,
   reconcileDefaultPoliciesProcessors,
 
-  syncSubspaceTenantQueueProcessor
+  syncSubspaceTenantProcessors
 ]);

--- a/src/backend/modules/organization/src/queues/syncSubspaceTenant.ts
+++ b/src/backend/modules/organization/src/queues/syncSubspaceTenant.ts
@@ -1,12 +1,15 @@
+import { createCron } from '@metorial/cron';
 import { db } from '@metorial/db';
 import {
   ensureInternalProjectTenant,
   ensureInternalScope,
   type InternalService
 } from '@metorial/internal-clients';
-import { createQueue, QueueRetryError } from '@metorial/queue';
+import { combineQueueProcessors, createQueue, QueueRetryError } from '@metorial/queue';
 
 let internalTenantServices: InternalService[] = ['cargo', 'synthesis', 'subspace'];
+
+export let SUBSPACE_TENANT_SYNC_BATCH_SIZE = 500;
 
 export let syncSubspaceTenantQueue = createQueue<{ projectId: string }>({
   name: 'org/sync/subspaceTenant'
@@ -41,3 +44,51 @@ export let syncSubspaceTenantQueueProcessor = syncSubspaceTenantQueue.process(as
     }
   }
 });
+
+export let syncSubspaceTenantCron = createCron(
+  {
+    name: 'org/sync/subspaceTenant/cron',
+    cron: '0 4 * * *'
+  },
+  async () => {
+    await syncSubspaceTenantSearchQueue.add({}, { id: 'org-sync-subspace-tenant-search' });
+  }
+);
+
+export let syncSubspaceTenantSearchQueue = createQueue<{ cursor?: string }>({
+  name: 'org/sync/subspaceTenant/search'
+});
+
+export let syncSubspaceTenantSearchQueueProcessor = syncSubspaceTenantSearchQueue.process(
+  async data => {
+    let projects = await db.project.findMany({
+      where: {
+        status: 'active',
+        id: data.cursor ? { gt: data.cursor } : undefined
+      },
+      orderBy: { id: 'asc' },
+      take: SUBSPACE_TENANT_SYNC_BATCH_SIZE,
+      select: { id: true }
+    });
+    if (projects.length === 0) return;
+
+    await syncSubspaceTenantQueue.addMany(
+      projects.map(project => ({
+        projectId: project.id
+      }))
+    );
+
+    let lastProject = projects[projects.length - 1];
+    if (!lastProject) return;
+
+    await syncSubspaceTenantSearchQueue.add({
+      cursor: lastProject.id
+    });
+  }
+);
+
+export let syncSubspaceTenantProcessors = combineQueueProcessors([
+  syncSubspaceTenantCron,
+  syncSubspaceTenantSearchQueueProcessor,
+  syncSubspaceTenantQueueProcessor
+]);

--- a/src/backend/modules/organization/src/services/index.ts
+++ b/src/backend/modules/organization/src/services/index.ts
@@ -12,4 +12,5 @@ export * from './organizationInviteJoin';
 export * from './organizationMember';
 export * from './project';
 export * from './projectBrand';
+export * from './projectRetention';
 export * from './team';

--- a/src/backend/modules/organization/src/services/projectRetention.ts
+++ b/src/backend/modules/organization/src/services/projectRetention.ts
@@ -1,0 +1,77 @@
+import { forbiddenError, ServiceError } from '@lowerdeck/error';
+import { Service } from '@lowerdeck/service';
+import { Context } from '@metorial/context';
+import {
+  addAfterTransactionHook,
+  Organization,
+  OrganizationActor,
+  Project,
+  withTransaction
+} from '@metorial/db';
+import { Fabric } from '@metorial/fabric';
+import { syncSubspaceTenantQueue } from '../queues/syncSubspaceTenant';
+
+class ProjectRetentionService {
+  private async ensureProjectActive(project: Project) {
+    if (project.status !== 'active') {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Cannot perform this action on a deleted project'
+        })
+      );
+    }
+  }
+
+  async getProjectRetention(d: { project: Project }) {
+    await this.ensureProjectActive(d.project);
+
+    return {
+      logRetentionInDays: d.project.logRetentionInDays,
+      enforceSessionExpiry: d.project.enforceSessionExpiry
+    };
+  }
+
+  async updateProjectRetention(d: {
+    project: Project;
+    organization: Organization;
+    performedBy: OrganizationActor;
+    context: Context;
+    input: {
+      logRetentionInDays?: number;
+      enforceSessionExpiry?: boolean;
+    };
+  }) {
+    await this.ensureProjectActive(d.project);
+
+    return withTransaction(async db => {
+      await Fabric.fire('organization.project.retention.updated:before', d);
+
+      let project = await db.project.update({
+        where: { oid: d.project.oid },
+        data: {
+          logRetentionInDays: d.input.logRetentionInDays,
+          enforceSessionExpiry: d.input.enforceSessionExpiry
+        },
+        include: {
+          organization: true
+        }
+      });
+
+      await addAfterTransactionHook(() =>
+        syncSubspaceTenantQueue.add({ projectId: project.id })
+      );
+
+      await Fabric.fire('organization.project.retention.updated:after', {
+        ...d,
+        project
+      });
+
+      return project;
+    });
+  }
+}
+
+export let projectRetentionService = Service.create(
+  'projectRetentionService',
+  () => new ProjectRetentionService()
+).build();

--- a/src/backend/modules/organization/test/projectRetention.test.ts
+++ b/src/backend/modules/organization/test/projectRetention.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@metorial/queue', () => ({
+  createQueue: vi.fn().mockImplementation(config => ({
+    name: config.name,
+    add: vi.fn(),
+    addMany: vi.fn(),
+    process: vi.fn(handler => ({ handler }))
+  })),
+  combineQueueProcessors: vi.fn(processors => processors),
+  QueueRetryError: class QueueRetryError extends Error {
+    constructor(message?: string) {
+      super(message);
+      this.name = 'QueueRetryError';
+    }
+  }
+}));
+
+vi.mock('@metorial/db', () => ({
+  db: {
+    project: {
+      update: vi.fn()
+    }
+  },
+  addAfterTransactionHook: vi.fn(async callback => await callback()),
+  withTransaction: vi.fn(callback =>
+    callback({
+      project: {
+        update: vi.fn()
+      }
+    })
+  )
+}));
+
+vi.mock('@metorial/fabric', () => ({
+  Fabric: {
+    fire: vi.fn()
+  }
+}));
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: vi.fn((name, factory) => ({
+      build: () => factory()
+    }))
+  }
+}));
+
+vi.mock('../src/queues/syncSubspaceTenant', () => ({
+  syncSubspaceTenantQueue: {
+    add: vi.fn()
+  }
+}));
+
+import { withTransaction } from '@metorial/db';
+import { Fabric } from '@metorial/fabric';
+import { syncSubspaceTenantQueue } from '../src/queues/syncSubspaceTenant';
+import { projectRetentionService } from '../src/services/projectRetention';
+
+describe('ProjectRetentionService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getProjectRetention', () => {
+    it('returns retention fields from the project', async () => {
+      let project = {
+        id: 'proj-1',
+        status: 'active',
+        logRetentionInDays: 14,
+        enforceSessionExpiry: true
+      };
+
+      let result = await projectRetentionService.getProjectRetention({
+        project: project as any
+      });
+
+      expect(result).toEqual({
+        logRetentionInDays: 14,
+        enforceSessionExpiry: true
+      });
+    });
+  });
+
+  describe('updateProjectRetention', () => {
+    it('persists retention fields and enqueues subspace tenant sync', async () => {
+      let mockOrg = { id: 'org-1', oid: 1 };
+      let mockActor = { id: 'actor-1', oid: 1 };
+      let mockProject = {
+        id: 'proj-1',
+        oid: 1,
+        status: 'active',
+        logRetentionInDays: 30,
+        enforceSessionExpiry: false,
+        organization: mockOrg
+      };
+      let updatedProject = {
+        ...mockProject,
+        logRetentionInDays: 7,
+        enforceSessionExpiry: true
+      };
+      let update = vi.fn().mockResolvedValue(updatedProject);
+
+      vi.mocked(withTransaction).mockImplementation(async callback => {
+        let mockDb = {
+          project: {
+            update
+          }
+        };
+        return callback(mockDb as any);
+      });
+
+      let result = await projectRetentionService.updateProjectRetention({
+        project: mockProject as any,
+        organization: mockOrg as any,
+        performedBy: mockActor as any,
+        context: {} as any,
+        input: {
+          logRetentionInDays: 7,
+          enforceSessionExpiry: true
+        }
+      });
+
+      expect(result).toEqual(updatedProject);
+      expect(update).toHaveBeenCalledWith({
+        where: { oid: mockProject.oid },
+        data: {
+          logRetentionInDays: 7,
+          enforceSessionExpiry: true
+        },
+        include: {
+          organization: true
+        }
+      });
+      expect(Fabric.fire).toHaveBeenCalledWith(
+        'organization.project.retention.updated:before',
+        expect.any(Object)
+      );
+      expect(Fabric.fire).toHaveBeenCalledWith(
+        'organization.project.retention.updated:after',
+        expect.objectContaining({
+          project: updatedProject
+        })
+      );
+      expect(syncSubspaceTenantQueue.add).toHaveBeenCalledWith({
+        projectId: 'proj-1'
+      });
+    });
+  });
+});

--- a/src/backend/modules/organization/test/syncSubspaceTenant.test.ts
+++ b/src/backend/modules/organization/test/syncSubspaceTenant.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { syncSubspaceTenantCronHandler } = vi.hoisted(() => ({
+  syncSubspaceTenantCronHandler: undefined as (() => Promise<void>) | undefined
+}));
+
+vi.mock('@metorial/db', () => ({
+  db: {
+    project: {
+      findMany: vi.fn(),
+      findUnique: vi.fn()
+    }
+  }
+}));
+
+vi.mock('@metorial/cron', () => ({
+  createCron: vi.fn((_config, handler) => {
+    syncSubspaceTenantCronHandler = handler;
+    return { handler };
+  })
+}));
+
+vi.mock('@metorial/queue', () => ({
+  createQueue: vi.fn().mockImplementation(config => ({
+    name: config.name,
+    add: vi.fn(),
+    addMany: vi.fn(),
+    process: vi.fn(handler => ({ handler }))
+  })),
+  combineQueueProcessors: vi.fn(processors => processors),
+  QueueRetryError: class QueueRetryError extends Error {
+    constructor(message?: string) {
+      super(message);
+      this.name = 'QueueRetryError';
+    }
+  }
+}));
+
+vi.mock('@metorial/internal-clients', () => ({
+  ensureInternalProjectTenant: vi.fn(),
+  ensureInternalScope: vi.fn()
+}));
+
+import { db } from '@metorial/db';
+import {
+  syncSubspaceTenantCron,
+  syncSubspaceTenantQueue,
+  syncSubspaceTenantSearchQueue,
+  syncSubspaceTenantSearchQueueProcessor
+} from '../src/queues/syncSubspaceTenant';
+
+describe('syncSubspaceTenant queues', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a daily cron that enqueues the search queue', async () => {
+    expect(syncSubspaceTenantCron).toBeDefined();
+
+    await syncSubspaceTenantCronHandler!();
+
+    expect(syncSubspaceTenantSearchQueue.add).toHaveBeenCalledWith(
+      {},
+      { id: 'org-sync-subspace-tenant-search' }
+    );
+  });
+
+  it('fans out active projects into single sync jobs', async () => {
+    vi.mocked(db.project.findMany).mockResolvedValue([
+      { id: 'proj-1' },
+      { id: 'proj-2' }
+    ] as any);
+
+    await (syncSubspaceTenantSearchQueueProcessor as any).handler({});
+
+    expect(db.project.findMany).toHaveBeenCalledWith({
+      where: {
+        status: 'active',
+        id: undefined
+      },
+      orderBy: { id: 'asc' },
+      take: 500,
+      select: { id: true }
+    });
+    expect(syncSubspaceTenantQueue.addMany).toHaveBeenCalledWith([
+      { projectId: 'proj-1' },
+      { projectId: 'proj-2' }
+    ]);
+    expect(syncSubspaceTenantSearchQueue.add).toHaveBeenCalledWith({
+      cursor: 'proj-2'
+    });
+  });
+});

--- a/src/frontend/state/src/organization/index.ts
+++ b/src/frontend/state/src/organization/index.ts
@@ -9,6 +9,7 @@ export * from './loaders/organizationInviteAccept';
 export * from './loaders/organizationMember';
 export * from './loaders/project';
 export * from './loaders/projectBrand';
+export * from './loaders/projectRetention';
 export * from './loaders/team';
 
 export * from './current';

--- a/src/frontend/state/src/organization/loaders/projectRetention.ts
+++ b/src/frontend/state/src/organization/loaders/projectRetention.ts
@@ -1,0 +1,40 @@
+import type { DashboardProjectsConfigureRetentionUpdateBody } from '@metorial/dashboard-sdk';
+import { createLoader } from '@metorial/data-hooks';
+import { withAuth } from '../../user';
+import { projectLoader } from './project';
+
+export let projectRetentionLoader = createLoader({
+  name: 'projectRetention',
+  parents: [projectLoader],
+  fetch: (i: { organizationId: string; projectId: string }) =>
+    withAuth(sdk =>
+      sdk.projects.configureRetention.get(i.organizationId, i.projectId)
+    ),
+  mutators: {
+    update: (
+      i: DashboardProjectsConfigureRetentionUpdateBody,
+      { input }: { input: { organizationId: string; projectId: string } }
+    ) =>
+      withAuth(sdk =>
+        sdk.projects.configureRetention.update(
+          input.organizationId,
+          input.projectId,
+          i
+        )
+      )
+  }
+});
+
+export let useProjectRetention = (
+  organizationId: string | null | undefined,
+  projectId: string | null | undefined
+) => {
+  let retention = projectRetentionLoader.use(
+    organizationId && projectId ? { organizationId, projectId } : null
+  );
+
+  return {
+    ...retention,
+    updateMutator: retention.useMutator('update')
+  };
+};

--- a/src/packages/backend/fabric/src/types.ts
+++ b/src/packages/backend/fabric/src/types.ts
@@ -152,6 +152,8 @@ export interface FabricEvents {
   'organization.project.created:after': { organization: Organization, project: Project, performedBy: OrganizationActor; context?: Context };
   'organization.project.updated:before': { organization: Organization, project: Project, performedBy: OrganizationActor; context?: Context };
   'organization.project.updated:after': { organization: Organization, project: Project, performedBy: OrganizationActor; context?: Context };
+  'organization.project.retention.updated:before': { organization: Organization, project: Project, performedBy: OrganizationActor; context?: Context; input: { logRetentionInDays?: number; enforceSessionExpiry?: boolean } };
+  'organization.project.retention.updated:after': { organization: Organization, project: Project, performedBy: OrganizationActor; context?: Context; input: { logRetentionInDays?: number; enforceSessionExpiry?: boolean } };
   'organization.project.deleted:before': { organization: Organization, project: Project, performedBy: OrganizationActor; context?: Context };
   'organization.project.deleted:after': { organization: Organization, project: Project, performedBy: OrganizationActor; context?: Context };
 

--- a/src/systems/subspace/apps/controller/src/controllers/providerRunUsageRecord.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerRunUsageRecord.ts
@@ -11,6 +11,7 @@ export let providerRunUsageRecordController = app.controller({
     .do(async ctx => {
       let paginator = await providerRunUsageRecordService.listProviderRunUsageRecords({
         ...ctx.input,
+        tenant: ctx.tenant,
         solution: ctx.solution
       });
 

--- a/src/systems/subspace/apps/controller/src/controllers/providerRunUsageRecord.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerRunUsageRecord.ts
@@ -3,11 +3,12 @@ import { v } from '@lowerdeck/validation';
 import { providerRunUsageRecordService } from '@metorial-subspace/module-session';
 import { providerRunUsageRecordPresenter } from '@metorial-subspace/presenters';
 import { app } from './_app';
+import { tenantOptionalWithoutEnvironmentApp } from './tenant';
 
 export let providerRunUsageRecordController = app.controller({
-  list: app
+  list: tenantOptionalWithoutEnvironmentApp
     .handler()
-    .input(Paginator.validate(v.object({})))
+    .input(Paginator.validate(v.object({ tenantId: v.optional(v.string()) })))
     .do(async ctx => {
       let paginator = await providerRunUsageRecordService.listProviderRunUsageRecords({
         ...ctx.input,

--- a/src/systems/subspace/apps/controller/src/controllers/sessionUsageRecord.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/sessionUsageRecord.ts
@@ -11,6 +11,7 @@ export let sessionUsageRecordController = app.controller({
     .do(async ctx => {
       let paginator = await sessionUsageRecordService.listSessionUsageRecords({
         ...ctx.input,
+        tenant: ctx.tenant,
         solution: ctx.solution
       });
 

--- a/src/systems/subspace/apps/controller/src/controllers/sessionUsageRecord.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/sessionUsageRecord.ts
@@ -3,11 +3,12 @@ import { v } from '@lowerdeck/validation';
 import { sessionUsageRecordService } from '@metorial-subspace/module-session';
 import { sessionUsageRecordPresenter } from '@metorial-subspace/presenters';
 import { app } from './_app';
+import { tenantOptionalWithoutEnvironmentApp } from './tenant';
 
 export let sessionUsageRecordController = app.controller({
-  list: app
+  list: tenantOptionalWithoutEnvironmentApp
     .handler()
-    .input(Paginator.validate(v.object({})))
+    .input(Paginator.validate(v.object({ tenantId: v.optional(v.string()) })))
     .do(async ctx => {
       let paginator = await sessionUsageRecordService.listSessionUsageRecords({
         ...ctx.input,

--- a/src/systems/subspace/apps/controller/src/controllers/tenant.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/tenant.ts
@@ -12,6 +12,15 @@ export let tenantWithoutEnvironmentApp = app.use(async ctx => {
   return { tenant };
 });
 
+export let tenantOptionalWithoutEnvironmentApp = app.use(async ctx => {
+  let tenantId = ctx.body.tenantId;
+  if (!tenantId) return { tenant: undefined };
+
+  let tenant = await tenantService.getTenantById({ id: tenantId });
+
+  return { tenant };
+});
+
 export let tenantApp = tenantWithoutEnvironmentApp.use(async ctx => {
   let tenantId = ctx.body.tenantId;
   let environmentId = ctx.body.environmentId;

--- a/src/systems/subspace/apps/controller/src/controllers/tenant.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/tenant.ts
@@ -51,6 +51,7 @@ export let tenantController = app.controller({
         onlyAllowTrustedProviders: v.optional(v.boolean()),
         isWhitelabel: v.optional(v.boolean()),
         logRetentionInDays: v.optional(v.number()),
+        enforceSessionExpiry: v.optional(v.boolean()),
         environments: v.array(
           v.object({
             name: v.string(),
@@ -68,7 +69,8 @@ export let tenantController = app.controller({
           environments: ctx.input.environments as any,
           onlyAllowTrustedProviders: ctx.input.onlyAllowTrustedProviders,
           isWhitelabel: ctx.input.isWhitelabel,
-          logRetentionInDays: ctx.input.logRetentionInDays
+          logRetentionInDays: ctx.input.logRetentionInDays,
+          enforceSessionExpiry: ctx.input.enforceSessionExpiry
         }
       });
       return tenantPresenter(tenant);

--- a/src/systems/subspace/db/prisma/schema/tenant.prisma
+++ b/src/systems/subspace/db/prisma/schema/tenant.prisma
@@ -21,7 +21,8 @@ model Tenant {
 
   createdAt DateTime @default(now())
 
-  logRetentionInDays Int @default(30)
+  logRetentionInDays     Int     @default(30)
+  enforceSessionExpiry Boolean @default(false)
 
   providers                                Provider[]
   providerListingGroups                    ProviderListingGroup[]

--- a/src/systems/subspace/modules/session/src/queues/delete/_config.ts
+++ b/src/systems/subspace/modules/session/src/queues/delete/_config.ts
@@ -19,9 +19,3 @@ export let sessionRetentionStorageCleanupWorkerOpts = {
     duration: 1000
   }
 };
-
-export let getRetentionCutoffDate = (logRetentionInDays: number) => {
-  let cutoffDate = new Date();
-  cutoffDate.setDate(cutoffDate.getDate() - Math.max(logRetentionInDays, 0));
-  return cutoffDate;
-};

--- a/src/systems/subspace/modules/session/src/queues/delete/session.ts
+++ b/src/systems/subspace/modules/session/src/queues/delete/session.ts
@@ -1,9 +1,10 @@
 import { createCron } from '@lowerdeck/cron';
 import { createQueue } from '@lowerdeck/queue';
 import { db } from '@metorial-subspace/db';
+import { getRetentionCutoffDate } from '@metorial-subspace/list-utils';
 import { env } from '../../env';
 import { sessionDeletedQueue } from '../lifecycle/session';
-import { getRetentionCutoffDate, RETENTION_BATCH_SIZE } from './_config';
+import { getCutoffDate, RETENTION_BATCH_SIZE } from './_config';
 
 export let sessionRetentionCleanupCron = createCron(
   {
@@ -59,14 +60,16 @@ export let sessionRetentionTenantQueueProcessor = sessionRetentionTenantQueue.pr
       where: { id: data.tenantId },
       select: {
         oid: true,
-        logRetentionInDays: true
+        logRetentionInDays: true,
+        enforceSessionExpiry: true
       }
     });
     if (!tenant) return;
 
     await sessionDeleteManyQueue.add({
       tenantOid: tenant.oid,
-      logRetentionInDays: tenant.logRetentionInDays
+      logRetentionInDays: tenant.logRetentionInDays,
+      enforceSessionExpiry: tenant.enforceSessionExpiry
     });
   }
 );
@@ -74,6 +77,7 @@ export let sessionRetentionTenantQueueProcessor = sessionRetentionTenantQueue.pr
 export let sessionDeleteManyQueue = createQueue<{
   tenantOid: bigint;
   logRetentionInDays: number;
+  enforceSessionExpiry: boolean;
   cursor?: string;
 }>({
   name: 'sub/ses/delete/session/many',
@@ -83,13 +87,18 @@ export let sessionDeleteManyQueue = createQueue<{
 export let enqueueArchivedSessionDeletes = async (d: {
   tenantOid: bigint;
   logRetentionInDays: number;
+  enforceSessionExpiry: boolean;
   cursor?: string;
 }) => {
+  let archivedBefore = d.enforceSessionExpiry
+    ? getRetentionCutoffDate(d.logRetentionInDays)
+    : getCutoffDate();
+
   let sessions = await db.session.findMany({
     where: {
       tenantOid: d.tenantOid,
       status: 'archived',
-      archivedAt: { lt: getRetentionCutoffDate(d.logRetentionInDays) },
+      archivedAt: { lt: archivedBefore },
       id: d.cursor ? { gt: d.cursor } : undefined
     },
     orderBy: { id: 'asc' },
@@ -106,6 +115,7 @@ export let enqueueArchivedSessionDeletes = async (d: {
   await sessionDeleteManyQueue.add({
     tenantOid: d.tenantOid,
     logRetentionInDays: d.logRetentionInDays,
+    enforceSessionExpiry: d.enforceSessionExpiry,
     cursor: lastSession.id
   });
 };

--- a/src/systems/subspace/modules/session/src/services/providerRun.ts
+++ b/src/systems/subspace/modules/session/src/services/providerRun.ts
@@ -10,6 +10,7 @@ import {
 } from '@metorial-subspace/db';
 import {
   type DateFilter,
+  mergeRetentionWithDateFilter,
   normalizeDateFilter,
   normalizeStatusForGet,
   normalizeStatusForList,
@@ -75,7 +76,7 @@ class providerRunServiceImpl {
                 providers ? { providerOid: providers.in } : undefined!,
                 providerVersions ? { providerVersionOid: providerVersions.in } : undefined!,
 
-                d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+                mergeRetentionWithDateFilter(d.tenant, d.createdAt),
                 d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
               ].filter(Boolean)
             },

--- a/src/systems/subspace/modules/session/src/services/providerRun.ts
+++ b/src/systems/subspace/modules/session/src/services/providerRun.ts
@@ -99,7 +99,8 @@ class providerRunServiceImpl {
         tenantOid: d.tenant.oid,
         solutionOid: d.solution.oid,
         environmentOid: d.environment.oid,
-        ...normalizeStatusForGet(d).onlyParent
+        ...normalizeStatusForGet(d).onlyParent,
+        ...mergeRetentionWithDateFilter(d.tenant)
       },
       include
     });

--- a/src/systems/subspace/modules/session/src/services/providerRunLogs.ts
+++ b/src/systems/subspace/modules/session/src/services/providerRunLogs.ts
@@ -1,3 +1,4 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
 import { Service } from '@lowerdeck/service';
 import {
   db,
@@ -6,6 +7,7 @@ import {
   type Solution,
   type Tenant
 } from '@metorial-subspace/db';
+import { mergeRetentionWithDateFilter } from '@metorial-subspace/list-utils';
 import { getBackend } from '@metorial-subspace/provider';
 
 export type ProviderRunLog = {
@@ -25,10 +27,19 @@ class providerRunLogsServiceImpl {
       sessionMessageIds?: string[];
     };
   }) {
-    let fullProviderRun = await db.providerRun.findFirstOrThrow({
-      where: { oid: d.providerRun.oid },
+    let fullProviderRun = await db.providerRun.findFirst({
+      where: {
+        oid: d.providerRun.oid,
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid,
+        ...mergeRetentionWithDateFilter(d.tenant)
+      },
       include: { providerVersion: true }
     });
+    if (!fullProviderRun) {
+      throw new ServiceError(notFoundError('provider_run', d.providerRun.id));
+    }
 
     let backend = await getBackend({ entity: fullProviderRun.providerVersion });
 

--- a/src/systems/subspace/modules/session/src/services/providerRunUsageRecord.ts
+++ b/src/systems/subspace/modules/session/src/services/providerRunUsageRecord.ts
@@ -9,7 +9,7 @@ let include = {
 };
 
 class providerRunUsageRecordServiceImpl {
-  async listProviderRunUsageRecords(d: { tenant: Tenant; solution: Solution }) {
+  async listProviderRunUsageRecords(d: { tenant?: Tenant; solution: Solution }) {
     return Paginator.create(({ prisma }) =>
       prisma(
         async opts =>
@@ -17,7 +17,7 @@ class providerRunUsageRecordServiceImpl {
             ...opts,
             where: {
               solutionOid: d.solution.oid,
-              ...mergeRetentionWithDateFilter(d.tenant)
+              ...(d.tenant ? mergeRetentionWithDateFilter(d.tenant) : {})
             },
             include
           })

--- a/src/systems/subspace/modules/session/src/services/providerRunUsageRecord.ts
+++ b/src/systems/subspace/modules/session/src/services/providerRunUsageRecord.ts
@@ -1,6 +1,7 @@
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import { db, type Solution } from '@metorial-subspace/db';
+import { db, type Solution, type Tenant } from '@metorial-subspace/db';
+import { mergeRetentionWithDateFilter } from '@metorial-subspace/list-utils';
 
 let include = {
   providerRun: true,
@@ -8,13 +9,16 @@ let include = {
 };
 
 class providerRunUsageRecordServiceImpl {
-  async listProviderRunUsageRecords(d: { solution: Solution }) {
+  async listProviderRunUsageRecords(d: { tenant: Tenant; solution: Solution }) {
     return Paginator.create(({ prisma }) =>
       prisma(
         async opts =>
           await db.providerRunUsageRecord.findMany({
             ...opts,
-            where: { solutionOid: d.solution.oid },
+            where: {
+              solutionOid: d.solution.oid,
+              ...mergeRetentionWithDateFilter(d.tenant)
+            },
             include
           })
       )

--- a/src/systems/subspace/modules/session/src/services/session.ts
+++ b/src/systems/subspace/modules/session/src/services/session.ts
@@ -138,7 +138,7 @@ class sessionServiceImpl {
                   ? { providers: { some: { authConfigOid: authConfigs.in } } }
                   : undefined!,
 
-                getSessionRetentionFilter(d.tenant, d.createdAt),
+                getSessionRetentionFilter(d.tenant, d.createdAt)!,
                 !d.tenant.enforceSessionExpiry && d.createdAt
                   ? { createdAt: normalizeDateFilter(d.createdAt) }
                   : undefined!,
@@ -165,7 +165,8 @@ class sessionServiceImpl {
         solutionOid: d.solution.oid,
         environmentOid: d.environment.oid,
 
-        ...normalizeStatusForGet(d).noParent
+        ...normalizeStatusForGet(d).noParent,
+        ...getSessionRetentionFilter(d.tenant)
       },
       include
     });
@@ -187,7 +188,8 @@ class sessionServiceImpl {
         tenantOid: d.tenant.oid,
         solutionOid: d.solution.oid,
         environmentOid: d.environment.oid,
-        ...normalizeStatusForGet(d).noParent
+        ...normalizeStatusForGet(d).noParent,
+        ...getSessionRetentionFilter(d.tenant)
       },
       include
     });

--- a/src/systems/subspace/modules/session/src/services/session.ts
+++ b/src/systems/subspace/modules/session/src/services/session.ts
@@ -14,6 +14,7 @@ import {
 import {
   checkDeletedEdit,
   type DateFilter,
+  getSessionRetentionFilter,
   normalizeDateFilter,
   normalizeStatusForGet,
   normalizeStatusForList,
@@ -137,7 +138,10 @@ class sessionServiceImpl {
                   ? { providers: { some: { authConfigOid: authConfigs.in } } }
                   : undefined!,
 
-                d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+                getSessionRetentionFilter(d.tenant, d.createdAt),
+                !d.tenant.enforceSessionExpiry && d.createdAt
+                  ? { createdAt: normalizeDateFilter(d.createdAt) }
+                  : undefined!,
                 d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
               ].filter(Boolean)
             },

--- a/src/systems/subspace/modules/session/src/services/sessionConnection.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionConnection.ts
@@ -11,6 +11,8 @@ import {
 } from '@metorial-subspace/db';
 import {
   type DateFilter,
+  getConnectionRetentionFilter,
+  mergeRetentionWithDateFilter,
   normalizeDateFilter,
   normalizeStatusForGet,
   normalizeStatusForList,
@@ -88,7 +90,8 @@ class sessionConnectionServiceImpl {
                   : undefined!,
                 participants ? { participantOid: participants.in } : undefined!,
 
-                d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+                getConnectionRetentionFilter(d.tenant),
+                mergeRetentionWithDateFilter(d.tenant, d.createdAt),
                 d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
               ].filter(Boolean)
             },

--- a/src/systems/subspace/modules/session/src/services/sessionConnection.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionConnection.ts
@@ -114,7 +114,8 @@ class sessionConnectionServiceImpl {
         tenantOid: d.tenant.oid,
         solutionOid: d.solution.oid,
         environmentOid: d.environment.oid,
-        ...normalizeStatusForGet(d).hasParent
+        ...normalizeStatusForGet(d).hasParent,
+        ...getConnectionRetentionFilter(d.tenant)
       },
       include
     });

--- a/src/systems/subspace/modules/session/src/services/sessionConnection.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionConnection.ts
@@ -12,7 +12,6 @@ import {
 import {
   type DateFilter,
   getConnectionRetentionFilter,
-  mergeRetentionWithDateFilter,
   normalizeDateFilter,
   normalizeStatusForGet,
   normalizeStatusForList,
@@ -91,7 +90,7 @@ class sessionConnectionServiceImpl {
                 participants ? { participantOid: participants.in } : undefined!,
 
                 getConnectionRetentionFilter(d.tenant),
-                mergeRetentionWithDateFilter(d.tenant, d.createdAt),
+                d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
                 d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
               ].filter(Boolean)
             },

--- a/src/systems/subspace/modules/session/src/services/sessionError.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionError.ts
@@ -10,6 +10,7 @@ import {
 } from '@metorial-subspace/db';
 import {
   type DateFilter,
+  mergeRetentionWithDateFilter,
   normalizeDateFilter,
   normalizeStatusForGet,
   normalizeStatusForList,
@@ -84,7 +85,7 @@ class sessionErrorServiceImpl {
                 messages ? { sessionMessages: { some: { oid: messages.in } } } : undefined!,
                 providers ? { providerRun: { providerOid: providers.in } } : undefined!,
 
-                d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+                mergeRetentionWithDateFilter(d.tenant, d.createdAt),
                 d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
               ].filter(Boolean)
             },

--- a/src/systems/subspace/modules/session/src/services/sessionError.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionError.ts
@@ -108,7 +108,8 @@ class sessionErrorServiceImpl {
         tenantOid: d.tenant.oid,
         solutionOid: d.solution.oid,
         environmentOid: d.environment.oid,
-        ...normalizeStatusForGet(d).onlyParent
+        ...normalizeStatusForGet(d).onlyParent,
+        ...mergeRetentionWithDateFilter(d.tenant)
       },
       include
     });

--- a/src/systems/subspace/modules/session/src/services/sessionErrorGroup.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionErrorGroup.ts
@@ -10,6 +10,7 @@ import {
 } from '@metorial-subspace/db';
 import {
   type DateFilter,
+  mergeRetentionWithDateFilter,
   normalizeDateFilter,
   resolveProviders,
   resolveSessions
@@ -53,7 +54,7 @@ class sessionErrorGroupServiceImpl {
                 sessions ? { instances: { some: { sessionOid: sessions.in } } } : undefined!,
                 providers ? { providerOid: providers.in } : undefined!,
 
-                d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+                mergeRetentionWithDateFilter(d.tenant, d.createdAt),
                 d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
               ].filter(Boolean)
             },

--- a/src/systems/subspace/modules/session/src/services/sessionErrorGroup.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionErrorGroup.ts
@@ -75,7 +75,8 @@ class sessionErrorGroupServiceImpl {
       where: {
         id: d.sessionErrorGroupId,
         tenantOid: d.tenant.oid,
-        environmentOid: d.environment.oid
+        environmentOid: d.environment.oid,
+        ...mergeRetentionWithDateFilter(d.tenant)
       },
       include
     });

--- a/src/systems/subspace/modules/session/src/services/sessionEvent.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionEvent.ts
@@ -11,6 +11,7 @@ import {
 } from '@metorial-subspace/db';
 import {
   type DateFilter,
+  mergeRetentionWithDateFilter,
   normalizeDateFilter,
   normalizeStatusForGet,
   normalizeStatusForList,
@@ -135,7 +136,7 @@ class sessionEventServiceImpl {
               messages ? { messageOid: messages.in } : undefined!,
               errors ? { errorOid: errors.in } : undefined!,
 
-              d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+              mergeRetentionWithDateFilter(d.tenant, d.createdAt),
               d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
             ].filter(Boolean)
           },

--- a/src/systems/subspace/modules/session/src/services/sessionEvent.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionEvent.ts
@@ -3,8 +3,8 @@ import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import {
   db,
-  type SessionEvent,
   type Environment,
+  type SessionEvent,
   type SessionEventType,
   type Solution,
   type Tenant
@@ -161,7 +161,8 @@ class sessionEventServiceImpl {
         tenantOid: d.tenant.oid,
         solutionOid: d.solution.oid,
         environmentOid: d.environment.oid,
-        ...normalizeStatusForGet(d).onlyParent
+        ...normalizeStatusForGet(d).onlyParent,
+        ...mergeRetentionWithDateFilter(d.tenant)
       },
       include
     });

--- a/src/systems/subspace/modules/session/src/services/sessionMessage.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionMessage.ts
@@ -12,6 +12,7 @@ import {
 } from '@metorial-subspace/db';
 import {
   type DateFilter,
+  mergeRetentionWithDateFilter,
   normalizeDateFilter,
   normalizeStatusForGet,
   normalizeStatusForList,
@@ -187,7 +188,7 @@ class sessionMessageServiceImpl {
                   }
                 : undefined!,
 
-              d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+              mergeRetentionWithDateFilter(d.tenant, d.createdAt),
               d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
             ].filter(Boolean)
           },

--- a/src/systems/subspace/modules/session/src/services/sessionMessage.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionMessage.ts
@@ -3,8 +3,8 @@ import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import {
   db,
-  type SessionMessage,
   type Environment,
+  type SessionMessage,
   type SessionMessageSource,
   type SessionMessageType,
   type Solution,
@@ -214,7 +214,11 @@ class sessionMessageServiceImpl {
         solutionOid: d.solution.oid,
         environmentOid: d.environment.oid,
 
-        AND: [normalizeStatusForGet(d).onlyParent, { status: { not: 'waiting_for_response' } }]
+        AND: [
+          normalizeStatusForGet(d).onlyParent,
+          { status: { not: 'waiting_for_response' } },
+          mergeRetentionWithDateFilter(d.tenant)
+        ]
       },
       include: include
     });

--- a/src/systems/subspace/modules/session/src/services/sessionUsageRecord.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionUsageRecord.ts
@@ -9,7 +9,7 @@ let include = {
 };
 
 class sessionUsageRecordServiceImpl {
-  async listSessionUsageRecords(d: { tenant: Tenant; solution: Solution }) {
+  async listSessionUsageRecords(d: { tenant?: Tenant; solution: Solution }) {
     return Paginator.create(({ prisma }) =>
       prisma(
         async opts =>
@@ -17,7 +17,7 @@ class sessionUsageRecordServiceImpl {
             ...opts,
             where: {
               solutionOid: d.solution.oid,
-              ...mergeRetentionWithDateFilter(d.tenant)
+              ...(d.tenant ? mergeRetentionWithDateFilter(d.tenant) : {})
             },
             include
           })

--- a/src/systems/subspace/modules/session/src/services/sessionUsageRecord.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionUsageRecord.ts
@@ -1,6 +1,7 @@
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import { db, type Solution } from '@metorial-subspace/db';
+import { db, type Solution, type Tenant } from '@metorial-subspace/db';
+import { mergeRetentionWithDateFilter } from '@metorial-subspace/list-utils';
 
 let include = {
   session: true,
@@ -8,13 +9,16 @@ let include = {
 };
 
 class sessionUsageRecordServiceImpl {
-  async listSessionUsageRecords(d: { solution: Solution }) {
+  async listSessionUsageRecords(d: { tenant: Tenant; solution: Solution }) {
     return Paginator.create(({ prisma }) =>
       prisma(
         async opts =>
           await db.sessionUsageRecord.findMany({
             ...opts,
-            where: { solutionOid: d.solution.oid },
+            where: {
+              solutionOid: d.solution.oid,
+              ...mergeRetentionWithDateFilter(d.tenant)
+            },
             include
           })
       )

--- a/src/systems/subspace/modules/session/src/services/toolCall.ts
+++ b/src/systems/subspace/modules/session/src/services/toolCall.ts
@@ -15,6 +15,7 @@ import {
 import {
   checkDeletedRelation,
   type DateFilter,
+  mergeRetentionWithDateFilter,
   normalizeDateFilter,
   normalizeStatusForGet,
   normalizeStatusForList,
@@ -204,7 +205,7 @@ class toolCallServiceImpl {
                 ? { session: { providers: { some: { authConfigOid: authConfigs.in } } } }
                 : undefined!,
 
-              d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+              mergeRetentionWithDateFilter(d.tenant, d.createdAt),
               d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
             ].filter(Boolean)
           },

--- a/src/systems/subspace/modules/session/src/services/toolCall.ts
+++ b/src/systems/subspace/modules/session/src/services/toolCall.ts
@@ -231,7 +231,8 @@ class toolCallServiceImpl {
         solutionOid: d.solution.oid,
         environmentOid: d.environment.oid,
 
-        message: normalizeStatusForGet(d).onlyParent
+        message: normalizeStatusForGet(d).onlyParent,
+        ...mergeRetentionWithDateFilter(d.tenant)
       },
       include
     });

--- a/src/systems/subspace/modules/tenant/package.json
+++ b/src/systems/subspace/modules/tenant/package.json
@@ -18,7 +18,8 @@
     "@lowerdeck/service": "^1.0.7",
     "@lowerdeck/validation": "^1.0.10",
     "@metorial-subspace/connection-utils": "^1.0.0",
-    "@metorial-subspace/db": "^1.0.0"
+    "@metorial-subspace/db": "^1.0.0",
+    "@metorial-subspace/list-utils": "^1.0.0"
   },
   "devDependencies": {
     "@metorial-subspace/tsconfig": "^1.0.0",

--- a/src/systems/subspace/modules/tenant/src/queues/retention/_config.ts
+++ b/src/systems/subspace/modules/tenant/src/queues/retention/_config.ts
@@ -1,3 +1,5 @@
+export { getRetentionCutoffDate } from '@metorial-subspace/list-utils';
+
 export let RETENTION_BATCH_SIZE = 500;
 
 export let retentionCleanupWorkerOpts = {
@@ -22,10 +24,4 @@ export let retentionSyncWorkerOpts = {
     max: 5,
     duration: 1000
   }
-};
-
-export let getRetentionCutoffDate = (logRetentionInDays: number) => {
-  let cutoffDate = new Date();
-  cutoffDate.setDate(cutoffDate.getDate() - Math.max(logRetentionInDays, 0));
-  return cutoffDate;
 };

--- a/src/systems/subspace/modules/tenant/src/queues/retention/cleanup.ts
+++ b/src/systems/subspace/modules/tenant/src/queues/retention/cleanup.ts
@@ -3,6 +3,7 @@ import { createQueue } from '@lowerdeck/queue';
 import { sessionMessageBucketRecord, storage } from '@metorial-subspace/connection-utils';
 import { db, withTransaction } from '@metorial-subspace/db';
 import { env } from '../../env';
+import { getConnectionRetentionWhere } from '@metorial-subspace/list-utils';
 import {
   getRetentionCutoffDate,
   RETENTION_BATCH_SIZE,
@@ -278,9 +279,11 @@ let cleanupSessionConnections = async (d: { tenantOid: bigint; cutoffDate: Date 
       db.sessionConnection.findMany({
         where: {
           tenantOid: d.tenantOid,
-          lastActiveAt: { lt: d.cutoffDate },
-          state: 'disconnected',
-          providerRuns: { none: {} }
+          providerRuns: { none: {} },
+          ...getConnectionRetentionWhere({
+            cutoff: d.cutoffDate,
+            beforeCutoff: true
+          })
         },
         orderBy: { createdAt: 'asc' },
         take: RETENTION_BATCH_SIZE,

--- a/src/systems/subspace/modules/tenant/src/services/tenant.ts
+++ b/src/systems/subspace/modules/tenant/src/services/tenant.ts
@@ -15,6 +15,7 @@ class tenantServiceImpl {
       onlyAllowTrustedProviders?: boolean;
       isWhitelabel?: boolean;
       logRetentionInDays?: number;
+      enforceSessionExpiry?: boolean;
       environments: {
         name: string;
         identifier: string;
@@ -37,7 +38,8 @@ class tenantServiceImpl {
           name: d.input.name,
           onlyAllowTrustedProviders: d.input.onlyAllowTrustedProviders,
           isWhitelabel: d.input.isWhitelabel,
-          logRetentionInDays: d.input.logRetentionInDays
+          logRetentionInDays: d.input.logRetentionInDays,
+          enforceSessionExpiry: d.input.enforceSessionExpiry
         },
         create: {
           ...getId('tenant'),
@@ -46,6 +48,7 @@ class tenantServiceImpl {
           onlyAllowTrustedProviders: d.input.onlyAllowTrustedProviders,
           isWhitelabel: d.input.isWhitelabel,
           logRetentionInDays: d.input.logRetentionInDays ?? 30,
+          enforceSessionExpiry: d.input.enforceSessionExpiry ?? false,
 
           urlKey: generatePlainId(10).toLowerCase()
         }

--- a/src/systems/subspace/packages/list-utils/package.json
+++ b/src/systems/subspace/packages/list-utils/package.json
@@ -5,9 +5,12 @@
   "type": "module",
   "private": true,
   "version": "1.0.0",
-  "scripts": {},
+  "scripts": {
+    "test": "vitest run"
+  },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "vitest": "^3.1.2"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/src/systems/subspace/packages/list-utils/src/index.ts
+++ b/src/systems/subspace/packages/list-utils/src/index.ts
@@ -1,5 +1,6 @@
 export * from './dateFilter';
 export * from './deleteCheck';
 export * from './resources';
+export * from './retention';
 export * from './status';
 export * from './tenant';

--- a/src/systems/subspace/packages/list-utils/src/resolver.ts
+++ b/src/systems/subspace/packages/list-utils/src/resolver.ts
@@ -1,4 +1,4 @@
-import { startOfDay, subDays } from 'date-fns';
+import { getRetentionCutoffDate } from './retention';
 import type { TenantSelector, TenantSelectorOptional } from './tenant';
 
 let getSelectors = (oids: bigint[]) => ({
@@ -12,7 +12,7 @@ export let createResolver =
     cb: (d: {
       selector: TenantSelector;
       ts: { tenantOid: bigint; solutionOid: number; environmentOid: bigint };
-      onlyLogsAfter: Date;
+      retentionCutoff: Date;
       ids: string[];
     }) => Promise<R[]>
   ) =>
@@ -25,7 +25,7 @@ export let createResolver =
     let res = await cb({
       ids,
       selector,
-      onlyLogsAfter: startOfDay(subDays(new Date(), selector.tenant.logRetentionInDays)),
+      retentionCutoff: getRetentionCutoffDate(selector.tenant.logRetentionInDays),
       ts: {
         tenantOid: selector.tenant.oid,
         solutionOid: selector.solution.oid,

--- a/src/systems/subspace/packages/list-utils/src/resources/session.ts
+++ b/src/systems/subspace/packages/list-utils/src/resources/session.ts
@@ -29,37 +29,44 @@ export let resolveSessionProviders = createResolver(async ({ ts, ids }) =>
   })
 );
 
-export let resolveSessionEvents = createResolver(async ({ ts, ids, onlyLogsAfter }) =>
+export let resolveSessionEvents = createResolver(async ({ ts, ids, retentionCutoff }) =>
   db.sessionEvent.findMany({
-    where: { ...ts, id: { in: ids }, createdAt: { gt: onlyLogsAfter } },
+    where: { ...ts, id: { in: ids }, createdAt: { gte: retentionCutoff } },
     select: { oid: true }
   })
 );
 
-export let resolveSessionMessages = createResolver(async ({ ts, ids, onlyLogsAfter }) =>
+export let resolveSessionMessages = createResolver(async ({ ts, ids, retentionCutoff }) =>
   db.sessionMessage.findMany({
-    where: { ...ts, id: { in: ids }, createdAt: { gt: onlyLogsAfter } },
+    where: { ...ts, id: { in: ids }, createdAt: { gte: retentionCutoff } },
     select: { oid: true }
   })
 );
 
-export let resolveSessionConnections = createResolver(async ({ ts, ids, onlyLogsAfter }) =>
+export let resolveSessionConnections = createResolver(async ({ ts, ids, retentionCutoff }) =>
   db.sessionConnection.findMany({
-    where: { ...ts, id: { in: ids }, createdAt: { gt: onlyLogsAfter } },
+    where: {
+      ...ts,
+      id: { in: ids },
+      OR: [
+        { lastActiveAt: { gte: retentionCutoff } },
+        { lastActiveAt: null, createdAt: { gte: retentionCutoff } }
+      ]
+    },
     select: { oid: true }
   })
 );
 
-export let resolveSessionErrors = createResolver(async ({ ts, ids, onlyLogsAfter }) =>
+export let resolveSessionErrors = createResolver(async ({ ts, ids, retentionCutoff }) =>
   db.sessionError.findMany({
-    where: { ...ts, id: { in: ids }, createdAt: { gt: onlyLogsAfter } },
+    where: { ...ts, id: { in: ids }, createdAt: { gte: retentionCutoff } },
     select: { oid: true }
   })
 );
 
-export let resolveSessionErrorGroups = createResolver(async ({ ts, ids }) =>
+export let resolveSessionErrorGroups = createResolver(async ({ ts, ids, retentionCutoff }) =>
   db.sessionErrorGroup.findMany({
-    where: { tenantOid: ts.tenantOid, id: { in: ids } },
+    where: { tenantOid: ts.tenantOid, id: { in: ids }, createdAt: { gte: retentionCutoff } },
     select: { oid: true }
   })
 );
@@ -71,9 +78,9 @@ export let resolveSessionParticipants = createResolver(async ({ ts, ids }) =>
   })
 );
 
-export let resolveProviderRuns = createResolver(async ({ ts, ids, onlyLogsAfter }) =>
+export let resolveProviderRuns = createResolver(async ({ ts, ids, retentionCutoff }) =>
   db.providerRun.findMany({
-    where: { ...ts, id: { in: ids }, createdAt: { gt: onlyLogsAfter } },
+    where: { ...ts, id: { in: ids }, createdAt: { gte: retentionCutoff } },
     select: { oid: true }
   })
 );

--- a/src/systems/subspace/packages/list-utils/src/retention.test.ts
+++ b/src/systems/subspace/packages/list-utils/src/retention.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getConnectionRetentionFilter,
+  getRetentionCutoffDate,
+  getSessionRetentionFilter,
+  mergeRetentionWithDateFilter
+} from './retention';
+
+describe('retention', () => {
+  it('clamps negative retention to now', () => {
+    let before = Date.now();
+    let cutoff = getRetentionCutoffDate(-5);
+    let after = Date.now();
+
+    expect(cutoff.getTime()).toBeGreaterThanOrEqual(before - 1000);
+    expect(cutoff.getTime()).toBeLessThanOrEqual(after + 1000);
+  });
+
+  it('merges caller createdAt.gt with retention floor', () => {
+    let floor = getRetentionCutoffDate(30);
+    let later = new Date(floor.getTime() + 60_000);
+
+    let filter = mergeRetentionWithDateFilter({ logRetentionInDays: 30 }, { gt: later });
+
+    expect(filter.createdAt.gte).toEqual(later);
+  });
+
+  it('skips session retention when enforceSessionExpiry is false', () => {
+    expect(
+      getSessionRetentionFilter({ logRetentionInDays: 30, enforceSessionExpiry: false })
+    ).toBeUndefined();
+  });
+
+  it('applies session retention when enforceSessionExpiry is true', () => {
+    expect(
+      getSessionRetentionFilter({ logRetentionInDays: 7, enforceSessionExpiry: true })
+    ).toHaveProperty('createdAt.gte');
+  });
+
+  it('hides stale connections regardless of connection state', () => {
+    let filter = getConnectionRetentionFilter({ logRetentionInDays: 30 });
+
+    expect(filter.OR).toEqual([
+      { lastActiveAt: { gte: expect.any(Date) } },
+      { lastActiveAt: null, createdAt: { gte: expect.any(Date) } }
+    ]);
+    expect(filter.OR).not.toEqual(
+      expect.arrayContaining([{ state: { not: 'disconnected' } }])
+    );
+  });
+});

--- a/src/systems/subspace/packages/list-utils/src/retention.ts
+++ b/src/systems/subspace/packages/list-utils/src/retention.ts
@@ -1,0 +1,65 @@
+import type { DateFilter } from './dateFilter';
+import { normalizeDateFilter } from './dateFilter';
+
+export type LogRetentionTenant = {
+  logRetentionInDays: number;
+  enforceSessionExpiry?: boolean;
+};
+
+export let getRetentionCutoffDate = (logRetentionInDays: number) => {
+  let cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - Math.max(logRetentionInDays, 0));
+  return cutoffDate;
+};
+
+export let mergeRetentionWithDateFilter = (
+  tenant: Pick<LogRetentionTenant, 'logRetentionInDays'>,
+  filter?: DateFilter
+) => {
+  let floor = getRetentionCutoffDate(tenant.logRetentionInDays);
+  let normalized = normalizeDateFilter(filter);
+
+  if (!normalized) {
+    return { createdAt: { gte: floor } };
+  }
+
+  return {
+    createdAt: {
+      ...(normalized.lt ? { lt: normalized.lt } : {}),
+      gte: normalized.gt && normalized.gt > floor ? normalized.gt : floor
+    }
+  };
+};
+
+export let getSessionRetentionFilter = (
+  tenant: LogRetentionTenant,
+  dateFilter?: DateFilter
+) => {
+  if (!tenant.enforceSessionExpiry) return undefined;
+
+  return mergeRetentionWithDateFilter(tenant, dateFilter);
+};
+
+export let getConnectionRetentionWhere = (d: { cutoff: Date; beforeCutoff: boolean }) => {
+  if (d.beforeCutoff) {
+    return {
+      OR: [
+        { lastActiveAt: { lt: d.cutoff } },
+        { lastActiveAt: null, createdAt: { lt: d.cutoff } }
+      ]
+    };
+  }
+
+  return {
+    OR: [
+      { lastActiveAt: { gte: d.cutoff } },
+      { lastActiveAt: null, createdAt: { gte: d.cutoff } }
+    ]
+  };
+};
+
+export let getConnectionRetentionFilter = (tenant: Pick<LogRetentionTenant, 'logRetentionInDays'>) =>
+  getConnectionRetentionWhere({
+    cutoff: getRetentionCutoffDate(tenant.logRetentionInDays),
+    beforeCutoff: false
+  });

--- a/src/systems/subspace/packages/presenters/src/tenant.ts
+++ b/src/systems/subspace/packages/presenters/src/tenant.ts
@@ -7,6 +7,7 @@ export let tenantPresenter = (tenant: Tenant) => ({
   identifier: tenant.identifier,
   name: tenant.name,
   logRetentionInDays: tenant.logRetentionInDays,
+  enforceSessionExpiry: tenant.enforceSessionExpiry,
 
   onlyAllowTrustedProviders: tenant.onlyAllowTrustedProviders,
   isWhitelabel: tenant.isWhitelabel,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches persistence and query filtering across many Subspace session listing/read paths and adds new retention configuration endpoints; mistakes could hide data unexpectedly or cause load issues. Changes are scoped and validated, with tests added for the new retention helpers and services.
> 
> **Overview**
> Adds **project-level retention configuration** (`logRetentionInDays`, `enforceSessionExpiry`) including Prisma schema fields, a new dashboard API (`GET/PATCH /dashboard/.../configure/retention`) with validation, presenter support, and a dashboard SDK + frontend state loader (`useProjectRetention`) to fetch/update it.
> 
> Enforces retention across Subspace data access by introducing shared helpers in `@metorial-subspace/list-utils` (`mergeRetentionWithDateFilter`, `getSessionRetentionFilter`, `getConnectionRetentionFilter`) and wiring them into many session/provider-run list and get queries so older records fall outside results; session retention is conditional on `enforceSessionExpiry`, while other log-like resources use a retention floor.
> 
> Updates background processing: `syncSubspaceTenant` is refactored into combined processors and gains a daily cron + batched project fan-out search queue, and retention cleanup code is adjusted to reuse shared cutoff/connection-retention logic. Tests are added for the new retention service, queues, and retention utilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03833c1c34f31bc2b6e0d8b61338adec042c9bb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->