### PR TITLE
Improve performance for session traces

### DIFF
--- a/src/frontend/apps/dashboard/package.json
+++ b/src/frontend/apps/dashboard/package.json
@@ -31,6 +31,7 @@
     "@metorial/ui-product": "^1.0.0",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
+    "@tanstack/react-virtual": "^3.13.12",
     "@remixicon/react": "^4.2.0",
     "@sentry/react": "^8.54.0",
     "@tiptap/extension-color": "^3.6.1",

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/entry.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerInvocations/entry.tsx
@@ -1,7 +1,8 @@
 import type { DashboardInstanceProviderInvocationsListOutput } from '@metorial/dashboard-sdk';
 import { Badge, Button, RenderDate, theme } from '@metorial/ui';
 import { RiKey2Line, RiPulseLine, RiShieldKeyholeLine, RiToolsLine } from '@remixicon/react';
-import type { ReactNode } from 'react';
+import { useInView } from 'framer-motion';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { RunLogs } from '../../components/runLogs';
 import { formatTitleCase } from './helpers';
@@ -79,7 +80,42 @@ let getInvocationTitle = (invocation: InvocationItem): string => {
   return formatTitleCase(invocation.type);
 };
 
-export let ProviderInvocationEntry = ({ invocation }: { invocation: InvocationItem }) => {
+let InvocationLogs = ({
+  deferBody,
+  invocation
+}: {
+  deferBody?: boolean;
+  invocation: InvocationItem;
+}) => {
+  let ref = useRef<HTMLDivElement>(null);
+  let inView = useInView(ref, { margin: '200px 0px' });
+  let [canRender, setCanRender] = useState(!deferBody);
+
+  useEffect(() => {
+    if (inView) setCanRender(true);
+  }, [inView]);
+
+  return (
+    <div ref={ref}>
+      {canRender ? (
+        <RunLogs
+          logs={invocation.logs}
+          hideWhenEmpty={false}
+          title="Output"
+          emptyText="No output logs captured."
+        />
+      ) : null}
+    </div>
+  );
+};
+
+export let ProviderInvocationEntry = ({
+  deferBody = false,
+  invocation
+}: {
+  deferBody?: boolean;
+  invocation: InvocationItem;
+}) => {
   let variant: 'error' | 'default' = invocation.status === 'error' ? 'error' : 'default';
 
   return (
@@ -110,12 +146,7 @@ export let ProviderInvocationEntry = ({ invocation }: { invocation: InvocationIt
         </time>
       </Header>
 
-      <RunLogs
-        logs={invocation.logs}
-        hideWhenEmpty={false}
-        title="Output"
-        emptyText="No output logs captured."
-      />
+      <InvocationLogs deferBody={deferBody} invocation={invocation} />
     </Wrapper>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionMessages/components/message.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionMessages/components/message.tsx
@@ -1,3 +1,5 @@
+import { useInView } from 'framer-motion';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { Entry } from '../../session/components/entry';
 import type { AggregatedMessages } from '../../session/hooks/useAggregatedMessages';
 import { getMessagePresentation } from '../presentations/getMessagePresentation';
@@ -11,9 +13,9 @@ import {
 } from '../utils';
 import { MessageCard } from './messageCard';
 
-export let Message = ({
-  message,
-  aggregatedMessages
+export let useMessagePresentation = ({
+  aggregatedMessages,
+  message
 }: {
   message: DashboardInstanceSessionsMessagesGetOutput;
   aggregatedMessages: Map<string, AggregatedMessages>;
@@ -51,6 +53,94 @@ export let Message = ({
   let messageError = outputMessage?.error ?? message.error ?? undefined;
   let hasError = !!messageError || isToolError;
 
+  return {
+    agg,
+    date,
+    hasError,
+    input,
+    isToolError,
+    messageError,
+    output,
+    position,
+    presentation
+  };
+};
+
+let MessageBody = ({
+  date,
+  defaultViewMode,
+  error,
+  id,
+  input,
+  isToolError,
+  label,
+  output,
+  overviewSections,
+  position
+}: {
+  date: Date;
+  defaultViewMode?: 'overview' | 'properties' | 'raw';
+  error?: DashboardInstanceSessionsMessagesGetOutput['error'];
+  id?: string;
+  input?: Record<string, any> | null;
+  isToolError?: boolean;
+  label: React.ReactNode;
+  output?: Record<string, any> | null;
+  overviewSections?: ReturnType<
+    typeof getMessagePresentation
+  >['overviewSections'];
+  position: string;
+}) => {
+  let ref = useRef<HTMLDivElement>(null);
+  let inView = useInView(ref, { margin: '200px 0px' });
+  let [canRender, setCanRender] = useState(false);
+
+  useEffect(() => {
+    if (inView) setCanRender(true);
+  }, [inView]);
+
+  return (
+    <div ref={ref}>
+      {canRender ? (
+        <MessageCard
+          id={id}
+          label={label}
+          input={input}
+          output={output}
+          date={date}
+          position={position}
+          overviewSections={overviewSections}
+          defaultViewMode={defaultViewMode}
+          error={error}
+          isToolError={isToolError}
+        />
+      ) : null}
+    </div>
+  );
+};
+
+export let Message = ({
+  aggregatedMessages,
+  message
+}: {
+  message: DashboardInstanceSessionsMessagesGetOutput;
+  aggregatedMessages: Map<string, AggregatedMessages>;
+}) => {
+  let presentationData = useMessagePresentation({ aggregatedMessages, message });
+  if (!presentationData) return null;
+
+  let {
+    agg,
+    date,
+    hasError,
+    input,
+    isToolError,
+    messageError,
+    output,
+    position,
+    presentation
+  } = presentationData;
+
   return (
     <MessageStack>
       <Entry
@@ -61,7 +151,7 @@ export let Message = ({
       />
 
       {!presentation.hideCard && (
-        <MessageCard
+        <MessageBody
           id={agg?.originalId}
           label={presentation.label}
           input={input}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/components/connectionLogs.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/components/connectionLogs.tsx
@@ -1,11 +1,11 @@
 import { DashboardInstanceSessionsGetOutput } from '@metorial/dashboard-sdk';
 import { Callout, CenteredSpinner } from '@metorial/ui';
-import { useEffect, useRef } from 'react';
+import { RefObject, useCallback, useEffect, useRef } from 'react';
 import styled from 'styled-components';
-import { ItemList } from '../../session/components/itemList';
 import { useConnectionTimeline } from '../hooks/useConnectionTimeline';
 import { SessionConnection } from '../types';
 import { ConnectionTraceHeader } from './connectionTraceHeader';
+import { VirtualizedTimelineList } from './virtualizedTimelineList';
 
 let DetailContent = styled.div`
   display: flex;
@@ -29,45 +29,53 @@ let LoadingWrap = styled.div`
 `;
 
 export let ConnectionLogs = ({
-  session,
   connection,
-  focusedItemId
+  focusedItemId,
+  scrollRef,
+  session
 }: {
-  session: DashboardInstanceSessionsGetOutput;
   connection: SessionConnection;
   focusedItemId?: string | null;
+  scrollRef: RefObject<HTMLElement | null>;
+  session: DashboardInstanceSessionsGetOutput;
 }) => {
   let {
     connection: connectionDetails,
     connectionProviders,
+    hasMoreAfter,
     hasTimelineActivity,
     isLoading,
+    isLoadingMore,
+    loadMore,
     mcp,
-    sessionEntry,
-    timelineItems
+    timelineItemData,
+    timelineRowContext
   } = useConnectionTimeline({
     session,
     connection
   });
   let handledFocusKeysRef = useRef(new Set<string>());
+  let scrollToIndexRef = useRef<(index: number) => void>(() => {});
+
+  let handleScrollToIndexReady = useCallback((scrollToIndex: (index: number) => void) => {
+    scrollToIndexRef.current = scrollToIndex;
+  }, []);
 
   useEffect(() => {
     if (!focusedItemId) return;
     let focusKey = `${connection.id}:${focusedItemId}`;
     if (handledFocusKeysRef.current.has(focusKey)) return;
 
-    let id = window.requestAnimationFrame(() => {
-      let element = document.querySelector(
-        `[data-timeline-item-id="${focusedItemId}"]`
-      ) as HTMLElement | null;
-      if (!element) return;
+    let index = timelineItemData.findIndex(item => item.id === focusedItemId);
+    if (index < 0) return;
 
+    let id = window.requestAnimationFrame(() => {
+      scrollToIndexRef.current(index);
       handledFocusKeysRef.current.add(focusKey);
-      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
 
     return () => window.cancelAnimationFrame(id);
-  }, [connection.id, focusedItemId, timelineItems]);
+  }, [connection.id, focusedItemId, timelineItemData]);
 
   return (
     <DetailContent>
@@ -79,9 +87,16 @@ export let ConnectionLogs = ({
       />
 
       <DetailTimeline>
-        {sessionEntry}
-
-        <ItemList items={timelineItems} selectedItemId={focusedItemId} />
+        <VirtualizedTimelineList
+          context={timelineRowContext}
+          focusedItemId={focusedItemId}
+          hasMoreAfter={hasMoreAfter}
+          isLoadingMore={isLoadingMore}
+          items={timelineItemData}
+          loadMore={loadMore}
+          onScrollToIndexReady={handleScrollToIndexReady}
+          scrollRef={scrollRef}
+        />
 
         {!hasTimelineActivity && !isLoading && (
           <Callout color="gray">
@@ -90,6 +105,12 @@ export let ConnectionLogs = ({
         )}
 
         {isLoading && (
+          <LoadingWrap>
+            <CenteredSpinner size={16} />
+          </LoadingWrap>
+        )}
+
+        {isLoadingMore && hasTimelineActivity && (
           <LoadingWrap>
             <CenteredSpinner size={16} />
           </LoadingWrap>

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/components/sessionTraceTabsPane.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/components/sessionTraceTabsPane.tsx
@@ -1,5 +1,6 @@
 import { DashboardInstanceSessionsGetOutput } from '@metorial/dashboard-sdk';
 import { theme } from '@metorial/ui';
+import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { EditorTabItem, EditorTabs } from '../../../../../components/editorTabs';
 import { TracingConnectionItem } from '../types';
@@ -104,6 +105,21 @@ export let SessionTraceTabsPane = ({
   openTabs: EditorTabItem[];
   session: DashboardInstanceSessionsGetOutput;
 }) => {
+  let paneBodyRef = useRef<HTMLDivElement>(null);
+  let [mountedExplorerTabIds, setMountedExplorerTabIds] = useState<Set<string>>(
+    () => new Set()
+  );
+
+  useEffect(() => {
+    if (!activeTabId || !explorerTabIds.includes(activeTabId)) return;
+    setMountedExplorerTabIds(current => {
+      if (current.has(activeTabId)) return current;
+      let next = new Set(current);
+      next.add(activeTabId);
+      return next;
+    });
+  }, [activeTabId, explorerTabIds]);
+
   return (
     <PaneSection>
       <EditorTabs
@@ -115,6 +131,8 @@ export let SessionTraceTabsPane = ({
       />
 
       {explorerTabIds.map(id => {
+        if (!mountedExplorerTabIds.has(id)) return null;
+
         let connectionId = connectionIdByExplorerTabId[id];
         return (
           <ExplorerHost key={id} data-active={id === activeTabId}>
@@ -129,7 +147,7 @@ export let SessionTraceTabsPane = ({
       })}
 
       {!isExplorerActive && (
-        <PaneBody>
+        <PaneBody ref={paneBodyRef}>
           {activeTabId === CONNECT_TAB_ID ? (
             <ConnectTabPanel session={session} />
           ) : activeConnection ? (
@@ -137,6 +155,7 @@ export let SessionTraceTabsPane = ({
               session={session}
               connection={activeConnection}
               focusedItemId={focusedItemId}
+              scrollRef={paneBodyRef}
             />
           ) : (
             <DetailEmptyState>

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/components/timelineItemRow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/components/timelineItemRow.tsx
@@ -1,0 +1,139 @@
+import {
+  RiCornerUpRightDoubleLine,
+  RiErrorWarningLine,
+  RiPlugLine,
+  RiRadarLine,
+  RiSendPlane2Line,
+  RiServerLine
+} from '@remixicon/react';
+import { memo } from 'react';
+import { ProviderInvocationEntry } from '../../providerInvocations';
+import { Entry } from '../../session/components/entry';
+import { ProviderRunLogs } from '../../session/components/providerRunLogs';
+import { ExplorerCapabilitiesMessageGroup, Message } from '../../sessionMessages';
+import { TimelineItemData, TimelineRowContext } from '../types';
+
+let TimelineEventRow = memo(
+  ({ event }: { event: TimelineItemData & { kind: 'event' } }) => {
+    let type = event.event.type as string;
+
+    if (type === 'error_occurred') {
+      let errorMsg =
+        event.event.error?.code && event.event.error?.message
+          ? `${event.event.error.code} - ${event.event.error.message}`
+          : (event.event.error?.message ?? event.event.warning?.message ?? null);
+      return (
+        <Entry
+          icon={<RiErrorWarningLine />}
+          title={errorMsg ? `Error: ${errorMsg}` : 'Error occurred'}
+          time={event.time}
+          variant="error"
+        />
+      );
+    }
+
+    if (type === 'warning_occurred') {
+      let warningMsg =
+        event.event.warning?.code && event.event.warning?.message
+          ? `${event.event.warning.code} - ${event.event.warning.message}`
+          : (event.event.warning?.message ?? null);
+      return (
+        <Entry
+          icon={<RiErrorWarningLine />}
+          title={warningMsg ? `warning: ${warningMsg}` : 'warning occurred'}
+          time={event.time}
+          variant="warning"
+        />
+      );
+    }
+
+    if (type === 'provider_run_started') {
+      return (
+        <Entry icon={<RiServerLine />} title="Provider started" time={event.time} />
+      );
+    }
+
+    if (type === 'provider_run_stopped') {
+      return (
+        <Entry icon={<RiServerLine />} title="Provider stopped" time={event.time} />
+      );
+    }
+
+    if (type === 'connection_disconnected') {
+      return (
+        <Entry icon={<RiPlugLine />} title="Connection disconnected" time={event.time} />
+      );
+    }
+
+    return null;
+  }
+);
+
+TimelineEventRow.displayName = 'TimelineEventRow';
+
+export let TimelineItemRow = memo(
+  ({ context, item }: { context: TimelineRowContext; item: TimelineItemData }) => {
+    switch (item.kind) {
+      case 'session_created':
+        return (
+          <Entry
+            icon={<RiCornerUpRightDoubleLine />}
+            title="Session created"
+            time={item.time}
+          />
+        );
+
+      case 'connection_marker':
+        return (
+          <Entry
+            icon={item.variant === 'connected' ? <RiRadarLine /> : <RiSendPlane2Line />}
+            title={
+              item.variant === 'connected'
+                ? 'Client connected'
+                : 'Session connection created'
+            }
+            time={item.time}
+          />
+        );
+
+      case 'message': {
+        let message = context.messageById.get(item.messageId);
+        if (!message) return null;
+        return (
+          <Message message={message} aggregatedMessages={context.aggregatedMessages} />
+        );
+      }
+
+      case 'explorer_capabilities': {
+        let messages = item.messageIds
+          .map(id => context.messageById.get(id))
+          .filter((message): message is NonNullable<typeof message> => !!message);
+        if (!messages.length) return null;
+        return (
+          <ExplorerCapabilitiesMessageGroup
+            aggregatedMessages={context.aggregatedMessages}
+            clientName={context.clientName}
+            messages={messages}
+          />
+        );
+      }
+
+      case 'event':
+        return <TimelineEventRow event={item} />;
+
+      case 'provider_run_logs':
+        return <ProviderRunLogs providerRunId={item.providerRunId} lazy />;
+
+      case 'invocation': {
+        let invocation = context.invocationById.get(item.invocationId);
+        if (!invocation) return null;
+        return <ProviderInvocationEntry invocation={invocation} deferBody />;
+      }
+
+      default:
+        return null;
+    }
+  }
+);
+
+TimelineItemRow.displayName = 'TimelineItemRow';

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/components/virtualizedTimelineList.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/components/virtualizedTimelineList.tsx
@@ -1,0 +1,95 @@
+import { useVirtualizer, type VirtualItem } from '@tanstack/react-virtual';
+import { RefObject, useEffect, useMemo } from 'react';
+import styled from 'styled-components';
+import { TimelineItemData, TimelineRowContext } from '../types';
+import { TimelineItemRow } from './timelineItemRow';
+
+let ListWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+let ItemWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding-bottom: 20px;
+
+  &[data-selected='true'] {
+    scroll-margin-top: 16px;
+    border-radius: 8px;
+    outline: 2px solid rgba(59, 130, 246, 0.35);
+    outline-offset: 6px;
+  }
+`;
+
+export let VirtualizedTimelineList = ({
+  context,
+  focusedItemId,
+  hasMoreAfter,
+  isLoadingMore,
+  items,
+  loadMore,
+  onScrollToIndexReady,
+  scrollRef
+}: {
+  context: TimelineRowContext;
+  focusedItemId?: string | null;
+  hasMoreAfter?: boolean;
+  isLoadingMore?: boolean;
+  items: TimelineItemData[];
+  loadMore?: () => void;
+  onScrollToIndexReady?: (scrollToIndex: (index: number) => void) => void;
+  scrollRef: RefObject<HTMLElement | null>;
+}) => {
+  let sortedItems = useMemo(
+    () => [...items].sort((a, b) => a.time.getTime() - b.time.getTime()),
+    [items]
+  );
+
+  let virtualizer = useVirtualizer({
+    count: sortedItems.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 72,
+    overscan: 8,
+    measureElement: (element: Element) => element.getBoundingClientRect().height,
+    onChange: instance => {
+      if (!loadMore || !hasMoreAfter || isLoadingMore) return;
+      let virtualItems = instance.getVirtualItems();
+      if (!virtualItems.length) return;
+      if (virtualItems[0]?.index <= 2) loadMore();
+    }
+  });
+
+  useEffect(() => {
+    if (!onScrollToIndexReady) return;
+    onScrollToIndexReady(index => {
+      virtualizer.scrollToIndex(index, { align: 'start', behavior: 'smooth' });
+    });
+  }, [onScrollToIndexReady, virtualizer]);
+
+  return (
+    <ListWrapper style={{ height: `${virtualizer.getTotalSize()}px` }}>
+      {virtualizer.getVirtualItems().map((virtualRow: VirtualItem) => {
+        let item = sortedItems[virtualRow.index];
+        if (!item) return null;
+
+        return (
+          <ItemWrapper
+            key={item.id}
+            data-index={virtualRow.index}
+            ref={virtualizer.measureElement}
+            data-selected={focusedItemId && item.id === focusedItemId ? 'true' : undefined}
+            data-timeline-item-id={item.id}
+            style={{
+              transform: `translateY(${virtualRow.start}px)`
+            }}
+          >
+            <TimelineItemRow context={context} item={item} />
+          </ItemWrapper>
+        );
+      })}
+    </ListWrapper>
+  );
+};

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/hooks/useConnectionTimeline.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/hooks/useConnectionTimeline.tsx
@@ -3,35 +3,25 @@ import {
   DashboardInstanceSessionsMessagesGetOutput
 } from '@metorial/dashboard-sdk';
 import {
+  useAccumulatedProviderRuns,
+  useAccumulatedSessionEvents,
+  useAccumulatedSessionMessages,
   useCurrentInstance,
+  useDocumentVisible,
   useProviderInvocations,
-  useProviderRuns,
-  useSessionConnection,
-  useSessionEvents,
-  useSessionMessages
+  useSessionConnection
 } from '@metorial/state';
-import {
-  RiCornerUpRightDoubleLine,
-  RiErrorWarningLine,
-  RiPlugLine,
-  RiRadarLine,
-  RiSendPlane2Line,
-  RiServerLine
-} from '@remixicon/react';
 import { useEffect, useMemo, useRef } from 'react';
-import { ProviderInvocationEntry } from '../../providerInvocations';
-import { Entry } from '../../session/components/entry';
-import { ProviderRunLogs } from '../../session/components/providerRunLogs';
 import { useAggregatedMessages } from '../../session/hooks/useAggregatedMessages';
 import {
-  ExplorerCapabilitiesMessageGroup,
-  Message,
   getMessageMethod,
   isExplorerCapabilityMethod,
   shouldRenderStandaloneMessage
 } from '../../sessionMessages';
-import { SessionConnection, TimelineItem } from '../types';
+import { SessionConnection, TimelineItemData, TimelineRowContext } from '../types';
 import { formatConnectionLabel, getEventConnectionId } from '../utils';
+
+let TIMELINE_PAGE_SIZE = 50;
 
 export let useConnectionTimeline = ({
   session,
@@ -42,27 +32,29 @@ export let useConnectionTimeline = ({
 }) => {
   let instance = useCurrentInstance();
   let instanceId = instance.data?.id;
+  let documentVisible = useDocumentVisible();
+  let pausePolling = !documentVisible;
 
   let connectionQuery = useSessionConnection(instanceId, connectionProp.id);
   let connection = (connectionQuery.data ?? connectionProp) as SessionConnection;
 
-  let messages = useSessionMessages(instanceId, session.id, {
-    limit: 100,
+  let connectionQueryParams = {
+    limit: TIMELINE_PAGE_SIZE,
+    order: 'desc' as const,
     sessionConnectionId: [connection.id]
+  };
+
+  let messages = useAccumulatedSessionMessages(instanceId, session.id, connectionQueryParams, {
+    pausePolling
   });
-  let events = useSessionEvents(instanceId, session.id, {
-    limit: 100,
-    sessionConnectionId: [connection.id]
+  let events = useAccumulatedSessionEvents(instanceId, session.id, connectionQueryParams, {
+    pausePolling
   });
-  let providerRuns = useProviderRuns(instanceId, session.id, {
-    limit: 100,
-    sessionConnectionId: [connection.id]
+  let providerRuns = useAccumulatedProviderRuns(instanceId, session.id, connectionQueryParams, {
+    pausePolling
   });
 
-  let providerRunItems = useMemo(
-    () => providerRuns.data?.items ?? [],
-    [providerRuns.data?.items]
-  );
+  let providerRunItems = useMemo(() => providerRuns.items ?? [], [providerRuns.items]);
   let providerRunIds = useMemo(
     () => providerRunItems.map(run => run.id),
     [providerRunItems]
@@ -87,7 +79,7 @@ export let useConnectionTimeline = ({
   providerInvocationsLoadingRef.current = providerInvocations.isLoading;
 
   useEffect(() => {
-    if (!instanceId) return;
+    if (!instanceId || pausePolling) return;
     let id = setInterval(() => {
       refetchConnectionRef.current?.();
       refetchMessagesRef.current?.();
@@ -98,16 +90,16 @@ export let useConnectionTimeline = ({
       }
     }, 5_000);
     return () => clearInterval(id);
-  }, [instanceId, session.id, connection.id]);
+  }, [instanceId, pausePolling, session.id, connection.id]);
 
   let allMessages = useMemo(() => {
     let messageMap = new Map<string, DashboardInstanceSessionsMessagesGetOutput>();
 
-    for (let msg of messages.data?.items ?? []) {
+    for (let msg of messages.items ?? []) {
       messageMap.set(msg.id, msg);
     }
 
-    for (let evt of events.data?.items ?? []) {
+    for (let evt of events.items ?? []) {
       if (evt.type === 'message_created' && evt.message) {
         let evtMsg = evt.message as DashboardInstanceSessionsMessagesGetOutput;
         let existing = messageMap.get(evtMsg.id);
@@ -123,7 +115,7 @@ export let useConnectionTimeline = ({
       if (aId !== bId) return aId - bId;
       return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
     });
-  }, [events.data?.items, messages.data?.items]);
+  }, [events.items, messages.items]);
 
   let messageById = useMemo(
     () => new Map(allMessages.map(message => [message.id, message])),
@@ -138,6 +130,8 @@ export let useConnectionTimeline = ({
         connectionType?: string | null;
       })
     | undefined;
+  let clientName = mcp?.client?.name ?? connection.participant?.name ?? 'Client';
+
   let visibleMessages = useMemo(
     () =>
       allMessages.filter(message =>
@@ -145,41 +139,6 @@ export let useConnectionTimeline = ({
       ),
     [aggregatedMessages, allMessages]
   );
-
-  let messageItems = useMemo<TimelineItem[]>(() => {
-    let capabilityMessages = visibleMessages.filter(message =>
-      isExplorerCapabilityMethod(getMessageMethod(message, aggregatedMessages))
-    );
-    let capabilityMessageIds = new Set(capabilityMessages.map(message => message.id));
-    let clientName = mcp?.client?.name ?? connection.participant?.name ?? 'Client';
-    let items: TimelineItem[] = [];
-
-    if (capabilityMessages.length > 0) {
-      items.push({
-        id: capabilityMessages[0]?.id,
-        component: (
-          <ExplorerCapabilitiesMessageGroup
-            aggregatedMessages={aggregatedMessages}
-            clientName={clientName}
-            messages={capabilityMessages}
-          />
-        ),
-        time: capabilityMessages[0].createdAt
-      });
-    }
-
-    for (let message of visibleMessages) {
-      if (capabilityMessageIds.has(message.id)) continue;
-
-      items.push({
-        id: message.id,
-        component: <Message message={message} aggregatedMessages={aggregatedMessages} />,
-        time: message.createdAt
-      });
-    }
-
-    return items;
-  }, [aggregatedMessages, connection.participant?.name, mcp?.client?.name, visibleMessages]);
 
   let providerRunById = useMemo(
     () => new Map(providerRunItems.map(run => [run.id, run])),
@@ -190,13 +149,47 @@ export let useConnectionTimeline = ({
     () => providerInvocations.data?.items ?? [],
     [providerInvocations.data?.items]
   );
+  let invocationById = useMemo(
+    () => new Map(invocationItems.map(invocation => [invocation.id, invocation])),
+    [invocationItems]
+  );
   let hasInvocations = invocationItems.length > 0;
 
-  let eventItems = useMemo(() => {
-    let items: TimelineItem[] = [];
+  let messageItemData = useMemo<TimelineItemData[]>(() => {
+    let capabilityMessages = visibleMessages.filter(message =>
+      isExplorerCapabilityMethod(getMessageMethod(message, aggregatedMessages))
+    );
+    let capabilityMessageIds = new Set(capabilityMessages.map(message => message.id));
+    let items: TimelineItemData[] = [];
+
+    if (capabilityMessages.length > 0) {
+      items.push({
+        kind: 'explorer_capabilities',
+        id: capabilityMessages[0]?.id,
+        time: capabilityMessages[0].createdAt,
+        messageIds: capabilityMessages.map(message => message.id)
+      });
+    }
+
+    for (let message of visibleMessages) {
+      if (capabilityMessageIds.has(message.id)) continue;
+
+      items.push({
+        kind: 'message',
+        id: message.id,
+        time: message.createdAt,
+        messageId: message.id
+      });
+    }
+
+    return items;
+  }, [aggregatedMessages, visibleMessages]);
+
+  let eventItemData = useMemo<TimelineItemData[]>(() => {
+    let items: TimelineItemData[] = [];
     let renderedProviderRunLogs = new Set<string>();
 
-    for (let evt of events.data?.items ?? []) {
+    for (let evt of events.items ?? []) {
       if (getEventConnectionId(evt) !== connection.id) continue;
 
       let type = evt.type as string;
@@ -204,83 +197,33 @@ export let useConnectionTimeline = ({
       let providerRun = runId ? providerRunById.get(runId) : undefined;
       let providerRunLogTime = providerRun?.createdAt ?? evt.createdAt;
 
-      if (type === 'error_occurred') {
-        let errorMsg =
-          evt.error?.code && evt.error?.message
-            ? `${evt.error.code} - ${evt.error.message}`
-            : (evt.error?.message ?? evt.warning?.message ?? null);
+      if (
+        type === 'error_occurred' ||
+        type === 'warning_occurred' ||
+        type === 'provider_run_started' ||
+        type === 'provider_run_stopped' ||
+        type === 'connection_disconnected'
+      ) {
         items.push({
+          kind: 'event',
           id: evt.message?.id ?? evt.id,
-          component: (
-            <Entry
-              icon={<RiErrorWarningLine />}
-              title={errorMsg ? `Error: ${errorMsg}` : 'Error occurred'}
-              time={evt.createdAt}
-              variant="error"
-            />
-          ),
-          time: evt.createdAt
+          time: evt.createdAt,
+          event: evt
         });
-      } else if (type === 'warning_occurred') {
-        let warningMsg =
-          evt.warning?.code && evt.warning?.message
-            ? `${evt.warning.code} - ${evt.warning.message}`
-            : (evt.warning?.message ?? evt.warning?.message ?? null);
+      }
+
+      if (
+        !hasInvocations &&
+        runId &&
+        !renderedProviderRunLogs.has(runId) &&
+        (type === 'provider_run_started' || type === 'provider_run_stopped')
+      ) {
+        renderedProviderRunLogs.add(runId);
         items.push({
-          id: evt.message?.id ?? evt.id,
-          component: (
-            <Entry
-              icon={<RiErrorWarningLine />}
-              title={warningMsg ? `warning: ${warningMsg}` : 'warning occurred'}
-              time={evt.createdAt}
-              variant="warning"
-            />
-          ),
-          time: evt.createdAt
-        });
-      } else if (type === 'provider_run_started') {
-        items.push({
-          id: evt.message?.id ?? evt.id,
-          component: (
-            <Entry icon={<RiServerLine />} title="Provider started" time={evt.createdAt} />
-          ),
-          time: evt.createdAt
-        });
-        if (!hasInvocations && runId && !renderedProviderRunLogs.has(runId)) {
-          renderedProviderRunLogs.add(runId);
-          items.push({
-            id: runId,
-            component: <ProviderRunLogs providerRunId={runId} lazy />,
-            time: providerRunLogTime
-          });
-        }
-      } else if (type === 'provider_run_stopped') {
-        items.push({
-          id: evt.message?.id ?? evt.id,
-          component: (
-            <Entry icon={<RiServerLine />} title="Provider stopped" time={evt.createdAt} />
-          ),
-          time: evt.createdAt
-        });
-        if (!hasInvocations && runId && !renderedProviderRunLogs.has(runId)) {
-          renderedProviderRunLogs.add(runId);
-          items.push({
-            id: runId,
-            component: <ProviderRunLogs providerRunId={runId} lazy />,
-            time: providerRunLogTime
-          });
-        }
-      } else if (type === 'connection_disconnected') {
-        items.push({
-          id: evt.message?.id ?? evt.id,
-          component: (
-            <Entry
-              icon={<RiPlugLine />}
-              title="Connection disconnected"
-              time={evt.createdAt}
-            />
-          ),
-          time: evt.createdAt
+          kind: 'provider_run_logs',
+          id: runId,
+          time: providerRunLogTime,
+          providerRunId: runId
         });
       }
     }
@@ -288,16 +231,17 @@ export let useConnectionTimeline = ({
     if (!hasInvocations) {
       for (let run of providerRunItems) {
         if (!renderedProviderRunLogs.has(run.id)) {
-          let evtForConn = (events.data?.items ?? []).some(
+          let evtForConn = (events.items ?? []).some(
             event =>
               getEventConnectionId(event) === connection.id &&
               event.providerRun?.id === run.id
           );
           if (evtForConn) {
             items.push({
+              kind: 'provider_run_logs',
               id: run.id,
-              component: <ProviderRunLogs providerRunId={run.id} lazy />,
-              time: run.createdAt
+              time: run.createdAt,
+              providerRunId: run.id
             });
           }
         }
@@ -318,16 +262,17 @@ export let useConnectionTimeline = ({
       }
 
       items.push({
+        kind: 'invocation',
         id: invocation.id,
-        component: <ProviderInvocationEntry invocation={invocation} />,
-        time
+        time,
+        invocationId: invocation.id
       });
     }
 
     return items;
   }, [
     connection.id,
-    events.data?.items,
+    events.items,
     hasInvocations,
     invocationItems,
     messageById,
@@ -335,30 +280,47 @@ export let useConnectionTimeline = ({
     providerRunItems
   ]);
 
-  let timelineItems = useMemo<TimelineItem[]>(
+  let timelineItemData = useMemo<TimelineItemData[]>(
     () => [
       {
-        id: connection.id,
-        component: (
-          <Entry icon={<RiRadarLine />} title="Client connected" time={connection.createdAt} />
-        ),
-        time: connection.createdAt
+        kind: 'session_created',
+        id: `${session.id}__session_created`,
+        time: session.createdAt
       },
       {
-        id: `${connection.id}__created`,
-        component: (
-          <Entry
-            icon={<RiSendPlane2Line />}
-            title="Session connection created"
-            time={connection.createdAt}
-          />
-        ),
-        time: connection.createdAt
+        kind: 'connection_marker',
+        id: connection.id,
+        time: connection.createdAt,
+        variant: 'connected'
       },
-      ...eventItems,
-      ...messageItems
+      {
+        kind: 'connection_marker',
+        id: `${connection.id}__created`,
+        time: connection.createdAt,
+        variant: 'created'
+      },
+      ...eventItemData,
+      ...messageItemData
     ],
-    [connection.createdAt, eventItems, messageItems]
+    [
+      connection.createdAt,
+      connection.id,
+      eventItemData,
+      messageItemData,
+      session.createdAt,
+      session.id
+    ]
+  );
+
+  let timelineRowContext = useMemo<TimelineRowContext>(
+    () => ({
+      aggregatedMessages,
+      clientName,
+      invocationById,
+      messageById,
+      session
+    }),
+    [aggregatedMessages, clientName, invocationById, messageById, session]
   );
 
   let connectionProviders = useMemo(() => {
@@ -371,24 +333,32 @@ export let useConnectionTimeline = ({
     return (session.providers ?? []).filter(provider => sessionProviderIds.has(provider.id));
   }, [providerRunItems, session.providers]);
 
+  let hasMoreAfter =
+    messages.hasMoreAfter || events.hasMoreAfter || providerRuns.hasMoreAfter;
+  let isLoadingMore =
+    messages.isLoadingMore || events.isLoadingMore || providerRuns.isLoadingMore;
+
+  let loadMore = () => {
+    if (messages.hasMoreAfter) messages.loadMore();
+    if (events.hasMoreAfter) events.loadMore();
+    if (providerRuns.hasMoreAfter) providerRuns.loadMore();
+  };
+
   return {
     connection,
     connectionName: formatConnectionLabel(connection, session),
     connectionProviders,
+    hasMoreAfter,
+    hasTimelineActivity: timelineItemData.length > 3,
     isLoading:
       messages.isLoading ||
       events.isLoading ||
       providerRuns.isLoading ||
       (providerRunIds.length > 0 && providerInvocations.isLoading),
-    hasTimelineActivity: timelineItems.length > 2,
+    isLoadingMore,
+    loadMore,
     mcp,
-    timelineItems,
-    sessionEntry: (
-      <Entry
-        icon={<RiCornerUpRightDoubleLine />}
-        title="Session created"
-        time={session.createdAt}
-      />
-    )
+    timelineItemData,
+    timelineRowContext
   };
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/providerErrorScene.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/providerErrorScene.tsx
@@ -306,6 +306,7 @@ export let ProviderErrorTracingScene = ({ errorGroupId }: { errorGroupId: string
 
   let listBodyRef = useRef<HTMLDivElement>(null);
   let listHeaderRef = useRef<HTMLDivElement>(null);
+  let rightPaneBodyRef = useRef<HTMLDivElement>(null);
 
   let isLoadingConnections = errors.isLoading || connections.isLoading;
   let connectionCount = connectionItems.length;
@@ -348,8 +349,12 @@ export let ProviderErrorTracingScene = ({ errorGroupId }: { errorGroupId: string
                   <CenteredSpinner size={16} />
                 </LoadingWrap>
               ) : (
-                <RightPaneBody>
-                  <ConnectionLogs connection={activeConnection} session={activeSession.data} />
+                <RightPaneBody ref={rightPaneBodyRef}>
+                  <ConnectionLogs
+                    connection={activeConnection}
+                    scrollRef={rightPaneBodyRef}
+                    session={activeSession.data}
+                  />
                 </RightPaneBody>
               )
             ) : isLoadingConnections ? (

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/types.ts
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/types.ts
@@ -1,8 +1,12 @@
 import {
+  DashboardInstanceProviderInvocationsListOutput,
   DashboardInstanceSessionsConnectionsListOutput,
-  DashboardInstanceSessionsEventsListOutput
+  DashboardInstanceSessionsEventsListOutput,
+  DashboardInstanceSessionsGetOutput,
+  DashboardInstanceSessionsMessagesGetOutput
 } from '@metorial/dashboard-sdk';
 import { ReactNode } from 'react';
+import type { AggregatedMessages } from '../session/hooks/useAggregatedMessages';
 
 export type SessionEvent = DashboardInstanceSessionsEventsListOutput['items'][number];
 export type SessionConnection =
@@ -24,3 +28,28 @@ export type GroupedConnectionItems = {
   dayTime: number;
 };
 export type TimelineItem = { id?: string; component: ReactNode; time: Date };
+
+export type TimelineItemData =
+  | { kind: 'session_created'; id: string; time: Date }
+  | {
+      kind: 'connection_marker';
+      id: string;
+      time: Date;
+      variant: 'connected' | 'created';
+    }
+  | { kind: 'message'; id: string; time: Date; messageId: string }
+  | { kind: 'explorer_capabilities'; id: string; time: Date; messageIds: string[] }
+  | { kind: 'event'; id: string; time: Date; event: SessionEvent }
+  | { kind: 'provider_run_logs'; id: string; time: Date; providerRunId: string }
+  | { kind: 'invocation'; id: string; time: Date; invocationId: string };
+
+export type TimelineRowContext = {
+  aggregatedMessages: Map<string, AggregatedMessages>;
+  clientName: string;
+  invocationById: Map<
+    string,
+    DashboardInstanceProviderInvocationsListOutput['items'][number]
+  >;
+  messageById: Map<string, DashboardInstanceSessionsMessagesGetOutput>;
+  session: DashboardInstanceSessionsGetOutput;
+};

--- a/src/frontend/state/src/lib/useAccumulatedPaginatedLoader.ts
+++ b/src/frontend/state/src/lib/useAccumulatedPaginatedLoader.ts
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+type PaginatedItems<TItem extends { id: string }> = {
+  items: TItem[];
+  pagination: {
+    hasMoreAfter: boolean;
+    hasMoreBefore?: boolean;
+  };
+};
+
+type LoaderResult<TItem extends { id: string }> = {
+  data: PaginatedItems<TItem> | null;
+  isLoading: boolean;
+  error: unknown;
+  refetch?: () => void;
+};
+
+type LoaderParams<TParams> = (TParams & { after?: string }) | null;
+
+let DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+export let useAccumulatedPaginatedLoader = <
+  TItem extends { id: string },
+  TParams extends Record<string, unknown>
+>({
+  enabledParams,
+  queryKey,
+  useLoader,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  pausePolling = false
+}: {
+  enabledParams: TParams | null;
+  queryKey: string;
+  useLoader: (params: LoaderParams<TParams>) => LoaderResult<TItem>;
+  pollIntervalMs?: number;
+  pausePolling?: boolean;
+}) => {
+  let [after, setAfter] = useState<string | undefined>(undefined);
+  let [pendingAfter, setPendingAfter] = useState<string | null>(null);
+  let [itemsMap, setItemsMap] = useState<Map<string, TItem>>(() => new Map());
+
+  useEffect(() => {
+    setAfter(undefined);
+    setPendingAfter(null);
+    setItemsMap(new Map());
+  }, [queryKey]);
+
+  let firstPage = useLoader(enabledParams);
+  let cursorPage = useLoader(
+    enabledParams && after !== undefined
+      ? ({ ...enabledParams, after } as TParams & { after?: string })
+      : null
+  );
+
+  useEffect(() => {
+    let firstItems = firstPage.data?.items ?? [];
+    let cursorItems = cursorPage.data?.items ?? [];
+    if (!firstItems.length && !cursorItems.length) return;
+
+    setItemsMap(current => {
+      let next = new Map(current);
+      for (let item of firstItems) next.set(item.id, item);
+      for (let item of cursorItems) next.set(item.id, item);
+      return next;
+    });
+  }, [firstPage.data?.items, cursorPage.data?.items]);
+
+  useEffect(() => {
+    if (!pendingAfter) return;
+    if (after !== pendingAfter) return;
+    if (!cursorPage.data && !cursorPage.error) return;
+    setPendingAfter(null);
+  }, [after, cursorPage.data, cursorPage.error, pendingAfter]);
+
+  let refetchFirstPageRef = useRef(firstPage.refetch);
+  refetchFirstPageRef.current = firstPage.refetch;
+
+  useEffect(() => {
+    if (!enabledParams || pausePolling) return;
+    let id = setInterval(() => {
+      refetchFirstPageRef.current?.();
+    }, pollIntervalMs);
+    return () => clearInterval(id);
+  }, [enabledParams, pausePolling, pollIntervalMs, queryKey]);
+
+  let items = useMemo(() => Array.from(itemsMap.values()), [itemsMap]);
+
+  let pageForPagination = after !== undefined ? cursorPage : firstPage;
+  let hasMoreAfter = pageForPagination.data?.pagination.hasMoreAfter ?? false;
+  let isLoading = firstPage.isLoading && items.length === 0;
+  let isLoadingMore = pendingAfter !== null;
+
+  let loadMore = () => {
+    if (pendingAfter !== null || firstPage.isLoading || cursorPage.isLoading) return;
+    let currentItems = pageForPagination.data?.items ?? [];
+    let lastItem = currentItems[currentItems.length - 1];
+    if (!lastItem || !hasMoreAfter) return;
+    setPendingAfter(lastItem.id);
+    setAfter(current => (current === lastItem.id ? current : lastItem.id));
+  };
+
+  return {
+    ...firstPage,
+    isLoading,
+    data: firstPage.data
+      ? {
+          ...firstPage.data,
+          items,
+          pagination: {
+            ...firstPage.data.pagination,
+            hasMoreBefore: false,
+            hasMoreAfter
+          }
+        }
+      : null,
+    items,
+    hasMoreAfter,
+    hasMoreBefore: false,
+    isLoadingMore,
+    loadMore,
+    reset: () => {
+      setAfter(undefined);
+      setPendingAfter(null);
+      setItemsMap(new Map());
+    }
+  };
+};

--- a/src/frontend/state/src/lib/useDocumentVisible.ts
+++ b/src/frontend/state/src/lib/useDocumentVisible.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+export let useDocumentVisible = () => {
+  let [visible, setVisible] = useState(() =>
+    typeof document === 'undefined' ? true : !document.hidden
+  );
+
+  useEffect(() => {
+    let onChange = () => setVisible(!document.hidden);
+    document.addEventListener('visibilitychange', onChange);
+    return () => document.removeEventListener('visibilitychange', onChange);
+  }, []);
+
+  return visible;
+};

--- a/src/frontend/state/src/session/index.ts
+++ b/src/frontend/state/src/session/index.ts
@@ -8,3 +8,4 @@ export * from './loaders/sessions';
 export * from './loaders/sessionTemplateProviders';
 export * from './loaders/sessionTemplates';
 export * from './loaders/toolCalls';
+export { useDocumentVisible } from '../lib/useDocumentVisible';

--- a/src/frontend/state/src/session/loaders/providerRun.ts
+++ b/src/frontend/state/src/session/loaders/providerRun.ts
@@ -1,5 +1,10 @@
-import { DashboardInstanceProviderRunsListQuery } from '@metorial/dashboard-sdk';
+import {
+  DashboardInstanceProviderRunsListOutput,
+  DashboardInstanceProviderRunsListQuery
+} from '@metorial/dashboard-sdk';
 import { createLoader } from '@metorial/data-hooks';
+import { useMemo } from 'react';
+import { useAccumulatedPaginatedLoader } from '../../lib/useAccumulatedPaginatedLoader';
 import { usePaginator } from '../../lib/usePaginator';
 import { withAuth } from '../../user';
 
@@ -54,6 +59,44 @@ export let useProviderRuns = (
   );
 
   return data;
+};
+
+type ProviderRunsItem = DashboardInstanceProviderRunsListOutput['items'][number];
+
+export let useAccumulatedProviderRuns = (
+  instanceId: string | null | undefined,
+  sessionId: string | null | undefined,
+  query?: DashboardInstanceProviderRunsListQuery,
+  options?: { pollIntervalMs?: number; pausePolling?: boolean }
+) => {
+  let queryKey = useMemo(
+    () =>
+      JSON.stringify({
+        instanceId: instanceId ?? null,
+        sessionId: sessionId ?? null,
+        query: query ?? null
+      }),
+    [instanceId, query, sessionId]
+  );
+
+  let enabledParams =
+    instanceId && sessionId
+      ? ({ instanceId, sessionId, ...query } as {
+          instanceId: string;
+          sessionId: string;
+        } & DashboardInstanceProviderRunsListQuery)
+      : null;
+
+  return useAccumulatedPaginatedLoader<
+    ProviderRunsItem,
+    { instanceId: string; sessionId: string } & DashboardInstanceProviderRunsListQuery
+  >({
+    enabledParams,
+    queryKey,
+    useLoader: params => providerRunsLoader.use(params),
+    pollIntervalMs: options?.pollIntervalMs,
+    pausePolling: options?.pausePolling
+  });
 };
 
 export let providerRunLoader = createLoader({

--- a/src/frontend/state/src/session/loaders/sessionEvents.ts
+++ b/src/frontend/state/src/session/loaders/sessionEvents.ts
@@ -1,9 +1,15 @@
-import { DashboardInstanceSessionsEventsListQuery } from '@metorial/dashboard-sdk';
+import {
+  DashboardInstanceSessionsEventsListOutput,
+  DashboardInstanceSessionsEventsListQuery
+} from '@metorial/dashboard-sdk';
 import { createLoader } from '@metorial/data-hooks';
+import { useMemo } from 'react';
+import { useAccumulatedPaginatedLoader } from '../../lib/useAccumulatedPaginatedLoader';
 import { usePaginator } from '../../lib/usePaginator';
 import { withAuth } from '../../user';
 
 type SessionEventsQuery = Omit<DashboardInstanceSessionsEventsListQuery, 'sessionId'>;
+type SessionEventsItem = DashboardInstanceSessionsEventsListOutput['items'][number];
 
 export let sessionEventsLoader = createLoader({
   name: 'sessionEvents',
@@ -51,4 +57,35 @@ export let useSessionEvent = (
   );
 
   return data;
+};
+
+export let useAccumulatedSessionEvents = (
+  instanceId: string | null | undefined,
+  sessionId: string | null | undefined,
+  query?: SessionEventsQuery,
+  options?: { pollIntervalMs?: number; pausePolling?: boolean }
+) => {
+  let queryKey = useMemo(
+    () =>
+      JSON.stringify({
+        instanceId: instanceId ?? null,
+        sessionId: sessionId ?? null,
+        query: query ?? null
+      }),
+    [instanceId, query, sessionId]
+  );
+
+  let enabledParams =
+    instanceId && sessionId ? { instanceId, sessionId, ...query } : null;
+
+  return useAccumulatedPaginatedLoader<
+    SessionEventsItem,
+    { instanceId: string; sessionId: string } & SessionEventsQuery
+  >({
+    enabledParams,
+    queryKey,
+    useLoader: params => sessionEventsLoader.use(params),
+    pollIntervalMs: options?.pollIntervalMs,
+    pausePolling: options?.pausePolling
+  });
 };

--- a/src/frontend/state/src/session/loaders/sessionMessages.ts
+++ b/src/frontend/state/src/session/loaders/sessionMessages.ts
@@ -1,9 +1,15 @@
-import { DashboardInstanceSessionsMessagesListQuery } from '@metorial/dashboard-sdk';
+import {
+  DashboardInstanceSessionsMessagesListOutput,
+  DashboardInstanceSessionsMessagesListQuery
+} from '@metorial/dashboard-sdk';
 import { createLoader } from '@metorial/data-hooks';
+import { useMemo } from 'react';
+import { useAccumulatedPaginatedLoader } from '../../lib/useAccumulatedPaginatedLoader';
 import { usePaginator } from '../../lib/usePaginator';
 import { withAuth } from '../../user';
 
 type SessionMessagesQuery = Omit<DashboardInstanceSessionsMessagesListQuery, 'sessionId'>;
+type SessionMessagesItem = DashboardInstanceSessionsMessagesListOutput['items'][number];
 
 export let sessionMessagesLoader = createLoader({
   name: 'sessionMessages',
@@ -51,4 +57,35 @@ export let useSessionMessage = (
   );
 
   return data;
+};
+
+export let useAccumulatedSessionMessages = (
+  instanceId: string | null | undefined,
+  sessionId: string | null | undefined,
+  query?: SessionMessagesQuery,
+  options?: { pollIntervalMs?: number; pausePolling?: boolean }
+) => {
+  let queryKey = useMemo(
+    () =>
+      JSON.stringify({
+        instanceId: instanceId ?? null,
+        sessionId: sessionId ?? null,
+        query: query ?? null
+      }),
+    [instanceId, query, sessionId]
+  );
+
+  let enabledParams =
+    instanceId && sessionId ? { instanceId, sessionId, ...query } : null;
+
+  return useAccumulatedPaginatedLoader<
+    SessionMessagesItem,
+    { instanceId: string; sessionId: string } & SessionMessagesQuery
+  >({
+    enabledParams,
+    queryKey,
+    useLoader: params => sessionMessagesLoader.use(params),
+    pollIntervalMs: options?.pollIntervalMs,
+    pausePolling: options?.pausePolling
+  });
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core session-tracing rendering and data-loading/polling behavior (virtualization, pagination, and scroll-to-focus), which could introduce missing/duplicated rows or scroll glitches if edge cases are missed.
> 
> **Overview**
> Improves session trace performance by **virtualizing the connection timeline** (via `@tanstack/react-virtual`) and replacing the previous full in-memory list render with a `VirtualizedTimelineList` that supports incremental loading.
> 
> Refactors `useConnectionTimeline` to build lightweight `TimelineItemData` + `TimelineRowContext` and to use new accumulated/paginated loaders (`useAccumulatedSessionMessages`/`useAccumulatedSessionEvents`/`useAccumulatedProviderRuns`), including *load-more* state and pausing polling when the document is hidden.
> 
> Adds viewport-based deferred rendering for heavy bodies (message cards and provider invocation logs) using `useInView`, updates focus scrolling to target a virtualized index, and ensures trace panes pass a scroll container ref (including the provider error tracing scene).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a29eb739a3ecb4553543d79200db229bd13f55ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->