### PR TITLE
Harden subspace relations

### DIFF
--- a/src/backend/apis/connection/src/magic.ts
+++ b/src/backend/apis/connection/src/magic.ts
@@ -20,6 +20,7 @@ import {
   resolveMagicMcpTargetByIdOrAliasSafe,
   syncMagicMcpSubspaceSession
 } from '@metorial/module-magic';
+import { assertMagicMcpTargetLinkedResourcesActive } from '@metorial/module-magic';
 import {
   proxyMcpRequestToSubspace,
   type SubspaceProxyAgentClient
@@ -253,6 +254,8 @@ export let resolveMagicMcpSubspaceSession = async (d: {
       magicMcpTarget
     });
   }
+
+  await assertMagicMcpTargetLinkedResourcesActive(magicMcpTarget);
 
   let subspaceSessionId = await ensureMagicMcpSubspaceSession(magicMcpTarget);
   let consumerToken = magicMcpToken

--- a/src/backend/modules/magic/src/index.ts
+++ b/src/backend/modules/magic/src/index.ts
@@ -3,6 +3,7 @@ import { magicQueues } from './queues';
 
 export * from './lib/ensureSession';
 export * from './lib/backing';
+export * from './lib/magicMcpConnectHealth';
 export * from './lib/magicMcpTarget';
 export * from './queues';
 export * from './services';

