### PR TITLE
Fix provider grid pagination

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/grid.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/grid.tsx
@@ -1,5 +1,5 @@
 import type { DashboardInstanceProviderListingsListQuery } from '@metorial/dashboard-sdk';
-import { renderWithLoader } from '@metorial/data-hooks';
+import { renderWithPagination } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { useCurrentInstance, useProviderListings } from '@metorial/state';
 import { Avatar, Badge, Text } from '@metorial/ui';
@@ -29,7 +29,7 @@ export let ProvidersGrid = (filter: DashboardInstanceProviderListingsListQuery) 
   let instance = useCurrentInstance();
   let providers = useProviderListings(instance.data?.id, filter);
 
-  return renderWithLoader({ providers })(({ providers }) => (
+  return renderWithPagination(providers)(providers => (
     <>
       {providers.data.items.length > 0 && (
         <ItemGrid.Root width="300px">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI change that swaps the providers grid to use the standard pagination wrapper; main risk is minor regressions in loading/empty-state behavior.
> 
> **Overview**
> Fixes the providers listing grid to render via `renderWithPagination` instead of `renderWithLoader`, aligning it with other paginated lists and enabling correct pagination behavior.
> 
> This updates the `ProvidersGrid` scene to pass the `useProviderListings` result directly into the pagination renderer while keeping the grid/empty-state rendering logic the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c61bc7210e6d6ccb492f822394bc0a3c068d4e66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->