### PR TITLE
Improve integration performance

### DIFF
--- a/src/backend/apis/core/src/controllers/instance/integrations/integrationInstance.ts
+++ b/src/backend/apis/core/src/controllers/instance/integrations/integrationInstance.ts
@@ -1,10 +1,7 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
-import {
-  subspaceIntegrationInstanceService,
-  subspaceSessionService
-} from '@metorial/module-subspace';
+import { subspaceIntegrationInstanceService } from '@metorial/module-subspace';
 import { Controller } from '@metorial/rest';
 import { dateFilterValidator } from '../../../lib/dateFilter';
 import { normalizeArrayParam } from '../../../lib/normalizeArrayParam';
@@ -187,26 +184,12 @@ export let integrationInstanceController = Controller.create(
       )
       .output(providerSessionPresenter)
       .do(async ctx => {
-        if (!ctx.integrationInstance.defaultSessionTemplateId) {
-          throw new ServiceError(
-            badRequestError({
-              message:
-                'This integration instance does not have a shared session template yet.',
-              code: 'integration_instance_shared_session_template_missing'
-            })
-          );
-        }
-
-        let session = await subspaceSessionService.create({
+        let session = await subspaceIntegrationInstanceService.createSession({
           instance: ctx.instance,
+          integrationInstanceId: ctx.integrationInstance.id,
           name: ctx.body.name ?? `Session ${new Date().toISOString()}`,
           description: ctx.body.description,
-          metadata: ctx.body.metadata,
-          providers: [
-            {
-              sessionTemplateId: ctx.integrationInstance.defaultSessionTemplateId
-            }
-          ]
+          metadata: ctx.body.metadata
         });
 
         return providerSessionPresenter.present({ session });

--- a/src/backend/apis/core/src/controllers/instance/integrations/integrationInstanceGroup.ts
+++ b/src/backend/apis/core/src/controllers/instance/integrations/integrationInstanceGroup.ts
@@ -1,10 +1,7 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
-import {
-  subspaceIntegrationInstanceGroupService,
-  subspaceSessionService
-} from '@metorial/module-subspace';
+import { subspaceIntegrationInstanceGroupService } from '@metorial/module-subspace';
 import { Controller } from '@metorial/rest';
 import { dateFilterValidator } from '../../../lib/dateFilter';
 import { normalizeArrayParam } from '../../../lib/normalizeArrayParam';
@@ -187,26 +184,12 @@ export let integrationInstanceGroupController = Controller.create(
       )
       .output(providerSessionPresenter)
       .do(async ctx => {
-        if (!ctx.integrationInstanceGroup.defaultSessionTemplateId) {
-          throw new ServiceError(
-            badRequestError({
-              message:
-                'This integration instance group does not have a shared session template yet.',
-              code: 'integration_instance_group_shared_session_template_missing'
-            })
-          );
-        }
-
-        let session = await subspaceSessionService.create({
+        let session = await subspaceIntegrationInstanceGroupService.createSession({
           instance: ctx.instance,
+          integrationInstanceGroupId: ctx.integrationInstanceGroup.id,
           name: ctx.body.name ?? `Session ${new Date().toISOString()}`,
           description: ctx.body.description,
-          metadata: ctx.body.metadata,
-          providers: [
-            {
-              sessionTemplateId: ctx.integrationInstanceGroup.defaultSessionTemplateId
-            }
-          ]
+          metadata: ctx.body.metadata
         });
 
         return providerSessionPresenter.present({ session });

--- a/src/backend/modules/subspace/src/services/integrationInstance.ts
+++ b/src/backend/modules/subspace/src/services/integrationInstance.ts
@@ -1,10 +1,20 @@
 import { createSubspaceService } from '../lib/subspaceService';
+import { finalizeSubspaceSessionCreate } from './session';
 import { subspace } from '../subspace';
 
 export let subspaceIntegrationInstanceService = createSubspaceService(
   subspace.integrationInstance,
-  ['get', 'list', 'create', 'update', 'delete', 'createSessionTemplate'],
-  () => ({})
+  ['get', 'list', 'create', 'update', 'delete', 'createSessionTemplate', 'createSession'],
+  inner => ({
+    createSession: async (...params: Parameters<typeof inner.createSession>) => {
+      let session = await inner.createSession(...params);
+
+      return await finalizeSubspaceSessionCreate({
+        instance: params[0].instance,
+        session
+      });
+    }
+  })
 );
 
 export type SubspaceIntegrationInstance = Awaited<

--- a/src/backend/modules/subspace/src/services/integrationInstanceGroup.ts
+++ b/src/backend/modules/subspace/src/services/integrationInstanceGroup.ts
@@ -1,10 +1,20 @@
 import { createSubspaceService } from '../lib/subspaceService';
+import { finalizeSubspaceSessionCreate } from './session';
 import { subspace } from '../subspace';
 
 export let subspaceIntegrationInstanceGroupService = createSubspaceService(
   subspace.integrationInstanceGroup,
-  ['get', 'list', 'create', 'update', 'delete', 'createSessionTemplate'],
-  () => ({})
+  ['get', 'list', 'create', 'update', 'delete', 'createSessionTemplate', 'createSession'],
+  inner => ({
+    createSession: async (...params: Parameters<typeof inner.createSession>) => {
+      let session = await inner.createSession(...params);
+
+      return await finalizeSubspaceSessionCreate({
+        instance: params[0].instance,
+        session
+      });
+    }
+  })
 );
 
 export type SubspaceIntegrationInstanceGroup = Awaited<

--- a/src/backend/modules/subspace/src/services/session.ts
+++ b/src/backend/modules/subspace/src/services/session.ts
@@ -86,6 +86,108 @@ let enrichSessionEnsuringClientSecret = async (d: {
   };
 };
 
+export let finalizeSubspaceSessionCreate = async (d: {
+  instance: Instance;
+  session: RawSubspaceSession;
+}) => {
+  let eventBase = toEventBase({ instance: d.instance });
+  await Fabric.fire('provider.session.created:before', eventBase);
+
+  await sessionClientSecretReferenceService.createForSession({
+    instance: d.instance,
+    sessionId: d.session.id
+  });
+
+  await Fabric.fire('provider.session.created:after', { ...eventBase, session: d.session });
+
+  for (let provider of d.session.providers) {
+    if (provider.fromTemplateId) {
+      usageService
+        .ingestUsageRecord({
+          owner: {
+            id: eventBase.instance.id,
+            type: 'instance'
+          },
+          entity: {
+            id: provider.fromTemplateId,
+            type: 'provider_template'
+          },
+          type: 'provider_template.used'
+        })
+        .catch(e => Sentry.captureException(e));
+    }
+
+    if (provider.authConfig) {
+      usageService
+        .ingestUsageRecord({
+          owner: {
+            id: eventBase.instance.id,
+            type: 'instance'
+          },
+          entity: {
+            id: provider.authConfig.id,
+            type: 'provider_auth_config'
+          },
+          type: 'provider_auth_config.used'
+        })
+        .catch(e => Sentry.captureException(e));
+    }
+
+    if (provider.config) {
+      usageService
+        .ingestUsageRecord({
+          owner: {
+            id: eventBase.instance.id,
+            type: 'instance'
+          },
+          entity: {
+            id: provider.config.id,
+            type: 'provider_config'
+          },
+          type: 'provider_config.used'
+        })
+        .catch(e => Sentry.captureException(e));
+    }
+
+    if (provider.deployment) {
+      usageService
+        .ingestUsageRecord({
+          owner: {
+            id: eventBase.instance.id,
+            type: 'instance'
+          },
+          entity: {
+            id: provider.deployment.id,
+            type: 'provider_deployment'
+          },
+          type: 'provider_deployment.used'
+        })
+        .catch(e => Sentry.captureException(e));
+    }
+
+    if (provider.providerId) {
+      usageService
+        .ingestUsageRecord({
+          owner: {
+            id: eventBase.instance.id,
+            type: 'instance'
+          },
+          entity: {
+            id: provider.providerId,
+            type: 'provider'
+          },
+          type: 'provider.used'
+        })
+        .catch(e => Sentry.captureException(e));
+    }
+  }
+
+  return await enrichSession({
+    instance: d.instance,
+    session: d.session
+  });
+};
+
 export let subspaceSessionService = createSubspaceService(
   subspace.session,
   ['get', 'getMany', 'list', 'create', 'update', 'delete'],
@@ -127,100 +229,9 @@ export let subspaceSessionService = createSubspaceService(
       );
     },
     create: async (...params: Parameters<typeof inner.create>) => {
-      let eventBase = toEventBase(params[0]);
-      await Fabric.fire('provider.session.created:before', eventBase);
-
       let session = await inner.create(...params);
-      await sessionClientSecretReferenceService.createForSession({
-        instance: params[0].instance,
-        sessionId: session.id
-      });
 
-      await Fabric.fire('provider.session.created:after', { ...eventBase, session });
-
-      for (let provider of session.providers) {
-        if (provider.fromTemplateId) {
-          usageService
-            .ingestUsageRecord({
-              owner: {
-                id: eventBase.instance.id,
-                type: 'instance'
-              },
-              entity: {
-                id: provider.fromTemplateId,
-                type: 'provider_template'
-              },
-              type: 'provider_template.used'
-            })
-            .catch(e => Sentry.captureException(e));
-        }
-
-        if (provider.authConfig) {
-          usageService
-            .ingestUsageRecord({
-              owner: {
-                id: eventBase.instance.id,
-                type: 'instance'
-              },
-              entity: {
-                id: provider.authConfig.id,
-                type: 'provider_auth_config'
-              },
-              type: 'provider_auth_config.used'
-            })
-            .catch(e => Sentry.captureException(e));
-        }
-
-        if (provider.config) {
-          usageService
-            .ingestUsageRecord({
-              owner: {
-                id: eventBase.instance.id,
-                type: 'instance'
-              },
-              entity: {
-                id: provider.config.id,
-                type: 'provider_config'
-              },
-              type: 'provider_config.used'
-            })
-            .catch(e => Sentry.captureException(e));
-        }
-
-        if (provider.deployment) {
-          usageService
-            .ingestUsageRecord({
-              owner: {
-                id: eventBase.instance.id,
-                type: 'instance'
-              },
-              entity: {
-                id: provider.deployment.id,
-                type: 'provider_deployment'
-              },
-              type: 'provider_deployment.used'
-            })
-            .catch(e => Sentry.captureException(e));
-        }
-
-        if (provider.providerId) {
-          usageService
-            .ingestUsageRecord({
-              owner: {
-                id: eventBase.instance.id,
-                type: 'instance'
-              },
-              entity: {
-                id: provider.providerId,
-                type: 'provider'
-              },
-              type: 'provider.used'
-            })
-            .catch(e => Sentry.captureException(e));
-        }
-      }
-
-      return await enrichSession({
+      return await finalizeSubspaceSessionCreate({
         instance: params[0].instance,
         session
       });

--- a/src/systems/subspace/apps/controller/src/controllers/integrationInstance.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/integrationInstance.ts
@@ -6,6 +6,7 @@ import {
 } from '@metorial-subspace/module-integration';
 import {
   integrationInstancePresenter,
+  sessionPresenter,
   sessionTemplatePresenter
 } from '@metorial-subspace/presenters';
 import { app } from './_app';
@@ -241,6 +242,37 @@ export let integrationInstanceController = app.controller({
         });
 
       return sessionTemplatePresenter(sessionTemplate);
+    }),
+
+  createSession: integrationInstanceApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        integrationInstanceId: v.string(),
+
+        name: v.optional(v.string()),
+        description: v.optional(v.string()),
+        metadata: v.optional(v.record(v.any())),
+        privateMetadata: v.optional(v.record(v.any()))
+      })
+    )
+    .do(async ctx => {
+      let session = await integrationInstanceService.createSessionForIntegrationInstance({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+        integrationInstance: ctx.integrationInstance,
+        input: {
+          name: ctx.input.name,
+          description: ctx.input.description,
+          metadata: ctx.input.metadata,
+          privateMetadata: ctx.input.privateMetadata
+        }
+      });
+
+      return sessionPresenter(session);
     }),
 
   delete: integrationInstanceApp

--- a/src/systems/subspace/apps/controller/src/controllers/integrationInstanceGroup.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/integrationInstanceGroup.ts
@@ -3,6 +3,7 @@ import { v } from '@lowerdeck/validation';
 import { integrationInstanceGroupService } from '@metorial-subspace/module-integration';
 import {
   integrationInstanceGroupPresenter,
+  sessionPresenter,
   sessionTemplatePresenter
 } from '@metorial-subspace/presenters';
 import { app } from './_app';
@@ -214,6 +215,38 @@ export let integrationInstanceGroupController = app.controller({
         );
 
       return sessionTemplatePresenter(sessionTemplate);
+    }),
+
+  createSession: integrationInstanceGroupApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        integrationInstanceGroupId: v.string(),
+
+        name: v.optional(v.string()),
+        description: v.optional(v.string()),
+        metadata: v.optional(v.record(v.any())),
+        privateMetadata: v.optional(v.record(v.any()))
+      })
+    )
+    .do(async ctx => {
+      let session =
+        await integrationInstanceGroupService.createSessionForIntegrationInstanceGroup({
+          tenant: ctx.tenant,
+          environment: ctx.environment,
+          solution: ctx.solution,
+          integrationInstanceGroup: ctx.integrationInstanceGroup,
+          input: {
+            name: ctx.input.name,
+            description: ctx.input.description,
+            metadata: ctx.input.metadata,
+            privateMetadata: ctx.input.privateMetadata
+          }
+        });
+
+      return sessionPresenter(session);
     }),
 
   delete: integrationInstanceGroupApp

--- a/src/systems/subspace/modules/integration/src/lib/integrationIncludes.ts
+++ b/src/systems/subspace/modules/integration/src/lib/integrationIncludes.ts
@@ -1,0 +1,6 @@
+export let integrationProviderVersionInclude = {
+  deployment: true,
+  authMethod: { include: { specification: { omit: { value: true } } } },
+  authCredentials: true,
+  config: true
+};

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstance.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstance.ts
@@ -10,6 +10,7 @@ import {
 import { env } from '../../env';
 import { indexIntegrationInstanceQueue } from '../search/integrationInstance';
 import { enqueueIntegrationInstanceProvidersSet } from './integrationInstanceProvider';
+import { integrationInstanceService } from '../../services/integrationInstance';
 
 let syncIntegrationInstanceProviderCredentials = async (integrationInstanceId: string) => {
   let integrationInstanceProviders = await db.integrationInstanceProvider.findMany({
@@ -174,6 +175,31 @@ export let integrationInstanceCreatedQueue = createQueue<{ integrationInstanceId
 
 export let integrationInstanceCreatedQueueProcessor = integrationInstanceCreatedQueue.process(
   async data => {
+    let integrationInstance = await db.integrationInstance.findUnique({
+      where: { id: data.integrationInstanceId },
+      include: {
+        tenant: true,
+        solution: true,
+        environment: true,
+        defaultSessionTemplate: true
+      }
+    });
+    if (
+      !integrationInstance ||
+      integrationInstance.status === 'archived' ||
+      integrationInstance.status === 'deleted'
+    ) {
+      return;
+    }
+
+    await integrationInstanceService.createSessionTemplateForIntegrationInstance({
+      tenant: integrationInstance.tenant,
+      solution: integrationInstance.solution,
+      environment: integrationInstance.environment,
+      integrationInstance,
+      input: {}
+    });
+
     await indexIntegrationInstanceQueue.add({
       integrationInstanceId: data.integrationInstanceId
     });

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstance.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstance.ts
@@ -2,14 +2,14 @@ import { createQueue } from '@lowerdeck/queue';
 import { db } from '@metorial-subspace/db';
 import { identityInternalService } from '@metorial-subspace/module-identity';
 import { identityDeletedQueue } from '@metorial-subspace/module-identity/src/queues/lifecycle/identity';
-import { syncIntegrationInstanceGroupSessionTemplatesQueue } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
+import { enqueueSyncIntegrationInstanceGroupSessionTemplatesMany } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
 import {
-  archiveIntegrationInstanceSessionTemplatesQueue,
-  syncIntegrationInstanceSessionTemplatesQueue
+  enqueueArchiveIntegrationInstanceSessionTemplates,
+  enqueueSyncIntegrationInstanceSessionTemplates
 } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate';
 import { env } from '../../env';
 import { indexIntegrationInstanceQueue } from '../search/integrationInstance';
-import { integrationInstanceProviderSetQueue } from './integrationInstanceProvider';
+import { enqueueIntegrationInstanceProvidersSet } from './integrationInstanceProvider';
 
 let syncIntegrationInstanceProviderCredentials = async (integrationInstanceId: string) => {
   let integrationInstanceProviders = await db.integrationInstanceProvider.findMany({
@@ -86,11 +86,11 @@ export let runIntegrationInstanceArchivedEffects = async (d: {
   await indexIntegrationInstanceQueue.add({
     integrationInstanceId: d.integrationInstanceId
   });
-  await archiveIntegrationInstanceSessionTemplatesQueue.add({
+  await enqueueArchiveIntegrationInstanceSessionTemplates({
     integrationInstanceId: d.integrationInstanceId
   });
   if (archivedIntegrationInstanceProviders.length) {
-    await integrationInstanceProviderSetQueue.addMany(
+    await enqueueIntegrationInstanceProvidersSet(
       archivedIntegrationInstanceProviders.map(integrationInstanceProvider => ({
         integrationInstanceId: d.integrationInstanceId,
         integrationInstanceProviderId: integrationInstanceProvider.id
@@ -152,10 +152,10 @@ export let integrationInstanceArchiveGroupSourcesManyQueueProcessor =
       }
     });
 
-    await syncIntegrationInstanceGroupSessionTemplatesQueue.addMany(
-      Array.from(
-        new Set(groupSources.map(source => source.integrationInstanceGroup.id))
-      ).map(integrationInstanceGroupId => ({ integrationInstanceGroupId }))
+    await enqueueSyncIntegrationInstanceGroupSessionTemplatesMany(
+      Array.from(new Set(groupSources.map(source => source.integrationInstanceGroup.id))).map(
+        integrationInstanceGroupId => ({ integrationInstanceGroupId })
+      )
     );
 
     let lastSource = groupSources[groupSources.length - 1];
@@ -177,7 +177,7 @@ export let integrationInstanceCreatedQueueProcessor = integrationInstanceCreated
     await indexIntegrationInstanceQueue.add({
       integrationInstanceId: data.integrationInstanceId
     });
-    await syncIntegrationInstanceSessionTemplatesQueue.add({
+    await enqueueSyncIntegrationInstanceSessionTemplates({
       integrationInstanceId: data.integrationInstanceId
     });
     await syncIntegrationInstanceProviderCredentials(data.integrationInstanceId);
@@ -194,7 +194,7 @@ export let integrationInstanceUpdatedQueueProcessor = integrationInstanceUpdated
     await indexIntegrationInstanceQueue.add({
       integrationInstanceId: data.integrationInstanceId
     });
-    await syncIntegrationInstanceSessionTemplatesQueue.add({
+    await enqueueSyncIntegrationInstanceSessionTemplates({
       integrationInstanceId: data.integrationInstanceId
     });
     await syncIntegrationInstanceProviderCredentials(data.integrationInstanceId);

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstanceGroup.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstanceGroup.ts
@@ -1,11 +1,11 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db } from '@metorial-subspace/db';
 import {
-  archiveIntegrationInstanceGroupSessionTemplatesQueue,
-  syncIntegrationInstanceGroupSessionTemplatesQueue
+  enqueueArchiveIntegrationInstanceGroupSessionTemplates,
+  enqueueSyncIntegrationInstanceGroupSessionTemplates
 } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
 import { env } from '../../env';
-import { integrationInstanceGroupProviderSetQueue } from './integrationInstanceGroupProvider';
+import { enqueueIntegrationInstanceGroupProvidersSet } from './integrationInstanceGroupProvider';
 
 export let runIntegrationInstanceGroupArchivedEffects = async (d: {
   integrationInstanceGroupId: string;
@@ -23,7 +23,7 @@ export let runIntegrationInstanceGroupArchivedEffects = async (d: {
     }
   });
 
-  await archiveIntegrationInstanceGroupSessionTemplatesQueue.add({
+  await enqueueArchiveIntegrationInstanceGroupSessionTemplates({
     integrationInstanceGroupId: d.integrationInstanceGroupId
   });
 
@@ -71,7 +71,7 @@ export let integrationInstanceGroupArchiveProvidersManyQueueProcessor =
       }
     });
 
-    await integrationInstanceGroupProviderSetQueue.addMany(
+    await enqueueIntegrationInstanceGroupProvidersSet(
       providers.map(provider => ({
         integrationInstanceGroupId: data.integrationInstanceGroupId,
         integrationInstanceGroupProviderId: provider.id
@@ -96,7 +96,7 @@ export let integrationInstanceGroupCreatedQueue = createQueue<{
 
 export let integrationInstanceGroupCreatedQueueProcessor =
   integrationInstanceGroupCreatedQueue.process(async data => {
-    await syncIntegrationInstanceGroupSessionTemplatesQueue.add({
+    await enqueueSyncIntegrationInstanceGroupSessionTemplates({
       integrationInstanceGroupId: data.integrationInstanceGroupId
     });
   });
@@ -110,7 +110,7 @@ export let integrationInstanceGroupUpdatedQueue = createQueue<{
 
 export let integrationInstanceGroupUpdatedQueueProcessor =
   integrationInstanceGroupUpdatedQueue.process(async data => {
-    await syncIntegrationInstanceGroupSessionTemplatesQueue.add({
+    await enqueueSyncIntegrationInstanceGroupSessionTemplates({
       integrationInstanceGroupId: data.integrationInstanceGroupId
     });
   });

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstanceGroup.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstanceGroup.ts
@@ -5,6 +5,7 @@ import {
   enqueueSyncIntegrationInstanceGroupSessionTemplates
 } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
 import { env } from '../../env';
+import { integrationInstanceGroupService } from '../../services/integrationInstanceGroup';
 import { enqueueIntegrationInstanceGroupProvidersSet } from './integrationInstanceGroupProvider';
 
 export let runIntegrationInstanceGroupArchivedEffects = async (d: {
@@ -96,6 +97,31 @@ export let integrationInstanceGroupCreatedQueue = createQueue<{
 
 export let integrationInstanceGroupCreatedQueueProcessor =
   integrationInstanceGroupCreatedQueue.process(async data => {
+    let integrationInstanceGroup = await db.integrationInstanceGroup.findUnique({
+      where: { id: data.integrationInstanceGroupId },
+      include: {
+        tenant: true,
+        solution: true,
+        environment: true,
+        defaultSessionTemplate: true
+      }
+    });
+    if (
+      !integrationInstanceGroup ||
+      integrationInstanceGroup.status === 'archived' ||
+      integrationInstanceGroup.status === 'deleted'
+    ) {
+      return;
+    }
+
+    await integrationInstanceGroupService.createSessionTemplateForIntegrationInstanceGroup({
+      tenant: integrationInstanceGroup.tenant,
+      solution: integrationInstanceGroup.solution,
+      environment: integrationInstanceGroup.environment,
+      integrationInstanceGroup,
+      input: {}
+    });
+
     await enqueueSyncIntegrationInstanceGroupSessionTemplates({
       integrationInstanceGroupId: data.integrationInstanceGroupId
     });

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstanceGroupProvider.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstanceGroupProvider.ts
@@ -1,6 +1,7 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db } from '@metorial-subspace/db';
-import { syncIntegrationInstanceGroupSessionTemplatesQueue } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
+import { queueJobId } from '@metorial-subspace/module-session/src/lib/sessionTemplateSync';
+import { enqueueSyncIntegrationInstanceGroupSessionTemplates } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
 import { env } from '../../env';
 
 export let integrationInstanceGroupProviderSetQueue = createQueue<{
@@ -11,6 +12,31 @@ export let integrationInstanceGroupProviderSetQueue = createQueue<{
   redisUrl: env.service.REDIS_URL
 });
 
+export let enqueueIntegrationInstanceGroupProviderSet = async (d: {
+  integrationInstanceGroupId: string;
+  integrationInstanceGroupProviderId: string;
+}) => {
+  await integrationInstanceGroupProviderSetQueue.add(d, {
+    id: queueJobId('iigp', d.integrationInstanceGroupProviderId)
+  });
+};
+
+export let enqueueIntegrationInstanceGroupProvidersSet = async (
+  items: {
+    integrationInstanceGroupId: string;
+    integrationInstanceGroupProviderId: string;
+  }[]
+) => {
+  if (!items.length) return;
+
+  await integrationInstanceGroupProviderSetQueue.addManyWithOps(
+    items.map(item => ({
+      data: item,
+      opts: { id: queueJobId('iigp', item.integrationInstanceGroupProviderId) }
+    }))
+  );
+};
+
 export let integrationInstanceGroupProviderSetQueueProcessor =
   integrationInstanceGroupProviderSetQueue.process(async data => {
     let provider = await db.integrationInstanceGroupProvider.findUnique({
@@ -19,7 +45,7 @@ export let integrationInstanceGroupProviderSetQueueProcessor =
     });
     if (!provider) return;
 
-    await syncIntegrationInstanceGroupSessionTemplatesQueue.add({
+    await enqueueSyncIntegrationInstanceGroupSessionTemplates({
       integrationInstanceGroupId: data.integrationInstanceGroupId
     });
   });

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstanceProvider.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstanceProvider.ts
@@ -3,8 +3,9 @@ import { db } from '@metorial-subspace/db';
 import { providerAuthConfigService } from '@metorial-subspace/module-auth';
 import { providerConfigService } from '@metorial-subspace/module-deployment';
 import { identityInternalService } from '@metorial-subspace/module-identity';
-import { syncIntegrationInstanceGroupSessionTemplatesQueue } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
-import { syncIntegrationInstanceSessionTemplatesQueue } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate';
+import { queueJobId } from '@metorial-subspace/module-session/src/lib/sessionTemplateSync';
+import { enqueueSyncIntegrationInstanceGroupSessionTemplatesMany } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
+import { enqueueSyncIntegrationInstanceSessionTemplates } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate';
 import { env } from '../../env';
 import { indexIntegrationInstanceQueue } from '../search/integrationInstance';
 
@@ -29,6 +30,31 @@ export let integrationInstanceProviderSetQueue = createQueue<{
   redisUrl: env.service.REDIS_URL
 });
 
+export let enqueueIntegrationInstanceProviderSet = async (d: {
+  integrationInstanceId: string;
+  integrationInstanceProviderId: string;
+}) => {
+  await integrationInstanceProviderSetQueue.add(d, {
+    id: queueJobId('iip', d.integrationInstanceProviderId)
+  });
+};
+
+export let enqueueIntegrationInstanceProvidersSet = async (
+  items: {
+    integrationInstanceId: string;
+    integrationInstanceProviderId: string;
+  }[]
+) => {
+  if (!items.length) return;
+
+  await integrationInstanceProviderSetQueue.addManyWithOps(
+    items.map(item => ({
+      data: item,
+      opts: { id: queueJobId('iip', item.integrationInstanceProviderId) }
+    }))
+  );
+};
+
 export let integrationInstanceProviderSetQueueProcessor =
   integrationInstanceProviderSetQueue.process(async data => {
     let integrationInstanceProvider = await db.integrationInstanceProvider.findUnique({
@@ -43,11 +69,11 @@ export let integrationInstanceProviderSetQueueProcessor =
     await identityInternalService.syncIntegrationInstanceProviderCredential({
       integrationInstanceProviderId: data.integrationInstanceProviderId
     });
-    await syncIntegrationInstanceSessionTemplatesQueue.add({
+    await enqueueSyncIntegrationInstanceSessionTemplates({
       integrationInstanceId: data.integrationInstanceId
     });
 
-    await integrationInstanceProviderSyncGroupProvidersManyQueue.add({
+    await enqueueIntegrationInstanceProviderSyncGroupProvidersMany({
       integrationInstanceProviderId: data.integrationInstanceProviderId
     });
 
@@ -107,6 +133,15 @@ export let integrationInstanceProviderSyncGroupProvidersManyQueue = createQueue<
   redisUrl: env.service.REDIS_URL
 });
 
+let enqueueIntegrationInstanceProviderSyncGroupProvidersMany = async (d: {
+  integrationInstanceProviderId: string;
+  cursor?: string;
+}) => {
+  await integrationInstanceProviderSyncGroupProvidersManyQueue.add(d, {
+    id: queueJobId('iipg', d.integrationInstanceProviderId, d.cursor ?? 'start')
+  });
+};
+
 export let integrationInstanceProviderSyncGroupProvidersManyQueueProcessor =
   integrationInstanceProviderSyncGroupProvidersManyQueue.process(async data => {
     let integrationInstanceProvider = await db.integrationInstanceProvider.findUnique({
@@ -136,7 +171,7 @@ export let integrationInstanceProviderSyncGroupProvidersManyQueueProcessor =
       });
     }
 
-    await syncIntegrationInstanceGroupSessionTemplatesQueue.addMany(
+    await enqueueSyncIntegrationInstanceGroupSessionTemplatesMany(
       Array.from(
         new Set(groupProviders.map(provider => provider.integrationInstanceGroup.id))
       ).map(integrationInstanceGroupId => ({ integrationInstanceGroupId }))
@@ -145,7 +180,7 @@ export let integrationInstanceProviderSyncGroupProvidersManyQueueProcessor =
     let lastProvider = groupProviders[groupProviders.length - 1];
     if (!lastProvider) return;
 
-    await integrationInstanceProviderSyncGroupProvidersManyQueue.add({
+    await enqueueIntegrationInstanceProviderSyncGroupProvidersMany({
       integrationInstanceProviderId: data.integrationInstanceProviderId,
       cursor: lastProvider.id
     });

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationProvider.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationProvider.ts
@@ -1,13 +1,13 @@
 import { createQueue, QueueRetryError } from '@lowerdeck/queue';
 import { db } from '@metorial-subspace/db';
 import { identityInternalService } from '@metorial-subspace/module-identity';
-import { syncIntegrationInstanceGroupSessionTemplatesQueue } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
-import { syncIntegrationInstanceSessionTemplatesQueue } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate';
+import { enqueueSyncIntegrationInstanceGroupSessionTemplatesMany } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
+import { enqueueSyncIntegrationInstanceSessionTemplatesMany } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate';
 import { reconcileSkillProviderLinksForIntegrationProviderQueue } from '@metorial-subspace/module-skills/src/queues/reconciler/reconcileSkillProviderLink';
 import { env } from '../../env';
 import { indexIntegrationQueue } from '../search/integration';
 import { indexIntegrationInstanceQueue } from '../search/integrationInstance';
-import { integrationInstanceProviderSetQueue } from './integrationInstanceProvider';
+import { enqueueIntegrationInstanceProvidersSet } from './integrationInstanceProvider';
 
 let indexParentIntegration = async (integrationProviderId: string) => {
   let integrationProvider = await db.integrationProvider.findUnique({
@@ -22,7 +22,7 @@ let indexParentIntegration = async (integrationProviderId: string) => {
 let syncIntegrationInstanceSessionTemplates = async (integrationInstanceIds: string[]) => {
   if (integrationInstanceIds.length === 0) return;
 
-  await syncIntegrationInstanceSessionTemplatesQueue.addMany(
+  await enqueueSyncIntegrationInstanceSessionTemplatesMany(
     integrationInstanceIds.map(integrationInstanceId => ({ integrationInstanceId }))
   );
 };
@@ -139,7 +139,7 @@ export let integrationProviderArchiveInstanceProvidersManyQueueProcessor =
       }
     });
 
-    await integrationInstanceProviderSetQueue.addMany(
+    await enqueueIntegrationInstanceProvidersSet(
       integrationInstanceProviders.map(provider => ({
         integrationInstanceId: provider.integrationInstance.id,
         integrationInstanceProviderId: provider.id
@@ -200,7 +200,7 @@ export let integrationProviderArchiveGroupProvidersManyQueueProcessor =
       data: { isParentDeleted: true }
     });
 
-    await syncIntegrationInstanceGroupSessionTemplatesQueue.addMany(
+    await enqueueSyncIntegrationInstanceGroupSessionTemplatesMany(
       Array.from(
         new Set(groupProviders.map(provider => provider.integrationInstanceGroup.id))
       ).map(integrationInstanceGroupId => ({ integrationInstanceGroupId }))

--- a/src/systems/subspace/modules/integration/src/services/integration.ts
+++ b/src/systems/subspace/modules/integration/src/services/integration.ts
@@ -25,6 +25,7 @@ import {
 } from '@metorial-subspace/list-utils';
 import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
 import { checkTenant } from '@metorial-subspace/module-tenant';
+import { integrationProviderVersionInclude } from '../lib/integrationIncludes';
 import { createIntegrationVersion } from '../lib/versions';
 import {
   integrationArchivedQueue,
@@ -34,12 +35,7 @@ import {
 
 import { integrationVersionInclude } from './integrationVersion';
 
-export let integrationProviderVersionInclude = {
-  deployment: true,
-  authMethod: { include: { specification: { omit: { value: true } } } },
-  authCredentials: true,
-  config: true
-};
+export { integrationProviderVersionInclude };
 
 export let integrationInclude = {
   currentVersion: {

--- a/src/systems/subspace/modules/integration/src/services/integrationInstance.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstance.ts
@@ -11,7 +11,6 @@ import {
   type Integration,
   type IntegrationInstance,
   type IntegrationInstanceStatus,
-  type SessionTemplate,
   type Solution,
   type Tenant,
   type TransactionDB,
@@ -41,15 +40,16 @@ import {
   identityInternalService
 } from '@metorial-subspace/module-identity';
 import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
-import { sessionTemplateService } from '@metorial-subspace/module-session';
+import { sessionService, sessionTemplateService } from '@metorial-subspace/module-session';
 import { enqueueSyncIntegrationInstanceSessionTemplate } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate';
+import { type SessionProviderTemplateInput } from '@metorial-subspace/module-session/src/services/sessionProviderInput';
 import { checkTenant } from '@metorial-subspace/module-tenant';
 import {
   integrationInstanceArchivedQueue,
   integrationInstanceCreatedQueue,
   integrationInstanceUpdatedQueue
 } from '../queues/lifecycle/integrationInstance';
-import { integrationProviderVersionInclude } from './integration';
+import { integrationProviderVersionInclude } from '../lib/integrationIncludes';
 import {
   integrationInstanceProviderService,
   type SetIntegrationInstanceProviderInput
@@ -106,6 +106,17 @@ type IntegrationInstanceWriteInput = {
   identityId?: string | null;
   providers?: SetIntegrationInstanceProviderInput[];
 };
+
+let DEFAULT_SESSION_TEMPLATE_POLL_INTERVAL_MS = 250;
+let DEFAULT_SESSION_TEMPLATE_POLL_ATTEMPTS = 20;
+
+let wait = async (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+let defaultSessionTemplateTimeoutError = () =>
+  badRequestError({
+    message: 'Timed out waiting for the default session template to become available.',
+    code: 'default_session_template_timeout'
+  });
 
 let mergeIntegrationIdentityInput = (d: {
   current?: {
@@ -254,25 +265,6 @@ class integrationInstanceServiceImpl {
     }
 
     return integrationInstance;
-  }
-
-  private async ensureDefaultSessionTemplateForIntegrationInstance(d: {
-    tenant: Tenant;
-    solution: Solution;
-    environment: Environment;
-    integrationInstance: IntegrationInstance & {
-      defaultSessionTemplate?: SessionTemplate | null;
-    };
-  }) {
-    return await sessionTemplateService.upsertInternalLinkedSessionTemplate({
-      tenant: d.tenant,
-      solution: d.solution,
-      environment: d.environment,
-      sessionTemplate: d.integrationInstance.defaultSessionTemplate,
-      input: {
-        integrationInstance: d.integrationInstance
-      }
-    });
   }
 
   private async getAutomaticProviderInputs(d: {
@@ -616,13 +608,6 @@ class integrationInstanceServiceImpl {
         }
       });
 
-      await this.ensureDefaultSessionTemplateForIntegrationInstance({
-        tenant: d.tenant,
-        solution: d.solution,
-        environment: d.environment,
-        integrationInstance
-      });
-
       integrationInstance = await db.integrationInstance.findUniqueOrThrow({
         where: { oid: integrationInstance.oid },
         include: integrationInstanceInclude
@@ -849,6 +834,101 @@ class integrationInstanceServiceImpl {
       );
 
       return sessionTemplate;
+    });
+  }
+
+  async waitForDefaultSessionTemplateForIntegrationInstance(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    integrationInstance: IntegrationInstance;
+  }) {
+    checkTenant(d, d.integrationInstance);
+    checkDeletedRelation(d.integrationInstance);
+
+    for (let attempt = 0; attempt < DEFAULT_SESSION_TEMPLATE_POLL_ATTEMPTS; attempt++) {
+      let integrationInstance = await db.integrationInstance.findFirst({
+        where: {
+          oid: d.integrationInstance.oid,
+          tenantOid: d.tenant.oid,
+          solutionOid: d.solution.oid,
+          environmentOid: d.environment.oid,
+          status: { notIn: ['archived', 'deleted'] }
+        },
+        include: {
+          integrationInstanceProviders: {
+            where: {
+              status: 'active',
+              isParentDeleted: false,
+              currentVersion: { configOid: { not: null } }
+            },
+            select: { oid: true }
+          },
+          defaultSessionTemplate: {
+            include: {
+              providers: {
+                where: { status: 'active' },
+                include: {
+                  deployment: true,
+                  config: true,
+                  authConfig: true
+                }
+              }
+            }
+          }
+        }
+      });
+
+      let template = integrationInstance?.defaultSessionTemplate;
+      let expectedProviderCount =
+        integrationInstance?.integrationInstanceProviders.length ?? 0;
+      if (template && template.providers.length >= expectedProviderCount) {
+        return template as SessionProviderTemplateInput;
+      }
+
+      if (attempt < DEFAULT_SESSION_TEMPLATE_POLL_ATTEMPTS - 1) {
+        await wait(DEFAULT_SESSION_TEMPLATE_POLL_INTERVAL_MS);
+      }
+    }
+
+    throw new ServiceError(defaultSessionTemplateTimeoutError());
+  }
+
+  async createSessionForIntegrationInstance(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    integrationInstance: IntegrationInstance;
+    input: {
+      name?: string;
+      description?: string;
+      metadata?: Record<string, any>;
+      privateMetadata?: Record<string, any>;
+    };
+  }) {
+    checkTenant(d, d.integrationInstance);
+    checkDeletedRelation(d.integrationInstance);
+
+    let template = await this.waitForDefaultSessionTemplateForIntegrationInstance({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      integrationInstance: d.integrationInstance
+    });
+
+    return await sessionService.createSession({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      input: {
+        ...d.input,
+        providers: [
+          {
+            sessionTemplateId: template.id,
+            __sessionTemplate: template
+          }
+        ]
+      }
     });
   }
 

--- a/src/systems/subspace/modules/integration/src/services/integrationInstance.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstance.ts
@@ -42,7 +42,7 @@ import {
 } from '@metorial-subspace/module-identity';
 import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
 import { sessionTemplateService } from '@metorial-subspace/module-session';
-import { syncIntegrationInstanceSessionTemplateQueue } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate';
+import { enqueueSyncIntegrationInstanceSessionTemplate } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate';
 import { checkTenant } from '@metorial-subspace/module-tenant';
 import {
   integrationInstanceArchivedQueue,
@@ -845,9 +845,7 @@ class integrationInstanceServiceImpl {
       });
 
       await addAfterTransactionHook(async () =>
-        syncIntegrationInstanceSessionTemplateQueue.add({
-          sessionTemplateId: sessionTemplate.id
-        })
+        enqueueSyncIntegrationInstanceSessionTemplate(sessionTemplate.id)
       );
 
       return sessionTemplate;

--- a/src/systems/subspace/modules/integration/src/services/integrationInstanceGroup.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstanceGroup.ts
@@ -32,7 +32,7 @@ import {
 } from '@metorial-subspace/list-utils';
 import { identityActorService, identityService } from '@metorial-subspace/module-identity';
 import { sessionTemplateService } from '@metorial-subspace/module-session';
-import { syncIntegrationInstanceGroupSessionTemplateQueue } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
+import { enqueueSyncIntegrationInstanceGroupSessionTemplate } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
 import { checkTenant } from '@metorial-subspace/module-tenant';
 import {
   integrationInstanceGroupArchivedQueue,
@@ -665,9 +665,7 @@ class integrationInstanceGroupServiceImpl {
       });
 
       await addAfterTransactionHook(async () =>
-        syncIntegrationInstanceGroupSessionTemplateQueue.add({
-          sessionTemplateId: sessionTemplate.id
-        })
+        enqueueSyncIntegrationInstanceGroupSessionTemplate(sessionTemplate.id)
       );
 
       return sessionTemplate;

--- a/src/systems/subspace/modules/integration/src/services/integrationInstanceGroup.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstanceGroup.ts
@@ -31,8 +31,9 @@ import {
   resolveSessionTemplates
 } from '@metorial-subspace/list-utils';
 import { identityActorService, identityService } from '@metorial-subspace/module-identity';
-import { sessionTemplateService } from '@metorial-subspace/module-session';
+import { sessionService, sessionTemplateService } from '@metorial-subspace/module-session';
 import { enqueueSyncIntegrationInstanceGroupSessionTemplate } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate';
+import { type SessionProviderTemplateInput } from '@metorial-subspace/module-session/src/services/sessionProviderInput';
 import { checkTenant } from '@metorial-subspace/module-tenant';
 import {
   integrationInstanceGroupArchivedQueue,
@@ -109,6 +110,17 @@ type IntegrationInstanceGroupWriteInput = {
     'identityActorOid' | 'identityOid'
   >[];
 };
+
+let DEFAULT_SESSION_TEMPLATE_POLL_INTERVAL_MS = 250;
+let DEFAULT_SESSION_TEMPLATE_POLL_ATTEMPTS = 20;
+
+let wait = async (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+let defaultSessionTemplateTimeoutError = () =>
+  badRequestError({
+    message: 'Timed out waiting for the default session template to become available.',
+    code: 'default_session_template_timeout'
+  });
 
 class integrationInstanceGroupServiceImpl {
   private async resolveIdentitySnapshot(d: {
@@ -669,6 +681,104 @@ class integrationInstanceGroupServiceImpl {
       );
 
       return sessionTemplate;
+    });
+  }
+
+  async waitForDefaultSessionTemplateForIntegrationInstanceGroup(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    integrationInstanceGroup: IntegrationInstanceGroup;
+  }) {
+    checkTenant(d, d.integrationInstanceGroup);
+    checkDeletedRelation(d.integrationInstanceGroup);
+
+    for (let attempt = 0; attempt < DEFAULT_SESSION_TEMPLATE_POLL_ATTEMPTS; attempt++) {
+      let integrationInstanceGroup = await db.integrationInstanceGroup.findFirst({
+        where: {
+          oid: d.integrationInstanceGroup.oid,
+          tenantOid: d.tenant.oid,
+          solutionOid: d.solution.oid,
+          environmentOid: d.environment.oid,
+          status: { notIn: ['archived', 'deleted'] }
+        },
+        include: {
+          providers: {
+            where: {
+              status: 'active',
+              isParentDeleted: false,
+              integrationInstanceProvider: {
+                status: 'active',
+                isParentDeleted: false,
+                currentVersion: { configOid: { not: null } }
+              }
+            },
+            select: { oid: true }
+          },
+          defaultSessionTemplate: {
+            include: {
+              providers: {
+                where: { status: 'active' },
+                include: {
+                  deployment: true,
+                  config: true,
+                  authConfig: true
+                }
+              }
+            }
+          }
+        }
+      });
+
+      let template = integrationInstanceGroup?.defaultSessionTemplate;
+      let expectedProviderCount = integrationInstanceGroup?.providers.length ?? 0;
+      if (template && template.providers.length >= expectedProviderCount) {
+        return template as SessionProviderTemplateInput;
+      }
+
+      if (attempt < DEFAULT_SESSION_TEMPLATE_POLL_ATTEMPTS - 1) {
+        await wait(DEFAULT_SESSION_TEMPLATE_POLL_INTERVAL_MS);
+      }
+    }
+
+    throw new ServiceError(defaultSessionTemplateTimeoutError());
+  }
+
+  async createSessionForIntegrationInstanceGroup(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    integrationInstanceGroup: IntegrationInstanceGroup;
+    input: {
+      name?: string;
+      description?: string;
+      metadata?: Record<string, any>;
+      privateMetadata?: Record<string, any>;
+    };
+  }) {
+    checkTenant(d, d.integrationInstanceGroup);
+    checkDeletedRelation(d.integrationInstanceGroup);
+
+    let template = await this.waitForDefaultSessionTemplateForIntegrationInstanceGroup({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      integrationInstanceGroup: d.integrationInstanceGroup
+    });
+
+    return await sessionService.createSession({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      input: {
+        ...d.input,
+        providers: [
+          {
+            sessionTemplateId: template.id,
+            __sessionTemplate: template
+          }
+        ]
+      }
     });
   }
 

--- a/src/systems/subspace/modules/integration/src/services/integrationInstanceGroupProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstanceGroupProvider.ts
@@ -33,7 +33,10 @@ import {
 } from '@metorial-subspace/list-utils';
 import { normalizeToolFilters } from '@metorial-subspace/module-provider-internal';
 import { checkTenant } from '@metorial-subspace/module-tenant';
-import { integrationInstanceGroupProviderSetQueue } from '../queues/lifecycle/integrationInstanceGroupProvider';
+import {
+  enqueueIntegrationInstanceGroupProviderSet,
+  enqueueIntegrationInstanceGroupProvidersSet
+} from '../queues/lifecycle/integrationInstanceGroupProvider';
 import { integrationInstanceGroupProviderInclude } from './integrationInstanceGroup';
 
 export type SetIntegrationInstanceGroupProviderInput = {
@@ -203,6 +206,7 @@ class integrationInstanceGroupProviderServiceImpl {
     integrationInstanceGroup: IntegrationInstanceGroup;
     input: SetIntegrationInstanceGroupProviderInput[];
     _allowMagicMcpBacking?: boolean;
+    _skipLifecycleSync?: boolean;
   }) {
     checkTenant(d, d.integrationInstanceGroup);
     checkDeletedRelation(d.integrationInstanceGroup);
@@ -425,14 +429,16 @@ class integrationInstanceGroupProviderServiceImpl {
       let providersByOid = new Map(providers.map(provider => [provider.oid, provider]));
       let orderedProviders = providerOids.map(oid => providersByOid.get(oid)!);
 
-      await addAfterTransactionHook(async () =>
-        integrationInstanceGroupProviderSetQueue.addMany(
-          orderedProviders.map(provider => ({
-            integrationInstanceGroupId: d.integrationInstanceGroup.id,
-            integrationInstanceGroupProviderId: provider.id
-          }))
-        )
-      );
+      if (!d._skipLifecycleSync) {
+        await addAfterTransactionHook(async () =>
+          enqueueIntegrationInstanceGroupProvidersSet(
+            orderedProviders.map(provider => ({
+              integrationInstanceGroupId: d.integrationInstanceGroup.id,
+              integrationInstanceGroupProviderId: provider.id
+            }))
+          )
+        );
+      }
 
       return orderedProviders;
     });
@@ -472,7 +478,8 @@ class integrationInstanceGroupProviderServiceImpl {
   }) {
     let providers = await this.setIntegrationInstanceGroupProviders({
       ...d,
-      _allowMagicMcpBacking: true
+      _allowMagicMcpBacking: true,
+      _skipLifecycleSync: true
     });
 
     await withTransaction(async db => {
@@ -537,7 +544,7 @@ class integrationInstanceGroupProviderServiceImpl {
       });
 
       await addAfterTransactionHook(async () =>
-        integrationInstanceGroupProviderSetQueue.add({
+        enqueueIntegrationInstanceGroupProviderSet({
           integrationInstanceGroupId: provider.integrationInstanceGroup.id,
           integrationInstanceGroupProviderId: provider.id
         })

--- a/src/systems/subspace/modules/integration/src/services/integrationInstanceProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstanceProvider.ts
@@ -40,7 +40,10 @@ import {
   normalizeIntegrationProviderToolFilter,
   refreshIntegrationInstanceStatus
 } from '../lib/versions';
-import { integrationInstanceProviderSetQueue } from '../queues/lifecycle/integrationInstanceProvider';
+import {
+  enqueueIntegrationInstanceProviderSet,
+  enqueueIntegrationInstanceProvidersSet
+} from '../queues/lifecycle/integrationInstanceProvider';
 import { getIntegrationToolFilterCapabilities } from './integration';
 import {
   integrationInstanceProviderInclude,
@@ -756,7 +759,7 @@ class integrationInstanceProviderServiceImpl {
       let orderedRes = integrationInstanceProviderOids.map(oid => resByOid.get(oid)!);
 
       await addAfterTransactionHook(async () =>
-        integrationInstanceProviderSetQueue.addMany(
+        enqueueIntegrationInstanceProvidersSet(
           orderedRes.map(integrationInstanceProvider => ({
             integrationInstanceId: d.integrationInstance.id,
             integrationInstanceProviderId: integrationInstanceProvider.id
@@ -899,7 +902,7 @@ class integrationInstanceProviderServiceImpl {
       });
 
       await addAfterTransactionHook(async () =>
-        integrationInstanceProviderSetQueue.add({
+        enqueueIntegrationInstanceProviderSet({
           integrationInstanceId: res.integrationInstance.id,
           integrationInstanceProviderId: res.id
         })

--- a/src/systems/subspace/modules/integration/src/services/integrationProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationProvider.ts
@@ -54,7 +54,7 @@ import {
   integrationProviderCreatedQueue,
   integrationProviderUpdatedQueue
 } from '../queues/lifecycle/integrationProvider';
-import { integrationProviderVersionInclude } from './integration';
+import { integrationProviderVersionInclude } from '../lib/integrationIncludes';
 
 export let integrationProviderInclude = {
   integration: true,

--- a/src/systems/subspace/modules/integration/src/services/integrationSetupSession.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationSetupSession.ts
@@ -29,10 +29,8 @@ import {
 import { checkTenant } from '@metorial-subspace/module-tenant';
 import { addMinutes } from 'date-fns';
 import { normalizeIntegrationProviderToolFilter } from '../lib/versions';
-import {
-  getIntegrationToolFilterCapabilities,
-  integrationProviderVersionInclude
-} from './integration';
+import { integrationProviderVersionInclude } from '../lib/integrationIncludes';
+import { getIntegrationToolFilterCapabilities } from './integration';
 import {
   integrationInstanceInclude,
   integrationInstanceProviderInclude,

--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/endpoint.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/endpoint.ts
@@ -13,7 +13,7 @@ import {
   sessionTemplateProviderService,
   sessionTemplateService
 } from '@metorial-subspace/module-session';
-import { sessionTemplateSyncHashQueue } from '@metorial-subspace/module-session/src/queues/lifecycle/sessionTemplateProvider';
+import { enqueueSessionTemplateSyncHash } from '@metorial-subspace/module-session/src/queues/lifecycle/sessionTemplateProvider';
 import { checkTenant } from '@metorial-subspace/module-tenant';
 import { integrationInstanceGroupService } from '../integrationInstanceGroup';
 import { integrationInstanceGroupProviderService } from '../integrationInstanceGroupProvider';
@@ -209,9 +209,7 @@ class magicMcpEndpointBackingServiceImpl {
       sessionTemplate: syncTarget.sessionTemplate,
       integrationInstanceGroup: syncTarget.group
     });
-    await sessionTemplateSyncHashQueue.add({
-      sessionTemplateId: syncTarget.sessionTemplate.id
-    });
+    await enqueueSessionTemplateSyncHash(syncTarget.sessionTemplate.id);
 
     return await db.magicMcpEndpointBacking.findUniqueOrThrow({
       where: { id: d.input.id },

--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/server.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/server.ts
@@ -13,7 +13,7 @@ import {
   sessionTemplateProviderService,
   sessionTemplateService
 } from '@metorial-subspace/module-session';
-import { sessionTemplateSyncHashQueue } from '@metorial-subspace/module-session/src/queues/lifecycle/sessionTemplateProvider';
+import { enqueueSessionTemplateSyncHash } from '@metorial-subspace/module-session/src/queues/lifecycle/sessionTemplateProvider';
 import { checkTenant } from '@metorial-subspace/module-tenant';
 import { integrationService } from '../integration';
 import { integrationInstanceService } from '../integrationInstance';
@@ -313,9 +313,7 @@ class magicMcpServerBackingServiceImpl {
       sessionTemplate: syncTarget.sessionTemplate,
       integrationInstance: syncTarget.integrationInstance
     });
-    await sessionTemplateSyncHashQueue.add({
-      sessionTemplateId: syncTarget.sessionTemplate.id
-    });
+    await enqueueSessionTemplateSyncHash(syncTarget.sessionTemplate.id);
 
     await reconcileMagicMcpServerProvidersForBackingWithoutLock({
       tenant: d.tenant,

--- a/src/systems/subspace/modules/integration/test/defaultSessionTemplateLifecycle.test.ts
+++ b/src/systems/subspace/modules/integration/test/defaultSessionTemplateLifecycle.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let {
+  processors,
+  db,
+  createQueueMock,
+  createInstanceTemplateMock,
+  createGroupTemplateMock,
+  enqueueSyncInstanceTemplatesMock,
+  enqueueSyncGroupTemplatesMock,
+  indexIntegrationInstanceQueueAddMock,
+  syncProviderCredentialsMock
+} = vi.hoisted(() => {
+  let processors = new Map<string, (data: any) => Promise<void>>();
+  let db = {
+    integrationInstance: {
+      findUnique: vi.fn()
+    },
+    integrationInstanceGroup: {
+      findUnique: vi.fn()
+    },
+    integrationInstanceProvider: {
+      findMany: vi.fn()
+    }
+  };
+
+  return {
+    processors,
+    db,
+    createQueueMock: vi.fn((config: { name: string }) => ({
+      add: vi.fn(),
+      addMany: vi.fn(),
+      addManyWithOps: vi.fn(),
+      process: vi.fn((handler: (data: any) => Promise<void>) => {
+        processors.set(config.name, handler);
+        return { name: config.name };
+      })
+    })),
+    createInstanceTemplateMock: vi.fn(),
+    createGroupTemplateMock: vi.fn(),
+    enqueueSyncInstanceTemplatesMock: vi.fn(),
+    enqueueSyncGroupTemplatesMock: vi.fn(),
+    indexIntegrationInstanceQueueAddMock: vi.fn(),
+    syncProviderCredentialsMock: vi.fn()
+  };
+});
+
+vi.mock('@lowerdeck/queue', () => ({
+  createQueue: createQueueMock
+}));
+
+vi.mock('@metorial-subspace/db', () => ({
+  db
+}));
+
+vi.mock('@metorial-subspace/module-identity', () => ({
+  identityInternalService: {
+    syncIntegrationInstanceProviderCredentials: syncProviderCredentialsMock
+  }
+}));
+
+vi.mock(
+  '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate',
+  () => ({
+    enqueueArchiveIntegrationInstanceSessionTemplates: vi.fn(),
+    enqueueSyncIntegrationInstanceSessionTemplates: enqueueSyncInstanceTemplatesMock
+  })
+);
+
+vi.mock(
+  '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate',
+  () => ({
+    enqueueArchiveIntegrationInstanceGroupSessionTemplates: vi.fn(),
+    enqueueSyncIntegrationInstanceGroupSessionTemplates: enqueueSyncGroupTemplatesMock,
+    enqueueSyncIntegrationInstanceGroupSessionTemplatesMany: vi.fn()
+  })
+);
+
+vi.mock('@metorial-subspace/module-identity/src/queues/lifecycle/identity', () => ({
+  identityDeletedQueue: { addMany: vi.fn() }
+}));
+
+vi.mock('../src/queues/search/integrationInstance', () => ({
+  indexIntegrationInstanceQueue: {
+    add: indexIntegrationInstanceQueueAddMock
+  }
+}));
+
+vi.mock('../src/queues/lifecycle/integrationInstanceProvider', () => ({
+  enqueueIntegrationInstanceProvidersSet: vi.fn()
+}));
+
+vi.mock('../src/queues/lifecycle/integrationInstanceGroupProvider', () => ({
+  enqueueIntegrationInstanceGroupProvidersSet: vi.fn()
+}));
+
+vi.mock('../src/services/integrationInstance', () => ({
+  integrationInstanceService: {
+    createSessionTemplateForIntegrationInstance: createInstanceTemplateMock
+  }
+}));
+
+vi.mock('../src/services/integrationInstanceGroup', () => ({
+  integrationInstanceGroupService: {
+    createSessionTemplateForIntegrationInstanceGroup: createGroupTemplateMock
+  }
+}));
+
+vi.mock('../src/env', () => ({
+  env: {
+    service: {
+      REDIS_URL: 'redis://test'
+    }
+  }
+}));
+
+import '../src/queues/lifecycle/integrationInstance';
+import '../src/queues/lifecycle/integrationInstanceGroup';
+
+describe('default session template lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates an integration instance default session template in the created job', async () => {
+    let integrationInstance = {
+      id: 'ini_1',
+      status: 'active',
+      tenant: { oid: 1n },
+      solution: { oid: 2n },
+      environment: { oid: 3n }
+    };
+    vi.mocked(db.integrationInstance.findUnique).mockResolvedValue(integrationInstance as any);
+    vi.mocked(db.integrationInstanceProvider.findMany).mockResolvedValue([]);
+
+    let processor = processors.get('sub/int/lc/integrationInstance/created');
+    expect(processor).toBeDefined();
+
+    await processor!({ integrationInstanceId: 'ini_1' });
+
+    expect(createInstanceTemplateMock).toHaveBeenCalledWith({
+      tenant: integrationInstance.tenant,
+      solution: integrationInstance.solution,
+      environment: integrationInstance.environment,
+      integrationInstance,
+      input: {}
+    });
+    expect(enqueueSyncInstanceTemplatesMock).toHaveBeenCalledWith({
+      integrationInstanceId: 'ini_1'
+    });
+    expect(syncProviderCredentialsMock).not.toHaveBeenCalled();
+  });
+
+  it('creates an integration instance group default session template in the created job', async () => {
+    let integrationInstanceGroup = {
+      id: 'iig_1',
+      status: 'active',
+      tenant: { oid: 1n },
+      solution: { oid: 2n },
+      environment: { oid: 3n }
+    };
+    vi.mocked(db.integrationInstanceGroup.findUnique).mockResolvedValue(
+      integrationInstanceGroup as any
+    );
+
+    let processor = processors.get('sub/int/lc/integrationInstanceGroup/created');
+    expect(processor).toBeDefined();
+
+    await processor!({ integrationInstanceGroupId: 'iig_1' });
+
+    expect(createGroupTemplateMock).toHaveBeenCalledWith({
+      tenant: integrationInstanceGroup.tenant,
+      solution: integrationInstanceGroup.solution,
+      environment: integrationInstanceGroup.environment,
+      integrationInstanceGroup,
+      input: {}
+    });
+    expect(enqueueSyncGroupTemplatesMock).toHaveBeenCalledWith({
+      integrationInstanceGroupId: 'iig_1'
+    });
+  });
+});

--- a/src/systems/subspace/modules/integration/test/integrationInstanceProviderQueue.test.ts
+++ b/src/systems/subspace/modules/integration/test/integrationInstanceProviderQueue.test.ts
@@ -8,8 +8,8 @@ let {
   providerAuthConfigArchiveMock,
   identityCredentialSyncMock,
   indexIntegrationInstanceQueueAddMock,
-  syncIntegrationInstanceSessionTemplatesQueueAddMock,
-  syncIntegrationInstanceGroupSessionTemplatesQueueAddMock
+  enqueueSyncIntegrationInstanceSessionTemplatesMock,
+  enqueueSyncIntegrationInstanceGroupSessionTemplatesMock
 } = vi.hoisted(() => {
   let processors = new Map<string, (data: any) => Promise<void>>();
   let db = {
@@ -40,8 +40,8 @@ let {
     providerAuthConfigArchiveMock: vi.fn(),
     identityCredentialSyncMock: vi.fn(),
     indexIntegrationInstanceQueueAddMock: vi.fn(),
-    syncIntegrationInstanceSessionTemplatesQueueAddMock: vi.fn(),
-    syncIntegrationInstanceGroupSessionTemplatesQueueAddMock: vi.fn()
+    enqueueSyncIntegrationInstanceSessionTemplatesMock: vi.fn(),
+    enqueueSyncIntegrationInstanceGroupSessionTemplatesMock: vi.fn()
   };
 });
 
@@ -74,20 +74,22 @@ vi.mock('@metorial-subspace/module-identity', () => ({
 vi.mock(
   '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate',
   () => ({
-    syncIntegrationInstanceSessionTemplatesQueue: {
-      add: syncIntegrationInstanceSessionTemplatesQueueAddMock
-    }
+    enqueueSyncIntegrationInstanceSessionTemplates:
+      enqueueSyncIntegrationInstanceSessionTemplatesMock
   })
 );
 
 vi.mock(
   '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate',
   () => ({
-    syncIntegrationInstanceGroupSessionTemplatesQueue: {
-      addMany: syncIntegrationInstanceGroupSessionTemplatesQueueAddMock
-    }
+    enqueueSyncIntegrationInstanceGroupSessionTemplates:
+      enqueueSyncIntegrationInstanceGroupSessionTemplatesMock
   })
 );
+
+vi.mock('@metorial-subspace/module-session/src/lib/sessionTemplateSync', () => ({
+  queueJobId: (...parts: string[]) => parts.filter(Boolean).join('-')
+}));
 
 vi.mock('../src/env', () => ({
   env: {

--- a/src/systems/subspace/modules/integration/test/sharedSessionTemplate.test.ts
+++ b/src/systems/subspace/modules/integration/test/sharedSessionTemplate.test.ts
@@ -7,6 +7,7 @@ let {
   getIdMock,
   ensureIntegrationIdentityMock,
   upsertInternalLinkedSessionTemplateMock,
+  createSessionMock,
   integrationInstanceCreatedQueueAddMock,
   enqueueSyncIntegrationInstanceSessionTemplateMock,
   enqueueSyncIntegrationInstanceGroupSessionTemplateMock
@@ -16,12 +17,14 @@ let {
       integrationInstance: {
         create: vi.fn(),
         update: vi.fn(),
+        findFirst: vi.fn(),
         findUniqueOrThrow: vi.fn()
       },
       integrationProvider: {
         findMany: vi.fn()
       },
       integrationInstanceGroup: {
+        findFirst: vi.fn(),
         findUniqueOrThrow: vi.fn()
       }
     };
@@ -41,6 +44,7 @@ let {
   })),
   ensureIntegrationIdentityMock: vi.fn(),
   upsertInternalLinkedSessionTemplateMock: vi.fn(),
+  createSessionMock: vi.fn(),
   integrationInstanceCreatedQueueAddMock: vi.fn(),
   enqueueSyncIntegrationInstanceSessionTemplateMock: vi.fn(),
   enqueueSyncIntegrationInstanceGroupSessionTemplateMock: vi.fn()
@@ -104,6 +108,9 @@ vi.mock('@metorial-subspace/module-identity', () => ({
 }));
 
 vi.mock('@metorial-subspace/module-session', () => ({
+  sessionService: {
+    createSession: createSessionMock
+  },
   sessionTemplateService: {
     upsertInternalLinkedSessionTemplate: upsertInternalLinkedSessionTemplateMock
   }
@@ -176,6 +183,7 @@ import { integrationInstanceService } from '../src/services/integrationInstance'
 
 describe('shared integration session templates', () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
     withTransactionMock.mockImplementation(async (callback: (db: any) => Promise<any>) =>
       callback(db)
@@ -192,7 +200,7 @@ describe('shared integration session templates', () => {
     });
   });
 
-  it('creates the default shared template when creating an integration instance', async () => {
+  it('defers default shared template creation when creating an integration instance', async () => {
     let createdIntegrationInstance = {
       oid: 11n,
       id: 'int_instance_1',
@@ -208,7 +216,6 @@ describe('shared integration session templates', () => {
       ...integrationInstanceWithIdentity,
       defaultSessionTemplate: { oid: 101n, id: 'stm_default' }
     };
-    let createdTemplate = { id: 'stm_default' };
 
     vi.mocked(db.integrationProvider.findMany).mockResolvedValue([]);
     vi.mocked(db.integrationInstance.create).mockResolvedValue(
@@ -220,7 +227,6 @@ describe('shared integration session templates', () => {
     vi.mocked(db.integrationInstance.findUniqueOrThrow).mockResolvedValue(
       refreshedIntegrationInstance as any
     );
-    upsertInternalLinkedSessionTemplateMock.mockResolvedValue(createdTemplate);
 
     let result = await integrationInstanceService.createIntegrationInstance({
       tenant: { oid: 1n } as any,
@@ -232,15 +238,7 @@ describe('shared integration session templates', () => {
       }
     });
 
-    expect(upsertInternalLinkedSessionTemplateMock).toHaveBeenCalledWith({
-      tenant: expect.anything(),
-      solution: expect.anything(),
-      environment: expect.anything(),
-      sessionTemplate: null,
-      input: {
-        integrationInstance: integrationInstanceWithIdentity
-      }
-    });
+    expect(upsertInternalLinkedSessionTemplateMock).not.toHaveBeenCalled();
     expect(db.integrationInstance.findUniqueOrThrow).toHaveBeenCalledWith({
       where: { oid: integrationInstanceWithIdentity.oid },
       include: expect.anything()
@@ -249,6 +247,77 @@ describe('shared integration session templates', () => {
       integrationInstanceId: 'int_instance_1'
     });
     expect(result).toBe(refreshedIntegrationInstance);
+  });
+
+  it('creates a session for an integration instance after the default template is ready', async () => {
+    let template = {
+      id: 'stm_default',
+      providers: [
+        {
+          id: 'stp_1',
+          deployment: { id: 'dep_1' },
+          config: { id: 'cfg_1' },
+          authConfig: null
+        }
+      ]
+    };
+    let integrationInstance = {
+      oid: 11n,
+      id: 'int_instance_1'
+    } as any;
+    let createdSession = { id: 'ses_1' };
+
+    vi.mocked(db.integrationInstance.findFirst).mockResolvedValue({
+      defaultSessionTemplate: template,
+      integrationInstanceProviders: [{ oid: 101n }]
+    } as any);
+    createSessionMock.mockResolvedValue(createdSession);
+
+    let result = await integrationInstanceService.createSessionForIntegrationInstance({
+      tenant: { oid: 1n } as any,
+      solution: { oid: 2 } as any,
+      environment: { oid: 3n } as any,
+      integrationInstance,
+      input: { name: 'Session' }
+    });
+
+    expect(createSessionMock).toHaveBeenCalledWith({
+      tenant: expect.anything(),
+      solution: expect.anything(),
+      environment: expect.anything(),
+      input: {
+        name: 'Session',
+        providers: [
+          {
+            sessionTemplateId: 'stm_default',
+            __sessionTemplate: template
+          }
+        ]
+      }
+    });
+    expect(result).toBe(createdSession);
+  });
+
+  it('times out when an integration instance default template is not ready', async () => {
+    vi.useFakeTimers();
+    vi.mocked(db.integrationInstance.findFirst).mockResolvedValue({
+      defaultSessionTemplate: null,
+      integrationInstanceProviders: []
+    } as any);
+
+    let promise = integrationInstanceService.createSessionForIntegrationInstance({
+      tenant: { oid: 1n } as any,
+      solution: { oid: 2 } as any,
+      environment: { oid: 3n } as any,
+      integrationInstance: { oid: 11n, id: 'int_instance_1' } as any,
+      input: {}
+    });
+    let rejection = expect(promise).rejects.toThrow();
+
+    await vi.advanceTimersByTimeAsync(250 * 20);
+    await rejection;
+    expect(createSessionMock).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 
   it('upserts the default shared template for an integration instance', async () => {
@@ -344,5 +413,77 @@ describe('shared integration session templates', () => {
       'stm_group_default'
     );
     expect(result).toBe(createdTemplate);
+  });
+
+  it('creates a session for an integration instance group after the default template is ready', async () => {
+    let template = {
+      id: 'stm_group_default',
+      providers: [
+        {
+          id: 'stp_group_1',
+          deployment: { id: 'dep_1' },
+          config: { id: 'cfg_1' },
+          authConfig: null
+        }
+      ]
+    };
+    let integrationInstanceGroup = {
+      oid: 22n,
+      id: 'int_group_1'
+    } as any;
+    let createdSession = { id: 'ses_group_1' };
+
+    vi.mocked(db.integrationInstanceGroup.findFirst).mockResolvedValue({
+      defaultSessionTemplate: template,
+      providers: [{ oid: 101n }]
+    } as any);
+    createSessionMock.mockResolvedValue(createdSession);
+
+    let result =
+      await integrationInstanceGroupService.createSessionForIntegrationInstanceGroup({
+        tenant: { oid: 1n } as any,
+        solution: { oid: 2 } as any,
+        environment: { oid: 3n } as any,
+        integrationInstanceGroup,
+        input: { name: 'Grouped session' }
+      });
+
+    expect(createSessionMock).toHaveBeenCalledWith({
+      tenant: expect.anything(),
+      solution: expect.anything(),
+      environment: expect.anything(),
+      input: {
+        name: 'Grouped session',
+        providers: [
+          {
+            sessionTemplateId: 'stm_group_default',
+            __sessionTemplate: template
+          }
+        ]
+      }
+    });
+    expect(result).toBe(createdSession);
+  });
+
+  it('times out when an integration instance group default template is not ready', async () => {
+    vi.useFakeTimers();
+    vi.mocked(db.integrationInstanceGroup.findFirst).mockResolvedValue({
+      defaultSessionTemplate: null,
+      providers: []
+    } as any);
+
+    let promise = integrationInstanceGroupService.createSessionForIntegrationInstanceGroup({
+      tenant: { oid: 1n } as any,
+      solution: { oid: 2 } as any,
+      environment: { oid: 3n } as any,
+      integrationInstanceGroup: { oid: 22n, id: 'int_group_1' } as any,
+      input: {}
+    });
+    let rejection = expect(promise).rejects.toThrow();
+
+    await vi.advanceTimersByTimeAsync(250 * 20);
+    await rejection;
+    expect(createSessionMock).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 });

--- a/src/systems/subspace/modules/integration/test/sharedSessionTemplate.test.ts
+++ b/src/systems/subspace/modules/integration/test/sharedSessionTemplate.test.ts
@@ -8,8 +8,8 @@ let {
   ensureIntegrationIdentityMock,
   upsertInternalLinkedSessionTemplateMock,
   integrationInstanceCreatedQueueAddMock,
-  syncIntegrationInstanceSessionTemplateQueueAddMock,
-  syncIntegrationInstanceGroupSessionTemplateQueueAddMock
+  enqueueSyncIntegrationInstanceSessionTemplateMock,
+  enqueueSyncIntegrationInstanceGroupSessionTemplateMock
 } = vi.hoisted(() => ({
   ...(() => {
     let db = {
@@ -42,8 +42,8 @@ let {
   ensureIntegrationIdentityMock: vi.fn(),
   upsertInternalLinkedSessionTemplateMock: vi.fn(),
   integrationInstanceCreatedQueueAddMock: vi.fn(),
-  syncIntegrationInstanceSessionTemplateQueueAddMock: vi.fn(),
-  syncIntegrationInstanceGroupSessionTemplateQueueAddMock: vi.fn()
+  enqueueSyncIntegrationInstanceSessionTemplateMock: vi.fn(),
+  enqueueSyncIntegrationInstanceGroupSessionTemplateMock: vi.fn()
 }));
 
 vi.mock('@metorial-subspace/db', () => ({
@@ -126,18 +126,16 @@ vi.mock('@metorial-subspace/module-search', () => ({
 vi.mock(
   '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate',
   () => ({
-    syncIntegrationInstanceSessionTemplateQueue: {
-      add: syncIntegrationInstanceSessionTemplateQueueAddMock
-    }
+    enqueueSyncIntegrationInstanceSessionTemplate:
+      enqueueSyncIntegrationInstanceSessionTemplateMock
   })
 );
 
 vi.mock(
   '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate',
   () => ({
-    syncIntegrationInstanceGroupSessionTemplateQueue: {
-      add: syncIntegrationInstanceGroupSessionTemplateQueueAddMock
-    }
+    enqueueSyncIntegrationInstanceGroupSessionTemplate:
+      enqueueSyncIntegrationInstanceGroupSessionTemplateMock
   })
 );
 
@@ -213,7 +211,9 @@ describe('shared integration session templates', () => {
     let createdTemplate = { id: 'stm_default' };
 
     vi.mocked(db.integrationProvider.findMany).mockResolvedValue([]);
-    vi.mocked(db.integrationInstance.create).mockResolvedValue(createdIntegrationInstance as any);
+    vi.mocked(db.integrationInstance.create).mockResolvedValue(
+      createdIntegrationInstance as any
+    );
     vi.mocked(db.integrationInstance.update).mockResolvedValue(
       integrationInstanceWithIdentity as any
     );
@@ -292,9 +292,9 @@ describe('shared integration session templates', () => {
         integrationInstance
       }
     });
-    expect(syncIntegrationInstanceSessionTemplateQueueAddMock).toHaveBeenCalledWith({
-      sessionTemplateId: 'stm_default'
-    });
+    expect(enqueueSyncIntegrationInstanceSessionTemplateMock).toHaveBeenCalledWith(
+      'stm_default'
+    );
     expect(result).toBe(createdTemplate);
   });
 
@@ -340,9 +340,9 @@ describe('shared integration session templates', () => {
         integrationInstanceGroup: currentIntegrationInstanceGroup
       }
     });
-    expect(syncIntegrationInstanceGroupSessionTemplateQueueAddMock).toHaveBeenCalledWith({
-      sessionTemplateId: 'stm_group_default'
-    });
+    expect(enqueueSyncIntegrationInstanceGroupSessionTemplateMock).toHaveBeenCalledWith(
+      'stm_group_default'
+    );
     expect(result).toBe(createdTemplate);
   });
 });

--- a/src/systems/subspace/modules/session/src/lib/sessionTemplateSync.ts
+++ b/src/systems/subspace/modules/session/src/lib/sessionTemplateSync.ts
@@ -1,0 +1,20 @@
+import { createLock } from '@lowerdeck/lock';
+import { env } from '../env';
+
+let sessionTemplateSyncLock = createLock({
+  name: 'sub-ses-st-sync-lock',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let queueJobId = (...parts: (string | undefined | null)[]) =>
+  parts
+    .filter((part): part is string => !!part)
+    .join('-')
+    .replace(/:/g, '-');
+
+export let withSessionTemplateSyncLock = async <T>(
+  sessionTemplateId: string,
+  cb: () => Promise<T>
+) => {
+  return await sessionTemplateSyncLock.usingLock(queueJobId('st', sessionTemplateId), cb);
+};

--- a/src/systems/subspace/modules/session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate.ts
+++ b/src/systems/subspace/modules/session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate.ts
@@ -2,10 +2,11 @@ import { createQueue } from '@lowerdeck/queue';
 import { db, getId, withTransaction } from '@metorial-subspace/db';
 import { buildIntegrationProviderToolFilterChain } from '@metorial-subspace/module-provider-internal';
 import { env } from '../../env';
+import { queueJobId, withSessionTemplateSyncLock } from '../../lib/sessionTemplateSync';
 import { sessionTemplateArchivedQueue } from './sessionTemplate';
 import {
-  sessionTemplateProviderCreatedQueue,
-  sessionTemplateSyncHashQueue
+  enqueueSessionTemplateProvidersCreated,
+  enqueueSessionTemplateSyncHash
 } from './sessionTemplateProvider';
 
 export let syncIntegrationInstanceGroupSessionTemplatesQueue = createQueue<{
@@ -15,6 +16,33 @@ export let syncIntegrationInstanceGroupSessionTemplatesQueue = createQueue<{
   name: 'sub/ses/lc/linkedIntegrationInstanceGroupTemplate/syncMany',
   redisUrl: env.service.REDIS_URL
 });
+
+export let enqueueSyncIntegrationInstanceGroupSessionTemplates = async (d: {
+  integrationInstanceGroupId: string;
+  cursor?: string;
+}) => {
+  await syncIntegrationInstanceGroupSessionTemplatesQueue.add(d, {
+    id: queueJobId('iigstm', d.integrationInstanceGroupId, d.cursor ?? 'start')
+  });
+};
+
+export let enqueueSyncIntegrationInstanceGroupSessionTemplatesMany = async (
+  items: {
+    integrationInstanceGroupId: string;
+    cursor?: string;
+  }[]
+) => {
+  if (!items.length) return;
+
+  await syncIntegrationInstanceGroupSessionTemplatesQueue.addManyWithOps(
+    items.map(d => ({
+      data: d,
+      opts: {
+        id: queueJobId('iigstm', d.integrationInstanceGroupId, d.cursor ?? 'start')
+      }
+    }))
+  );
+};
 
 export let syncIntegrationInstanceGroupSessionTemplatesQueueProcessor =
   syncIntegrationInstanceGroupSessionTemplatesQueue.process(async data => {
@@ -41,16 +69,14 @@ export let syncIntegrationInstanceGroupSessionTemplatesQueueProcessor =
     });
     if (sessionTemplates.length === 0) return;
 
-    await syncIntegrationInstanceGroupSessionTemplateQueue.addMany(
-      sessionTemplates.map(sessionTemplate => ({
-        sessionTemplateId: sessionTemplate.id
-      }))
+    await enqueueSyncIntegrationInstanceGroupSessionTemplateMany(
+      sessionTemplates.map(sessionTemplate => sessionTemplate.id)
     );
 
     let lastSessionTemplate = sessionTemplates[sessionTemplates.length - 1];
     if (!lastSessionTemplate) return;
 
-    await syncIntegrationInstanceGroupSessionTemplatesQueue.add({
+    await enqueueSyncIntegrationInstanceGroupSessionTemplates({
       integrationInstanceGroupId: data.integrationInstanceGroupId,
       cursor: lastSessionTemplate.id
     });
@@ -63,164 +89,180 @@ export let syncIntegrationInstanceGroupSessionTemplateQueue = createQueue<{
   redisUrl: env.service.REDIS_URL
 });
 
+export let enqueueSyncIntegrationInstanceGroupSessionTemplate = async (
+  sessionTemplateId: string
+) => {
+  await syncIntegrationInstanceGroupSessionTemplateQueue.add(
+    { sessionTemplateId },
+    { id: queueJobId('iigst', sessionTemplateId) }
+  );
+};
+
+export let enqueueSyncIntegrationInstanceGroupSessionTemplateMany = async (
+  sessionTemplateIds: string[]
+) => {
+  if (!sessionTemplateIds.length) return;
+
+  await syncIntegrationInstanceGroupSessionTemplateQueue.addManyWithOps(
+    sessionTemplateIds.map(sessionTemplateId => ({
+      data: { sessionTemplateId },
+      opts: { id: queueJobId('iigst', sessionTemplateId) }
+    }))
+  );
+};
+
 export let syncIntegrationInstanceGroupSessionTemplate = async (data: {
   sessionTemplateId: string;
 }) => {
-  let sessionTemplate = await db.sessionTemplate.findUnique({
-    where: { id: data.sessionTemplateId },
-    include: { integrationInstanceGroup: true }
-  });
-  let integrationInstanceGroup = sessionTemplate?.integrationInstanceGroup;
-  if (
-    !sessionTemplate ||
-    !integrationInstanceGroup ||
-    !sessionTemplate.integrationInstanceGroupOid ||
-    sessionTemplate.status !== 'active' ||
-    integrationInstanceGroup.status === 'archived' ||
-    integrationInstanceGroup.status === 'deleted'
-  ) {
-    return;
-  }
+  await withSessionTemplateSyncLock(data.sessionTemplateId, async () => {
+    let sessionTemplate = await db.sessionTemplate.findUnique({
+      where: { id: data.sessionTemplateId },
+      include: { integrationInstanceGroup: true }
+    });
+    let integrationInstanceGroup = sessionTemplate?.integrationInstanceGroup;
+    if (
+      !sessionTemplate ||
+      !integrationInstanceGroup ||
+      !sessionTemplate.integrationInstanceGroupOid ||
+      sessionTemplate.status !== 'active' ||
+      integrationInstanceGroup.status === 'archived' ||
+      integrationInstanceGroup.status === 'deleted'
+    ) {
+      return;
+    }
 
-  let groupProviders = await db.integrationInstanceGroupProvider.findMany({
-    where: {
-      integrationInstanceGroupOid: sessionTemplate.integrationInstanceGroupOid,
-      status: 'active',
-      isParentDeleted: false,
-      integrationInstanceGroupSource: {
+    let groupProviders = await db.integrationInstanceGroupProvider.findMany({
+      where: {
+        integrationInstanceGroupOid: sessionTemplate.integrationInstanceGroupOid,
         status: 'active',
-        isParentDeleted: false
+        isParentDeleted: false,
+        integrationInstanceGroupSource: {
+          status: 'active',
+          isParentDeleted: false
+        },
+        integrationInstanceProvider: {
+          status: 'active',
+          isParentDeleted: false
+        }
       },
-      integrationInstanceProvider: {
-        status: 'active',
-        isParentDeleted: false
-      }
-    },
-    orderBy: { id: 'asc' },
-    include: {
-      integration: true,
-      integrationProvider: true,
-      integrationInstanceProvider: {
-        include: {
-          integrationProvider: true,
-          currentVersion: {
-            include: {
-              integrationProviderVersion: true
+      orderBy: { id: 'asc' },
+      include: {
+        integration: true,
+        integrationProvider: true,
+        integrationInstanceProvider: {
+          include: {
+            integrationProvider: true,
+            currentVersion: {
+              include: {
+                integrationProviderVersion: true
+              }
             }
           }
         }
       }
-    }
-  });
-
-  let materialProviders = groupProviders.filter(
-    groupProvider => !!groupProvider.integrationInstanceProvider.currentVersion?.configOid
-  );
-  let materialProviderOids = new Set(
-    materialProviders.map(groupProvider => groupProvider.oid.toString())
-  );
-
-  let existingTemplateProviders = await db.sessionTemplateProvider.findMany({
-    where: {
-      sessionTemplateOid: sessionTemplate.oid,
-      status: { not: 'deleted' }
-    }
-  });
-  let existingByDelegatedProviderOid = new Map(
-    existingTemplateProviders
-      .filter(provider => provider.integrationInstanceGroupProviderOid)
-      .map(provider => [provider.integrationInstanceGroupProviderOid!, provider])
-  );
-
-  let createdSessionTemplateProviderIds = await withTransaction(async db => {
-    let createdSessionTemplateProviderIds: string[] = [];
-
-    await db.sessionTemplate.update({
-      where: { oid: sessionTemplate.oid },
-      data: {
-        identityActorOid: integrationInstanceGroup.identityActorOid ?? null,
-        identityOid: integrationInstanceGroup.identityOid ?? null
-      }
     });
 
-    for (let groupProvider of materialProviders) {
-      let sourceProvider = groupProvider.integrationInstanceProvider;
-      let currentVersion = sourceProvider.currentVersion!;
-      let existing = existingByDelegatedProviderOid.get(groupProvider.oid);
-      let toolFilter = buildIntegrationProviderToolFilterChain({
-        canAttachCustomToolFilters: groupProvider.integration.canAttachCustomToolFilters,
-        canOverrideToolFilters: groupProvider.integration.canOverrideToolFilters,
-        integrationProviderToolFilter: currentVersion.integrationProviderVersion
-          .toolFilter as PrismaJson.ToolFilter | null,
-        integrationInstanceProviderToolFilter:
-          currentVersion.toolFilter as PrismaJson.ToolFilter | null,
-        integrationInstanceProviderIsOverride: currentVersion.isOverrideToolFilter,
-        integrationInstanceGroupProviderToolFilter:
-          groupProvider.toolFilter as PrismaJson.ToolFilter | null,
-        integrationInstanceGroupProviderIsOverride: groupProvider.isOverrideToolFilter
-      });
+    let materialProviders = groupProviders.filter(
+      groupProvider => !!groupProvider.integrationInstanceProvider.currentVersion?.configOid
+    );
+    let materialProviderOids = new Set(
+      materialProviders.map(groupProvider => groupProvider.oid.toString())
+    );
 
-      let data = {
-        status: 'active' as const,
-        toolFilter,
-        sessionTemplateOid: sessionTemplate.oid,
-        providerOid: sourceProvider.integrationProvider.providerOid,
-        deploymentOid: currentVersion.integrationProviderVersion.deploymentOid,
-        configOid: currentVersion.configOid!,
-        authConfigOid: currentVersion.authConfigOid,
-        integrationInstanceProviderOid: sourceProvider.oid,
-        integrationInstanceGroupProviderOid: groupProvider.oid,
-        tenantOid: sessionTemplate.tenantOid,
-        solutionOid: sessionTemplate.solutionOid,
-        environmentOid: sessionTemplate.environmentOid
-      };
-
-      if (existing) {
-        await db.sessionTemplateProvider.update({
-          where: { oid: existing.oid },
-          data
-        });
-      } else {
-        let created = await db.sessionTemplateProvider.create({
-          data: {
-            ...getId('sessionTemplateProvider'),
-            ...data
-          },
-          select: { id: true }
-        });
-        createdSessionTemplateProviderIds.push(created.id);
-      }
-    }
-
-    await db.sessionTemplateProvider.updateMany({
+    let existingTemplateProviders = await db.sessionTemplateProvider.findMany({
       where: {
         sessionTemplateOid: sessionTemplate.oid,
-        status: 'active',
-        OR: [
-          { integrationInstanceGroupProviderOid: null },
-          {
-            integrationInstanceGroupProviderOid: {
-              notIn: Array.from(materialProviderOids).map(oid => BigInt(oid))
+        status: { not: 'deleted' }
+      }
+    });
+    let existingByDelegatedProviderOid = new Map(
+      existingTemplateProviders
+        .filter(provider => provider.integrationInstanceGroupProviderOid)
+        .map(provider => [provider.integrationInstanceGroupProviderOid!, provider])
+    );
+
+    let createdSessionTemplateProviderIds = await withTransaction(async db => {
+      let createdSessionTemplateProviderIds: string[] = [];
+
+      await db.sessionTemplate.update({
+        where: { oid: sessionTemplate.oid },
+        data: {
+          identityActorOid: integrationInstanceGroup.identityActorOid ?? null,
+          identityOid: integrationInstanceGroup.identityOid ?? null
+        }
+      });
+
+      for (let groupProvider of materialProviders) {
+        let sourceProvider = groupProvider.integrationInstanceProvider;
+        let currentVersion = sourceProvider.currentVersion!;
+        let existing = existingByDelegatedProviderOid.get(groupProvider.oid);
+        let toolFilter = buildIntegrationProviderToolFilterChain({
+          canAttachCustomToolFilters: groupProvider.integration.canAttachCustomToolFilters,
+          canOverrideToolFilters: groupProvider.integration.canOverrideToolFilters,
+          integrationProviderToolFilter: currentVersion.integrationProviderVersion
+            .toolFilter as PrismaJson.ToolFilter | null,
+          integrationInstanceProviderToolFilter:
+            currentVersion.toolFilter as PrismaJson.ToolFilter | null,
+          integrationInstanceProviderIsOverride: currentVersion.isOverrideToolFilter,
+          integrationInstanceGroupProviderToolFilter:
+            groupProvider.toolFilter as PrismaJson.ToolFilter | null,
+          integrationInstanceGroupProviderIsOverride: groupProvider.isOverrideToolFilter
+        });
+
+        let data = {
+          status: 'active' as const,
+          toolFilter,
+          sessionTemplateOid: sessionTemplate.oid,
+          providerOid: sourceProvider.integrationProvider.providerOid,
+          deploymentOid: currentVersion.integrationProviderVersion.deploymentOid,
+          configOid: currentVersion.configOid!,
+          authConfigOid: currentVersion.authConfigOid,
+          integrationInstanceProviderOid: sourceProvider.oid,
+          integrationInstanceGroupProviderOid: groupProvider.oid,
+          tenantOid: sessionTemplate.tenantOid,
+          solutionOid: sessionTemplate.solutionOid,
+          environmentOid: sessionTemplate.environmentOid
+        };
+
+        if (existing) {
+          await db.sessionTemplateProvider.update({
+            where: { oid: existing.oid },
+            data
+          });
+        } else {
+          let created = await db.sessionTemplateProvider.create({
+            data: {
+              ...getId('sessionTemplateProvider'),
+              ...data
+            },
+            select: { id: true }
+          });
+          createdSessionTemplateProviderIds.push(created.id);
+        }
+      }
+
+      await db.sessionTemplateProvider.updateMany({
+        where: {
+          sessionTemplateOid: sessionTemplate.oid,
+          status: 'active',
+          OR: [
+            { integrationInstanceGroupProviderOid: null },
+            {
+              integrationInstanceGroupProviderOid: {
+                notIn: Array.from(materialProviderOids).map(oid => BigInt(oid))
+              }
             }
-          }
-        ]
-      },
-      data: { status: 'archived' }
+          ]
+        },
+        data: { status: 'archived' }
+      });
+
+      return createdSessionTemplateProviderIds;
     });
 
-    return createdSessionTemplateProviderIds;
-  });
+    await enqueueSessionTemplateProvidersCreated(createdSessionTemplateProviderIds);
 
-  if (createdSessionTemplateProviderIds.length) {
-    await sessionTemplateProviderCreatedQueue.addMany(
-      createdSessionTemplateProviderIds.map(sessionTemplateProviderId => ({
-        sessionTemplateProviderId
-      }))
-    );
-  }
-
-  await sessionTemplateSyncHashQueue.add({
-    sessionTemplateId: sessionTemplate.id
+    await enqueueSessionTemplateSyncHash(sessionTemplate.id);
   });
 };
 
@@ -236,6 +278,15 @@ export let archiveIntegrationInstanceGroupSessionTemplatesQueue = createQueue<{
   name: 'sub/ses/lc/linkedIntegrationInstanceGroupTemplate/archiveMany',
   redisUrl: env.service.REDIS_URL
 });
+
+export let enqueueArchiveIntegrationInstanceGroupSessionTemplates = async (d: {
+  integrationInstanceGroupId: string;
+  cursor?: string;
+}) => {
+  await archiveIntegrationInstanceGroupSessionTemplatesQueue.add(d, {
+    id: queueJobId('iigatm', d.integrationInstanceGroupId, d.cursor ?? 'start')
+  });
+};
 
 export let archiveIntegrationInstanceGroupSessionTemplatesQueueProcessor =
   archiveIntegrationInstanceGroupSessionTemplatesQueue.process(async data => {
@@ -258,16 +309,14 @@ export let archiveIntegrationInstanceGroupSessionTemplatesQueueProcessor =
     });
     if (sessionTemplates.length === 0) return;
 
-    await archiveIntegrationInstanceGroupSessionTemplateQueue.addMany(
-      sessionTemplates.map(sessionTemplate => ({
-        sessionTemplateId: sessionTemplate.id
-      }))
+    await enqueueArchiveIntegrationInstanceGroupSessionTemplateMany(
+      sessionTemplates.map(sessionTemplate => sessionTemplate.id)
     );
 
     let lastSessionTemplate = sessionTemplates[sessionTemplates.length - 1];
     if (!lastSessionTemplate) return;
 
-    await archiveIntegrationInstanceGroupSessionTemplatesQueue.add({
+    await enqueueArchiveIntegrationInstanceGroupSessionTemplates({
       integrationInstanceGroupId: data.integrationInstanceGroupId,
       cursor: lastSessionTemplate.id
     });
@@ -280,41 +329,66 @@ export let archiveIntegrationInstanceGroupSessionTemplateQueue = createQueue<{
   redisUrl: env.service.REDIS_URL
 });
 
+export let enqueueArchiveIntegrationInstanceGroupSessionTemplate = async (
+  sessionTemplateId: string
+) => {
+  await archiveIntegrationInstanceGroupSessionTemplateQueue.add(
+    { sessionTemplateId },
+    { id: queueJobId('iigat', sessionTemplateId) }
+  );
+};
+
+export let enqueueArchiveIntegrationInstanceGroupSessionTemplateMany = async (
+  sessionTemplateIds: string[]
+) => {
+  if (!sessionTemplateIds.length) return;
+
+  await archiveIntegrationInstanceGroupSessionTemplateQueue.addManyWithOps(
+    sessionTemplateIds.map(sessionTemplateId => ({
+      data: { sessionTemplateId },
+      opts: { id: queueJobId('iigat', sessionTemplateId) }
+    }))
+  );
+};
+
 export let archiveIntegrationInstanceGroupSessionTemplateQueueProcessor =
   archiveIntegrationInstanceGroupSessionTemplateQueue.process(async data => {
-    let sessionTemplate = await db.sessionTemplate.findUnique({
-      where: { id: data.sessionTemplateId },
-      include: { integrationInstanceGroup: true }
-    });
-    let integrationInstanceGroup = sessionTemplate?.integrationInstanceGroup;
-    if (
-      !sessionTemplate ||
-      !integrationInstanceGroup ||
-      !sessionTemplate.integrationInstanceGroupOid ||
-      sessionTemplate.status !== 'active' ||
-      integrationInstanceGroup.status !== 'archived'
-    ) {
-      return;
-    }
+    await withSessionTemplateSyncLock(data.sessionTemplateId, async () => {
+      let sessionTemplate = await db.sessionTemplate.findUnique({
+        where: { id: data.sessionTemplateId },
+        include: { integrationInstanceGroup: true }
+      });
+      let integrationInstanceGroup = sessionTemplate?.integrationInstanceGroup;
+      if (
+        !sessionTemplate ||
+        !integrationInstanceGroup ||
+        !sessionTemplate.integrationInstanceGroupOid ||
+        sessionTemplate.status !== 'active' ||
+        integrationInstanceGroup.status !== 'archived'
+      ) {
+        return;
+      }
 
-    let archivedAt = integrationInstanceGroup.archivedAt ?? new Date();
+      let archivedAt = integrationInstanceGroup.archivedAt ?? new Date();
 
-    await withTransaction(async db => {
-      await db.sessionTemplateProvider.updateMany({
-        where: { sessionTemplateOid: sessionTemplate.oid },
-        data: { status: 'archived' }
+      await withTransaction(async db => {
+        await db.sessionTemplateProvider.updateMany({
+          where: { sessionTemplateOid: sessionTemplate.oid },
+          data: { status: 'archived' }
+        });
+
+        await db.sessionTemplate.update({
+          where: { oid: sessionTemplate.oid },
+          data: {
+            status: 'archived',
+            archivedAt
+          }
+        });
       });
 
-      await db.sessionTemplate.update({
-        where: { oid: sessionTemplate.oid },
-        data: {
-          status: 'archived',
-          archivedAt
-        }
-      });
-    });
-
-    await sessionTemplateArchivedQueue.add({
-      sessionTemplateId: sessionTemplate.id
+      await sessionTemplateArchivedQueue.add(
+        { sessionTemplateId: sessionTemplate.id },
+        { id: queueJobId('sta', sessionTemplate.id) }
+      );
     });
   });

--- a/src/systems/subspace/modules/session/src/queues/lifecycle/linkedSessionTemplate.ts
+++ b/src/systems/subspace/modules/session/src/queues/lifecycle/linkedSessionTemplate.ts
@@ -2,10 +2,11 @@ import { createQueue } from '@lowerdeck/queue';
 import { db, getId, withTransaction } from '@metorial-subspace/db';
 import { buildIntegrationProviderToolFilterChain } from '@metorial-subspace/module-provider-internal';
 import { env } from '../../env';
+import { queueJobId, withSessionTemplateSyncLock } from '../../lib/sessionTemplateSync';
 import { sessionTemplateArchivedQueue } from './sessionTemplate';
 import {
-  sessionTemplateProviderCreatedQueue,
-  sessionTemplateSyncHashQueue
+  enqueueSessionTemplateProvidersCreated,
+  enqueueSessionTemplateSyncHash
 } from './sessionTemplateProvider';
 
 export let syncIntegrationInstanceSessionTemplatesQueue = createQueue<{
@@ -15,6 +16,33 @@ export let syncIntegrationInstanceSessionTemplatesQueue = createQueue<{
   name: 'sub/ses/lc/linkedSessionTemplate/syncMany',
   redisUrl: env.service.REDIS_URL
 });
+
+export let enqueueSyncIntegrationInstanceSessionTemplates = async (d: {
+  integrationInstanceId: string;
+  cursor?: string;
+}) => {
+  await syncIntegrationInstanceSessionTemplatesQueue.add(d, {
+    id: queueJobId('iistm', d.integrationInstanceId, d.cursor ?? 'start')
+  });
+};
+
+export let enqueueSyncIntegrationInstanceSessionTemplatesMany = async (
+  items: {
+    integrationInstanceId: string;
+    cursor?: string;
+  }[]
+) => {
+  if (!items.length) return;
+
+  await syncIntegrationInstanceSessionTemplatesQueue.addManyWithOps(
+    items.map(d => ({
+      data: d,
+      opts: {
+        id: queueJobId('iistm', d.integrationInstanceId, d.cursor ?? 'start')
+      }
+    }))
+  );
+};
 
 export let syncIntegrationInstanceSessionTemplatesQueueProcessor =
   syncIntegrationInstanceSessionTemplatesQueue.process(async data => {
@@ -41,16 +69,14 @@ export let syncIntegrationInstanceSessionTemplatesQueueProcessor =
     });
     if (sessionTemplates.length === 0) return;
 
-    await syncIntegrationInstanceSessionTemplateQueue.addMany(
-      sessionTemplates.map(sessionTemplate => ({
-        sessionTemplateId: sessionTemplate.id
-      }))
+    await enqueueSyncIntegrationInstanceSessionTemplateMany(
+      sessionTemplates.map(sessionTemplate => sessionTemplate.id)
     );
 
     let lastSessionTemplate = sessionTemplates[sessionTemplates.length - 1];
     if (!lastSessionTemplate) return;
 
-    await syncIntegrationInstanceSessionTemplatesQueue.add({
+    await enqueueSyncIntegrationInstanceSessionTemplates({
       integrationInstanceId: data.integrationInstanceId,
       cursor: lastSessionTemplate.id
     });
@@ -63,151 +89,167 @@ export let syncIntegrationInstanceSessionTemplateQueue = createQueue<{
   redisUrl: env.service.REDIS_URL
 });
 
+export let enqueueSyncIntegrationInstanceSessionTemplate = async (
+  sessionTemplateId: string
+) => {
+  await syncIntegrationInstanceSessionTemplateQueue.add(
+    { sessionTemplateId },
+    { id: queueJobId('iist', sessionTemplateId) }
+  );
+};
+
+export let enqueueSyncIntegrationInstanceSessionTemplateMany = async (
+  sessionTemplateIds: string[]
+) => {
+  if (!sessionTemplateIds.length) return;
+
+  await syncIntegrationInstanceSessionTemplateQueue.addManyWithOps(
+    sessionTemplateIds.map(sessionTemplateId => ({
+      data: { sessionTemplateId },
+      opts: { id: queueJobId('iist', sessionTemplateId) }
+    }))
+  );
+};
+
 export let syncIntegrationInstanceSessionTemplateQueueProcessor =
   syncIntegrationInstanceSessionTemplateQueue.process(async data => {
-    let sessionTemplate = await db.sessionTemplate.findUnique({
-      where: { id: data.sessionTemplateId },
-      include: { integrationInstance: true }
-    });
-    let integrationInstance = sessionTemplate?.integrationInstance;
-    if (
-      !sessionTemplate ||
-      !integrationInstance ||
-      !sessionTemplate.integrationInstanceOid ||
-      sessionTemplate.status !== 'active' ||
-      integrationInstance.status === 'archived' ||
-      integrationInstance.status === 'deleted'
-    ) {
-      return;
-    }
+    await withSessionTemplateSyncLock(data.sessionTemplateId, async () => {
+      let sessionTemplate = await db.sessionTemplate.findUnique({
+        where: { id: data.sessionTemplateId },
+        include: { integrationInstance: true }
+      });
+      let integrationInstance = sessionTemplate?.integrationInstance;
+      if (
+        !sessionTemplate ||
+        !integrationInstance ||
+        !sessionTemplate.integrationInstanceOid ||
+        sessionTemplate.status !== 'active' ||
+        integrationInstance.status === 'archived' ||
+        integrationInstance.status === 'deleted'
+      ) {
+        return;
+      }
 
-    let integrationInstanceProviders = await db.integrationInstanceProvider.findMany({
-      where: {
-        integrationInstanceOid: sessionTemplate.integrationInstanceOid,
-        status: 'active',
-        isParentDeleted: false
-      },
-      orderBy: { id: 'asc' },
-      include: {
-        integration: true,
-        integrationProvider: true,
-        currentVersion: {
-          include: {
-            integrationProviderVersion: true
+      let integrationInstanceProviders = await db.integrationInstanceProvider.findMany({
+        where: {
+          integrationInstanceOid: sessionTemplate.integrationInstanceOid,
+          status: 'active',
+          isParentDeleted: false
+        },
+        orderBy: { id: 'asc' },
+        include: {
+          integration: true,
+          integrationProvider: true,
+          currentVersion: {
+            include: {
+              integrationProviderVersion: true
+            }
           }
         }
-      }
-    });
-
-    let materialProviders = integrationInstanceProviders.filter(
-      integrationInstanceProvider => !!integrationInstanceProvider.currentVersion?.configOid
-    );
-    let materialProviderOids = new Set(
-      materialProviders.map(integrationInstanceProvider =>
-        integrationInstanceProvider.oid.toString()
-      )
-    );
-
-    let existingTemplateProviders = await db.sessionTemplateProvider.findMany({
-      where: {
-        sessionTemplateOid: sessionTemplate.oid,
-        status: { not: 'deleted' }
-      }
-    });
-    let existingByIntegrationInstanceProviderOid = new Map(
-      existingTemplateProviders
-        .filter(provider => provider.integrationInstanceProviderOid)
-        .map(provider => [provider.integrationInstanceProviderOid!, provider])
-    );
-
-    let createdSessionTemplateProviderIds = await withTransaction(async db => {
-      let createdSessionTemplateProviderIds: string[] = [];
-
-      await db.sessionTemplate.update({
-        where: { oid: sessionTemplate.oid },
-        data: {
-          identityActorOid: integrationInstance.identityActorOid ?? null,
-          identityOid: integrationInstance.identityOid ?? null
-        }
       });
 
-      for (let integrationInstanceProvider of materialProviders) {
-        let currentVersion = integrationInstanceProvider.currentVersion!;
-        let existing = existingByIntegrationInstanceProviderOid.get(
-          integrationInstanceProvider.oid
-        );
-        let toolFilter = buildIntegrationProviderToolFilterChain({
-          canAttachCustomToolFilters:
-            integrationInstanceProvider.integration.canAttachCustomToolFilters,
-          canOverrideToolFilters:
-            integrationInstanceProvider.integration.canOverrideToolFilters,
-          integrationProviderToolFilter: currentVersion.integrationProviderVersion
-            .toolFilter as PrismaJson.ToolFilter | null,
-          integrationInstanceProviderToolFilter:
-            currentVersion.toolFilter as PrismaJson.ToolFilter | null,
-          integrationInstanceProviderIsOverride: currentVersion.isOverrideToolFilter
-        });
+      let materialProviders = integrationInstanceProviders.filter(
+        integrationInstanceProvider => !!integrationInstanceProvider.currentVersion?.configOid
+      );
+      let materialProviderOids = new Set(
+        materialProviders.map(integrationInstanceProvider =>
+          integrationInstanceProvider.oid.toString()
+        )
+      );
 
-        let data = {
-          status: 'active' as const,
-          toolFilter,
-          sessionTemplateOid: sessionTemplate.oid,
-          providerOid: integrationInstanceProvider.integrationProvider.providerOid,
-          deploymentOid: currentVersion.integrationProviderVersion.deploymentOid,
-          configOid: currentVersion.configOid!,
-          authConfigOid: currentVersion.authConfigOid,
-          integrationInstanceProviderOid: integrationInstanceProvider.oid,
-          tenantOid: sessionTemplate.tenantOid,
-          solutionOid: sessionTemplate.solutionOid,
-          environmentOid: sessionTemplate.environmentOid
-        };
-
-        if (existing) {
-          await db.sessionTemplateProvider.update({
-            where: { oid: existing.oid },
-            data
-          });
-        } else {
-          let created = await db.sessionTemplateProvider.create({
-            data: {
-              ...getId('sessionTemplateProvider'),
-              ...data
-            },
-            select: { id: true }
-          });
-          createdSessionTemplateProviderIds.push(created.id);
-        }
-      }
-
-      await db.sessionTemplateProvider.updateMany({
+      let existingTemplateProviders = await db.sessionTemplateProvider.findMany({
         where: {
           sessionTemplateOid: sessionTemplate.oid,
-          status: 'active',
-          OR: [
-            { integrationInstanceProviderOid: null },
-            {
-              integrationInstanceProviderOid: {
-                notIn: Array.from(materialProviderOids).map(oid => BigInt(oid))
+          status: { not: 'deleted' }
+        }
+      });
+      let existingByIntegrationInstanceProviderOid = new Map(
+        existingTemplateProviders
+          .filter(provider => provider.integrationInstanceProviderOid)
+          .map(provider => [provider.integrationInstanceProviderOid!, provider])
+      );
+
+      let createdSessionTemplateProviderIds = await withTransaction(async db => {
+        let createdSessionTemplateProviderIds: string[] = [];
+
+        await db.sessionTemplate.update({
+          where: { oid: sessionTemplate.oid },
+          data: {
+            identityActorOid: integrationInstance.identityActorOid ?? null,
+            identityOid: integrationInstance.identityOid ?? null
+          }
+        });
+
+        for (let integrationInstanceProvider of materialProviders) {
+          let currentVersion = integrationInstanceProvider.currentVersion!;
+          let existing = existingByIntegrationInstanceProviderOid.get(
+            integrationInstanceProvider.oid
+          );
+          let toolFilter = buildIntegrationProviderToolFilterChain({
+            canAttachCustomToolFilters:
+              integrationInstanceProvider.integration.canAttachCustomToolFilters,
+            canOverrideToolFilters:
+              integrationInstanceProvider.integration.canOverrideToolFilters,
+            integrationProviderToolFilter: currentVersion.integrationProviderVersion
+              .toolFilter as PrismaJson.ToolFilter | null,
+            integrationInstanceProviderToolFilter:
+              currentVersion.toolFilter as PrismaJson.ToolFilter | null,
+            integrationInstanceProviderIsOverride: currentVersion.isOverrideToolFilter
+          });
+
+          let data = {
+            status: 'active' as const,
+            toolFilter,
+            sessionTemplateOid: sessionTemplate.oid,
+            providerOid: integrationInstanceProvider.integrationProvider.providerOid,
+            deploymentOid: currentVersion.integrationProviderVersion.deploymentOid,
+            configOid: currentVersion.configOid!,
+            authConfigOid: currentVersion.authConfigOid,
+            integrationInstanceProviderOid: integrationInstanceProvider.oid,
+            tenantOid: sessionTemplate.tenantOid,
+            solutionOid: sessionTemplate.solutionOid,
+            environmentOid: sessionTemplate.environmentOid
+          };
+
+          if (existing) {
+            await db.sessionTemplateProvider.update({
+              where: { oid: existing.oid },
+              data
+            });
+          } else {
+            let created = await db.sessionTemplateProvider.create({
+              data: {
+                ...getId('sessionTemplateProvider'),
+                ...data
+              },
+              select: { id: true }
+            });
+            createdSessionTemplateProviderIds.push(created.id);
+          }
+        }
+
+        await db.sessionTemplateProvider.updateMany({
+          where: {
+            sessionTemplateOid: sessionTemplate.oid,
+            status: 'active',
+            OR: [
+              { integrationInstanceProviderOid: null },
+              {
+                integrationInstanceProviderOid: {
+                  notIn: Array.from(materialProviderOids).map(oid => BigInt(oid))
+                }
               }
-            }
-          ]
-        },
-        data: { status: 'archived' }
+            ]
+          },
+          data: { status: 'archived' }
+        });
+
+        return createdSessionTemplateProviderIds;
       });
 
-      return createdSessionTemplateProviderIds;
-    });
+      await enqueueSessionTemplateProvidersCreated(createdSessionTemplateProviderIds);
 
-    if (createdSessionTemplateProviderIds.length) {
-      await sessionTemplateProviderCreatedQueue.addMany(
-        createdSessionTemplateProviderIds.map(sessionTemplateProviderId => ({
-          sessionTemplateProviderId
-        }))
-      );
-    }
-
-    await sessionTemplateSyncHashQueue.add({
-      sessionTemplateId: sessionTemplate.id
+      await enqueueSessionTemplateSyncHash(sessionTemplate.id);
     });
   });
 
@@ -218,6 +260,15 @@ export let archiveIntegrationInstanceSessionTemplatesQueue = createQueue<{
   name: 'sub/ses/lc/linkedSessionTemplate/archiveMany',
   redisUrl: env.service.REDIS_URL
 });
+
+export let enqueueArchiveIntegrationInstanceSessionTemplates = async (d: {
+  integrationInstanceId: string;
+  cursor?: string;
+}) => {
+  await archiveIntegrationInstanceSessionTemplatesQueue.add(d, {
+    id: queueJobId('iiatm', d.integrationInstanceId, d.cursor ?? 'start')
+  });
+};
 
 export let archiveIntegrationInstanceSessionTemplatesQueueProcessor =
   archiveIntegrationInstanceSessionTemplatesQueue.process(async data => {
@@ -238,16 +289,14 @@ export let archiveIntegrationInstanceSessionTemplatesQueueProcessor =
     });
     if (sessionTemplates.length === 0) return;
 
-    await archiveIntegrationInstanceSessionTemplateQueue.addMany(
-      sessionTemplates.map(sessionTemplate => ({
-        sessionTemplateId: sessionTemplate.id
-      }))
+    await enqueueArchiveIntegrationInstanceSessionTemplateMany(
+      sessionTemplates.map(sessionTemplate => sessionTemplate.id)
     );
 
     let lastSessionTemplate = sessionTemplates[sessionTemplates.length - 1];
     if (!lastSessionTemplate) return;
 
-    await archiveIntegrationInstanceSessionTemplatesQueue.add({
+    await enqueueArchiveIntegrationInstanceSessionTemplates({
       integrationInstanceId: data.integrationInstanceId,
       cursor: lastSessionTemplate.id
     });
@@ -260,41 +309,66 @@ export let archiveIntegrationInstanceSessionTemplateQueue = createQueue<{
   redisUrl: env.service.REDIS_URL
 });
 
+export let enqueueArchiveIntegrationInstanceSessionTemplate = async (
+  sessionTemplateId: string
+) => {
+  await archiveIntegrationInstanceSessionTemplateQueue.add(
+    { sessionTemplateId },
+    { id: queueJobId('iiat', sessionTemplateId) }
+  );
+};
+
+export let enqueueArchiveIntegrationInstanceSessionTemplateMany = async (
+  sessionTemplateIds: string[]
+) => {
+  if (!sessionTemplateIds.length) return;
+
+  await archiveIntegrationInstanceSessionTemplateQueue.addManyWithOps(
+    sessionTemplateIds.map(sessionTemplateId => ({
+      data: { sessionTemplateId },
+      opts: { id: queueJobId('iiat', sessionTemplateId) }
+    }))
+  );
+};
+
 export let archiveIntegrationInstanceSessionTemplateQueueProcessor =
   archiveIntegrationInstanceSessionTemplateQueue.process(async data => {
-    let sessionTemplate = await db.sessionTemplate.findUnique({
-      where: { id: data.sessionTemplateId },
-      include: { integrationInstance: true }
-    });
-    let integrationInstance = sessionTemplate?.integrationInstance;
-    if (
-      !sessionTemplate ||
-      !integrationInstance ||
-      !sessionTemplate.integrationInstanceOid ||
-      sessionTemplate.status !== 'active' ||
-      integrationInstance.status !== 'archived'
-    ) {
-      return;
-    }
+    await withSessionTemplateSyncLock(data.sessionTemplateId, async () => {
+      let sessionTemplate = await db.sessionTemplate.findUnique({
+        where: { id: data.sessionTemplateId },
+        include: { integrationInstance: true }
+      });
+      let integrationInstance = sessionTemplate?.integrationInstance;
+      if (
+        !sessionTemplate ||
+        !integrationInstance ||
+        !sessionTemplate.integrationInstanceOid ||
+        sessionTemplate.status !== 'active' ||
+        integrationInstance.status !== 'archived'
+      ) {
+        return;
+      }
 
-    let archivedAt = integrationInstance.archivedAt ?? new Date();
+      let archivedAt = integrationInstance.archivedAt ?? new Date();
 
-    await withTransaction(async db => {
-      await db.sessionTemplateProvider.updateMany({
-        where: { sessionTemplateOid: sessionTemplate.oid },
-        data: { status: 'archived' }
+      await withTransaction(async db => {
+        await db.sessionTemplateProvider.updateMany({
+          where: { sessionTemplateOid: sessionTemplate.oid },
+          data: { status: 'archived' }
+        });
+
+        await db.sessionTemplate.update({
+          where: { oid: sessionTemplate.oid },
+          data: {
+            status: 'archived',
+            archivedAt
+          }
+        });
       });
 
-      await db.sessionTemplate.update({
-        where: { oid: sessionTemplate.oid },
-        data: {
-          status: 'archived',
-          archivedAt
-        }
-      });
-    });
-
-    await sessionTemplateArchivedQueue.add({
-      sessionTemplateId: sessionTemplate.id
+      await sessionTemplateArchivedQueue.add(
+        { sessionTemplateId: sessionTemplate.id },
+        { id: queueJobId('sta', sessionTemplate.id) }
+      );
     });
   });

--- a/src/systems/subspace/modules/session/src/queues/lifecycle/sessionTemplateProvider.ts
+++ b/src/systems/subspace/modules/session/src/queues/lifecycle/sessionTemplateProvider.ts
@@ -3,6 +3,7 @@ import { Hash } from '@lowerdeck/hash';
 import { createQueue } from '@lowerdeck/queue';
 import { db, getId } from '@metorial-subspace/db';
 import { env } from '../../env';
+import { queueJobId, withSessionTemplateSyncLock } from '../../lib/sessionTemplateSync';
 
 export let sessionTemplateProviderCreatedQueue = createQueue<{
   sessionTemplateProviderId: string;
@@ -10,6 +11,28 @@ export let sessionTemplateProviderCreatedQueue = createQueue<{
   name: 'sub/ses/lc/sessionTemplateProvider/created',
   redisUrl: env.service.REDIS_URL
 });
+
+export let enqueueSessionTemplateProviderCreated = async (
+  sessionTemplateProviderId: string
+) => {
+  await sessionTemplateProviderCreatedQueue.add(
+    { sessionTemplateProviderId },
+    { id: queueJobId('stpc', sessionTemplateProviderId) }
+  );
+};
+
+export let enqueueSessionTemplateProvidersCreated = async (
+  sessionTemplateProviderIds: string[]
+) => {
+  if (!sessionTemplateProviderIds.length) return;
+
+  await sessionTemplateProviderCreatedQueue.addManyWithOps(
+    sessionTemplateProviderIds.map(sessionTemplateProviderId => ({
+      data: { sessionTemplateProviderId },
+      opts: { id: queueJobId('stpc', sessionTemplateProviderId) }
+    }))
+  );
+};
 
 export let sessionTemplateProviderCreatedQueueProcessor =
   sessionTemplateProviderCreatedQueue.process(async data => {
@@ -52,53 +75,62 @@ export let sessionTemplateSyncHashQueue = createQueue<{
   redisUrl: env.service.REDIS_URL
 });
 
+export let enqueueSessionTemplateSyncHash = async (sessionTemplateId: string) => {
+  await sessionTemplateSyncHashQueue.add(
+    { sessionTemplateId },
+    { id: queueJobId('sth', sessionTemplateId) }
+  );
+};
+
 export let sessionTemplateSyncHashQueueProcessor = sessionTemplateSyncHashQueue.process(
   async data => {
-    let sessionTemplate = await db.sessionTemplate.findUnique({
-      where: { id: data.sessionTemplateId }
-    });
-    if (!sessionTemplate || sessionTemplate.status !== 'active') {
-      return;
-    }
-
-    let providers = await db.sessionTemplateProvider.findMany({
-      where: {
-        sessionTemplateOid: sessionTemplate.oid,
-        status: 'active'
-      },
-      select: {
-        providerOid: true,
-        deploymentOid: true,
-        configOid: true,
-        authConfigOid: true,
-        toolFilter: true
+    await withSessionTemplateSyncLock(data.sessionTemplateId, async () => {
+      let sessionTemplate = await db.sessionTemplate.findUnique({
+        where: { id: data.sessionTemplateId }
+      });
+      if (!sessionTemplate || sessionTemplate.status !== 'active') {
+        return;
       }
-    });
 
-    let hash = await Hash.sha256(
-      canonicalize([
-        sessionTemplate.oid.toString(),
-        sessionTemplate.status,
-        sessionTemplate.integrationInstanceGroupOid?.toString() ?? null,
-        sessionTemplate.integrationInstanceOid?.toString() ?? null,
-        sessionTemplate.identityActorOid?.toString() ?? null,
-        sessionTemplate.identityOid?.toString() ?? null,
-        providers
-          .map(provider => ({
-            providerOid: provider.providerOid.toString(),
-            deploymentOid: provider.deploymentOid.toString(),
-            configOid: provider.configOid.toString(),
-            authConfigOid: provider.authConfigOid?.toString() ?? null,
-            toolFilter: provider.toolFilter
-          }))
-          .map(p => canonicalize(p))
-          .sort()
-      ])
-    );
+      let providers = await db.sessionTemplateProvider.findMany({
+        where: {
+          sessionTemplateOid: sessionTemplate.oid,
+          status: 'active'
+        },
+        select: {
+          providerOid: true,
+          deploymentOid: true,
+          configOid: true,
+          authConfigOid: true,
+          toolFilter: true
+        }
+      });
 
-    await db.sessionTemplate.update({
-      where: { oid: sessionTemplate.oid },
-      data: { hash }
+      let hash = await Hash.sha256(
+        canonicalize([
+          sessionTemplate.oid.toString(),
+          sessionTemplate.status,
+          sessionTemplate.integrationInstanceGroupOid?.toString() ?? null,
+          sessionTemplate.integrationInstanceOid?.toString() ?? null,
+          sessionTemplate.identityActorOid?.toString() ?? null,
+          sessionTemplate.identityOid?.toString() ?? null,
+          providers
+            .map(provider => ({
+              providerOid: provider.providerOid.toString(),
+              deploymentOid: provider.deploymentOid.toString(),
+              configOid: provider.configOid.toString(),
+              authConfigOid: provider.authConfigOid?.toString() ?? null,
+              toolFilter: provider.toolFilter
+            }))
+            .map(p => canonicalize(p))
+            .sort()
+        ])
+      );
+
+      await db.sessionTemplate.update({
+        where: { oid: sessionTemplate.oid },
+        data: { hash }
+      });
     });
   }
 );

--- a/src/systems/subspace/modules/session/src/services/sessionProviderInput.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionProviderInput.ts
@@ -15,8 +15,8 @@ import {
 import { providerCombinationService } from '@metorial-subspace/module-provider-internal';
 import { sessionProviderCreatedQueue } from '../queues/lifecycle/sessionProvider';
 import {
-  sessionTemplateProviderCreatedQueue,
-  sessionTemplateSyncHashQueue
+  enqueueSessionTemplateProviderCreated,
+  enqueueSessionTemplateSyncHash
 } from '../queues/lifecycle/sessionTemplateProvider';
 import { sessionProviderInclude } from './sessionProvider';
 import { sessionTemplateProviderInclude } from './sessionTemplateProvider';
@@ -280,15 +280,11 @@ class sessionProviderInputServiceImpl {
 
       for (let stp of sessionTemplateProviders) {
         await addAfterTransactionHook(async () =>
-          sessionTemplateProviderCreatedQueue.add({ sessionTemplateProviderId: stp.id })
+          enqueueSessionTemplateProviderCreated(stp.id)
         );
       }
 
-      await addAfterTransactionHook(async () =>
-        sessionTemplateSyncHashQueue.add({
-          sessionTemplateId: d.template.id
-        })
-      );
+      await addAfterTransactionHook(async () => enqueueSessionTemplateSyncHash(d.template.id));
 
       return sessionTemplateProviders;
     });

--- a/src/systems/subspace/modules/session/src/services/sessionTemplate.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionTemplate.ts
@@ -37,6 +37,7 @@ import { providerToolService } from '@metorial-subspace/module-catalog';
 import { checkToolAccess } from '@metorial-subspace/module-provider-internal';
 import { checkTenant } from '@metorial-subspace/module-tenant';
 import { sessionTemplateArchivedQueue } from '../queues/lifecycle/sessionTemplate';
+import { queueJobId, withSessionTemplateSyncLock } from '../lib/sessionTemplateSync';
 import {
   type SessionProviderInput,
   sessionProviderInputService
@@ -417,37 +418,42 @@ class sessionTemplateServiceImpl {
     checkDeletedEdit(d.sessionTemplate, 'archive');
     if (!d._allowLinked) await assertCanWriteSessionTemplate(d.sessionTemplate, 'archive');
 
-    return withTransaction(async db => {
-      let archivedAt = new Date();
+    return withSessionTemplateSyncLock(d.sessionTemplate.id, async () =>
+      withTransaction(async db => {
+        let archivedAt = new Date();
 
-      await db.sessionTemplateProvider.updateMany({
-        where: {
-          sessionTemplateOid: d.sessionTemplate.oid
-        },
-        data: {
-          status: 'archived' as const
-        }
-      });
+        await db.sessionTemplateProvider.updateMany({
+          where: {
+            sessionTemplateOid: d.sessionTemplate.oid
+          },
+          data: {
+            status: 'archived' as const
+          }
+        });
 
-      let sessionTemplate = await db.sessionTemplate.update({
-        where: {
-          oid: d.sessionTemplate.oid
-        },
-        data: {
-          status: 'archived' as const,
-          archivedAt
-        },
-        include
-      });
+        let sessionTemplate = await db.sessionTemplate.update({
+          where: {
+            oid: d.sessionTemplate.oid
+          },
+          data: {
+            status: 'archived' as const,
+            archivedAt
+          },
+          include
+        });
 
-      await addAfterTransactionHook(async () =>
-        sessionTemplateArchivedQueue.add({
-          sessionTemplateId: sessionTemplate.id
-        })
-      );
+        await addAfterTransactionHook(async () =>
+          sessionTemplateArchivedQueue.add(
+            {
+              sessionTemplateId: sessionTemplate.id
+            },
+            { id: queueJobId('sta', sessionTemplate.id) }
+          )
+        );
 
-      return sessionTemplate;
-    });
+        return sessionTemplate;
+      })
+    );
   }
 
   async deleteSessionTemplate(d: {

--- a/src/systems/subspace/modules/session/src/services/sessionTemplateProvider.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionTemplateProvider.ts
@@ -36,9 +36,10 @@ import {
 } from '@metorial-subspace/list-utils';
 import { checkTenant } from '@metorial-subspace/module-tenant';
 import {
-  sessionTemplateProviderCreatedQueue,
-  sessionTemplateSyncHashQueue
+  enqueueSessionTemplateProvidersCreated,
+  enqueueSessionTemplateSyncHash
 } from '../queues/lifecycle/sessionTemplateProvider';
+import { withSessionTemplateSyncLock } from '../lib/sessionTemplateSync';
 import {
   type SessionProviderInput,
   sessionProviderInputService,
@@ -289,103 +290,102 @@ class sessionTemplateProviderServiceImpl {
     sessionTemplate: SessionTemplate;
     integrationInstance: IntegrationInstance;
   }) {
-    await withTransaction(async db => {
-      let instanceProviders = await db.integrationInstanceProvider.findMany({
-        where: {
-          integrationInstanceOid: d.integrationInstance.oid,
-          status: 'active',
-          isParentDeleted: false,
-          currentVersion: { configOid: { not: null } }
-        },
-        include: {
-          integration: true,
-          integrationProvider: true,
-          currentVersion: {
-            include: {
-              integrationProviderVersion: true
-            }
-          }
-        }
-      });
-
-      let activeProviderOids = instanceProviders.map(provider => provider.oid);
-      let createdIds: string[] = [];
-
-      let existingProviders = await db.sessionTemplateProvider.findMany({
-        where: {
-          sessionTemplateOid: d.sessionTemplate.oid,
-          integrationInstanceProviderOid: { in: activeProviderOids }
-        },
-        select: {
-          id: true,
-          integrationInstanceProviderOid: true
-        }
-      });
-      let existingByProviderOid = new Map(
-        existingProviders.map(provider => [
-          provider.integrationInstanceProviderOid!.toString(),
-          provider
-        ])
-      );
-
-      for (let provider of instanceProviders) {
-        let currentVersion = provider.currentVersion!;
-        let data = {
-          status: 'active' as const,
-          toolFilter:
-            (currentVersion.toolFilter as PrismaJson.ToolFilter | null) ??
-            allowAllToolFilter(),
-          sessionTemplateOid: d.sessionTemplate.oid,
-          providerOid: provider.integrationProvider.providerOid,
-          deploymentOid: currentVersion.integrationProviderVersion.deploymentOid,
-          configOid: currentVersion.configOid!,
-          authConfigOid: currentVersion.authConfigOid,
-          integrationInstanceProviderOid: provider.oid,
-          tenantOid: provider.tenantOid,
-          solutionOid: provider.solutionOid,
-          environmentOid: provider.environmentOid
-        };
-
-        let createdBefore = existingByProviderOid.has(provider.oid.toString());
-        let synced = await db.sessionTemplateProvider.upsert({
+    await withSessionTemplateSyncLock(d.sessionTemplate.id, async () => {
+      await withTransaction(async db => {
+        let instanceProviders = await db.integrationInstanceProvider.findMany({
           where: {
-            sessionTemplateOid_integrationInstanceProviderOid: {
-              sessionTemplateOid: d.sessionTemplate.oid,
-              integrationInstanceProviderOid: provider.oid
-            }
+            integrationInstanceOid: d.integrationInstance.oid,
+            status: 'active',
+            isParentDeleted: false,
+            currentVersion: { configOid: { not: null } }
           },
-          create: {
-            ...getId('sessionTemplateProvider'),
-            ...data
-          },
-          update: data,
-          select: { id: true }
-        });
-        if (!createdBefore) createdIds.push(synced.id);
-      }
-
-      await db.sessionTemplateProvider.updateMany({
-        where: {
-          sessionTemplateOid: d.sessionTemplate.oid,
-          status: 'active',
-          OR: [
-            { integrationInstanceProviderOid: null },
-            {
-              integrationInstanceProviderOid: {
-                notIn: activeProviderOids
+          orderBy: { id: 'asc' },
+          include: {
+            integration: true,
+            integrationProvider: true,
+            currentVersion: {
+              include: {
+                integrationProviderVersion: true
               }
             }
-          ]
-        },
-        data: { status: 'archived' }
-      });
+          }
+        });
 
-      await addAfterTransactionHook(async () => {
-        if (createdIds.length) {
-          await sessionTemplateProviderCreatedQueue.addMany(
-            createdIds.map(sessionTemplateProviderId => ({ sessionTemplateProviderId }))
-          );
+        let activeProviderOids = instanceProviders.map(provider => provider.oid);
+        let createdIds: string[] = [];
+
+        let existingProviders = await db.sessionTemplateProvider.findMany({
+          where: {
+            sessionTemplateOid: d.sessionTemplate.oid,
+            integrationInstanceProviderOid: { in: activeProviderOids }
+          },
+          select: {
+            id: true,
+            integrationInstanceProviderOid: true
+          }
+        });
+        let existingByProviderOid = new Map(
+          existingProviders.map(provider => [
+            provider.integrationInstanceProviderOid!.toString(),
+            provider
+          ])
+        );
+
+        for (let provider of instanceProviders) {
+          let currentVersion = provider.currentVersion!;
+          let data = {
+            status: 'active' as const,
+            toolFilter:
+              (currentVersion.toolFilter as PrismaJson.ToolFilter | null) ??
+              allowAllToolFilter(),
+            sessionTemplateOid: d.sessionTemplate.oid,
+            providerOid: provider.integrationProvider.providerOid,
+            deploymentOid: currentVersion.integrationProviderVersion.deploymentOid,
+            configOid: currentVersion.configOid!,
+            authConfigOid: currentVersion.authConfigOid,
+            integrationInstanceProviderOid: provider.oid,
+            tenantOid: provider.tenantOid,
+            solutionOid: provider.solutionOid,
+            environmentOid: provider.environmentOid
+          };
+
+          let createdBefore = existingByProviderOid.has(provider.oid.toString());
+          let synced = await db.sessionTemplateProvider.upsert({
+            where: {
+              sessionTemplateOid_integrationInstanceProviderOid: {
+                sessionTemplateOid: d.sessionTemplate.oid,
+                integrationInstanceProviderOid: provider.oid
+              }
+            },
+            create: {
+              ...getId('sessionTemplateProvider'),
+              ...data
+            },
+            update: data,
+            select: { id: true }
+          });
+          if (!createdBefore) createdIds.push(synced.id);
         }
+
+        await db.sessionTemplateProvider.updateMany({
+          where: {
+            sessionTemplateOid: d.sessionTemplate.oid,
+            status: 'active',
+            OR: [
+              { integrationInstanceProviderOid: null },
+              {
+                integrationInstanceProviderOid: {
+                  notIn: activeProviderOids
+                }
+              }
+            ]
+          },
+          data: { status: 'archived' }
+        });
+
+        await addAfterTransactionHook(async () =>
+          enqueueSessionTemplateProvidersCreated(createdIds)
+        );
       });
     });
   }
@@ -394,185 +394,184 @@ class sessionTemplateProviderServiceImpl {
     sessionTemplate: SessionTemplate;
     integrationInstanceGroup: IntegrationInstanceGroup;
   }) {
-    await withTransaction(async db => {
-      let groupProviders = await db.integrationInstanceGroupProvider.findMany({
-        where: {
-          integrationInstanceGroupOid: d.integrationInstanceGroup.oid,
-          status: 'active',
-          isParentDeleted: false,
-          integrationInstanceProvider: {
+    await withSessionTemplateSyncLock(d.sessionTemplate.id, async () => {
+      await withTransaction(async db => {
+        let groupProviders = await db.integrationInstanceGroupProvider.findMany({
+          where: {
+            integrationInstanceGroupOid: d.integrationInstanceGroup.oid,
             status: 'active',
             isParentDeleted: false,
-            currentVersion: { configOid: { not: null } }
-          }
-        },
-        include: {
-          integrationProvider: true,
-          integrationInstanceProvider: {
-            include: {
-              currentVersion: {
-                include: {
-                  integrationProviderVersion: true
+            integrationInstanceProvider: {
+              status: 'active',
+              isParentDeleted: false,
+              currentVersion: { configOid: { not: null } }
+            }
+          },
+          orderBy: { id: 'asc' },
+          include: {
+            integrationProvider: true,
+            integrationInstanceProvider: {
+              include: {
+                currentVersion: {
+                  include: {
+                    integrationProviderVersion: true
+                  }
                 }
               }
             }
           }
+        });
+
+        let activeProviderOids = groupProviders.map(provider => provider.oid);
+        let activeInstanceProviderOids = groupProviders.map(
+          provider => provider.integrationInstanceProviderOid
+        );
+        let createdIds: string[] = [];
+
+        let existingProviders = await db.sessionTemplateProvider.findMany({
+          where: {
+            sessionTemplateOid: d.sessionTemplate.oid,
+            OR: [
+              { integrationInstanceGroupProviderOid: { in: activeProviderOids } },
+              { integrationInstanceProviderOid: { in: activeInstanceProviderOids } }
+            ]
+          },
+          select: {
+            oid: true,
+            id: true,
+            integrationInstanceProviderOid: true,
+            integrationInstanceGroupProviderOid: true
+          }
+        });
+        let existingByGroupProviderOid = new Map(
+          existingProviders
+            .filter(provider => provider.integrationInstanceGroupProviderOid)
+            .map(provider => [
+              provider.integrationInstanceGroupProviderOid!.toString(),
+              provider
+            ])
+        );
+        let existingByInstanceProviderOid = new Map(
+          existingProviders
+            .filter(provider => provider.integrationInstanceProviderOid)
+            .map(provider => [provider.integrationInstanceProviderOid!.toString(), provider])
+        );
+
+        let freeGroupProviderIdentity = async (input: {
+          groupProviderOid: bigint;
+          exceptSessionTemplateProviderOid?: bigint;
+        }) => {
+          await db.sessionTemplateProvider.updateMany({
+            where: {
+              sessionTemplateOid: d.sessionTemplate.oid,
+              integrationInstanceGroupProviderOid: input.groupProviderOid,
+              oid: input.exceptSessionTemplateProviderOid
+                ? { not: input.exceptSessionTemplateProviderOid }
+                : undefined
+            },
+            data: {
+              status: 'archived',
+              integrationInstanceGroupProviderOid: null
+            }
+          });
+        };
+
+        let updateOrCreateByInstanceProvider = async (d: {
+          existing?: (typeof existingProviders)[number];
+          data: {
+            status: 'active';
+            toolFilter: PrismaJson.ToolFilter;
+            sessionTemplateOid: bigint;
+            providerOid: bigint;
+            deploymentOid: bigint;
+            configOid: bigint;
+            authConfigOid: bigint | null;
+            integrationInstanceProviderOid: bigint;
+            integrationInstanceGroupProviderOid: bigint;
+            tenantOid: bigint;
+            solutionOid: number;
+            environmentOid: bigint;
+          };
+        }) => {
+          if (d.existing) {
+            await freeGroupProviderIdentity({
+              groupProviderOid: d.data.integrationInstanceGroupProviderOid,
+              exceptSessionTemplateProviderOid: d.existing.oid
+            });
+
+            return await db.sessionTemplateProvider.update({
+              where: { oid: d.existing.oid },
+              data: d.data,
+              select: { id: true }
+            });
+          }
+
+          await freeGroupProviderIdentity({
+            groupProviderOid: d.data.integrationInstanceGroupProviderOid
+          });
+
+          return await db.sessionTemplateProvider.upsert({
+            where: {
+              sessionTemplateOid_integrationInstanceProviderOid: {
+                sessionTemplateOid: d.data.sessionTemplateOid,
+                integrationInstanceProviderOid: d.data.integrationInstanceProviderOid
+              }
+            },
+            create: {
+              ...getId('sessionTemplateProvider'),
+              ...d.data
+            },
+            update: d.data,
+            select: { id: true }
+          });
+        };
+
+        for (let provider of groupProviders) {
+          let currentVersion = provider.integrationInstanceProvider.currentVersion!;
+          let data = {
+            status: 'active' as const,
+            toolFilter:
+              (provider.toolFilter as PrismaJson.ToolFilter | null) ?? allowAllToolFilter(),
+            sessionTemplateOid: d.sessionTemplate.oid,
+            providerOid: provider.integrationProvider.providerOid,
+            deploymentOid: currentVersion.integrationProviderVersion.deploymentOid,
+            configOid: currentVersion.configOid!,
+            authConfigOid: currentVersion.authConfigOid,
+            integrationInstanceProviderOid: provider.integrationInstanceProviderOid,
+            integrationInstanceGroupProviderOid: provider.oid,
+            tenantOid: provider.tenantOid,
+            solutionOid: provider.solutionOid,
+            environmentOid: provider.environmentOid
+          };
+
+          let existing =
+            existingByInstanceProviderOid.get(
+              provider.integrationInstanceProviderOid.toString()
+            ) ?? existingByGroupProviderOid.get(provider.oid.toString());
+          let createdBefore = !!existing;
+          let synced = await updateOrCreateByInstanceProvider({ existing, data });
+          if (!createdBefore) createdIds.push(synced.id);
         }
-      });
 
-      let activeProviderOids = groupProviders.map(provider => provider.oid);
-      let activeInstanceProviderOids = groupProviders.map(
-        provider => provider.integrationInstanceProviderOid
-      );
-      let createdIds: string[] = [];
-
-      let existingProviders = await db.sessionTemplateProvider.findMany({
-        where: {
-          sessionTemplateOid: d.sessionTemplate.oid,
-          OR: [
-            { integrationInstanceGroupProviderOid: { in: activeProviderOids } },
-            { integrationInstanceProviderOid: { in: activeInstanceProviderOids } }
-          ]
-        },
-        select: {
-          oid: true,
-          id: true,
-          integrationInstanceProviderOid: true,
-          integrationInstanceGroupProviderOid: true
-        }
-      });
-      let existingByGroupProviderOid = new Map(
-        existingProviders
-          .filter(provider => provider.integrationInstanceGroupProviderOid)
-          .map(provider => [
-            provider.integrationInstanceGroupProviderOid!.toString(),
-            provider
-          ])
-      );
-      let existingByInstanceProviderOid = new Map(
-        existingProviders
-          .filter(provider => provider.integrationInstanceProviderOid)
-          .map(provider => [provider.integrationInstanceProviderOid!.toString(), provider])
-      );
-
-      let freeGroupProviderIdentity = async (input: {
-        groupProviderOid: bigint;
-        exceptSessionTemplateProviderOid?: bigint;
-      }) => {
         await db.sessionTemplateProvider.updateMany({
           where: {
             sessionTemplateOid: d.sessionTemplate.oid,
-            integrationInstanceGroupProviderOid: input.groupProviderOid,
-            oid: input.exceptSessionTemplateProviderOid
-              ? { not: input.exceptSessionTemplateProviderOid }
-              : undefined
-          },
-          data: {
-            status: 'archived',
-            integrationInstanceGroupProviderOid: null
-          }
-        });
-      };
-
-      let updateOrCreateByInstanceProvider = async (d: {
-        existing?: (typeof existingProviders)[number];
-        data: {
-          status: 'active';
-          toolFilter: PrismaJson.ToolFilter;
-          sessionTemplateOid: bigint;
-          providerOid: bigint;
-          deploymentOid: bigint;
-          configOid: bigint;
-          authConfigOid: bigint | null;
-          integrationInstanceProviderOid: bigint;
-          integrationInstanceGroupProviderOid: bigint;
-          tenantOid: bigint;
-          solutionOid: number;
-          environmentOid: bigint;
-        };
-      }) => {
-        if (d.existing) {
-          await freeGroupProviderIdentity({
-            groupProviderOid: d.data.integrationInstanceGroupProviderOid,
-            exceptSessionTemplateProviderOid: d.existing.oid
-          });
-
-          return await db.sessionTemplateProvider.update({
-            where: { oid: d.existing.oid },
-            data: d.data,
-            select: { id: true }
-          });
-        }
-
-        await freeGroupProviderIdentity({
-          groupProviderOid: d.data.integrationInstanceGroupProviderOid
-        });
-
-        return await db.sessionTemplateProvider.upsert({
-          where: {
-            sessionTemplateOid_integrationInstanceProviderOid: {
-              sessionTemplateOid: d.data.sessionTemplateOid,
-              integrationInstanceProviderOid: d.data.integrationInstanceProviderOid
-            }
-          },
-          create: {
-            ...getId('sessionTemplateProvider'),
-            ...d.data
-          },
-          update: d.data,
-          select: { id: true }
-        });
-      };
-
-      for (let provider of groupProviders) {
-        let currentVersion = provider.integrationInstanceProvider.currentVersion!;
-        let data = {
-          status: 'active' as const,
-          toolFilter:
-            (provider.toolFilter as PrismaJson.ToolFilter | null) ?? allowAllToolFilter(),
-          sessionTemplateOid: d.sessionTemplate.oid,
-          providerOid: provider.integrationProvider.providerOid,
-          deploymentOid: currentVersion.integrationProviderVersion.deploymentOid,
-          configOid: currentVersion.configOid!,
-          authConfigOid: currentVersion.authConfigOid,
-          integrationInstanceProviderOid: provider.integrationInstanceProviderOid,
-          integrationInstanceGroupProviderOid: provider.oid,
-          tenantOid: provider.tenantOid,
-          solutionOid: provider.solutionOid,
-          environmentOid: provider.environmentOid
-        };
-
-        let existing =
-          existingByInstanceProviderOid.get(
-            provider.integrationInstanceProviderOid.toString()
-          ) ?? existingByGroupProviderOid.get(provider.oid.toString());
-        let createdBefore = !!existing;
-        let synced = await updateOrCreateByInstanceProvider({ existing, data });
-        if (!createdBefore) createdIds.push(synced.id);
-      }
-
-      await db.sessionTemplateProvider.updateMany({
-        where: {
-          sessionTemplateOid: d.sessionTemplate.oid,
-          status: 'active',
-          OR: [
-            { integrationInstanceGroupProviderOid: null },
-            {
-              integrationInstanceGroupProviderOid: {
-                notIn: activeProviderOids
+            status: 'active',
+            OR: [
+              { integrationInstanceGroupProviderOid: null },
+              {
+                integrationInstanceGroupProviderOid: {
+                  notIn: activeProviderOids
+                }
               }
-            }
-          ]
-        },
-        data: { status: 'archived' }
-      });
+            ]
+          },
+          data: { status: 'archived' }
+        });
 
-      await addAfterTransactionHook(async () => {
-        if (createdIds.length) {
-          await sessionTemplateProviderCreatedQueue.addMany(
-            createdIds.map(sessionTemplateProviderId => ({ sessionTemplateProviderId }))
-          );
-        }
+        await addAfterTransactionHook(async () =>
+          enqueueSessionTemplateProvidersCreated(createdIds)
+        );
       });
     });
   }
@@ -638,9 +637,7 @@ class sessionTemplateProviderServiceImpl {
       include
     });
 
-    await sessionTemplateSyncHashQueue.add({
-      sessionTemplateId: sessionTemplateProvider.sessionTemplate.id
-    });
+    await enqueueSessionTemplateSyncHash(sessionTemplateProvider.sessionTemplate.id);
 
     return sessionTemplateProvider;
   }
@@ -671,9 +668,7 @@ class sessionTemplateProviderServiceImpl {
       include
     });
 
-    await sessionTemplateSyncHashQueue.add({
-      sessionTemplateId: sessionTemplateProvider.sessionTemplate.id
-    });
+    await enqueueSessionTemplateSyncHash(sessionTemplateProvider.sessionTemplate.id);
 
     return sessionTemplateProvider;
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes lifecycle behavior for integration instance/group session templates by deferring default template creation to background queues and adding locking/idempotent queueing, which could affect session creation timing and template/provider sync consistency under load.
> 
> **Overview**
> **Refactors session/session-template lifecycle to be more idempotent and concurrency-safe.** Adds a shared `finalizeSubspaceSessionCreate` helper and new `createSession` methods on subspace integration instance/group services, then updates core API endpoints to create sessions via these services (removing the hard dependency on a preexisting default template ID).
> 
> **Moves default session template creation to async lifecycle jobs and introduces session creation APIs that wait for readiness.** Integration instance/group “created” queue processors now create the default shared session template and enqueue template sync; service methods poll for the default template/providers to be ready (with timeout) before creating a session from it, and controller apps expose new `createSession` handlers.
> 
> **Improves queue safety and performance for template syncing.** Introduces `queueJobId`-based dedupe, batch `enqueue*` helpers, and a Redis lock (`withSessionTemplateSyncLock`) around sync/archive/hash jobs to prevent concurrent mutations, plus extracts `integrationProviderVersionInclude` into a shared `integrationIncludes` module. Tests are updated/added to cover the new lifecycle and enqueue APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75f6c683978beb55a8747426b90fa0a124e24329. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->