### PR TITLE
Improve integration pages

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration-instance/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration-instance/_layout.tsx
@@ -2,24 +2,60 @@ import { renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
+  useCreateIntegrationInstanceSession,
   useCurrentInstance,
   useCurrentOrganization,
   useCurrentProject,
   useIntegration,
   useIntegrationInstance
 } from '@metorial/state';
-import { LinkTabs } from '@metorial/ui';
-import { Outlet, useLocation, useParams } from 'react-router-dom';
+import { Button, Flex, LinkTabs } from '@metorial/ui';
+import { useState } from 'react';
+import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { DeletedRecordCallout } from '../../../scenes/deletedRecordCallout';
 
 export let IntegrationInstanceLayout = () => {
   let instance = useCurrentInstance();
   let organization = useCurrentOrganization();
   let project = useCurrentProject();
+  let navigate = useNavigate();
   let { integrationInstanceId } = useParams();
   let integrationInstance = useIntegrationInstance(instance.data?.id, integrationInstanceId);
   let integration = useIntegration(instance.data?.id, integrationInstance.data?.integrationId);
+  let createSession = useCreateIntegrationInstanceSession();
+  let [isCreatingSession, setIsCreatingSession] = useState(false);
   let pathname = useLocation().pathname;
+
+  let handleOpenExplorer = async () => {
+    let activeIntegrationInstanceId =
+      integrationInstance.data?.id ?? integrationInstanceId;
+    if (
+      isCreatingSession ||
+      !instance.data ||
+      !activeIntegrationInstanceId ||
+      integrationInstance.data?.status !== 'active'
+    )
+      return;
+
+    setIsCreatingSession(true);
+
+    let [res] = await createSession.mutate({
+      instanceId: instance.data.id,
+      integrationInstanceId: activeIntegrationInstanceId
+    });
+    setIsCreatingSession(false);
+
+    if (res) {
+      navigate(
+        Paths.instance.explorer(organization.data, project.data, instance.data, {
+          session_id: res.id
+        }),
+        {
+          state: { integrationInstanceId: activeIntegrationInstanceId }
+        }
+      );
+    }
+  };
 
   let instancePathParams = [
     organization.data,
@@ -52,6 +88,23 @@ export let IntegrationInstanceLayout = () => {
             href: Paths.instance.integrationInstance(...instancePathParams)
           }
         ]}
