### PR TITLE
Patch slates discovery bug

### DIFF
--- a/src/systems/function-bay/service/src/providers/aws-lambda/deploy.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/deploy.ts
@@ -155,31 +155,64 @@ let nodeProxyWrapper = (originalHandler: string, bootstrapCode: string) => `
 ${bootstrapCode}
 const originalHandler = ${JSON.stringify(originalHandler)};
 const [modulePath, exportName = 'handler'] = originalHandler.split(/\\.([^.]*)$/).filter(Boolean);
+const fs = require('fs');
 const path = require('path');
 const { pathToFileURL } = require('url');
 let loaded;
 
-async function loadOriginalModule() {
-  try {
-    return require('./' + modulePath);
-  } catch (err) {
-    const candidates = [
-      modulePath,
-      /\\.[cm]?js$/.test(modulePath) ? undefined : modulePath + '.js',
-      /\\.[cm]?js$/.test(modulePath) ? undefined : modulePath + '.cjs',
-      /\\.[cm]?js$/.test(modulePath) ? undefined : modulePath + '.mjs'
-    ].filter(Boolean);
+function getModuleCandidates() {
+  if (/\\.[cm]?js$/.test(modulePath)) return [modulePath];
+  return [modulePath, modulePath + '.js', modulePath + '.cjs', modulePath + '.mjs'];
+}
 
-    let lastError = err;
-    for (const candidate of candidates) {
-      try {
-        return await import(pathToFileURL(path.resolve(__dirname, candidate)).href);
-      } catch (importErr) {
-        lastError = importErr;
-      }
-    }
-    throw lastError;
+function resolveOriginalModulePath() {
+  const candidates = getModuleCandidates();
+  for (const candidate of candidates) {
+    const resolved = path.resolve(__dirname, candidate);
+    if (fs.existsSync(resolved)) return resolved;
   }
+
+  let availableFiles = [];
+  try {
+    availableFiles = fs.readdirSync(__dirname).sort();
+  } catch {}
+
+  throw new Error(
+    'Original handler module not found. Handler=' +
+      originalHandler +
+      '; tried=' +
+      candidates.join(', ') +
+      '; available=' +
+      availableFiles.join(', ')
+  );
+}
+
+async function loadOriginalModule() {
+  const resolvedModulePath = resolveOriginalModulePath();
+
+  try {
+    return await import(pathToFileURL(resolvedModulePath).href);
+  } catch (err) {
+    if (err && err.code === 'ERR_UNKNOWN_FILE_EXTENSION') {
+      return require(resolvedModulePath);
+    }
+
+    throw err;
+  }
+}
+
+function getHandler(moduleExports) {
+  if (typeof moduleExports[exportName] === 'function') return moduleExports[exportName];
+
+  if (moduleExports.default && typeof moduleExports.default[exportName] === 'function') {
+    return moduleExports.default[exportName];
+  }
+
+  if (exportName === 'default' && typeof moduleExports.default === 'function') {
+    return moduleExports.default;
+  }
+
+  return undefined;
 }
 
 exports.handler = async (event, context) => {
@@ -187,7 +220,7 @@ exports.handler = async (event, context) => {
   if (!loaded) {
     loaded = await loadOriginalModule();
   }
-  const handler = loaded[exportName];
+  const handler = getHandler(loaded);
   if (typeof handler !== 'function') throw new Error('Original handler export not found');
   return await handler(event, context);
 };
@@ -273,7 +306,10 @@ let prepareZip = async (d: {
   }
 
   let zip = await JSZip.loadAsync(zipBytes);
-  zip.file('metorial_deflector_wrapper.cjs', await buildNodeProxyWrapper(d.runtimeConfig.handler));
+  zip.file(
+    'metorial_deflector_wrapper.cjs',
+    await buildNodeProxyWrapper(d.runtimeConfig.handler)
+  );
 
   return {
     zipBytes: Buffer.from(await zip.generateAsync({ type: 'uint8array' })),


### PR DESCRIPTION
Patch slates discovery bug

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Lambda wrapper’s module loading and handler export resolution, which can affect which code runs at invocation time and may break deployments with unusual module formats or paths.
> 
> **Overview**
> Improves the Node.js Lambda deflector wrapper to **more reliably locate and load the original handler module** by resolving the handler path against `__dirname`, trying common `.js`/`.cjs`/`.mjs` candidates, and emitting a clearer error that includes attempted/available files.
> 
> Switches module loading to prefer dynamic `import()` with a fallback to `require()` for unknown extensions, and expands handler selection to support `default` exports (including nested `default[exportName]`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90841a3d77b1e8fb59e8aa93b924d837b755e87f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->