--- a/src/backend/modules/magic/src/lib/backing.ts
+++ b/src/backend/modules/magic/src/lib/backing.ts
@@ -166,19 +166,6 @@ export let ensureMagicMcpServerBacking = async (d: {
   isReconciliation?: boolean;
 }) =>
   withLocalBackingLock(`server:${d.server.id}`, async () => {
-    if (d.isReconciliation && !d.providers?.length) {
-      let existing = await db.magicMcpServer.findFirst({
-        where: {
-          instanceOid: d.instance.oid,
-          id: d.server.id
-        }
-      });
-
-      if (existing?.hasSubspaceBacking && existing.subspaceEphemeralManagedSessionId) {
-        return existing;
-      }
-    }
-
     let owner =
       d.owner ??
       (await getConsumerOwnerForServer({
@@ -253,20 +240,6 @@ export let ensureMagicMcpEndpointBacking = async (d: {
   isReconciliation?: boolean;
 }) =>
   withLocalBackingLock(`endpoint:${d.endpoint.id}`, async () => {
-    if (d.isReconciliation) {
-      let existing = await db.magicMcpEndpoint.findFirst({
-        where: {
-          instanceOid: d.instance.oid,
-          id: d.endpoint.id
-        },
-        include: magicMcpEndpointBackingInclude
-      });
-
-      if (existing?.hasSubspaceBacking && existing.subspaceEphemeralManagedSessionId) {
-        return existing;
-      }
-    }
-
     await ensureEndpointServerIds(d.endpoint);
 
     let endpoint = await db.magicMcpEndpoint.findUniqueOrThrow({

--- a/src/backend/modules/magic/src/lib/ensureSession.ts
+++ b/src/backend/modules/magic/src/lib/ensureSession.ts
@@ -1,22 +1,20 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { ID, Instance, withTransaction } from '@metorial/db';
 import { ensureMagicMcpEndpointBacking, ensureMagicMcpServerBacking } from './backing';
+import { assertMagicMcpTargetReadyForConnect } from './magicMcpConnectHealth';
 import { MagicMcpResolvedTarget } from './magicMcpTarget';
 
 let ensureServerBackingSession = async (
   target: MagicMcpResolvedTarget & { type: 'server' }
 ) => {
-  let server = target.target;
-  if (!server.hasSubspaceBacking || !server.subspaceEphemeralManagedSessionId) {
-    server = {
-      ...server,
-      ...(await ensureMagicMcpServerBacking({
-        instance: server.instance as Instance,
-        server,
-        isReconciliation: true
-      }))
-    };
-  }
+  let server = {
+    ...target.target,
+    ...(await ensureMagicMcpServerBacking({
+      instance: target.target.instance as Instance,
+      server: target.target,
+      isReconciliation: true
+    }))
+  };
 
   if (!server.subspaceEphemeralManagedSessionId) {
     throw new ServiceError(
@@ -27,25 +25,25 @@ let ensureServerBackingSession = async (
     );
   }
 
+  await assertMagicMcpTargetReadyForConnect({
+    type: 'server',
+    target: {
+      ...target.target,
+      ...server
+    }
+  });
+
   return server.subspaceEphemeralManagedSessionId;
 };
 
 let ensureEndpointBackingSession = async (
   target: MagicMcpResolvedTarget & { type: 'endpoint' }
 ) => {
-  let endpoint = target.target;
-  if (!endpoint.hasSubspaceBacking || !endpoint.subspaceEphemeralManagedSessionId) {
-    let backingEndpoint = await ensureMagicMcpEndpointBacking({
-      instance: endpoint.instance as Instance,
-      endpoint,
-      isReconciliation: true
-    });
-    endpoint = {
-      ...endpoint,
-      subspaceEphemeralManagedSessionId: backingEndpoint.subspaceEphemeralManagedSessionId,
-      hasSubspaceBacking: backingEndpoint.hasSubspaceBacking
-    };
-  }
+  let endpoint = await ensureMagicMcpEndpointBacking({
+    instance: target.target.instance as Instance,
+    endpoint: target.target,
+    isReconciliation: true
+  });
 
   if (!endpoint.subspaceEphemeralManagedSessionId) {
     throw new ServiceError(
@@ -55,6 +53,14 @@ let ensureEndpointBackingSession = async (
       })
     );
   }
+
+  await assertMagicMcpTargetReadyForConnect({
+    type: 'endpoint',
+    target: {
+      ...target.target,
+      ...endpoint
+    }
+  });
 
   return endpoint.subspaceEphemeralManagedSessionId;
 };

--- a/src/backend/modules/magic/src/lib/magicMcpConnectHealth.ts
+++ b/src/backend/modules/magic/src/lib/magicMcpConnectHealth.ts
@@ -1,0 +1,144 @@
+import {
+  badRequestError,
+  preconditionFailedError,
+  ServiceError,
+  unauthorizedError
+} from '@lowerdeck/error';
+import { db, type Instance } from '@metorial/db';
+import { subspaceMagicMcpBackingService } from '@metorial/module-subspace';
+import { MagicMcpResolvedTarget } from './magicMcpTarget';
+
+let getInactiveLinkedResourceMessage = (resource: 'server' | 'endpoint' | 'group') => {
+  if (resource === 'server') {
+    return 'The magic MCP server is no longer active';
+  }
+  if (resource === 'endpoint') {
+    return 'The magic MCP endpoint is no longer active';
+  }
+  return 'The magic MCP group is no longer active';
+};
+
+export let assertMagicMcpTargetLinkedResourcesActive = async (
+  target: MagicMcpResolvedTarget
+) => {
+  if (target.type === 'server') {
+    if (target.target.status !== 'active') {
+      throw new ServiceError(
+        preconditionFailedError({
+          message: getInactiveLinkedResourceMessage('server')
+        })
+      );
+    }
+    return;
+  }
+
+  if (target.target.status !== 'active') {
+    throw new ServiceError(
+      preconditionFailedError({
+        message: getInactiveLinkedResourceMessage('endpoint')
+      })
+    );
+  }
+
+  let inactiveEndpointServerCount = await db.magicMcpEndpointServer.count({
+    where: {
+      magicMcpEndpointOid: target.target.oid,
+      magicMcpServer: {
+        status: {
+          not: 'active'
+        }
+      }
+    }
+  });
+
+  if (inactiveEndpointServerCount > 0) {
+    throw new ServiceError(
+      preconditionFailedError({
+        message:
+          'The magic MCP endpoint is linked to one or more magic MCP servers that are no longer active'
+      })
+    );
+  }
+};
+
+export let assertMagicMcpServerBackingProvidersActive = async (d: {
+  instance: Instance;
+  magicMcpServerBackingId: string;
+}) => {
+  let result = await subspaceMagicMcpBackingService.listServerProviders({
+    instance: d.instance,
+    magicMcpServerBackingIds: [d.magicMcpServerBackingId],
+    status: ['active'],
+    limit: 1
+  });
+
+  if (!result.items.length) {
+    throw new ServiceError(
+      preconditionFailedError({
+        message: 'Magic MCP server has no active providers and cannot accept connections.',
+        code: 'magic_mcp_backing_providers_unavailable'
+      })
+    );
+  }
+};
+
+export let assertMagicMcpEndpointBackingProvidersActive = async (d: {
+  instance: Instance;
+  endpointOid: bigint;
+}) => {
+  let endpointServers = await db.magicMcpEndpointServer.findMany({
+    where: {
+      magicMcpEndpointOid: d.endpointOid,
+      magicMcpServer: {
+        status: 'active'
+      }
+    },
+    select: {
+      magicMcpServer: {
+        select: {
+          id: true,
+          status: true
+        }
+      }
+    }
+  });
+
+  if (!endpointServers.length) {
+    throw new ServiceError(
+      preconditionFailedError({
+        message: 'Magic MCP endpoint has no active servers and cannot accept connections.',
+        code: 'magic_mcp_endpoint_servers_unavailable'
+      })
+    );
+  }
+
+  for (let endpointServer of endpointServers) {
+    await assertMagicMcpServerBackingProvidersActive({
+      instance: d.instance,
+      magicMcpServerBackingId: endpointServer.magicMcpServer.id
+    });
+  }
+};
+
+export let assertMagicMcpTargetReadyForConnect = async (target: MagicMcpResolvedTarget) => {
+  await assertMagicMcpTargetLinkedResourcesActive(target);
+
+  if (target.type === 'server') {
+    await assertMagicMcpServerBackingProvidersActive({
+      instance: target.target.instance as Instance,
+      magicMcpServerBackingId: target.target.id
+    });
+    return;
+  }
+
+  await assertMagicMcpEndpointBackingProvidersActive({
+    instance: target.target.instance as Instance,
+    endpointOid: target.target.oid
+  });
+};
+
+export let getMagicMcpConnectUnauthorizedMessage = (message: string) =>
+  new ServiceError(unauthorizedError({ message }));
+
+export let getMagicMcpConnectBadRequestMessage = (message: string) =>
+  new ServiceError(badRequestError({ message }));

--- a/src/backend/modules/magic/src/services/magicMcpEndpoint.ts
+++ b/src/backend/modules/magic/src/services/magicMcpEndpoint.ts
@@ -397,9 +397,18 @@ class MagicMcpEndpointImpl {
       },
       select: {
         id: true,
-        oid: true
+        oid: true,
+        status: true
       }
     });
+
+    if (servers.some(server => server.status !== 'active')) {
+      throw new ServiceError(
+        preconditionFailedError({
+          message: 'Magic MCP endpoints can only be linked to active magic MCP servers'
+        })
+      );
+    }
 
     let magicMcpEndpoint = await withTransaction(async db => {
       if (servers.length) {

--- a/src/backend/modules/magic/src/services/magicMcpServer.ts
+++ b/src/backend/modules/magic/src/services/magicMcpServer.ts
@@ -286,6 +286,12 @@ class MagicMcpServerImpl {
     }
 
     let magicMcpServer = await withTransaction(async db => {
+      await db.magicMcpEndpointServer.deleteMany({
+        where: {
+          magicMcpServerOid: d.server.oid
+        }
+      });
+
       return await db.magicMcpServer.update({
         where: { id: d.server.id },
         data: { status: 'archived', deletedAt: new Date() },

--- a/src/backend/modules/magic/test/ensureSession.test.ts
+++ b/src/backend/modules/magic/test/ensureSession.test.ts
@@ -1,21 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@metorial/db', () => ({
-  ID: {
-    generateId: vi.fn().mockResolvedValue('generated-id')
-  },
-  withTransaction: vi.fn(async callback => await callback({}))
-}));
-
 vi.mock('../src/lib/backing', () => ({
   ensureMagicMcpServerBacking: vi.fn(),
   ensureMagicMcpEndpointBacking: vi.fn()
+}));
+
+vi.mock('../src/lib/magicMcpConnectHealth', () => ({
+  assertMagicMcpTargetReadyForConnect: vi.fn()
+}));
+
+vi.mock('@metorial/db', () => ({
+  db: {},
+  ID: {
+    generateId: vi.fn()
+  },
+  withTransaction: vi.fn()
 }));
 
 import {
   ensureMagicMcpEndpointBacking,
   ensureMagicMcpServerBacking
 } from '../src/lib/backing';
+import { assertMagicMcpTargetReadyForConnect } from '../src/lib/magicMcpConnectHealth';
 import { ensureMagicMcpSubspaceSession } from '../src/lib/ensureSession';
 
 describe('ensureMagicMcpSubspaceSession', () => {
@@ -23,31 +29,16 @@ describe('ensureMagicMcpSubspaceSession', () => {
     vi.clearAllMocks();
   });
 
-  it('uses an existing server backing ephemeral managed session id', async () => {
-    let result = await ensureMagicMcpSubspaceSession({
-      type: 'server',
-      target: {
-        id: 'server-1',
-        hasSubspaceBacking: true,
-        subspaceEphemeralManagedSessionId: 'ems_1',
-        instance: { id: 'ins_1' }
-      } as any
-    });
-
-    expect(result).toBe('ems_1');
-    expect(ensureMagicMcpServerBacking).not.toHaveBeenCalled();
-  });
-
   it('reconciles a server before returning its backing session id', async () => {
     vi.mocked(ensureMagicMcpServerBacking).mockResolvedValue({
       hasSubspaceBacking: true,
-      subspaceEphemeralManagedSessionId: 'ems_2'
+      subspaceEphemeralManagedSessionId: 'ems_1'
     } as any);
 
     let target = {
-      id: 'server-2',
-      hasSubspaceBacking: false,
-      subspaceEphemeralManagedSessionId: null,
+      id: 'server-1',
+      hasSubspaceBacking: true,
+      subspaceEphemeralManagedSessionId: 'ems_1',
       instance: { id: 'ins_1' }
     } as any;
     let result = await ensureMagicMcpSubspaceSession({ type: 'server', target });
@@ -57,7 +48,8 @@ describe('ensureMagicMcpSubspaceSession', () => {
       server: target,
       isReconciliation: true
     });
-    expect(result).toBe('ems_2');
+    expect(assertMagicMcpTargetReadyForConnect).toHaveBeenCalled();
+    expect(result).toBe('ems_1');
   });
 
   it('reconciles an endpoint before returning its backing session id', async () => {
@@ -79,6 +71,7 @@ describe('ensureMagicMcpSubspaceSession', () => {
       endpoint: target,
       isReconciliation: true
     });
+    expect(assertMagicMcpTargetReadyForConnect).toHaveBeenCalled();
     expect(result).toBe('ems_endpoint');
   });
 });

--- a/src/backend/modules/magic/test/magicMcpConnectHealth.test.ts
+++ b/src/backend/modules/magic/test/magicMcpConnectHealth.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let magicMcpEndpointServerCount = vi.hoisted(() => vi.fn());
+let listServerProviders = vi.hoisted(() => vi.fn());
+
+vi.mock('@metorial/db', () => ({
+  db: {
+    magicMcpEndpointServer: {
+      count: magicMcpEndpointServerCount,
+      findMany: vi.fn()
+    }
+  }
+}));
+
+vi.mock('@metorial/module-subspace', () => ({
+  subspaceMagicMcpBackingService: {
+    listServerProviders
+  }
+}));
+
+import {
+  assertMagicMcpServerBackingProvidersActive,
+  assertMagicMcpTargetLinkedResourcesActive
+} from '../src/lib/magicMcpConnectHealth';
+
+describe('magicMcpConnectHealth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects inactive servers on endpoints', async () => {
+    magicMcpEndpointServerCount.mockResolvedValue(1);
+
+    await expect(
+      assertMagicMcpTargetLinkedResourcesActive({
+        type: 'endpoint',
+        target: {
+          oid: 1n,
+          status: 'active',
+          instance: { id: 'ins_1' }
+        } as any
+      })
+    ).rejects.toThrow('no longer active');
+  });
+
+  it('rejects servers without active subspace providers', async () => {
+    listServerProviders.mockResolvedValue({
+      items: []
+    });
+
+    await expect(
+      assertMagicMcpServerBackingProvidersActive({
+        instance: { id: 'ins_1' } as any,
+        magicMcpServerBackingId: 'server_1'
+      })
+    ).rejects.toThrow('magic_mcp_backing_providers_unavailable');
+  });
+});

--- a/src/backend/modules/magic/test/magicMcpLinks.test.ts
+++ b/src/backend/modules/magic/test/magicMcpLinks.test.ts
@@ -20,7 +20,8 @@ vi.mock('@metorial/db', () => {
       findFirst: vi.fn()
     },
     magicMcpEndpointServer: {
-      count: vi.fn()
+      count: vi.fn(),
+      upsert: vi.fn()
     },
     magicMcpGroup: {
       findMany: vi.fn()
@@ -114,7 +115,18 @@ vi.mock('../src/queues/lifecycle/magicMcpGroup', () => ({
   enqueueMagicMcpGroupUpdated: vi.fn()
 }));
 
+vi.mock('../src/lib/backing', () => ({
+  ensureMagicMcpEndpointBacking: vi.fn()
+}));
+
+vi.mock('../src/queues/lifecycle/magicMcpEndpoint', () => ({
+  magicMcpEndpointCreatedQueue: { add: vi.fn() },
+  magicMcpEndpointDeletedQueue: { add: vi.fn() },
+  magicMcpEndpointUpdatedQueue: { add: vi.fn() }
+}));
+
 import { db } from '@metorial/db';
+import { magicMcpEndpointService } from '../src/services/magicMcpEndpoint';
 import { magicMcpGroupService } from '../src/services/magicMcpGroup';
 import { magicMcpTokenService } from '../src/services/magicMcpToken';
 
@@ -171,6 +183,29 @@ describe('magic MCP link guards', () => {
         instance: { oid: 1n } as any
       })
     ).rejects.toThrow('inactive servers');
+  });
+
+  it('rejects linking an inactive server to an endpoint', async () => {
+    vi.mocked(db.magicMcpServer.findMany).mockResolvedValue([
+      {
+        oid: 5n,
+        id: 'magic-server-1',
+        status: 'archived'
+      }
+    ] as any);
+
+    await expect(
+      magicMcpEndpointService.addServersToEndpoint({
+        endpoint: {
+          oid: 8n,
+          id: 'magic-endpoint-1',
+          instanceOid: 1n
+        } as any,
+        servers: [{ magicMcpServerId: 'magic-server-1' }]
+      })
+    ).rejects.toThrow('only be linked to active magic MCP servers');
+
+    expect(db.magicMcpEndpointServer.upsert).not.toHaveBeenCalled();
   });
 
   it('rejects linking an inactive server to a group', async () => {

--- a/src/systems/subspace/modules/auth/src/lib/managedProviderAuthCredentialsBacking.ts
+++ b/src/systems/subspace/modules/auth/src/lib/managedProviderAuthCredentialsBacking.ts
@@ -4,7 +4,6 @@ import {
   addAfterTransactionHook,
   db,
   getId,
-  type Prisma,
   snowflake,
   type Solution,
   type Tenant,
@@ -12,46 +11,18 @@ import {
 } from '@metorial-subspace/db';
 import { getBackend } from '@metorial-subspace/provider';
 import { normalizeManagedOAuthScopeIds } from './managedOAuthScopes';
+import {
+  type ManagedProviderAuthCredentialsBackingSource,
+  managedProviderAuthCredentialsBackingSourceInclude
+} from './managedProviderAuthCredentialsBackingInclude';
 import { env } from '../env';
 import {
   providerAuthCredentialsCreatedQueue,
   providerAuthCredentialsUpdatedQueue
 } from '../queues/lifecycle/providerAuthCredentials';
 
-export let managedProviderAuthCredentialsBackingSourceInclude = {
-  provider: {
-    include: {
-      defaultVariant: true
-    }
-  },
-  initialProviderAuthMethod: {
-    include: {
-      provider: {
-        include: {
-          defaultVariant: true
-        }
-      }
-    }
-  },
-  backings: {
-    include: {
-      providerAuthCredentials: {
-        select: {
-          oid: true,
-          id: true,
-          status: true,
-          scopes: true,
-          updatedAt: true
-        }
-      }
-    }
-  }
-};
-
-export type ManagedProviderAuthCredentialsBackingSource =
-  Prisma.ManagedProviderAuthCredentialsGetPayload<{
-    include: typeof managedProviderAuthCredentialsBackingSourceInclude;
-  }>;
+export type { ManagedProviderAuthCredentialsBackingSource } from './managedProviderAuthCredentialsBackingInclude';
+export { managedProviderAuthCredentialsBackingSourceInclude } from './managedProviderAuthCredentialsBackingInclude';
 
 let createManagedBackingLock = createLock({
   name: 'sub/auth/acred/mng/backing/lock',

--- a/src/systems/subspace/modules/auth/src/lib/managedProviderAuthCredentialsBackingInclude.ts
+++ b/src/systems/subspace/modules/auth/src/lib/managedProviderAuthCredentialsBackingInclude.ts
@@ -1,0 +1,36 @@
+import { type Prisma } from '@metorial-subspace/db';
+
+export let managedProviderAuthCredentialsBackingSourceInclude = {
+  provider: {
+    include: {
+      defaultVariant: true
+    }
+  },
+  initialProviderAuthMethod: {
+    include: {
+      provider: {
+        include: {
+          defaultVariant: true
+        }
+      }
+    }
+  },
+  backings: {
+    include: {
+      providerAuthCredentials: {
+        select: {
+          oid: true,
+          id: true,
+          status: true,
+          scopes: true,
+          updatedAt: true
+        }
+      }
+    }
+  }
+};
+
+export type ManagedProviderAuthCredentialsBackingSource =
+  Prisma.ManagedProviderAuthCredentialsGetPayload<{
+    include: typeof managedProviderAuthCredentialsBackingSourceInclude;
+  }>;

--- a/src/systems/subspace/modules/auth/src/queues/delete/providerAuthConfig.ts
+++ b/src/systems/subspace/modules/auth/src/queues/delete/providerAuthConfig.ts
@@ -113,6 +113,11 @@ export let providerAuthConfigDeleteQueueProcessor = providerAuthConfigDeleteQueu
       data: { status: 'deleted' }
     });
 
+    await db.identityCredential.updateMany({
+      where: { authConfigOid: authConfig.oid },
+      data: { status: 'archived', archivedAt: new Date() }
+    });
+
     await db.providerDeployment.updateMany({
       where: { defaultAuthConfigOid: authConfig.oid },
       data: { defaultAuthConfigOid: null }

--- a/src/systems/subspace/modules/auth/src/queues/lifecycle/providerAuthConfig.ts
+++ b/src/systems/subspace/modules/auth/src/queues/lifecycle/providerAuthConfig.ts
@@ -1,5 +1,6 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db, getId } from '@metorial-subspace/db';
+import { integrationInstanceProviderCredentialSyncQueue } from '@metorial-subspace/module-identity/src/queues/lifecycle/integrationInstanceProviderCredential';
 import { env } from '../../env';
 import { indexProviderAuthConfigQueue } from '../search/providerAuthConfig';
 
@@ -100,6 +101,36 @@ export let providerAuthConfigArchivedQueueProcessor = providerAuthConfigArchived
         },
         data: { defaultAuthConfigOid: null }
       });
+    }
+
+    let archivedAtForCredentials = providerAuthConfig.archivedAt ?? new Date();
+
+    await db.identityCredential.updateMany({
+      where: {
+        authConfigOid: providerAuthConfig.oid,
+        status: 'active'
+      },
+      data: {
+        status: 'archived',
+        archivedAt: archivedAtForCredentials
+      }
+    });
+
+    let integrationInstanceProviders = await db.integrationInstanceProvider.findMany({
+      where: {
+        status: { not: 'deleted' },
+        currentVersion: {
+          authConfigOid: providerAuthConfig.oid
+        }
+      },
+      select: { id: true }
+    });
+    if (integrationInstanceProviders.length) {
+      await integrationInstanceProviderCredentialSyncQueue.addMany(
+        integrationInstanceProviders.map(integrationInstanceProvider => ({
+          integrationInstanceProviderId: integrationInstanceProvider.id
+        }))
+      );
     }
   }
 );

--- a/src/systems/subspace/modules/auth/src/queues/reconcile/tenantManagedBackings.ts
+++ b/src/systems/subspace/modules/auth/src/queues/reconcile/tenantManagedBackings.ts
@@ -1,7 +1,6 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db } from '@metorial-subspace/db';
 import { env } from '../../env';
-import { reconcileTenantManagedProviderAuthCredentialsBackings } from '../../lib/managedProviderAuthCredentialsBacking';
 
 let RECONCILE_ALL_TENANTS_BATCH_SIZE = 100;
 
@@ -29,6 +28,10 @@ export let reconcileTenantManagedBackingsQueueProcessor =
       }
     });
     if (!tenant || !solution) return;
+
+    let { reconcileTenantManagedProviderAuthCredentialsBackings } = await import(
+      '../../lib/managedProviderAuthCredentialsBacking'
+    );
 
     await reconcileTenantManagedProviderAuthCredentialsBackings({
       tenant,

--- a/src/systems/subspace/modules/auth/src/services/providerAuthConfig.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthConfig.ts
@@ -21,6 +21,8 @@ import {
   withTransaction
 } from '@metorial-subspace/db';
 import {
+  assertNoActiveIdentityCredentialAuthConfigLink,
+  assertNoActiveIntegrationInstanceProviderAuthConfigLink,
   checkDeletedEdit,
   checkDeletedRelation,
   type DateFilter,
@@ -582,6 +584,20 @@ class providerAuthConfigServiceImpl {
     checkTenant(d, d.providerAuthConfig);
     checkDeletedEdit(d.providerAuthConfig, 'archive');
     this.assertCanArchiveOwned(d);
+    await assertNoActiveIntegrationInstanceProviderAuthConfigLink({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      authConfigOid: d.providerAuthConfig.oid,
+      resourceId: d.providerAuthConfig.id
+    });
+    await assertNoActiveIdentityCredentialAuthConfigLink({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      authConfigOid: d.providerAuthConfig.oid,
+      resourceId: d.providerAuthConfig.id
+    });
 
     return withTransaction(async db => {
       let archivedAt = new Date();

--- a/src/systems/subspace/modules/auth/src/services/providerAuthCredentials.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthCredentials.ts
@@ -18,6 +18,7 @@ import {
   withTransaction
 } from '@metorial-subspace/db';
 import {
+  assertNoActiveIntegrationInstanceProviderAuthCredentialsLink,
   checkDeletedEdit,
   type DateFilter,
   normalizeDateFilter,
@@ -33,9 +34,9 @@ import { env } from '../env';
 import { normalizeManagedOAuthScopeIds } from '../lib/managedOAuthScopes';
 import {
   ensureManagedProviderAuthCredentialsBacking,
-  type ManagedProviderAuthCredentialsBackingSource,
-  managedProviderAuthCredentialsBackingSourceInclude
+  type ManagedProviderAuthCredentialsBackingSource
 } from '../lib/managedProviderAuthCredentialsBacking';
+import { managedProviderAuthCredentialsBackingSourceInclude } from '../lib/managedProviderAuthCredentialsBackingInclude';
 import {
   providerAuthCredentialsArchivedQueue,
   providerAuthCredentialsCreatedQueue,
@@ -471,6 +472,13 @@ class providerAuthCredentialsServiceImpl {
     }
 
     await this.assertNoActiveIntegrationProviderLink(d);
+    await assertNoActiveIntegrationInstanceProviderAuthCredentialsLink({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      authCredentialsOid: d.providerAuthCredentials.oid,
+      resourceId: d.providerAuthCredentials.id
+    });
 
     return withTransaction(async db => {
       let creds = await db.providerAuthCredentials.update({

--- a/src/systems/subspace/modules/deployment/src/queues/delete/providerConfig.ts
+++ b/src/systems/subspace/modules/deployment/src/queues/delete/providerConfig.ts
@@ -137,6 +137,11 @@ export let providerConfigDeleteQueueProcessor = providerConfigDeleteQueue.proces
       data: { status: 'deleted' }
     });
 
+    await db.identityCredential.updateMany({
+      where: { configOid: { in: relatedConfigOids } },
+      data: { status: 'archived', archivedAt: new Date() }
+    });
+
     await db.providerDeployment.updateMany({
       where: { defaultConfigOid: { in: relatedConfigOids } },
       data: { defaultConfigOid: null }

--- a/src/systems/subspace/modules/deployment/src/queues/lifecycle/providerConfig.ts
+++ b/src/systems/subspace/modules/deployment/src/queues/lifecycle/providerConfig.ts
@@ -1,5 +1,6 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db, getId } from '@metorial-subspace/db';
+import { integrationInstanceProviderCredentialSyncQueue } from '@metorial-subspace/module-identity/src/queues/lifecycle/integrationInstanceProviderCredential';
 import { env } from '../../env';
 import { indexProviderConfigQueue } from '../search/providerConfig';
 
@@ -106,6 +107,36 @@ export let providerConfigArchivedQueueProcessor = providerConfigArchivedQueue.pr
         },
         data: { defaultConfigOid: null }
       });
+    }
+
+    let archivedAtForCredentials = providerConfig.archivedAt ?? new Date();
+
+    await db.identityCredential.updateMany({
+      where: {
+        configOid: { in: relatedConfigs },
+        status: 'active'
+      },
+      data: {
+        status: 'archived',
+        archivedAt: archivedAtForCredentials
+      }
+    });
+
+    let integrationInstanceProviders = await db.integrationInstanceProvider.findMany({
+      where: {
+        status: { not: 'deleted' },
+        currentVersion: {
+          configOid: { in: relatedConfigs }
+        }
+      },
+      select: { id: true }
+    });
+    if (integrationInstanceProviders.length) {
+      await integrationInstanceProviderCredentialSyncQueue.addMany(
+        integrationInstanceProviders.map(integrationInstanceProvider => ({
+          integrationInstanceProviderId: integrationInstanceProvider.id
+        }))
+      );
     }
   }
 );

--- a/src/systems/subspace/modules/deployment/src/services/providerConfig.ts
+++ b/src/systems/subspace/modules/deployment/src/services/providerConfig.ts
@@ -25,6 +25,8 @@ import {
   withTransaction
 } from '@metorial-subspace/db';
 import {
+  assertNoActiveIdentityCredentialConfigLink,
+  assertNoActiveIntegrationInstanceProviderConfigLink,
   checkDeletedEdit,
   checkDeletedRelation,
   type DateFilter,
@@ -634,6 +636,20 @@ class providerConfigServiceImpl {
     checkDeletedEdit(d.providerConfig, 'archive');
     await this.assertNoActiveIntegrationProviderLink(d);
     this.assertCanArchiveOwned(d);
+    await assertNoActiveIntegrationInstanceProviderConfigLink({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      configOid: d.providerConfig.oid,
+      resourceId: d.providerConfig.id
+    });
+    await assertNoActiveIdentityCredentialConfigLink({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      configOid: d.providerConfig.oid,
+      resourceId: d.providerConfig.id
+    });
 
     return withTransaction(async db => {
       let archivedAt = new Date();

--- a/src/systems/subspace/modules/deployment/src/services/providerDeployment.ts
+++ b/src/systems/subspace/modules/deployment/src/services/providerDeployment.ts
@@ -21,6 +21,8 @@ import {
   withTransaction
 } from '@metorial-subspace/db';
 import {
+  assertNoActiveIdentityCredentialDeploymentLink,
+  assertNoActiveIntegrationInstanceProviderDeploymentLink,
   checkDeletedEdit,
   checkDeletedRelation,
   type DateFilter,
@@ -497,6 +499,20 @@ class providerDeploymentServiceImpl {
     checkTenant(d, d.providerDeployment);
     checkDeletedEdit(d.providerDeployment, 'archive');
     await this.assertNoActiveIntegrationProviderLink(d);
+    await assertNoActiveIntegrationInstanceProviderDeploymentLink({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      deploymentOid: d.providerDeployment.oid,
+      resourceId: d.providerDeployment.id
+    });
+    await assertNoActiveIdentityCredentialDeploymentLink({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      deploymentOid: d.providerDeployment.oid,
+      resourceId: d.providerDeployment.id
+    });
 
     return withTransaction(async db => {
       let archivedAt = new Date();

--- a/src/systems/subspace/modules/identity/src/queues/lifecycle/actor.ts
+++ b/src/systems/subspace/modules/identity/src/queues/lifecycle/actor.ts
@@ -1,8 +1,5 @@
 import { createQueue } from '@lowerdeck/queue';
-import { db } from '@metorial-subspace/db';
-import { archiveIntegrationInstanceQueue } from '@metorial-subspace/module-integration/src/queues/lifecycle/archiveIntegrationInstance';
 import { env } from '../../env';
-import { deleteIdentitiesForActorManyQueue } from '../archive/identity';
 import { indexIdentityActorQueue } from '../search/actor';
 import { lcOpts } from './_opts';
 
@@ -39,26 +36,5 @@ export let identityActorDeletedQueue = createQueue<{ identityActorId: string }>(
 export let identityActorDeletedQueueProcessor = identityActorDeletedQueue.process(
   async data => {
     await indexIdentityActorQueue.add({ identityActorId: data.identityActorId });
-
-    let integrationInstances = await db.integrationInstance.findMany({
-      where: {
-        identityActor: {
-          id: data.identityActorId
-        },
-        status: 'active'
-      },
-      select: {
-        id: true
-      }
-    });
-    if (integrationInstances.length) {
-      await archiveIntegrationInstanceQueue.addMany(
-        integrationInstances.map(integrationInstance => ({
-          integrationInstanceId: integrationInstance.id
-        }))
-      );
-    }
-
-    await deleteIdentitiesForActorManyQueue.add({ identityActorId: data.identityActorId });
   }
 );

--- a/src/systems/subspace/modules/identity/src/services/actor.ts
+++ b/src/systems/subspace/modules/identity/src/services/actor.ts
@@ -17,6 +17,7 @@ import {
   withTransaction
 } from '@metorial-subspace/db';
 import {
+  assertNoActiveIntegrationActorLink,
   checkDeletedEdit,
   type DateFilter,
   normalizeDateFilter,
@@ -301,6 +302,14 @@ class identityActorServiceImpl {
         })
       );
     }
+
+    await assertNoActiveIntegrationActorLink({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      identityActorOid: existingIdentityActor.oid,
+      identityActorId: existingIdentityActor.id
+    });
 
     return withTransaction(async db => {
       let identityActor = await db.identityActor.update({

--- a/src/systems/subspace/modules/identity/src/services/identity.ts
+++ b/src/systems/subspace/modules/identity/src/services/identity.ts
@@ -14,6 +14,7 @@ import {
   withTransaction
 } from '@metorial-subspace/db';
 import {
+  assertNoActiveIntegrationIdentityLink,
   checkDeletedEdit,
   checkDeletedRelation,
   type DateFilter,
@@ -322,32 +323,14 @@ class identityServiceImpl {
     checkTenant(d, d.identity);
     checkDeletedEdit(d.identity, 'archive');
 
-    let activeIntegrationInstance = await db.integrationInstance.findFirst({
-      where: {
-        status: 'active',
-        OR: [
-          { identityOid: d.identity.oid },
-          { oid: d.identity.ownedByIntegrationInstanceOid ?? -1n }
-        ]
-      },
-      select: {
-        id: true,
-        name: true
-      }
+    await assertNoActiveIntegrationIdentityLink({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      identityOid: d.identity.oid,
+      identityId: d.identity.id,
+      ownedByIntegrationInstanceOid: d.identity.ownedByIntegrationInstanceOid
     });
-    if (activeIntegrationInstance) {
-      throw new ServiceError(
-        badRequestError({
-          message:
-            'Identity is linked to an active integration instance and cannot be deleted.',
-          code: 'identity_in_use_by_active_integration_instance',
-          data: {
-            integrationInstanceId: activeIntegrationInstance.id,
-            integrationInstanceName: activeIntegrationInstance.name
-          }
-        })
-      );
-    }
 
     return withTransaction(async db => {
       let identity = await db.identity.update({

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integration.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integration.ts
@@ -47,8 +47,7 @@ export let integrationArchivedQueueProcessor = integrationArchivedQueue.process(
       status: { in: ['pending', 'successful'] }
     },
     data: {
-      status: 'archived',
-      archivedAt: integration.archivedAt ?? new Date()
+      status: 'archived'
     }
   });
 
@@ -58,12 +57,16 @@ export let integrationArchivedQueueProcessor = integrationArchivedQueue.process(
       status: 'active'
     },
     select: {
-      skillId: true
+      skill: {
+        select: {
+          id: true
+        }
+      }
     }
   });
   if (skillIntegrations.length) {
     await reconcileSkillProviderLinksQueue.addMany(
-      skillIntegrations.map(skillIntegration => ({ skillId: skillIntegration.skillId }))
+      skillIntegrations.map(skillIntegration => ({ skillId: skillIntegration.skill.id }))
     );
   }
 

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integration.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integration.ts
@@ -1,6 +1,7 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db } from '@metorial-subspace/db';
 import { identityInternalService } from '@metorial-subspace/module-identity';
+import { reconcileSkillProviderLinksQueue } from '@metorial-subspace/module-skills/src/queues/reconciler/reconcileSkillProviderLink';
 import { env } from '../../env';
 import {
   createIntegrationProviderVersion,
@@ -39,6 +40,32 @@ export let integrationArchivedQueueProcessor = integrationArchivedQueue.process(
     where: { id: data.integrationId }
   });
   if (!integration || integration.status !== 'archived') return;
+
+  await db.integrationSetupSession.updateMany({
+    where: {
+      integrationOid: integration.oid,
+      status: { in: ['pending', 'successful'] }
+    },
+    data: {
+      status: 'archived',
+      archivedAt: integration.archivedAt ?? new Date()
+    }
+  });
+
+  let skillIntegrations = await db.skillIntegration.findMany({
+    where: {
+      integrationOid: integration.oid,
+      status: 'active'
+    },
+    select: {
+      skillId: true
+    }
+  });
+  if (skillIntegrations.length) {
+    await reconcileSkillProviderLinksQueue.addMany(
+      skillIntegrations.map(skillIntegration => ({ skillId: skillIntegration.skillId }))
+    );
+  }
 
   await indexIntegrationQueue.add({ integrationId: data.integrationId });
   await integrationArchiveInstancesManyQueue.add({ integrationId: data.integrationId });

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationProvider.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationProvider.ts
@@ -7,6 +7,7 @@ import { reconcileSkillProviderLinksForIntegrationProviderQueue } from '@metoria
 import { env } from '../../env';
 import { indexIntegrationQueue } from '../search/integration';
 import { indexIntegrationInstanceQueue } from '../search/integrationInstance';
+import { integrationInstanceProviderSetQueue } from './integrationInstanceProvider';
 
 let indexParentIntegration = async (integrationProviderId: string) => {
   let integrationProvider = await db.integrationProvider.findUnique({
@@ -120,16 +121,30 @@ export let integrationProviderArchiveInstanceProvidersManyQueueProcessor =
     });
     if (integrationInstanceProviders.length === 0) return;
 
+    let archivedAt = integrationProvider.archivedAt ?? new Date();
+
     await db.integrationInstanceProvider.updateMany({
       where: {
         oid: {
           in: integrationInstanceProviders.map(
             integrationInstanceProvider => integrationInstanceProvider.oid
           )
-        }
+        },
+        status: 'active'
       },
-      data: { isParentDeleted: true }
+      data: {
+        status: 'archived',
+        archivedAt,
+        isParentDeleted: true
+      }
     });
+
+    await integrationInstanceProviderSetQueue.addMany(
+      integrationInstanceProviders.map(provider => ({
+        integrationInstanceId: provider.integrationInstance.id,
+        integrationInstanceProviderId: provider.id
+      }))
+    );
 
     await indexIntegrationInstanceQueue.addMany(
       integrationInstanceProviders.map(provider => ({

--- a/src/systems/subspace/modules/integration/src/services/integration.ts
+++ b/src/systems/subspace/modules/integration/src/services/integration.ts
@@ -1,4 +1,4 @@
-import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, conflictError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { generatePlainId } from '@lowerdeck/id';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
@@ -403,6 +403,38 @@ class integrationServiceImpl {
           code: 'magic_mcp_backing_integration_delete_blocked'
         })
       );
+    }
+
+    if (!d._canModifyMagicMcpBacking) {
+      let [activeInstanceCount, activeProviderCount] = await Promise.all([
+        db.integrationInstance.count({
+          where: {
+            integrationOid: d.integration.oid,
+            status: { in: ['draft', 'active'] }
+          }
+        }),
+        db.integrationProvider.count({
+          where: {
+            integrationOid: d.integration.oid,
+            status: 'active'
+          }
+        })
+      ]);
+
+      if (activeInstanceCount > 0 || activeProviderCount > 0) {
+        throw new ServiceError(
+          conflictError({
+            message:
+              'Integration still has active instances or providers and cannot be archived directly.',
+            code: 'integration_archive_blocked_by_active_children',
+            data: {
+              integrationId: d.integration.id,
+              activeInstanceCount,
+              activeProviderCount
+            }
+          })
+        );
+      }
     }
 
     return await withTransaction(async db => {

--- a/src/systems/subspace/modules/tenant/src/queues/retention/sync.ts
+++ b/src/systems/subspace/modules/tenant/src/queues/retention/sync.ts
@@ -1,8 +1,6 @@
 import { createCron } from '@lowerdeck/cron';
 import { createQueue } from '@lowerdeck/queue';
 import { db } from '@metorial-subspace/db';
-import { shuttleClient } from '@metorial-subspace/provider-shuttle';
-import { slatesClient } from '@metorial-subspace/provider-slates';
 import { env } from '../../env';
 import { RETENTION_BATCH_SIZE, retentionSyncWorkerOpts } from './_config';
 
@@ -60,6 +58,7 @@ export let tenantLogRetentionSyncQueueProcessor = tenantLogRetentionSyncQueue.pr
     if (!tenant) return;
 
     if (tenant.slateTenantId && env.service.SLATES_HUB_URL) {
+      let { slatesClient } = await import('@metorial-subspace/provider-slates');
       await slatesClient.tenant.upsert({
         identifier: tenant.slateTenantIdentifier ?? tenant.identifier,
         name: tenant.name,
@@ -68,6 +67,7 @@ export let tenantLogRetentionSyncQueueProcessor = tenantLogRetentionSyncQueue.pr
     }
 
     if (tenant.shuttleTenantId && env.service.SHUTTLE_URL) {
+      let { shuttleClient } = await import('@metorial-subspace/provider-shuttle');
       await shuttleClient.tenant.upsert({
         identifier: tenant.shuttleTenantIdentifier ?? tenant.identifier,
         name: tenant.name,

--- a/src/systems/subspace/packages/list-utils/package.json
+++ b/src/systems/subspace/packages/list-utils/package.json
@@ -5,9 +5,12 @@
   "type": "module",
   "private": true,
   "version": "1.0.0",
-  "scripts": {},
+  "scripts": {
+    "test": "vitest run --passWithNoTests"
+  },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "vitest": "^3.1.2"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/src/systems/subspace/packages/list-utils/src/index.ts
+++ b/src/systems/subspace/packages/list-utils/src/index.ts
@@ -1,5 +1,6 @@
 export * from './dateFilter';
 export * from './deleteCheck';
+export * from './linkGuards';
 export * from './resources';
 export * from './status';
 export * from './tenant';

--- a/src/systems/subspace/packages/list-utils/src/linkGuards.ts
+++ b/src/systems/subspace/packages/list-utils/src/linkGuards.ts
@@ -460,10 +460,12 @@ export let assertNoActiveIntegrationActorLink = async (
 
   let magicMcpServerBacking = await db.magicMcpServerBacking.findFirst({
     where: {
-      tenantOid: d.tenant.oid,
-      solutionOid: d.solution.oid,
-      environmentOid: d.environment.oid,
-      actorOid: d.identityActorOid
+      actorOid: d.identityActorOid,
+      integrationInstance: {
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid
+      }
     },
     select: {
       id: true
@@ -485,10 +487,12 @@ export let assertNoActiveIntegrationActorLink = async (
 
   let magicMcpEndpointBacking = await db.magicMcpEndpointBacking.findFirst({
     where: {
-      tenantOid: d.tenant.oid,
-      solutionOid: d.solution.oid,
-      environmentOid: d.environment.oid,
-      actorOid: d.identityActorOid
+      actorOid: d.identityActorOid,
+      integrationGroup: {
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid
+      }
     },
     select: {
       id: true

--- a/src/systems/subspace/packages/list-utils/src/linkGuards.ts
+++ b/src/systems/subspace/packages/list-utils/src/linkGuards.ts
@@ -1,0 +1,510 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { db, type Environment, type Solution, type Tenant } from '@metorial-subspace/db';
+
+type TenantScope = {
+  tenant: Tenant;
+  solution: Solution;
+  environment: Environment;
+};
+
+let activeIntegrationInstanceProviderWhere = (d: TenantScope) => ({
+  tenantOid: d.tenant.oid,
+  solutionOid: d.solution.oid,
+  environmentOid: d.environment.oid,
+  status: 'active' as const,
+  isParentDeleted: false,
+  integrationInstance: {
+    status: { in: ['draft' as const, 'active' as const] },
+    isParentDeleted: false,
+    integration: {
+      status: 'active' as const
+    }
+  }
+});
+
+let throwIntegrationInstanceProviderLinkError = (d: {
+  resourceLabel: string;
+  resourceId: string;
+  code: string;
+  integrationInstanceProvider: {
+    id: string;
+    name: string | null;
+    integrationInstance: { id: string; name: string | null };
+  };
+}) => {
+  throw new ServiceError(
+    badRequestError({
+      message: `${d.resourceLabel} is linked to an active integration instance provider and cannot be archived directly.`,
+      code: d.code,
+      data: {
+        id: d.resourceId,
+        integrationInstanceProviderId: d.integrationInstanceProvider.id,
+        integrationInstanceProviderName: d.integrationInstanceProvider.name,
+        integrationInstanceId: d.integrationInstanceProvider.integrationInstance.id,
+        integrationInstanceName: d.integrationInstanceProvider.integrationInstance.name
+      }
+    })
+  );
+};
+
+export let assertNoActiveIntegrationInstanceProviderConfigLink = async (
+  d: TenantScope & { configOid: bigint; resourceId: string }
+) => {
+  let integrationInstanceProvider = await db.integrationInstanceProvider.findFirst({
+    where: {
+      ...activeIntegrationInstanceProviderWhere(d),
+      currentVersion: {
+        configOid: d.configOid
+      }
+    },
+    select: {
+      id: true,
+      name: true,
+      integrationInstance: {
+        select: {
+          id: true,
+          name: true
+        }
+      }
+    }
+  });
+  if (!integrationInstanceProvider) return;
+
+  throwIntegrationInstanceProviderLinkError({
+    resourceLabel: 'Provider config',
+    resourceId: d.resourceId,
+    code: 'provider_config_integration_instance_provider_archive_not_allowed',
+    integrationInstanceProvider
+  });
+};
+
+export let assertNoActiveIntegrationInstanceProviderAuthConfigLink = async (
+  d: TenantScope & { authConfigOid: bigint; resourceId: string }
+) => {
+  let integrationInstanceProvider = await db.integrationInstanceProvider.findFirst({
+    where: {
+      ...activeIntegrationInstanceProviderWhere(d),
+      currentVersion: {
+        authConfigOid: d.authConfigOid
+      }
+    },
+    select: {
+      id: true,
+      name: true,
+      integrationInstance: {
+        select: {
+          id: true,
+          name: true
+        }
+      }
+    }
+  });
+  if (!integrationInstanceProvider) return;
+
+  throwIntegrationInstanceProviderLinkError({
+    resourceLabel: 'Provider auth config',
+    resourceId: d.resourceId,
+    code: 'provider_auth_config_integration_instance_provider_archive_not_allowed',
+    integrationInstanceProvider
+  });
+};
+
+export let assertNoActiveIntegrationInstanceProviderDeploymentLink = async (
+  d: TenantScope & { deploymentOid: bigint; resourceId: string }
+) => {
+  let integrationInstanceProvider = await db.integrationInstanceProvider.findFirst({
+    where: {
+      ...activeIntegrationInstanceProviderWhere(d),
+      currentVersion: {
+        integrationProviderVersion: {
+          deploymentOid: d.deploymentOid
+        }
+      }
+    },
+    select: {
+      id: true,
+      name: true,
+      integrationInstance: {
+        select: {
+          id: true,
+          name: true
+        }
+      }
+    }
+  });
+  if (!integrationInstanceProvider) return;
+
+  throwIntegrationInstanceProviderLinkError({
+    resourceLabel: 'Provider deployment',
+    resourceId: d.resourceId,
+    code: 'provider_deployment_integration_instance_provider_archive_not_allowed',
+    integrationInstanceProvider
+  });
+};
+
+export let assertNoActiveIntegrationInstanceProviderAuthCredentialsLink = async (
+  d: TenantScope & { authCredentialsOid: bigint; resourceId: string }
+) => {
+  let integrationInstanceProvider = await db.integrationInstanceProvider.findFirst({
+    where: {
+      ...activeIntegrationInstanceProviderWhere(d),
+      currentVersion: {
+        integrationProviderVersion: {
+          authCredentialsOid: d.authCredentialsOid
+        }
+      }
+    },
+    select: {
+      id: true,
+      name: true,
+      integrationInstance: {
+        select: {
+          id: true,
+          name: true
+        }
+      }
+    }
+  });
+  if (!integrationInstanceProvider) return;
+
+  throwIntegrationInstanceProviderLinkError({
+    resourceLabel: 'Provider auth credentials',
+    resourceId: d.resourceId,
+    code: 'provider_auth_credentials_integration_instance_provider_archive_not_allowed',
+    integrationInstanceProvider
+  });
+};
+
+export let assertNoActiveIntegrationInstanceProviderAuthMethodLink = async (
+  d: TenantScope & { authMethodOid: bigint; resourceId: string }
+) => {
+  let integrationInstanceProvider = await db.integrationInstanceProvider.findFirst({
+    where: {
+      ...activeIntegrationInstanceProviderWhere(d),
+      currentVersion: {
+        integrationProviderVersion: {
+          authMethodOid: d.authMethodOid
+        }
+      }
+    },
+    select: {
+      id: true,
+      name: true,
+      integrationInstance: {
+        select: {
+          id: true,
+          name: true
+        }
+      }
+    }
+  });
+  if (!integrationInstanceProvider) return;
+
+  throwIntegrationInstanceProviderLinkError({
+    resourceLabel: 'Provider auth method',
+    resourceId: d.resourceId,
+    code: 'provider_auth_method_integration_instance_provider_archive_not_allowed',
+    integrationInstanceProvider
+  });
+};
+
+let throwIdentityCredentialLinkError = (d: {
+  resourceLabel: string;
+  resourceId: string;
+  code: string;
+  identityCredential: {
+    id: string;
+    identity: { id: string; name: string | null };
+  };
+}) => {
+  throw new ServiceError(
+    badRequestError({
+      message: `${d.resourceLabel} is linked to an active identity credential and cannot be archived directly.`,
+      code: d.code,
+      data: {
+        id: d.resourceId,
+        identityCredentialId: d.identityCredential.id,
+        identityId: d.identityCredential.identity.id,
+        identityName: d.identityCredential.identity.name
+      }
+    })
+  );
+};
+
+export let assertNoActiveIdentityCredentialConfigLink = async (
+  d: TenantScope & { configOid: bigint; resourceId: string }
+) => {
+  let identityCredential = await db.identityCredential.findFirst({
+    where: {
+      status: 'active',
+      configOid: d.configOid,
+      identity: {
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid,
+        status: 'active',
+        isParentDeleted: false
+      }
+    },
+    select: {
+      id: true,
+      identity: {
+        select: {
+          id: true,
+          name: true
+        }
+      }
+    }
+  });
+  if (!identityCredential) return;
+
+  throwIdentityCredentialLinkError({
+    resourceLabel: 'Provider config',
+    resourceId: d.resourceId,
+    code: 'provider_config_identity_credential_archive_not_allowed',
+    identityCredential
+  });
+};
+
+export let assertNoActiveIdentityCredentialAuthConfigLink = async (
+  d: TenantScope & { authConfigOid: bigint; resourceId: string }
+) => {
+  let identityCredential = await db.identityCredential.findFirst({
+    where: {
+      status: 'active',
+      authConfigOid: d.authConfigOid,
+      identity: {
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid,
+        status: 'active',
+        isParentDeleted: false
+      }
+    },
+    select: {
+      id: true,
+      identity: {
+        select: {
+          id: true,
+          name: true
+        }
+      }
+    }
+  });
+  if (!identityCredential) return;
+
+  throwIdentityCredentialLinkError({
+    resourceLabel: 'Provider auth config',
+    resourceId: d.resourceId,
+    code: 'provider_auth_config_identity_credential_archive_not_allowed',
+    identityCredential
+  });
+};
+
+export let assertNoActiveIdentityCredentialDeploymentLink = async (
+  d: TenantScope & { deploymentOid: bigint; resourceId: string }
+) => {
+  let identityCredential = await db.identityCredential.findFirst({
+    where: {
+      status: 'active',
+      deploymentOid: d.deploymentOid,
+      identity: {
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid,
+        status: 'active',
+        isParentDeleted: false
+      }
+    },
+    select: {
+      id: true,
+      identity: {
+        select: {
+          id: true,
+          name: true
+        }
+      }
+    }
+  });
+  if (!identityCredential) return;
+
+  throwIdentityCredentialLinkError({
+    resourceLabel: 'Provider deployment',
+    resourceId: d.resourceId,
+    code: 'provider_deployment_identity_credential_archive_not_allowed',
+    identityCredential
+  });
+};
+
+export let assertNoActiveIntegrationIdentityLink = async (
+  d: TenantScope & {
+    identityOid: bigint;
+    identityId: string;
+    ownedByIntegrationInstanceOid?: bigint | null;
+  }
+) => {
+  let activeIntegrationInstance = await db.integrationInstance.findFirst({
+    where: {
+      tenantOid: d.tenant.oid,
+      solutionOid: d.solution.oid,
+      environmentOid: d.environment.oid,
+      status: 'active',
+      OR: [
+        { identityOid: d.identityOid },
+        { oid: d.ownedByIntegrationInstanceOid ?? -1n }
+      ]
+    },
+    select: {
+      id: true,
+      name: true
+    }
+  });
+  if (activeIntegrationInstance) {
+    throw new ServiceError(
+      badRequestError({
+        message:
+          'Identity is linked to an active integration instance and cannot be deleted.',
+        code: 'identity_in_use_by_active_integration_instance',
+        data: {
+          integrationInstanceId: activeIntegrationInstance.id,
+          integrationInstanceName: activeIntegrationInstance.name
+        }
+      })
+    );
+  }
+
+  let activeIntegrationInstanceGroup = await db.integrationInstanceGroup.findFirst({
+    where: {
+      tenantOid: d.tenant.oid,
+      solutionOid: d.solution.oid,
+      environmentOid: d.environment.oid,
+      status: 'active',
+      identityOid: d.identityOid
+    },
+    select: {
+      id: true,
+      name: true
+    }
+  });
+  if (activeIntegrationInstanceGroup) {
+    throw new ServiceError(
+      badRequestError({
+        message:
+          'Identity is linked to an active integration instance group and cannot be deleted.',
+        code: 'identity_in_use_by_active_integration_instance_group',
+        data: {
+          integrationInstanceGroupId: activeIntegrationInstanceGroup.id,
+          integrationInstanceGroupName: activeIntegrationInstanceGroup.name
+        }
+      })
+    );
+  }
+};
+
+export let assertNoActiveIntegrationActorLink = async (
+  d: TenantScope & { identityActorOid: bigint; identityActorId: string }
+) => {
+  let activeIntegrationInstance = await db.integrationInstance.findFirst({
+    where: {
+      tenantOid: d.tenant.oid,
+      solutionOid: d.solution.oid,
+      environmentOid: d.environment.oid,
+      status: { in: ['draft', 'active'] },
+      identityActorOid: d.identityActorOid
+    },
+    select: {
+      id: true,
+      name: true
+    }
+  });
+  if (activeIntegrationInstance) {
+    throw new ServiceError(
+      badRequestError({
+        message:
+          'Identity actor is linked to an active integration instance and cannot be deleted.',
+        code: 'identity_actor_in_use_by_active_integration_instance',
+        data: {
+          integrationInstanceId: activeIntegrationInstance.id,
+          integrationInstanceName: activeIntegrationInstance.name
+        }
+      })
+    );
+  }
+
+  let activeIntegrationInstanceGroup = await db.integrationInstanceGroup.findFirst({
+    where: {
+      tenantOid: d.tenant.oid,
+      solutionOid: d.solution.oid,
+      environmentOid: d.environment.oid,
+      status: { in: ['draft', 'active'] },
+      identityActorOid: d.identityActorOid
+    },
+    select: {
+      id: true,
+      name: true
+    }
+  });
+  if (activeIntegrationInstanceGroup) {
+    throw new ServiceError(
+      badRequestError({
+        message:
+          'Identity actor is linked to an active integration instance group and cannot be deleted.',
+        code: 'identity_actor_in_use_by_active_integration_instance_group',
+        data: {
+          integrationInstanceGroupId: activeIntegrationInstanceGroup.id,
+          integrationInstanceGroupName: activeIntegrationInstanceGroup.name
+        }
+      })
+    );
+  }
+
+  let magicMcpServerBacking = await db.magicMcpServerBacking.findFirst({
+    where: {
+      tenantOid: d.tenant.oid,
+      solutionOid: d.solution.oid,
+      environmentOid: d.environment.oid,
+      actorOid: d.identityActorOid
+    },
+    select: {
+      id: true
+    }
+  });
+  if (magicMcpServerBacking) {
+    throw new ServiceError(
+      badRequestError({
+        message:
+          'Identity actor is linked to a magic MCP server backing and cannot be deleted.',
+        code: 'identity_actor_in_use_by_magic_mcp_backing',
+        data: {
+          identityActorId: d.identityActorId,
+          magicMcpServerBackingId: magicMcpServerBacking.id
+        }
+      })
+    );
+  }
+
+  let magicMcpEndpointBacking = await db.magicMcpEndpointBacking.findFirst({
+    where: {
+      tenantOid: d.tenant.oid,
+      solutionOid: d.solution.oid,
+      environmentOid: d.environment.oid,
+      actorOid: d.identityActorOid
+    },
+    select: {
+      id: true
+    }
+  });
+  if (magicMcpEndpointBacking) {
+    throw new ServiceError(
+      badRequestError({
+        message:
+          'Identity actor is linked to a magic MCP endpoint backing and cannot be deleted.',
+        code: 'identity_actor_in_use_by_magic_mcp_backing',
+        data: {
+          identityActorId: d.identityActorId,
+          magicMcpEndpointBackingId: magicMcpEndpointBacking.id
+        }
+      })
+    );
+  }
+};

--- a/src/systems/subspace/packages/list-utils/test/linkGuards.test.ts
+++ b/src/systems/subspace/packages/list-utils/test/linkGuards.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let integrationInstanceProviderFindFirst = vi.hoisted(() => vi.fn());
+let identityCredentialFindFirst = vi.hoisted(() => vi.fn());
+
+vi.mock('@metorial-subspace/db', () => ({
+  db: {
+    integrationInstanceProvider: {
+      findFirst: integrationInstanceProviderFindFirst
+    },
+    identityCredential: {
+      findFirst: identityCredentialFindFirst
+    },
+    integrationInstance: {
+      findFirst: vi.fn()
+    },
+    integrationInstanceGroup: {
+      findFirst: vi.fn()
+    },
+    identityActor: {},
+    magicMcpServerBacking: {
+      findFirst: vi.fn()
+    },
+    magicMcpEndpointBacking: {
+      findFirst: vi.fn()
+    }
+  }
+}));
+
+import {
+  assertNoActiveIdentityCredentialConfigLink,
+  assertNoActiveIntegrationInstanceProviderConfigLink
+} from '../src/linkGuards';
+
+describe('linkGuards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('blocks provider config archive when linked to an active integration instance provider', async () => {
+    integrationInstanceProviderFindFirst.mockResolvedValueOnce({
+      id: 'iip_1',
+      name: 'Provider A',
+      integrationInstance: {
+        id: 'ii_1',
+        name: 'Instance A'
+      }
+    });
+
+    await expect(
+      assertNoActiveIntegrationInstanceProviderConfigLink({
+        tenant: { oid: 1n } as any,
+        solution: { oid: 1 } as any,
+        environment: { oid: 1n } as any,
+        configOid: 10n,
+        resourceId: 'cfg_1'
+      })
+    ).rejects.toThrow('provider_config_integration_instance_provider_archive_not_allowed');
+  });
+
+  it('blocks provider config archive when linked to an active identity credential', async () => {
+    identityCredentialFindFirst.mockResolvedValueOnce({
+      id: 'ic_1',
+      identity: {
+        id: 'id_1',
+        name: 'Identity A'
+      }
+    });
+
+    await expect(
+      assertNoActiveIdentityCredentialConfigLink({
+        tenant: { oid: 1n } as any,
+        solution: { oid: 1 } as any,
+        environment: { oid: 1n } as any,
+        configOid: 10n,
+        resourceId: 'cfg_1'
+      })
+    ).rejects.toThrow('provider_config_identity_credential_archive_not_allowed');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes tighten archival/linking rules and add additional runtime precondition checks before creating sessions, which could block previously-allowed operations and affect lifecycle/queue side effects. Risk is moderate due to cross-module DB updates (archiving credentials, unlinking endpoints) and new sync queues triggered on archival paths.
> 
> **Overview**
> **Hardens Magic MCP connectivity and linking rules.** Connection/session resolution now asserts targets (and endpoint-linked servers) are *active* and have active backing providers before connecting, and the API also rejects routing to inactive linked resources.
> 
> **Strengthens Magic MCP lifecycle integrity.** Linking endpoints to servers now blocks inactive servers, and archiving a Magic MCP server proactively removes `magicMcpEndpointServer` links.
> 
> **Adds Subspace-wide relation guards for safe archiving/deletion.** Introduces shared `@metorial-subspace/list-utils` `linkGuards` to prevent archiving provider configs/auth configs/deployments/credentials, identities, and actors while they are still linked to active integration instance providers, identity credentials, integration instances/groups, or Magic MCP backings.
> 
> **Improves cleanup/synchronization on archival flows.** Provider config/auth-config delete & archive processors now archive related `identityCredential` rows and enqueue integration-instance-provider credential resync; integration archival now archives setup sessions and triggers skill-provider link reconciliation; integration-provider archival now archives child instance providers and enqueues `integrationInstanceProviderSet` updates. Some queues now use dynamic imports to reduce module coupling/startup cost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cafd5a647daecedbd1784b68674a7e52b2b229a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->