+        actions={
+          instance.data ? (
+            <Flex gap={8}>
+              <Button
+                size="2"
+                variant="outline"
+                onClick={handleOpenExplorer}
+                disabled={
+                  isCreatingSession || integrationInstance.data?.status !== 'active'
+                }
+                loading={isCreatingSession}
+              >
+                Open Explorer
+              </Button>
+            </Flex>
+          ) : undefined
+        }
       />
 
       {renderWithLoader({ integrationInstance })(({ integrationInstance }) => (

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration-instance/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration-instance/index.tsx
@@ -1,65 +1,13 @@
 import { renderWithLoader } from '@metorial/data-hooks';
 import {
-  IntegrationInstanceProvider,
-  IntegrationProvider,
   useCurrentInstance,
   useIntegration,
-  useIntegrationInstance,
-  useIntegrationInstanceProviders,
-  useProviderListings
+  useIntegrationInstance
 } from '@metorial/state';
-import {
-  Attributes,
-  Avatar,
-  Badge,
-  Button,
-  Callout,
-  Entity,
-  Spacer,
-  Text
-} from '@metorial/ui';
+import { Attributes, Badge, Callout, Spacer } from '@metorial/ui';
 import { Box, ID } from '@metorial/ui-product';
-import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
-import styled from 'styled-components';
-import { showIntegrationInstanceProviderPanelFlow } from '../../../scenes/integrations/providerPanelFlow';
-
-let Items = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-`;
-
-let Actions = styled.div`
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-`;
-
-let getProviderConfigLabel = (
-  provider: IntegrationProvider,
-  instanceProvider?: IntegrationInstanceProvider
-) =>
-  instanceProvider?.config?.name ??
-  instanceProvider?.config?.id ??
-  provider.config?.name ??
-  provider.config?.id ??
-  'None';
-
-let getProviderAuthLabel = (
-  provider: IntegrationProvider,
-  instanceProvider?: IntegrationInstanceProvider
-) =>
-  instanceProvider?.authConfig?.name ??
-  instanceProvider?.authConfig?.id ??
-  provider.authMethod?.name ??
-  provider.authCredentials?.id ??
-  'None';
-
-type ProviderListingPreview = {
-  name: string | null | undefined;
-  imageUrl: string | null | undefined;
-};
+import { IntegrationInstanceProvidersManager } from '../../../scenes/integrations/providersManager';
 
 let getIntegrationInstanceStatusColor = (status: string) => {
   if (status === 'active') return 'green';
@@ -75,227 +23,63 @@ export let IntegrationInstanceOverviewPage = () => {
   let { integrationInstanceId } = useParams();
   let integrationInstance = useIntegrationInstance(instance.data?.id, integrationInstanceId);
   let integration = useIntegration(instance.data?.id, integrationInstance.data?.integrationId);
-  let instanceProviders = useIntegrationInstanceProviders(instance.data?.id, {
-    integrationInstanceId,
-    status: ['active', 'archived']
-  });
 
-  let providerIds = useMemo(
-    () =>
-      [
-        ...new Set((integration.data?.providers ?? []).map(provider => provider.provider.id))
-      ].sort(),
-    [integration.data?.providers]
-  );
+  return renderWithLoader({ integrationInstance, integration })(
+    ({ integrationInstance, integration }) => {
+      let onComplete = () => integrationInstance.refetch();
 
-  let providerListings = useProviderListings(
-    instance.data?.id,
-    providerIds.length > 0 ? { id: providerIds, limit: 100 } : null
-  );
+      return (
+        <>
+          <Attributes
+            itemWidth="360px"
+            attributes={[
+              { label: 'ID', content: <ID id={integrationInstance.data.id} /> },
+              {
+                label: 'Status',
+                content: (
+                  <Badge
+                    color={getIntegrationInstanceStatusColor(integrationInstance.data.status)}
+                  >
+                    {capitalize(integrationInstance.data.status)}
+                  </Badge>
+                )
+              },
+              {
+                label: 'Identity',
+                content: integrationInstance.data.identityId ? (
+                  <ID id={integrationInstance.data.identityId} />
+                ) : (
+                  '-'
+                )
+              }
+            ]}
+          />
 
-  let renderOverview = (
-    integrationData: NonNullable<typeof integration.data>,
-    integrationInstanceData: NonNullable<typeof integrationInstance.data>,
-    integrationProviders: IntegrationProvider[],
-    providersById: Map<string, ProviderListingPreview>
-  ) => {
-    let instanceProviderByIntegrationProviderId = new Map(
-      (instanceProviders.data?.items ?? []).map(
-        provider => [provider.integrationProvider.id, provider] as const
-      )
-    );
+          {integrationInstance.data.status === 'draft' ? (
+            <>
+              <Spacer height={20} />
+              <Callout color="orange">
+                This integration instance is still a draft and cannot be used yet. It first
+                needs to be configured.
+              </Callout>
+            </>
+          ) : null}
 
-    let rows = integrationProviders.map(provider => ({
-      integrationProvider: provider,
-      instanceProvider: instanceProviderByIntegrationProviderId.get(provider.id)
-    }));
+          <Spacer height={20} />
 
-    let onComplete = () => {
-      integrationInstance.refetch();
-      instanceProviders.refetch();
-    };
-
-    return (
-      <>
-        <Attributes
-          itemWidth="360px"
-          attributes={[
-            { label: 'ID', content: <ID id={integrationInstanceData.id} /> },
-            {
-              label: 'Status',
-              content: (
-                <Badge
-                  color={getIntegrationInstanceStatusColor(integrationInstanceData.status)}
-                >
-                  {capitalize(integrationInstanceData.status)}
-                </Badge>
-              )
-            },
-            {
-              label: 'Identity',
-              content: integrationInstanceData.identityId ? (
-                <ID id={integrationInstanceData.identityId} />
-              ) : (
-                '-'
-              )
-            }
-          ]}
-        />
-
-        {integrationInstanceData.status === 'draft' ? (
-          <>
-            <Spacer height={20} />
-            <Callout color="orange">
-              This integration instance is still a draft and cannot be used yet. It first needs
-              to be configured.
-            </Callout>
-          </>
-        ) : null}
-
-        <Spacer height={20} />
-
-        <Box
-          title="Providers"
-          description="Review the providers attached to this integration and configure per-instance overrides where needed."
-        >
-          {rows.length === 0 ? (
-            <Text size="2" color="gray600" align="center" style={{ padding: '20px 0' }}>
-              This integration does not have any providers yet.
-            </Text>
-          ) : (
-            <Items>
-              {rows.map(({ integrationProvider, instanceProvider }) => {
-                let listing = providersById.get(integrationProvider.provider.id);
-                let displayName =
-                  listing?.name ??
-                  integrationProvider.provider.name ??
-                  integrationProvider.provider.slug;
-                let description =
-                  integrationProvider.provider.slug &&
-                  integrationProvider.provider.slug !== displayName
-                    ? integrationProvider.provider.slug
-                    : instanceProvider
-                      ? 'Instance override configured'
-                      : 'Using integration defaults';
-
-                return (
-                  <Entity.Wrapper key={integrationProvider.id} aligned>
-                    <Entity.Content>
-                      <Entity.Field
-                        prefix={
-                          <Avatar
-                            entity={{
-                              name: displayName,
-                              photoUrl: listing?.imageUrl ?? undefined
-                            }}
-                            size={32}
-                            radius={8}
-                            noTooltip
-                            imageFit="contain"
-                          />
-                        }
-                        title={displayName}
-                        description={description}
-                      />
-
-                      <Entity.Field
-                        title="Config"
-                        value={getProviderConfigLabel(integrationProvider, instanceProvider)}
-                      />
-
-                      <Entity.Field
-                        title="Auth"
-                        value={getProviderAuthLabel(integrationProvider, instanceProvider)}
-                      />
-
-                      <Entity.Field
-                        title="Status"
-                        value={
-                          instanceProvider ? (
-                            <Badge size="2" color="green">
-                              Configured
-                            </Badge>
-                          ) : integrationInstanceData.status === 'draft' ? (
-                            <Badge size="2" color="orange">
-                              Pending
-                            </Badge>
-                          ) : (
-                            <Badge size="2" color="gray">
-                              Inherited
-                            </Badge>
-                          )
-                        }
-                      />
-
-                      <Entity.Field title="Actions" right>
-                        <Actions>
-                          <Button
-                            size="1"
-                            variant="outline"
-                            disabled={
-                              integrationInstanceData.status === 'archived' ||
-                              integrationInstanceData.status === 'deleted' ||
-                              (integrationInstanceData.status === 'active' &&
-                                !instanceProvider?.config &&
-                                !instanceProvider?.authConfig)
-                            }
-                            onClick={() =>
-                              showIntegrationInstanceProviderPanelFlow({
-                                integration: integrationData,
-                                integrationInstance: integrationInstanceData,
-                                integrationProvider,
-                                instanceProvider,
-                                onComplete
-                              })
-                            }
-                          >
-                            {instanceProvider ? 'Edit' : 'Configure'}
-                          </Button>
-                        </Actions>
-                      </Entity.Field>
-                    </Entity.Content>
-                  </Entity.Wrapper>
-                );
-              })}
-            </Items>
-          )}
-        </Box>
-      </>
-    );
-  };
-
-  if (providerIds.length > 0) {
-    return renderWithLoader({
-      integrationInstance,
-      integration,
-      instanceProviders,
-      providerListings
-    })(({ integrationInstance, integration, providerListings }) => {
-      let providersById = new Map<string, ProviderListingPreview>();
-
-      for (let listing of providerListings.data.items) {
-        providersById.set(listing.provider.id, {
-          name: listing.name ?? listing.provider.name,
-          imageUrl: listing.imageUrl
-        });
-      }
-
-      return renderOverview(
-        integration.data,
-        integrationInstance.data,
-        integration.data.providers ?? [],
-        providersById
+          <Box
+            title="Providers"
+            description="Review the providers attached to this integration and configure per-instance overrides where needed."
+          >
+            <IntegrationInstanceProvidersManager
+              instanceId={instance.data!.id}
+              integration={integration.data}
+              integrationInstance={integrationInstance.data}
+              onComplete={onComplete}
+            />
+          </Box>
+        </>
       );
-    });
-  }
-
-  return renderWithLoader({ integrationInstance, integration, instanceProviders })(
-    ({ integration, integrationInstance }) =>
-      renderOverview(
-        integration.data,
-        integrationInstance.data,
-        integration.data.providers ?? [],
-        new Map()
-      )
+    }
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration/index.tsx
@@ -1,257 +1,56 @@
 import { renderWithLoader } from '@metorial/data-hooks';
-import { PageHeader } from '@metorial/layout';
-import {
-  IntegrationPreview,
-  IntegrationProvider,
-  useAllIntegrationProviders,
-  useCurrentInstance,
-  useDeleteIntegrationProvider,
-  useIntegration,
-  useProviderListings
-} from '@metorial/state';
-import { Attributes, Avatar, Button, confirm, Entity, Menu, Spacer, Text } from '@metorial/ui';
-import { ID } from '@metorial/ui-product';
-import { RiMore2Line } from '@remixicon/react';
-import { useMemo } from 'react';
+import { useCurrentInstance, useIntegration } from '@metorial/state';
+import { Attributes, Button, Spacer } from '@metorial/ui';
+import { Box, ID } from '@metorial/ui-product';
 import { useParams } from 'react-router-dom';
-import styled from 'styled-components';
+import { IntegrationProvidersManager } from '../../../scenes/integrations/providersManager';
 import { showIntegrationProviderPanelFlow } from '../../../scenes/integrations/providerPanelFlow';
-
-let Items = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-`;
-
-let Actions = styled.div`
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-`;
-
-let getProviderConfigLabel = (provider: IntegrationProvider) => {
-  let configLabel = provider.config?.name ?? provider.config?.id ?? null;
-  let authLabel = provider.authMethod?.name ?? provider.authCredentials?.id ?? null;
-
-  if (configLabel && authLabel) return `${configLabel} and ${authLabel}`;
-  if (configLabel) return configLabel;
-  if (authLabel) return authLabel;
-  return 'None';
-};
-
-let ProvidersList = ({
-  integration,
-  providers,
-  listingByProviderId,
-  onAddProvider,
-  onEditProvider,
-  onDeleteProvider
-}: {
-  integration: IntegrationPreview;
-  providers: IntegrationProvider[];
-  listingByProviderId: Map<
-    string,
-    { name: string | null | undefined; imageUrl: string | null | undefined }
-  >;
-  onAddProvider: () => void;
-  onEditProvider: (provider: IntegrationProvider) => void;
-  onDeleteProvider: (provider: IntegrationProvider) => void;
-}) => {
-  return (
-    <>
-      <PageHeader
-        title="Providers"
-        description="Choose which providers are connected to this integration and manage their configuration and authentication settings."
-        actions={
-          <Button size="2" onClick={onAddProvider}>
-            Add Provider
-          </Button>
-        }
-        size="4"
-      />
-
-      {providers.length === 0 ? (
-        <Text size="2" color="gray600" align="center" style={{ padding: '20px 0' }}>
-          No providers are attached to this integration yet.
-        </Text>
-      ) : (
-        <Items>
-          {providers.map(provider => {
-            let listing = listingByProviderId.get(provider.provider.id);
-            let displayName =
-              listing?.name ?? provider.provider.name ?? provider.provider.slug;
-            let description =
-              provider.provider.slug && provider.provider.slug !== displayName
-                ? provider.provider.slug
-                : undefined;
-
-            return (
-              <Entity.Wrapper key={provider.id} aligned>
-                <Entity.Content>
-                  <Entity.Field
-                    prefix={
-                      <Avatar
-                        entity={{
-                          name: displayName,
-                          photoUrl: listing?.imageUrl ?? undefined
-                        }}
-                        size={32}
-                        radius={8}
-                        noTooltip
-                        imageFit="contain"
-                      />
-                    }
-                    title={displayName}
-                    description={description}
-                  />
-
-                  <Entity.Field title="Config" value={getProviderConfigLabel(provider)} />
-
-                  <Entity.Field title="Actions" right>
-                    <Actions>
-                      <Button
-                        size="1"
-                        variant="outline"
-                        onClick={() => onEditProvider(provider)}
-                      >
-                        Edit
-                      </Button>
-                      <Menu
-                        items={[
-                          { id: 'edit', label: 'Edit' },
-                          { id: 'delete', label: 'Delete' }
-                        ]}
-                        onItemClick={item => {
-                          if (item === 'edit') onEditProvider(provider);
-                          if (item === 'delete') onDeleteProvider(provider);
-                        }}
-                      >
-                        <Button
-                          size="1"
-                          variant="outline"
-                          iconRight={<RiMore2Line />}
-                          title="Provider options"
-                        />
-                      </Menu>
-                    </Actions>
-                  </Entity.Field>
-                </Entity.Content>
-              </Entity.Wrapper>
-            );
-          })}
-        </Items>
-      )}
-    </>
-  );
-};
 
 export let IntegrationOverviewPage = () => {
   let instance = useCurrentInstance();
   let { integrationId } = useParams();
   let integration = useIntegration(instance.data?.id, integrationId);
-  let providers = useAllIntegrationProviders(instance.data?.id, integrationId);
-  let deleteProvider = useDeleteIntegrationProvider();
 
-  let providerIds = useMemo(
-    () => [...new Set((providers.data ?? []).map(p => p.provider.id))].sort(),
-    [providers.data]
-  );
-
-  let providerListings = useProviderListings(
-    instance.data?.id,
-    providerIds.length > 0 ? { id: providerIds, limit: 100 } : null
-  );
-
-  let renderOverview = (
-    integrationData: IntegrationPreview,
-    providerData: IntegrationProvider[],
-    listingByProviderId: Map<
-      string,
-      { name: string | null | undefined; imageUrl: string | null | undefined }
-    >
-  ) => {
-    let onComplete = () => {
-      integration.refetch();
-      providers.refetch();
-    };
-
-    let handleDeleteProvider = (provider: IntegrationProvider) => {
-      let listing = listingByProviderId.get(provider.provider.id);
-      let displayName =
-        listing?.name ?? provider.provider.name ?? provider.provider.slug ?? 'this provider';
-
-      confirm({
-        title: `Remove ${displayName}?`,
-        description: `Remove the ${displayName} provider from this integration?`,
-        confirmText: 'Remove',
-        onConfirm: async () => {
-          if (!instance.data) return;
-          await deleteProvider.mutate({
-            instanceId: instance.data.id,
-            integrationProviderId: provider.id
-          });
-          onComplete();
-        }
-      });
-    };
+  return renderWithLoader({ integration })(({ integration }) => {
+    let onComplete = () => integration.refetch();
 
     return (
       <>
         <Attributes
           itemWidth="360px"
           attributes={[
-            { label: 'ID', content: <ID id={integrationData.id} /> },
-            { label: 'Status', content: integrationData.status },
-            { label: 'Slug', content: integrationData.slug ?? '-' }
+            { label: 'ID', content: <ID id={integration.data.id} /> },
+            { label: 'Status', content: integration.data.status },
+            { label: 'Slug', content: integration.data.slug ?? '-' }
           ]}
         />
 
         <Spacer height={20} />
 
-        <ProvidersList
-          integration={integrationData}
-          providers={providerData}
-          listingByProviderId={listingByProviderId}
-          onAddProvider={() =>
-            showIntegrationProviderPanelFlow({
-              integration: integrationData,
-              onComplete
-            })
+        <Box
+          title="Providers"
+          description="Choose which providers are connected to this integration and manage their configuration and authentication settings."
+          rightActions={
+            <Button
+              size="2"
+              onClick={() =>
+                showIntegrationProviderPanelFlow({
+                  integration: integration.data,
+                  onComplete
+                })
+              }
+            >
+              Add Provider
+            </Button>
           }
-          onEditProvider={provider =>
-            showIntegrationProviderPanelFlow({
-              integration: integrationData,
-              integrationProvider: provider,
-              onComplete
-            })
-          }
-          onDeleteProvider={handleDeleteProvider}
-        />
+        >
+          <IntegrationProvidersManager
+            instanceId={instance.data!.id}
+            integration={integration.data}
+            onComplete={onComplete}
+          />
+        </Box>
       </>
     );
-  };
-
-  if (providerIds.length > 0) {
-    return renderWithLoader({ integration, providers, providerListings })(
-      ({ integration, providers, providerListings }) => {
-        let listingByProviderId = new Map<
-          string,
-          { name: string | null | undefined; imageUrl: string | null | undefined }
-        >();
-
-        for (let listing of providerListings.data.items) {
-          listingByProviderId.set(listing.provider.id, {
-            name: listing.name ?? listing.provider.name,
-            imageUrl: listing.imageUrl
-          });
-        }
-
-        return renderOverview(integration.data, providers.data, listingByProviderId);
-      }
-    );
-  }
-
-  return renderWithLoader({ integration, providers })(({ integration, providers }) =>
-    renderOverview(integration.data, providers.data, new Map())
-  );
+  });
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providersManager.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providersManager.tsx
@@ -1,3 +1,4 @@
+import { renderWithLoader } from '@metorial/data-hooks';
 import {
   IntegrationInstance,
   IntegrationInstanceProvider,
@@ -5,11 +6,12 @@ import {
   IntegrationProvider,
   useDeleteIntegrationProvider,
   useIntegrationInstanceProviders,
-  useIntegrationProviders
+  useIntegrationProviders,
+  useProviderListings
 } from '@metorial/state';
-import { Badge, RenderDate, Text, confirm } from '@metorial/ui';
+import { Avatar, Badge, Flex, RenderDate, Text, confirm } from '@metorial/ui';
 import { ID } from '@metorial/ui-product';
-import { RiDeleteBinLine } from '@remixicon/react';
+import { RiDeleteBinLine, RiSettings3Line } from '@remixicon/react';
 import { useMemo, useState } from 'react';
 import { Table as DashboardTable } from '../../../../components/table';
 import { FilterPayload } from '../../../../components/table/filter';
@@ -24,15 +26,29 @@ let getProviderLabel = (provider?: { provider?: any }) =>
 
 let getConfigLabel = (config?: any | null) => config?.name ?? config?.id ?? 'None';
 
+let getAuthLabel = (
+  integrationProvider: IntegrationProvider,
+  instanceProvider?: IntegrationInstanceProvider
+) =>
+  instanceProvider?.authConfig?.name ??
+  instanceProvider?.authConfig?.id ??
+  integrationProvider.authMethod?.name ??
+  integrationProvider.authCredentials?.id ??
+  'None';
+
 let getProviderStatusColor = (status: IntegrationProvider['status']) => {
   if (status === 'active') return 'green';
   if (status === 'archived') return 'orange';
   return 'gray';
 };
 
+type ProviderListingLookup = Record<string, { name: string; imageUrl: string }>;
+
 type IntegrationProvidersManagerProps = {
   instanceId: string;
   integration: IntegrationPreview;
+  onComplete?: () => void;
+  listingLookup?: ProviderListingLookup;
 };
 
 let getProviderStatusFilterValue = (value: FilterPayload | undefined) =>
@@ -73,6 +89,7 @@ let useIntegrationProvidersTableHookState = (
     deleteProvider,
     instanceId: props.instanceId,
     integration: props.integration,
+    onComplete: props.onComplete,
     loadingIds,
     setLoadingIds
   };
@@ -89,6 +106,7 @@ let deleteIntegrationProviderImmediately = async (
       instanceId: state.instanceId,
       integrationProviderId: provider.id
     });
+    state.onComplete?.();
   } finally {
     state.setLoadingIds(current => current.filter(id => id !== provider.id));
   }
@@ -97,7 +115,7 @@ let deleteIntegrationProviderImmediately = async (
 let integrationProvidersTable = new DashboardTable<
   IntegrationProvidersManagerProps,
   IntegrationProvider
->('integration-providers')
+>('integration-providers', { hasPagination: false })
   .state(useIntegrationProvidersTableState)
   .hookState(useIntegrationProvidersTableHookState)
   .columns([
@@ -105,11 +123,25 @@ let integrationProvidersTable = new DashboardTable<
       id: 'provider',
       isDefault: true,
       header: 'Provider',
-      render: (provider: IntegrationProvider) => (
-        <Text size="2" weight="strong">
-          {getProviderLabel(provider)}
-        </Text>
-      )
+      render: (provider: IntegrationProvider, props: IntegrationProvidersManagerProps) => {
+        let listing = props.listingLookup?.[provider.provider.id];
+        let providerName = listing?.name ?? getProviderLabel(provider);
+
+        return (
+          <Flex gap={10} style={{ alignItems: 'center' }}>
+            <Avatar
+              entity={{ name: providerName, photoUrl: listing?.imageUrl }}
+              size={24}
+              radius={6}
+              noTooltip
+              imageFit="contain"
+            />
+            <Text size="2" weight="strong">
+              {providerName}
+            </Text>
+          </Flex>
+        );
+      }
     },
     {
       id: 'config',
@@ -189,7 +221,7 @@ let integrationProvidersTable = new DashboardTable<
     showIntegrationProviderPanelFlow({
       integration: props.integration,
       integrationProvider: provider,
-      onComplete: () => {}
+      onComplete: props.onComplete ?? (() => {})
     });
   }) as any)
   .actions({
@@ -235,11 +267,44 @@ let integrationProvidersTable = new DashboardTable<
   ])
   .build();
 
-export let IntegrationProvidersManager = (p: IntegrationProvidersManagerProps) => {
-  return integrationProvidersTable({
-    instanceId: p.instanceId,
-    integration: p.integration,
-    emptyState: 'No providers are attached to this integration yet.'
+export let IntegrationProvidersManager = (p: {
+  instanceId: string;
+  integration: IntegrationPreview;
+  onComplete?: () => void;
+}) => {
+  let providerIds = useMemo(
+    () => [...new Set((p.integration.providers ?? []).map(item => item.provider.id))],
+    [p.integration.providers]
+  );
+  let listings = useProviderListings(
+    p.instanceId,
+    providerIds.length > 0 ? { id: providerIds, limit: 100 } : null
+  );
+
+  let renderTable = (listingLookup: ProviderListingLookup) =>
+    integrationProvidersTable({
+      instanceId: p.instanceId,
+      integration: p.integration,
+      onComplete: p.onComplete,
+      listingLookup,
+      emptyState: 'No providers are attached to this integration yet.'
+    });
+
+  if (providerIds.length === 0) {
+    return renderTable({});
+  }
+
+  return renderWithLoader({ listings })(() => {
+    let listingLookup: ProviderListingLookup = {};
+
+    for (let listing of listings.data?.items ?? []) {
+      listingLookup[listing.provider.id] = {
+        name: listing.name ?? listing.provider.name,
+        imageUrl: listing.imageUrl
+      };
+    }
+
+    return renderTable(listingLookup);
   });
 };
 
@@ -247,12 +312,49 @@ type InstanceProviderRow = {
   id: string;
   integrationProvider: IntegrationProvider;
   instanceProvider: IntegrationInstanceProvider | undefined;
+  integrationInstanceStatus: IntegrationInstance['status'];
 };
 
 type IntegrationInstanceProvidersManagerProps = {
   instanceId: string;
   integration: IntegrationPreview;
   integrationInstance: IntegrationInstance;
+  onComplete?: () => void;
+  listingLookup?: ProviderListingLookup;
+};
+
+let isInstanceProviderConfigureDisabled = (row: InstanceProviderRow) => {
+  if (
+    row.integrationInstanceStatus === 'archived' ||
+    row.integrationInstanceStatus === 'deleted'
+  ) {
+    return true;
+  }
+
+  if (
+    row.integrationInstanceStatus === 'active' &&
+    !row.instanceProvider?.config &&
+    !row.instanceProvider?.authConfig
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+let openIntegrationInstanceProviderPanel = (
+  row: InstanceProviderRow,
+  state: ReturnType<typeof useIntegrationInstanceProvidersTableHookState>
+) => {
+  if (isInstanceProviderConfigureDisabled(row)) return;
+
+  showIntegrationInstanceProviderPanelFlow({
+    integration: state.integration,
+    integrationInstance: state.integrationInstance,
+    integrationProvider: row.integrationProvider,
+    instanceProvider: row.instanceProvider,
+    onComplete: state.onComplete ?? (() => {})
+  });
 };
 
 let useIntegrationInstanceProvidersTableState = (
@@ -277,9 +379,10 @@ let useIntegrationInstanceProvidersTableState = (
     return integrationProviders.map(integrationProvider => ({
       id: integrationProvider.id,
       integrationProvider: integrationProvider as IntegrationProvider,
-      instanceProvider: instanceProviderByIntegrationProviderId.get(integrationProvider.id)
+      instanceProvider: instanceProviderByIntegrationProviderId.get(integrationProvider.id),
+      integrationInstanceStatus: props.integrationInstance.status
     }));
-  }, [integrationProviders, providerItems]);
+  }, [integrationProviders, providerItems, props.integrationInstance.status]);
 
   return {
     isLoading: providers.isLoading,
@@ -302,6 +405,7 @@ let useIntegrationInstanceProvidersTableHookState = (
     instanceId: props.instanceId,
     integration: props.integration,
     integrationInstance: props.integrationInstance,
+    onComplete: props.onComplete,
     loadingIds,
     setLoadingIds
   };
@@ -318,16 +422,30 @@ let integrationInstanceProvidersTable = new DashboardTable<
       id: 'provider',
       isDefault: true,
       header: 'Provider',
-      render: (row: InstanceProviderRow) => (
-        <Text size="2" weight="strong">
-          {getProviderLabel(row.integrationProvider)}
-        </Text>
-      )
+      render: (row: InstanceProviderRow, props: IntegrationInstanceProvidersManagerProps) => {
+        let listing = props.listingLookup?.[row.integrationProvider.provider.id];
+        let providerName = listing?.name ?? getProviderLabel(row.integrationProvider);
+
+        return (
+          <Flex gap={10} style={{ alignItems: 'center' }}>
+            <Avatar
+              entity={{ name: providerName, photoUrl: listing?.imageUrl }}
+              size={24}
+              radius={6}
+              noTooltip
+              imageFit="contain"
+            />
+            <Text size="2" weight="strong">
+              {providerName}
+            </Text>
+          </Flex>
+        );
+      }
     },
     {
       id: 'config',
       isDefault: true,
-      header: 'Instance Config',
+      header: 'Config',
       render: (row: InstanceProviderRow) => (
         <Text size="2">
           {getConfigLabel(row.instanceProvider?.config ?? row.integrationProvider.config)}
@@ -339,23 +457,24 @@ let integrationInstanceProvidersTable = new DashboardTable<
       isDefault: true,
       header: 'Auth',
       render: (row: InstanceProviderRow) => (
-        <Text size="2">
-          {row.instanceProvider?.authConfig?.id ??
-            row.integrationProvider.authMethod?.name ??
-            'None'}
-        </Text>
+        <Text size="2">{getAuthLabel(row.integrationProvider, row.instanceProvider)}</Text>
       )
     },
     {
       id: 'status',
       isDefault: true,
       header: 'Status',
-      render: (row: InstanceProviderRow) =>
-        row.instanceProvider ? (
-          <Badge color="green">Configured</Badge>
-        ) : (
-          <Badge color="gray">Not set</Badge>
-        )
+      render: (row: InstanceProviderRow) => {
+        if (row.instanceProvider) {
+          return <Badge color="green">Configured</Badge>;
+        }
+
+        if (row.integrationInstanceStatus === 'draft') {
+          return <Badge color="orange">Pending</Badge>;
+        }
+
+        return <Badge color="gray">Inherited</Badge>;
+      }
     },
     {
       id: 'updatedAt',
@@ -378,23 +497,74 @@ let integrationInstanceProvidersTable = new DashboardTable<
     }
   ] as any)
   .clickable(((row: InstanceProviderRow, props: IntegrationInstanceProvidersManagerProps) => {
+    if (isInstanceProviderConfigureDisabled(row)) return;
+
     showIntegrationInstanceProviderPanelFlow({
       integration: props.integration,
       integrationInstance: props.integrationInstance,
       integrationProvider: row.integrationProvider,
       instanceProvider: row.instanceProvider,
-      onComplete: () => {}
+      onComplete: props.onComplete ?? (() => {})
     });
   }) as any)
+  .actions({
+    configure: async (rows, state) => {
+      let row = rows[0];
+      if (!row) return;
+
+      openIntegrationInstanceProviderPanel(row, state);
+    }
+  })
+  .rowActions([
+    {
+      id: 'configure',
+      label: 'Configure',
+      icon: <RiSettings3Line />,
+      action: 'configure',
+      disabled: isInstanceProviderConfigureDisabled
+    }
+  ])
   .build();
 
-export let IntegrationInstanceProvidersManager = (
-  p: IntegrationInstanceProvidersManagerProps
-) => {
-  return integrationInstanceProvidersTable({
-    instanceId: p.instanceId,
-    integration: p.integration,
-    integrationInstance: p.integrationInstance,
-    emptyState: 'This integration does not have any providers yet.'
+export let IntegrationInstanceProvidersManager = (p: {
+  instanceId: string;
+  integration: IntegrationPreview;
+  integrationInstance: IntegrationInstance;
+  onComplete?: () => void;
+}) => {
+  let providerIds = useMemo(
+    () => [...new Set((p.integration.providers ?? []).map(item => item.provider.id))],
+    [p.integration.providers]
+  );
+  let listings = useProviderListings(
+    p.instanceId,
+    providerIds.length > 0 ? { id: providerIds, limit: 100 } : null
+  );
+
+  let renderTable = (listingLookup: ProviderListingLookup) =>
+    integrationInstanceProvidersTable({
+      instanceId: p.instanceId,
+      integration: p.integration,
+      integrationInstance: p.integrationInstance,
+      onComplete: p.onComplete,
+      listingLookup,
+      emptyState: 'This integration does not have any providers yet.'
+    });
+
+  if (providerIds.length === 0) {
+    return renderTable({});
+  }
+
+  return renderWithLoader({ listings })(() => {
+    let listingLookup: ProviderListingLookup = {};
+
+    for (let listing of listings.data?.items ?? []) {
+      listingLookup[listing.provider.id] = {
+        name: listing.name ?? listing.provider.name,
+        imageUrl: listing.imageUrl
+      };
+    }
+
+    return renderTable(listingLookup);
   });
 };

--- a/src/frontend/state/src/integration/loaders/integrationInstances.ts
+++ b/src/frontend/state/src/integration/loaders/integrationInstances.ts
@@ -1,10 +1,11 @@
 import type {
   DashboardInstanceIntegrationsInstancesCreateBody,
+  DashboardInstanceIntegrationsInstancesCreateSessionOutput,
   DashboardInstanceIntegrationsInstancesListOutput,
   DashboardInstanceIntegrationsInstancesListQuery,
   DashboardInstanceIntegrationsInstancesUpdateBody
 } from '@metorial/dashboard-sdk';
-import { createLoader } from '@metorial/data-hooks';
+import { createLoader, useMutation } from '@metorial/data-hooks';
 import { usePaginator } from '../../lib/usePaginator';
 import { withAuth } from '../../user';
 import { integrationLoader, integrationsLoader } from './integrations';
@@ -77,3 +78,15 @@ export let useIntegrationInstance = (
     useDeleteMutator: data.useMutator('delete')
   };
 };
+
+export let useCreateIntegrationInstanceSession = () =>
+  useMutation(
+    (i: {
+      instanceId: string;
+      integrationInstanceId: string;
+    }): Promise<DashboardInstanceIntegrationsInstancesCreateSessionOutput> =>
+      withAuth(sdk =>
+        sdk.integration.instances.createSession(i.instanceId, i.integrationInstanceId, {})
+      ),
+    { disableToast: true }
+  );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate UI/data-flow changes: replaces bespoke provider lists with shared table managers and adds a new session-creation mutation + navigation path for “Open Explorer”, which could affect integration management UX and session creation behavior.
> 
> **Overview**
> Improves integration and integration-instance pages by replacing the bespoke provider listing/override UI with shared `IntegrationProvidersManager`/`IntegrationInstanceProvidersManager` table components (including provider avatars/listing lookup, refined status/auth labeling, and a per-row “Configure” action with better disabled-state handling).
> 
> Adds an **“Open Explorer”** action on the integration instance header that creates an integration-instance session via a new `useCreateIntegrationInstanceSession` mutation and navigates to the Explorer with the returned `session_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98f657e834513ec5b88cc4f0b97fa754ab8cad1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->