### PR TITLE
Auto create default session templates

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration-instance/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration-instance/index.tsx
@@ -228,6 +228,13 @@ export let IntegrationInstanceOverviewPage = () => {
                           <Button
                             size="1"
                             variant="outline"
+                            disabled={
+                              integrationInstanceData.status === 'archived' ||
+                              integrationInstanceData.status === 'deleted' ||
+                              (integrationInstanceData.status === 'active' &&
+                                !instanceProvider?.config &&
+                                !instanceProvider?.authConfig)
+                            }
                             onClick={() =>
                               showIntegrationInstanceProviderPanelFlow({
                                 integration: integrationData,

--- a/src/systems/subspace/modules/integration/src/services/integrationInstance.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstance.ts
@@ -11,6 +11,7 @@ import {
   type Integration,
   type IntegrationInstance,
   type IntegrationInstanceStatus,
+  type SessionTemplate,
   type Solution,
   type Tenant,
   type TransactionDB,
@@ -253,6 +254,25 @@ class integrationInstanceServiceImpl {
     }
 
     return integrationInstance;
+  }
+
+  private async ensureDefaultSessionTemplateForIntegrationInstance(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    integrationInstance: IntegrationInstance & {
+      defaultSessionTemplate?: SessionTemplate | null;
+    };
+  }) {
+    return await sessionTemplateService.upsertInternalLinkedSessionTemplate({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      sessionTemplate: d.integrationInstance.defaultSessionTemplate,
+      input: {
+        integrationInstance: d.integrationInstance
+      }
+    });
   }
 
   private async getAutomaticProviderInputs(d: {
@@ -594,6 +614,18 @@ class integrationInstanceServiceImpl {
           ...d.input,
           providers: [...(d.input.providers ?? []), ...automaticProviders]
         }
+      });
+
+      await this.ensureDefaultSessionTemplateForIntegrationInstance({
+        tenant: d.tenant,
+        solution: d.solution,
+        environment: d.environment,
+        integrationInstance
+      });
+
+      integrationInstance = await db.integrationInstance.findUniqueOrThrow({
+        where: { oid: integrationInstance.oid },
+        include: integrationInstanceInclude
       });
 
       await addAfterTransactionHook(async () =>

--- a/src/systems/subspace/modules/integration/test/sharedSessionTemplate.test.ts
+++ b/src/systems/subspace/modules/integration/test/sharedSessionTemplate.test.ts
@@ -4,14 +4,22 @@ let {
   addAfterTransactionHookMock,
   withTransactionMock,
   db,
+  getIdMock,
+  ensureIntegrationIdentityMock,
   upsertInternalLinkedSessionTemplateMock,
+  integrationInstanceCreatedQueueAddMock,
   syncIntegrationInstanceSessionTemplateQueueAddMock,
   syncIntegrationInstanceGroupSessionTemplateQueueAddMock
 } = vi.hoisted(() => ({
   ...(() => {
     let db = {
       integrationInstance: {
+        create: vi.fn(),
+        update: vi.fn(),
         findUniqueOrThrow: vi.fn()
+      },
+      integrationProvider: {
+        findMany: vi.fn()
       },
       integrationInstanceGroup: {
         findUniqueOrThrow: vi.fn()
@@ -28,7 +36,12 @@ let {
       db
     };
   })(),
+  getIdMock: vi.fn((prefix: string) => ({
+    id: `${prefix}_generated`
+  })),
+  ensureIntegrationIdentityMock: vi.fn(),
   upsertInternalLinkedSessionTemplateMock: vi.fn(),
+  integrationInstanceCreatedQueueAddMock: vi.fn(),
   syncIntegrationInstanceSessionTemplateQueueAddMock: vi.fn(),
   syncIntegrationInstanceGroupSessionTemplateQueueAddMock: vi.fn()
 }));
@@ -36,7 +49,7 @@ let {
 vi.mock('@metorial-subspace/db', () => ({
   addAfterTransactionHook: addAfterTransactionHookMock,
   db,
-  getId: vi.fn(),
+  getId: getIdMock,
   withTransaction: withTransactionMock
 }));
 
@@ -86,7 +99,7 @@ vi.mock('@metorial-subspace/module-identity', () => ({
     getIdentityActorById: vi.fn()
   },
   identityInternalService: {
-    ensureIntegrationIdentity: vi.fn()
+    ensureIntegrationIdentity: ensureIntegrationIdentityMock
   }
 }));
 
@@ -134,7 +147,7 @@ vi.mock('@metorial-subspace/module-tenant', () => ({
 
 vi.mock('../src/queues/lifecycle/integrationInstance', () => ({
   integrationInstanceArchivedQueue: { add: vi.fn() },
-  integrationInstanceCreatedQueue: { add: vi.fn() },
+  integrationInstanceCreatedQueue: { add: integrationInstanceCreatedQueueAddMock },
   integrationInstanceUpdatedQueue: { add: vi.fn() }
 }));
 
@@ -172,6 +185,70 @@ describe('shared integration session templates', () => {
     addAfterTransactionHookMock.mockImplementation(async (callback: () => Promise<void>) => {
       await callback();
     });
+    getIdMock.mockImplementation((prefix: string) => ({
+      id: `${prefix}_generated`
+    }));
+    ensureIntegrationIdentityMock.mockResolvedValue({
+      actor: null,
+      identity: null
+    });
+  });
+
+  it('creates the default shared template when creating an integration instance', async () => {
+    let createdIntegrationInstance = {
+      oid: 11n,
+      id: 'int_instance_1',
+      identityActorOid: null,
+      identityOid: null,
+      defaultSessionTemplate: null
+    };
+    let integrationInstanceWithIdentity = {
+      ...createdIntegrationInstance,
+      name: 'GitHub'
+    };
+    let refreshedIntegrationInstance = {
+      ...integrationInstanceWithIdentity,
+      defaultSessionTemplate: { oid: 101n, id: 'stm_default' }
+    };
+    let createdTemplate = { id: 'stm_default' };
+
+    vi.mocked(db.integrationProvider.findMany).mockResolvedValue([]);
+    vi.mocked(db.integrationInstance.create).mockResolvedValue(createdIntegrationInstance as any);
+    vi.mocked(db.integrationInstance.update).mockResolvedValue(
+      integrationInstanceWithIdentity as any
+    );
+    vi.mocked(db.integrationInstance.findUniqueOrThrow).mockResolvedValue(
+      refreshedIntegrationInstance as any
+    );
+    upsertInternalLinkedSessionTemplateMock.mockResolvedValue(createdTemplate);
+
+    let result = await integrationInstanceService.createIntegrationInstance({
+      tenant: { oid: 1n } as any,
+      solution: { oid: 2n } as any,
+      environment: { oid: 3n } as any,
+      integration: { oid: 4n } as any,
+      input: {
+        name: 'GitHub'
+      }
+    });
+
+    expect(upsertInternalLinkedSessionTemplateMock).toHaveBeenCalledWith({
+      tenant: expect.anything(),
+      solution: expect.anything(),
+      environment: expect.anything(),
+      sessionTemplate: null,
+      input: {
+        integrationInstance: integrationInstanceWithIdentity
+      }
+    });
+    expect(db.integrationInstance.findUniqueOrThrow).toHaveBeenCalledWith({
+      where: { oid: integrationInstanceWithIdentity.oid },
+      include: expect.anything()
+    });
+    expect(integrationInstanceCreatedQueueAddMock).toHaveBeenCalledWith({
+      integrationInstanceId: 'int_instance_1'
+    });
+    expect(result).toBe(refreshedIntegrationInstance);
   });
 
   it('upserts the default shared template for an integration instance', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new side effects to integration-instance creation by upserting a linked default session template and reloading the instance, which could impact transactional behavior and downstream expectations. Frontend also changes action availability logic, potentially affecting user flows for provider configuration.
> 
> **Overview**
> **Integration instance creation now auto-provisions a default shared session template.** `createIntegrationInstance` calls a new `ensureDefaultSessionTemplateForIntegrationInstance` helper to upsert a linked session template, then reloads the instance (including `defaultSessionTemplate`) before enqueueing the created event.
> 
> **Dashboard provider action gating is tightened.** The “Configure/Edit” button is now disabled for `archived`/`deleted` instances and for `active` instances that have neither per-instance `config` nor `authConfig`.
> 
> **Tests updated/added** to cover the new creation behavior, expanding mocks (DB create/update, `getId`, identity ensure, queue add) and asserting the default template upsert + refreshed fetch during `createIntegrationInstance`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70a75741bbf9ae012669e90af6827c215d908907. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->