### PR TITLE
Disable docker sync for global servers in shuttle

### DIFF
--- a/src/systems/shuttle/service/src/queues/container/monitor.ts
+++ b/src/systems/shuttle/service/src/queues/container/monitor.ts
@@ -106,7 +106,9 @@ export let deployContainerServerWatchQueueProcessor = deployContainerServerWatch
 
       step.log([
         `Container registry tag successfully discovered. Pinning to server version to digest ${tag.currentVersion?.digest}.`,
-        `New digests for tag '${tag.tag}' will trigger new deployments.`,
+        server.tenantOid
+          ? `New digests for tag '${tag.tag}' will trigger new deployments.`
+          : 'Public servers are pinned; new digests will not trigger automatic redeployments.',
         'MCP server deployment succeeded.'
       ]);
       step.succeed();

--- a/src/systems/shuttle/service/src/queues/tag/serverVersion.e2e.test.ts
+++ b/src/systems/shuttle/service/src/queues/tag/serverVersion.e2e.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { testDb, cleanDatabase } from '../../test/setup';
+import { fixtures } from '../../test/fixtures';
+import { getId } from '../../id';
+import { deployContainerServerStartQueue } from '../container/startDeployment';
+import { serverVersionCreatedQueue } from '../lifecycle/serverVersion';
+
+vi.mock('@lowerdeck/queue', () => ({
+  createQueue: vi.fn(() => ({
+    add: vi.fn(),
+    addManyWithOps: vi.fn(),
+    process: vi.fn((handler: (data: unknown) => Promise<void>) => handler)
+  })),
+  QueueRetryError: class QueueRetryError extends Error {
+    constructor(message?: string) {
+      super(message);
+      this.name = 'QueueRetryError';
+    }
+  }
+}));
+
+vi.mock('../container/startDeployment', () => ({
+  deployContainerServerStartQueue: { add: vi.fn() }
+}));
+
+vi.mock('../lifecycle/serverVersion', () => ({
+  serverVersionCreatedQueue: { add: vi.fn() }
+}));
+
+let propagateRepoVersionToServerQueueProcessor: (
+  data: {
+    repositoryVersionId: string;
+    repositoryTagId: string;
+    serverId: string;
+    serverDeploymentId?: string;
+  }
+) => Promise<void>;
+
+let propagateRepoVersionToServersQueueProcessor: (data: {
+  repositoryTagId: string;
+  repositoryVersionId: string;
+  serverDeploymentId?: string;
+}) => Promise<void>;
+
+describe('propagateRepoVersionToServerQueueProcessor', () => {
+  const f = fixtures(testDb);
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await cleanDatabase();
+
+    vi.resetModules();
+    let module = await import('./serverVersion');
+    propagateRepoVersionToServerQueueProcessor =
+      module.propagateRepoVersionToServerQueueProcessor as typeof propagateRepoVersionToServerQueueProcessor;
+    propagateRepoVersionToServersQueueProcessor =
+      module.propagateRepoVersionToServersQueueProcessor as typeof propagateRepoVersionToServersQueueProcessor;
+  });
+
+  let setupLinkedServer = async (opts: { global: boolean }) => {
+    let tenant = await f.tenant.default();
+    let tag = await f.containerRepositoryTag.withRepository({ tenantOid: tenant.oid });
+    let repositoryVersion = await f.containerRepositoryVersion.default({
+      repositoryOid: tag.repositoryOid,
+      tenantOid: tenant.oid
+    });
+
+    await testDb.containerRepositoryTag.update({
+      where: { oid: tag.oid },
+      data: {
+        currentVersionOid: repositoryVersion.oid,
+        discoveryStatus: 'succeeded'
+      }
+    });
+
+    let server = opts.global
+      ? await f.server.global({ overrides: { draftRepositoryTagOid: tag.oid } })
+      : await f.server.default({
+          tenantOid: tenant.oid,
+          overrides: { draftRepositoryTagOid: tag.oid }
+        });
+
+    return { tenant, tag, repositoryVersion, server };
+  };
+
+  it('skips cron-triggered propagation for global servers', async () => {
+    let { tag, repositoryVersion, server } = await setupLinkedServer({ global: true });
+
+    await propagateRepoVersionToServerQueueProcessor({
+      repositoryVersionId: repositoryVersion.id,
+      repositoryTagId: tag.id,
+      serverId: server.id
+    });
+
+    let versions = await testDb.serverVersion.findMany({ where: { serverOid: server.oid } });
+    let deployments = await testDb.serverDeployment.findMany({ where: { serverOid: server.oid } });
+
+    expect(versions).toHaveLength(0);
+    expect(deployments).toHaveLength(0);
+    expect(deployContainerServerStartQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('propagates to global servers when triggered by a specific deployment', async () => {
+    let { tag, repositoryVersion, server } = await setupLinkedServer({ global: true });
+    let deployment = await testDb.serverDeployment.create({
+      data: {
+        ...getId('serverDeployment'),
+        status: 'queued',
+        serverOid: server.oid,
+        tenantOid: null
+      }
+    });
+
+    await propagateRepoVersionToServerQueueProcessor({
+      repositoryVersionId: repositoryVersion.id,
+      repositoryTagId: tag.id,
+      serverId: server.id,
+      serverDeploymentId: deployment.id
+    });
+
+    let versions = await testDb.serverVersion.findMany({ where: { serverOid: server.oid } });
+
+    expect(versions).toHaveLength(1);
+    expect(versions[0]?.repositoryVersionOid).toBe(repositoryVersion.oid);
+    expect(deployContainerServerStartQueue.add).not.toHaveBeenCalled();
+    expect(serverVersionCreatedQueue.add).toHaveBeenCalled();
+  });
+
+  it('propagates cron-triggered digest changes to tenant servers', async () => {
+    let { tag, repositoryVersion, server } = await setupLinkedServer({ global: false });
+
+    await propagateRepoVersionToServerQueueProcessor({
+      repositoryVersionId: repositoryVersion.id,
+      repositoryTagId: tag.id,
+      serverId: server.id
+    });
+
+    let versions = await testDb.serverVersion.findMany({ where: { serverOid: server.oid } });
+    let deployments = await testDb.serverDeployment.findMany({ where: { serverOid: server.oid } });
+
+    expect(versions).toHaveLength(1);
+    expect(deployments).toHaveLength(1);
+    expect(deployContainerServerStartQueue.add).toHaveBeenCalled();
+    expect(serverVersionCreatedQueue.add).toHaveBeenCalled();
+  });
+
+  it('excludes global servers from cron-triggered batch propagation', async () => {
+    let { tag, repositoryVersion, server } = await setupLinkedServer({ global: true });
+
+    await propagateRepoVersionToServersQueueProcessor({
+      repositoryTagId: tag.id,
+      repositoryVersionId: repositoryVersion.id
+    });
+
+    let versions = await testDb.serverVersion.findMany({ where: { serverOid: server.oid } });
+    expect(versions).toHaveLength(0);
+  });
+});

--- a/src/systems/shuttle/service/src/queues/tag/serverVersion.ts
+++ b/src/systems/shuttle/service/src/queues/tag/serverVersion.ts
@@ -25,6 +25,7 @@ export let propagateRepoVersionToServersQueueProcessor =
         draftRepositoryTag: {
           id: data.repositoryTagId
         },
+        ...(data.serverDeploymentId ? {} : { tenantOid: { not: null } }),
         id: data.cursor ? { gt: data.cursor } : undefined,
         serverDeployments: data.serverDeploymentId
           ? {
@@ -77,6 +78,10 @@ export let propagateRepoVersionToServerQueueProcessor =
 
     if (!server.draftRepositoryTag || server.draftRepositoryTag.id != data.repositoryTagId) {
       // Tag changed, skip
+      return;
+    }
+
+    if (!data.serverDeploymentId && !server.tenantOid) {
       return;
     }
 

--- a/src/systems/shuttle/service/src/test/fixtures/serverFixtures.ts
+++ b/src/systems/shuttle/service/src/test/fixtures/serverFixtures.ts
@@ -81,8 +81,44 @@ export const ServerFixtures = (db: PrismaClient) => {
       }
     });
 
