### PR TITLE
Fix integration instance details

### DIFF
--- a/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationProvider.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/integrations/integrationProvider.ts
@@ -72,7 +72,7 @@ export let v1IntegrationProviderSnapshot = Object.assign(
 
 export let dashboardIntegrationProviderSnapshot = Object.assign(
   async (integrationProvider: SubspaceIntegrationInstanceProviderSnapshot, opts?: any) => {
-    let inner = v1IntegrationProviderSnapshot(integrationProvider, opts);
+    let inner = await v1IntegrationProviderSnapshot(integrationProvider, opts);
 
     return {
       ...inner,

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration-instance/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration-instance/index.tsx
@@ -215,6 +215,10 @@ export let IntegrationInstanceOverviewPage = () => {
                             <Badge size="2" color="green">
                               Configured
                             </Badge>
+                          ) : integrationInstanceData.status === 'draft' ? (
+                            <Badge size="2" color="orange">
+                              Pending
+                            </Badge>
                           ) : (
                             <Badge size="2" color="gray">
                               Inherited


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk bugfixes: ensures `dashboardIntegrationProviderSnapshot` awaits the async snapshot builder and tweaks dashboard status labeling for draft integration instances.
> 
> **Overview**
> Fixes an async bug in `dashboardIntegrationProviderSnapshot` by awaiting `v1IntegrationProviderSnapshot`, ensuring the returned snapshot is fully resolved before spreading/adding dashboard fields.
> 
> Updates the integration instance details page to show **Pending** (orange) instead of **Inherited** when an integration instance is in `draft` and a provider has no per-instance override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49bed2ff84fff72514fccb7671b890eb6e672a8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->