### PR TITLE
Fix integration list filters

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/filters.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/filters.tsx
@@ -10,8 +10,8 @@ import {
   getFilterPayload
 } from '../../../../components/table/filter';
 import {
+  getConstrainedEnumListFilterValue,
   getDateRangeFilterValue,
-  getEnumListFilterValue,
   getStringFilterValue
 } from '../../../../lib/dataTableUtils';
 import { useDebounced } from '../../../../hooks/useDebounced';
@@ -96,7 +96,11 @@ export let useIntegrationFilters = (p: {
   );
 
   let filterPayload = useMemo(() => getFilterPayload(p.filterState), [p.filterState]);
-  let status = getEnumListFilterValue(filterPayload.status, integrationStatusValues);
+  let status = getConstrainedEnumListFilterValue(
+    filterPayload.status,
+    integrationStatusValues,
+    ['active']
+  );
   let providerId = getStringFilterValue(filterPayload.providerId);
   let createdAt = getDateRangeFilterValue(filterPayload.createdAt);
   let updatedAt = getDateRangeFilterValue(filterPayload.updatedAt);

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/grid.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/grid.tsx
@@ -55,7 +55,7 @@ export let IntegrationsGrid = (
   let navigate = useNavigate();
   let integrations = useIntegrations(instanceId, {
     order: 'desc',
-    status: ['active', 'archived'],
+    status: ['active'],
     ...query
   });
   let providerIds = useMemo(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/query filtering change; main risk is unintentionally hiding archived integrations or altering default filter behavior in the integrations list.
> 
> **Overview**
> Adjusts the integrations list to **only query and display `active` integrations by default**, removing `archived` from the grid’s `useIntegrations` request.
> 
> Fixes the status filter payload generation by switching to `getConstrainedEnumListFilterValue`, constraining selected status values to an `['active']` fallback so invalid/empty selections don’t expand results beyond active integrations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9a9d3ee3cdd9980936888f0dc71d9e98da8acc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->