+  const global = async (data?: { overrides?: Partial<Server> }): Promise<Server> => {
+    const { oid, id } = getId('server');
+    const name = data?.overrides?.name ?? `Global Server ${randomBytes(4).toString('hex')}`;
+
+    const factory = defineFactory<Server>(
+      {
+        oid,
+        id,
+        type: ServerType.container,
+        name,
+        description: data?.overrides?.description ?? null,
+        draftConfigSchema: data?.overrides?.draftConfigSchema ?? {
+          type: 'object',
+          properties: {}
+        },
+        draftConfigTransformer: data?.overrides?.draftConfigTransformer ?? '$.config',
+        draftRemoteUrl: data?.overrides?.draftRemoteUrl ?? null,
+        draftRemoteProtocol: data?.overrides?.draftRemoteProtocol ?? null,
+        draftRepositoryTagOid: data?.overrides?.draftRepositoryTagOid ?? null,
+        tenantOid: null,
+        currentVersionOid: data?.overrides?.currentVersionOid ?? null,
+        remoteOauthConfigOid: data?.overrides?.remoteOauthConfigOid ?? null,
+        delegatedOauthConfigOid: data?.overrides?.delegatedOauthConfigOid ?? null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ...data?.overrides
+      } as Server,
+      {
+        persist: value => db.server.create({ data: value })
+      }
+    );
+
+    return factory.create(data?.overrides ?? {});
+  };
+
   return {
     default: defaultServer,
+    global,
     withTenant,
     withDescription
   };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes deployment propagation behavior so global/public servers no longer auto-create deployments on tag digest updates, which could impact update cadence if misclassified servers rely on this path.
> 
> **Overview**
> Prevents cron-driven container tag digest propagation from triggering new `serverVersion`/deployment creation for *global (tenant-less/public)* servers; they are only updated when a specific `serverDeploymentId` is provided.
> 
> Updates deployment watcher logging to reflect that public servers are pinned and won’t auto-redeploy on new digests, and adds e2e coverage plus a `server` fixture for creating global servers to validate the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23eec98b40fe6bb723a5116346ad564abbbc3b01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->