### PR TITLE
Harden magic mcp ops

### DIFF
--- a/src/backend/apis/connection/src/magic.ts
+++ b/src/backend/apis/connection/src/magic.ts
@@ -20,7 +20,6 @@ import {
   resolveMagicMcpTargetByIdOrAliasSafe,
   syncMagicMcpSubspaceSession
 } from '@metorial/module-magic';
-import { assertMagicMcpTargetLinkedResourcesActive } from '@metorial/module-magic';
 import {
   proxyMcpRequestToSubspace,
   type SubspaceProxyAgentClient
@@ -254,8 +253,6 @@ export let resolveMagicMcpSubspaceSession = async (d: {
       magicMcpTarget
     });
   }
-
-  await assertMagicMcpTargetLinkedResourcesActive(magicMcpTarget);
 
   let subspaceSessionId = await ensureMagicMcpSubspaceSession(magicMcpTarget);
   let consumerToken = magicMcpToken

--- a/src/backend/db/prisma/schema/magic/endpoint.prisma
+++ b/src/backend/db/prisma/schema/magic/endpoint.prisma
@@ -11,6 +11,7 @@ model MagicMcpEndpoint {
   status               MagicMcpEndpointStatus
   isConsumerReconciled Boolean                @default(false)
   hasSubspaceBacking   Boolean                @default(false)
+  isSubspaceBackingReconciling Boolean        @default(false)
 
   instanceOid BigInt
   instance    Instance @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)

--- a/src/backend/db/prisma/schema/magic/server.prisma
+++ b/src/backend/db/prisma/schema/magic/server.prisma
@@ -24,6 +24,7 @@ model MagicMcpServer {
   ownerType            MagicMcpServerOwnerType @default(server_owned)
   isConsumerReconciled Boolean                 @default(false)
   hasSubspaceBacking   Boolean                 @default(false)
+  isSubspaceBackingReconciling Boolean         @default(false)
 
   providerTemplateId                String?
   legacySubspaceSessionTemplateId   String? @map("subspaceSessionTemplateId")

--- a/src/backend/modules/magic/src/lib/backing.ts
+++ b/src/backend/modules/magic/src/lib/backing.ts
@@ -55,6 +55,12 @@ let getMagicMcpSessionDuration = async (instance: Instance) => {
   return project.magicMcpSessionDurationMinutes;
 };
 
+let BACKING_READY_POLL_INTERVAL_MS = 100;
+let BACKING_READY_CONNECT_ATTEMPTS = 20;
+let BACKING_READY_WORKER_ATTEMPTS = 600;
+
+let wait = async (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
 let getConsumerOwnerForProfile = async (d: {
   instance: Instance;
   consumerProfileOid?: bigint | null;
@@ -164,14 +170,17 @@ export let ensureMagicMcpServerBacking = async (d: {
     toolFilters?: any;
   }[];
   isReconciliation?: boolean;
+  deferReconcile?: boolean;
 }) =>
   withLocalBackingLock(`server:${d.server.id}`, async () => {
-    let owner =
+    let [owner, maxSessionDurationInMinutes] = await Promise.all([
       d.owner ??
-      (await getConsumerOwnerForServer({
-        instance: d.instance,
-        server: d.server
-      }));
+        getConsumerOwnerForServer({
+          instance: d.instance,
+          server: d.server
+        }),
+      getMagicMcpSessionDuration(d.instance)
+    ]);
     let providerTemplateBackingId: string | null = null;
     if (d.server.providerTemplateId) {
       let providerTemplate = await db.providerTemplate.findFirst({
@@ -187,8 +196,7 @@ export let ensureMagicMcpServerBacking = async (d: {
     }
 
     let providers = d.providers ?? undefined;
-    let maxSessionDurationInMinutes = await getMagicMcpSessionDuration(d.instance);
-    let backing = await subspaceMagicMcpBackingService.upsertServer({
+    let backing = await (subspaceMagicMcpBackingService.upsertServer as any)({
       instance: d.instance,
       magicMcpServerBackingId: d.server.id,
       providerTemplateBackingId,
@@ -198,6 +206,7 @@ export let ensureMagicMcpServerBacking = async (d: {
       metadata: d.server.metadata as Record<string, any>,
       maxSessionDurationInMinutes,
       isReconciliation: d.isReconciliation,
+      deferReconcile: d.deferReconcile,
       legacySessionTemplateId: d.server.legacySubspaceSessionTemplateId,
       ...owner,
       ...(providers?.length ? { providers } : {})
@@ -208,7 +217,8 @@ export let ensureMagicMcpServerBacking = async (d: {
       data: {
         hasSubspaceBacking: true,
         ownerType: backing.ownerType,
-        subspaceEphemeralManagedSessionId: backing.ephemeralManagedSessionId
+        subspaceEphemeralManagedSessionId: backing.ephemeralManagedSessionId,
+        isSubspaceBackingReconciling: backing.isReconciling
       }
     });
   });
@@ -238,6 +248,7 @@ export let ensureMagicMcpEndpointBacking = async (d: {
   instance: Instance;
   endpoint: MagicMcpEndpointWithBackingRelations;
   isReconciliation?: boolean;
+  deferReconcile?: boolean;
 }) =>
   withLocalBackingLock(`endpoint:${d.endpoint.id}`, async () => {
     await ensureEndpointServerIds(d.endpoint);
@@ -253,16 +264,24 @@ export let ensureMagicMcpEndpointBacking = async (d: {
     });
 
     for (let server of endpoint.servers) {
-      await ensureMagicMcpServerBacking({
+      let ensuredServer = await ensureMagicMcpServerBacking({
         instance: d.instance,
         server: server.magicMcpServer,
         ...(endpoint.consumerProfileOid ? { owner } : {}),
-        isReconciliation: d.isReconciliation
+        isReconciliation: d.isReconciliation,
+        deferReconcile: d.deferReconcile
       });
+      if (d.deferReconcile !== false) {
+        await waitForMagicMcpServerBackingReady({
+          instance: d.instance,
+          server: ensuredServer,
+          attempts: BACKING_READY_WORKER_ATTEMPTS
+        });
+      }
     }
 
     let maxSessionDurationInMinutes = await getMagicMcpSessionDuration(d.instance);
-    let backing = await subspaceMagicMcpBackingService.upsertEndpoint({
+    let backing = await (subspaceMagicMcpBackingService.upsertEndpoint as any)({
       instance: d.instance,
       magicMcpEndpointBackingId: endpoint.id,
       name: endpoint.name,
@@ -270,6 +289,7 @@ export let ensureMagicMcpEndpointBacking = async (d: {
       metadata: endpoint.metadata as Record<string, any>,
       maxSessionDurationInMinutes,
       isReconciliation: d.isReconciliation,
+      deferReconcile: d.deferReconcile,
       ...owner,
       servers: endpoint.servers.map(server => ({
         id: server.id!,
@@ -282,8 +302,109 @@ export let ensureMagicMcpEndpointBacking = async (d: {
       where: { oid: endpoint.oid },
       data: {
         hasSubspaceBacking: true,
-        subspaceEphemeralManagedSessionId: backing.ephemeralManagedSessionId
+        subspaceEphemeralManagedSessionId: backing.ephemeralManagedSessionId,
+        isSubspaceBackingReconciling: backing.isReconciling
       },
       include: magicMcpEndpointBackingInclude
     });
   });
+
+export let waitForMagicMcpServerBackingReady = async (d: {
+  instance: Instance;
+  server: Pick<MagicMcpServer, 'oid' | 'id'>;
+  attempts?: number;
+}) => {
+  let latest: MagicMcpServer | null = null;
+
+  for (let attempt = 0; attempt < (d.attempts ?? BACKING_READY_CONNECT_ATTEMPTS); attempt++) {
+    latest = await db.magicMcpServer.findUnique({
+      where: { oid: d.server.oid }
+    });
+    if (!latest) return null;
+
+    if (
+      latest.hasSubspaceBacking &&
+      latest.subspaceEphemeralManagedSessionId &&
+      latest.isSubspaceBackingReconciling
+    ) {
+      try {
+        let backing = await (subspaceMagicMcpBackingService.getServer as any)({
+          instance: d.instance,
+          magicMcpServerBackingId: latest.id
+        });
+        if (!backing.isReconciling) {
+          latest = await db.magicMcpServer.update({
+            where: { oid: latest.oid },
+            data: { isSubspaceBackingReconciling: false }
+          });
+        }
+      } catch {
+        // Backing is still being created by the lifecycle queue.
+      }
+    }
+
+    if (
+      latest.hasSubspaceBacking &&
+      latest.subspaceEphemeralManagedSessionId &&
+      !latest.isSubspaceBackingReconciling
+    ) {
+      return latest;
+    }
+
+    await wait(BACKING_READY_POLL_INTERVAL_MS);
+  }
+
+  return latest;
+};
+
+export let waitForMagicMcpEndpointBackingReady = async (d: {
+  instance: Instance;
+  endpoint: Pick<MagicMcpEndpoint, 'oid' | 'id'>;
+  attempts?: number;
+}) => {
+  let latest: MagicMcpEndpointWithBackingRelations | null = null;
+
+  for (let attempt = 0; attempt < (d.attempts ?? BACKING_READY_CONNECT_ATTEMPTS); attempt++) {
+    latest = await db.magicMcpEndpoint.findUnique({
+      where: { oid: d.endpoint.oid },
+      include: magicMcpEndpointBackingInclude
+    });
+    if (!latest) return null;
+
+    if (
+      latest.hasSubspaceBacking &&
+      latest.subspaceEphemeralManagedSessionId &&
+      latest.isSubspaceBackingReconciling
+    ) {
+      try {
+        let backing = await (subspaceMagicMcpBackingService.getEndpoint as any)({
+          instance: d.instance,
+          magicMcpEndpointBackingId: latest.id
+        });
+        if (!backing.isReconciling) {
+          latest = await db.magicMcpEndpoint.update({
+            where: { oid: latest.oid },
+            data: { isSubspaceBackingReconciling: false },
+            include: magicMcpEndpointBackingInclude
+          });
+        }
+      } catch {
+        // Backing is still being created by the lifecycle queue.
+      }
+    }
+
+    if (
+      latest.hasSubspaceBacking &&
+      latest.subspaceEphemeralManagedSessionId &&
+      !latest.isSubspaceBackingReconciling
+    ) {
+      return latest;
+    }
+
+    await wait(BACKING_READY_POLL_INTERVAL_MS);
+  }
+
+  return latest;
+};
+
+export let MAGIC_MCP_BACKING_READY_WORKER_ATTEMPTS = BACKING_READY_WORKER_ATTEMPTS;

--- a/src/backend/modules/magic/src/lib/ensureSession.ts
+++ b/src/backend/modules/magic/src/lib/ensureSession.ts
@@ -1,6 +1,11 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { ID, Instance, withTransaction } from '@metorial/db';
-import { ensureMagicMcpEndpointBacking, ensureMagicMcpServerBacking } from './backing';
+import {
+  ensureMagicMcpEndpointBacking,
+  ensureMagicMcpServerBacking,
+  waitForMagicMcpEndpointBackingReady,
+  waitForMagicMcpServerBackingReady
+} from './backing';
 import {
   assertMagicMcpTargetLinkedResourcesActive,
   assertMagicMcpTargetReadyForConnect
@@ -10,17 +15,35 @@ import { MagicMcpResolvedTarget } from './magicMcpTarget';
 let ensureServerBackingSession = async (
   target: MagicMcpResolvedTarget & { type: 'server' }
 ) => {
-  if (target.target.hasSubspaceBacking && target.target.subspaceEphemeralManagedSessionId) {
+  let targetServer = target.target;
+  if (
+    !targetServer.hasSubspaceBacking ||
+    !targetServer.subspaceEphemeralManagedSessionId ||
+    targetServer.isSubspaceBackingReconciling
+  ) {
+    let latest = await waitForMagicMcpServerBackingReady({
+      instance: target.target.instance as Instance,
+      server: target.target
+    });
+    if (latest) targetServer = { ...targetServer, ...latest };
+  }
+
+  if (
+    targetServer.hasSubspaceBacking &&
+    targetServer.subspaceEphemeralManagedSessionId &&
+    !targetServer.isSubspaceBackingReconciling
+  ) {
     await assertMagicMcpTargetLinkedResourcesActive(target);
-    return target.target.subspaceEphemeralManagedSessionId;
+    return targetServer.subspaceEphemeralManagedSessionId;
   }
 
   let server = {
-    ...target.target,
+    ...targetServer,
     ...(await ensureMagicMcpServerBacking({
       instance: target.target.instance as Instance,
-      server: target.target,
-      isReconciliation: true
+      server: targetServer,
+      isReconciliation: true,
+      deferReconcile: false
     }))
   };
 
@@ -41,15 +64,40 @@ let ensureServerBackingSession = async (
 let ensureEndpointBackingSession = async (
   target: MagicMcpResolvedTarget & { type: 'endpoint' }
 ) => {
-  if (target.target.hasSubspaceBacking && target.target.subspaceEphemeralManagedSessionId) {
+  let targetEndpoint = target.target;
+  if (
+    !targetEndpoint.hasSubspaceBacking ||
+    !targetEndpoint.subspaceEphemeralManagedSessionId ||
+    targetEndpoint.isSubspaceBackingReconciling
+  ) {
+    let latest = await waitForMagicMcpEndpointBackingReady({
+      instance: target.target.instance as Instance,
+      endpoint: target.target
+    });
+    if (latest) {
+      targetEndpoint = {
+        ...targetEndpoint,
+        hasSubspaceBacking: latest.hasSubspaceBacking,
+        subspaceEphemeralManagedSessionId: latest.subspaceEphemeralManagedSessionId,
+        isSubspaceBackingReconciling: latest.isSubspaceBackingReconciling
+      };
+    }
+  }
+
+  if (
+    targetEndpoint.hasSubspaceBacking &&
+    targetEndpoint.subspaceEphemeralManagedSessionId &&
+    !targetEndpoint.isSubspaceBackingReconciling
+  ) {
     await assertMagicMcpTargetLinkedResourcesActive(target);
-    return target.target.subspaceEphemeralManagedSessionId;
+    return targetEndpoint.subspaceEphemeralManagedSessionId;
   }
 
   let endpoint = await ensureMagicMcpEndpointBacking({
     instance: target.target.instance as Instance,
-    endpoint: target.target,
-    isReconciliation: true
+    endpoint: targetEndpoint,
+    isReconciliation: true,
+    deferReconcile: false
   });
 
   if (!endpoint.subspaceEphemeralManagedSessionId) {

--- a/src/backend/modules/magic/src/queues/lifecycle/magicMcpEndpoint.ts
+++ b/src/backend/modules/magic/src/queues/lifecycle/magicMcpEndpoint.ts
@@ -1,13 +1,68 @@
 import { db } from '@metorial/db';
 import { subspaceMagicMcpBackingService } from '@metorial/module-subspace';
 import { createQueue } from '@metorial/queue';
+import {
+  ensureMagicMcpEndpointBacking,
+  MAGIC_MCP_BACKING_READY_WORKER_ATTEMPTS,
+  waitForMagicMcpEndpointBackingReady
+} from '../../lib/backing';
 
 export let magicMcpEndpointCreatedQueue = createQueue<{ magicMcpEndpointId: string }>({
   name: 'mgc/lc/endpoint/created'
 });
 
+let ensureQueuedMagicMcpEndpointBacking = async (magicMcpEndpointId: string) => {
+  let magicMcpEndpoint = await db.magicMcpEndpoint.findUnique({
+    where: { id: magicMcpEndpointId },
+    include: {
+      consumerProfile: true,
+      consumerIntegrationEndpoints: {
+        include: {
+          consumer: true,
+          consumerProfile: true
+        }
+      },
+      servers: {
+        include: {
+          magicMcpServer: {
+            include: {
+              aliases: true,
+              subspaceSession: true
+            }
+          }
+        }
+      },
+      subspaceSession: true,
+      skillPlugin: true,
+      instance: true
+    }
+  });
+  if (!magicMcpEndpoint || magicMcpEndpoint.status !== 'active') return;
+
+  await ensureMagicMcpEndpointBacking({
+    instance: magicMcpEndpoint.instance,
+    endpoint: magicMcpEndpoint,
+    deferReconcile: true
+  });
+
+  let latest = await waitForMagicMcpEndpointBackingReady({
+    instance: magicMcpEndpoint.instance,
+    endpoint: magicMcpEndpoint,
+    attempts: MAGIC_MCP_BACKING_READY_WORKER_ATTEMPTS
+  });
+
+  if (latest?.isSubspaceBackingReconciling) {
+    await db.magicMcpEndpoint.update({
+      where: { oid: latest.oid },
+      data: { isSubspaceBackingReconciling: false }
+    });
+  }
+};
+
 export let magicMcpEndpointCreatedQueueProcessor = magicMcpEndpointCreatedQueue.process(
-  async () => {}
+  async data => {
+    await ensureQueuedMagicMcpEndpointBacking(data.magicMcpEndpointId);
+  }
 );
 
 export let magicMcpEndpointUpdatedQueue = createQueue<{ magicMcpEndpointId: string }>({
@@ -15,7 +70,9 @@ export let magicMcpEndpointUpdatedQueue = createQueue<{ magicMcpEndpointId: stri
 });
 
 export let magicMcpEndpointUpdatedQueueProcessor = magicMcpEndpointUpdatedQueue.process(
-  async () => {}
+  async data => {
+    await ensureQueuedMagicMcpEndpointBacking(data.magicMcpEndpointId);
+  }
 );
 
 export let magicMcpEndpointDeletedQueue = createQueue<{ magicMcpEndpointId: string }>({

--- a/src/backend/modules/magic/src/queues/lifecycle/magicMcpServer.ts
+++ b/src/backend/modules/magic/src/queues/lifecycle/magicMcpServer.ts
@@ -1,28 +1,75 @@
 import { db } from '@metorial/db';
 import { subspaceMagicMcpBackingService } from '@metorial/module-subspace';
 import { createQueue } from '@metorial/queue';
+import {
+  ensureMagicMcpServerBacking,
+  MAGIC_MCP_BACKING_READY_WORKER_ATTEMPTS,
+  waitForMagicMcpServerBackingReady
+} from '../../lib/backing';
 import { indexMagicMcpServerSearchQueue } from '../search/magicMcpServer';
 
 let queueMagicMcpServerIndex = async (magicMcpServerId: string) => {
   await indexMagicMcpServerSearchQueue.add({ magicMcpServerId });
 };
 
-export let magicMcpServerCreatedQueue = createQueue<{ magicMcpServerId: string }>({
+type MagicMcpServerLifecycleQueueInput = {
+  magicMcpServerId: string;
+  providers?: {
+    providerDeploymentId: string;
+    providerConfigId?: string | null;
+    providerAuthConfigId?: string | null;
+    toolFilters?: any;
+  }[];
+  isReconciliation?: boolean;
+};
+
+let ensureQueuedMagicMcpServerBacking = async (data: MagicMcpServerLifecycleQueueInput) => {
+  let magicMcpServer = await db.magicMcpServer.findUnique({
+    where: { id: data.magicMcpServerId },
+    include: { instance: true }
+  });
+  if (!magicMcpServer || magicMcpServer.status !== 'active') return;
+
+  await ensureMagicMcpServerBacking({
+    instance: magicMcpServer.instance,
+    server: magicMcpServer,
+    providers: data.providers,
+    isReconciliation: data.isReconciliation,
+    deferReconcile: true
+  });
+
+  let latest = await waitForMagicMcpServerBackingReady({
+    instance: magicMcpServer.instance,
+    server: magicMcpServer,
+    attempts: MAGIC_MCP_BACKING_READY_WORKER_ATTEMPTS
+  });
+
+  if (latest?.isSubspaceBackingReconciling) {
+    await db.magicMcpServer.update({
+      where: { oid: latest.oid },
+      data: { isSubspaceBackingReconciling: false }
+    });
+  }
+};
+
+export let magicMcpServerCreatedQueue = createQueue<MagicMcpServerLifecycleQueueInput>({
   name: 'mgc/lc/server/created'
 });
 
 export let magicMcpServerCreatedQueueProcessor = magicMcpServerCreatedQueue.process(
   async data => {
+    await ensureQueuedMagicMcpServerBacking(data);
     await queueMagicMcpServerIndex(data.magicMcpServerId);
   }
 );
 
-export let magicMcpServerUpdatedQueue = createQueue<{ magicMcpServerId: string }>({
+export let magicMcpServerUpdatedQueue = createQueue<MagicMcpServerLifecycleQueueInput>({
   name: 'mgc/lc/server/updated'
 });
 
 export let magicMcpServerUpdatedQueueProcessor = magicMcpServerUpdatedQueue.process(
   async data => {
+    await ensureQueuedMagicMcpServerBacking(data);
     await queueMagicMcpServerIndex(data.magicMcpServerId);
   }
 );

--- a/src/backend/modules/magic/src/services/magicMcpEndpoint.ts
+++ b/src/backend/modules/magic/src/services/magicMcpEndpoint.ts
@@ -23,7 +23,6 @@ import {
   consumerMagicMcpWriteRoles,
   type AnyAccessTagSelector
 } from '@metorial/module-access';
-import { ensureMagicMcpEndpointBacking } from '../lib/backing';
 import {
   magicMcpEndpointCreatedQueue,
   magicMcpEndpointDeletedQueue,
@@ -271,6 +270,7 @@ class MagicMcpEndpointImpl {
             id: await ID.generateId('magicMcpEndpoint'),
             status: 'active',
             isConsumerReconciled: true,
+            isSubspaceBackingReconciling: true,
             instanceOid: d.instance.oid,
             consumerProfileOid: d.input.consumerProfile?.oid,
             skillPluginOid: d.input.skillPlugin?.oid,
@@ -291,11 +291,6 @@ class MagicMcpEndpointImpl {
       });
 
       await magicMcpEndpointCreatedQueue.add({ magicMcpEndpointId: magicMcpEndpoint.id });
-      await ensureMagicMcpEndpointBacking({
-        instance: d.instance,
-        endpoint: magicMcpEndpoint,
-        isReconciliation: false
-      });
 
       return magicMcpEndpoint;
     } catch (error) {
@@ -363,21 +358,14 @@ class MagicMcpEndpointImpl {
           name: d.input.name === undefined ? d.endpoint.name : d.input.name,
           description:
             d.input.description === undefined ? d.endpoint.description : d.input.description,
-          metadata: d.input.metadata === undefined ? d.endpoint.metadata : d.input.metadata
+          metadata: d.input.metadata === undefined ? d.endpoint.metadata : d.input.metadata,
+          isSubspaceBackingReconciling: true
         },
         include: magicMcpEndpointInclude
       });
     });
 
     await magicMcpEndpointUpdatedQueue.add({ magicMcpEndpointId: magicMcpEndpoint.id });
-    let instance = await db.instance.findUniqueOrThrow({
-      where: { oid: magicMcpEndpoint.instanceOid }
-    });
-    await ensureMagicMcpEndpointBacking({
-      instance,
-      endpoint: magicMcpEndpoint,
-      isReconciliation: false
-    });
 
     return magicMcpEndpoint;
   }
@@ -439,23 +427,18 @@ class MagicMcpEndpointImpl {
         );
       }
 
-      return await db.magicMcpEndpoint.findUniqueOrThrow({
+      return await db.magicMcpEndpoint.update({
         where: {
           id: d.endpoint.id
+        },
+        data: {
+          isSubspaceBackingReconciling: true
         },
         include: magicMcpEndpointInclude
       });
     });
 
     await magicMcpEndpointUpdatedQueue.add({ magicMcpEndpointId: magicMcpEndpoint.id });
-    let instance = await db.instance.findUniqueOrThrow({
-      where: { oid: magicMcpEndpoint.instanceOid }
-    });
-    await ensureMagicMcpEndpointBacking({
-      instance,
-      endpoint: magicMcpEndpoint,
-      isReconciliation: false
-    });
 
     return magicMcpEndpoint;
   }
@@ -481,23 +464,18 @@ class MagicMcpEndpointImpl {
         });
       }
 
-      return await db.magicMcpEndpoint.findUniqueOrThrow({
+      return await db.magicMcpEndpoint.update({
         where: {
           id: d.endpoint.id
+        },
+        data: {
+          isSubspaceBackingReconciling: true
         },
         include: magicMcpEndpointInclude
       });
     });
 
     await magicMcpEndpointUpdatedQueue.add({ magicMcpEndpointId: magicMcpEndpoint.id });
-    let instance = await db.instance.findUniqueOrThrow({
-      where: { oid: magicMcpEndpoint.instanceOid }
-    });
-    await ensureMagicMcpEndpointBacking({
-      instance,
-      endpoint: magicMcpEndpoint,
-      isReconciliation: false
-    });
 
     return magicMcpEndpoint;
   }

--- a/src/backend/modules/magic/src/services/magicMcpServer.ts
+++ b/src/backend/modules/magic/src/services/magicMcpServer.ts
@@ -152,7 +152,8 @@ class MagicMcpServerImpl {
         : await ensureMagicMcpServerBacking({
             instance: d.instance,
             server: d.server,
-            isReconciliation: true
+            isReconciliation: true,
+            deferReconcile: false
           });
       let backing = await subspaceMagicMcpBackingService.getServer({
         instance: d.instance,
@@ -198,6 +199,7 @@ class MagicMcpServerImpl {
           status: 'active',
           source: d.input.source ?? 'manual',
           isConsumerReconciled: true,
+          isSubspaceBackingReconciling: true,
           providerTemplateId: d.input.providerTemplateId,
           subspaceIntegrationInstanceId: d.input.subspaceIntegrationInstanceId,
           name: d.input.name,
@@ -216,11 +218,8 @@ class MagicMcpServerImpl {
       });
     });
 
-    await magicMcpServerCreatedQueue.add({ magicMcpServerId: magicMcpServer.id });
-
-    await ensureMagicMcpServerBacking({
-      instance: d.instance,
-      server: magicMcpServer,
+    await magicMcpServerCreatedQueue.add({
+      magicMcpServerId: magicMcpServer.id,
       providers: d.input.providers,
       isReconciliation: false
     });
@@ -365,6 +364,7 @@ class MagicMcpServerImpl {
             description:
               d.input.description === undefined ? d.server.description : d.input.description,
             metadata: d.input.metadata === undefined ? d.server.metadata : d.input.metadata,
+            isSubspaceBackingReconciling: true,
             aliases: {
               create: nextAliases.map(slug => ({ slug }))
             }
@@ -383,14 +383,10 @@ class MagicMcpServerImpl {
       throw error;
     }
 
-    await magicMcpServerUpdatedQueue.add({ magicMcpServerId: server.id });
-    if (d.instance) {
-      await ensureMagicMcpServerBacking({
-        instance: d.instance,
-        server,
-        isReconciliation: false
-      });
-    }
+    await magicMcpServerUpdatedQueue.add({
+      magicMcpServerId: server.id,
+      isReconciliation: false
+    });
 
     return server;
   }
@@ -422,7 +418,8 @@ class MagicMcpServerImpl {
       : await ensureMagicMcpServerBacking({
           instance: d.instance,
           server: d.server,
-          isReconciliation: true
+          isReconciliation: true,
+          deferReconcile: false
         });
 
     return {
@@ -478,7 +475,8 @@ class MagicMcpServerImpl {
       : await ensureMagicMcpServerBacking({
           instance: d.instance,
           server: d.server,
-          isReconciliation: true
+          isReconciliation: true,
+          deferReconcile: false
         });
     let provider = await subspaceMagicMcpBackingService.getServerProvider({
       instance: d.instance,
@@ -510,10 +508,16 @@ class MagicMcpServerImpl {
       accessTags: d.accessTags
     });
 
+    await db.magicMcpServer.update({
+      where: { oid: d.server.oid },
+      data: { isSubspaceBackingReconciling: true }
+    });
+
     let server = await ensureMagicMcpServerBacking({
       instance: d.instance,
       server: d.server,
-      isReconciliation: false
+      isReconciliation: false,
+      deferReconcile: false
     });
 
     return await subspaceMagicMcpBackingService.createServerProvider({

--- a/src/systems/subspace/apps/controller/src/controllers/magicMcpBacking.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/magicMcpBacking.ts
@@ -169,6 +169,7 @@ export let magicMcpBackingController = app.controller({
         privateMetadata: v.optional(v.nullable(v.record(v.any()))),
         maxSessionDurationInMinutes: v.number({ modifiers: [v.integer(), v.positive()] }),
         isReconciliation: v.optional(v.boolean()),
+        deferReconcile: v.optional(v.boolean()),
         providers: v.optional(v.array(backingProviderValidator))
       })
     )
@@ -191,6 +192,7 @@ export let magicMcpBackingController = app.controller({
           privateMetadata: ctx.input.privateMetadata,
           maxSessionDurationInMinutes: ctx.input.maxSessionDurationInMinutes,
           isReconciliation: ctx.input.isReconciliation,
+          deferReconcile: ctx.input.deferReconcile,
           providers: ctx.input.providers?.map(provider => ({
             providerDeploymentId: provider.providerDeploymentId,
             providerConfigId: provider.providerConfigId,
@@ -221,6 +223,7 @@ export let magicMcpBackingController = app.controller({
         privateMetadata: v.optional(v.nullable(v.record(v.any()))),
         maxSessionDurationInMinutes: v.number({ modifiers: [v.integer(), v.positive()] }),
         isReconciliation: v.optional(v.boolean()),
+        deferReconcile: v.optional(v.boolean()),
         servers: v.array(endpointServerValidator)
       })
     )
@@ -239,6 +242,7 @@ export let magicMcpBackingController = app.controller({
           privateMetadata: ctx.input.privateMetadata,
           maxSessionDurationInMinutes: ctx.input.maxSessionDurationInMinutes,
           isReconciliation: ctx.input.isReconciliation,
+          deferReconcile: ctx.input.deferReconcile,
           servers: ctx.input.servers.map(server => ({
             id: server.id,
             magicMcpServerBackingId: server.magicMcpServerBackingId,
@@ -516,7 +520,8 @@ export let magicMcpBackingController = app.controller({
 
       return {
         object: 'magic_mcp.server_backing.session',
-        sessionId: session.id
+        sessionId: session.id,
+        isReconciling: false
       };
     }),
 

--- a/src/systems/subspace/db/prisma/schema/intergration/backing.prisma
+++ b/src/systems/subspace/db/prisma/schema/intergration/backing.prisma
@@ -100,6 +100,8 @@ model MagicMcpEndpointServerBacking {
   magicMcpServerBackingOid BigInt
   magicMcpServerBacking    MagicMcpServerBacking @relation(fields: [magicMcpServerBackingOid], references: [oid], onDelete: Cascade)
 
+  toolFilters Json?
+
   createdAt DateTime @default(now())
 }
 

--- a/src/systems/subspace/db/prisma/schema/session/ephemeralManaged.prisma
+++ b/src/systems/subspace/db/prisma/schema/session/ephemeralManaged.prisma
@@ -14,6 +14,7 @@ model EphemeralManagedSession {
   maxSessionDurationInMinutes Int
   templateHash                String?
   willRotateAt                DateTime?
+  isReconciling               Boolean @default(false)
 
   tenantOid BigInt
   tenant    Tenant @relation(fields: [tenantOid], references: [oid])

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/index.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/index.ts
@@ -33,6 +33,7 @@ import {
   integrationProviderCreatedQueueProcessor,
   integrationProviderUpdatedQueueProcessor
 } from './integrationProvider';
+import { magicMcpBackingReconcileQueueProcessor } from './magicMcpBackingReconcile';
 
 export let lifecycleQueues = combineQueueProcessors([
   archiveIntegrationInstanceQueueProcessor,
@@ -58,5 +59,6 @@ export let lifecycleQueues = combineQueueProcessors([
   integrationProviderUpdatedQueueProcessor,
   integrationProviderArchivedQueueProcessor,
   integrationProviderArchiveInstanceProvidersManyQueueProcessor,
-  integrationProviderArchiveGroupProvidersManyQueueProcessor
+  integrationProviderArchiveGroupProvidersManyQueueProcessor,
+  magicMcpBackingReconcileQueueProcessor
 ]);

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstance.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstance.ts
@@ -192,6 +192,13 @@ export let integrationInstanceCreatedQueueProcessor = integrationInstanceCreated
       return;
     }
 
+    if (integrationInstance.isMagicMcpBacking) {
+      await indexIntegrationInstanceQueue.add({
+        integrationInstanceId: data.integrationInstanceId
+      });
+      return;
+    }
+
     await integrationInstanceService.createSessionTemplateForIntegrationInstance({
       tenant: integrationInstance.tenant,
       solution: integrationInstance.solution,
@@ -217,6 +224,18 @@ export let integrationInstanceUpdatedQueue = createQueue<{ integrationInstanceId
 
 export let integrationInstanceUpdatedQueueProcessor = integrationInstanceUpdatedQueue.process(
   async data => {
+    let integrationInstance = await db.integrationInstance.findUnique({
+      where: { id: data.integrationInstanceId }
+    });
+    if (!integrationInstance || integrationInstance.isMagicMcpBacking) {
+      if (integrationInstance?.isMagicMcpBacking) {
+        await indexIntegrationInstanceQueue.add({
+          integrationInstanceId: data.integrationInstanceId
+        });
+      }
+      return;
+    }
+
     await indexIntegrationInstanceQueue.add({
       integrationInstanceId: data.integrationInstanceId
     });

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstanceGroup.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationInstanceGroup.ts
@@ -114,6 +114,10 @@ export let integrationInstanceGroupCreatedQueueProcessor =
       return;
     }
 
+    if (integrationInstanceGroup.isMagicMcpBacking) {
+      return;
+    }
+
     await integrationInstanceGroupService.createSessionTemplateForIntegrationInstanceGroup({
       tenant: integrationInstanceGroup.tenant,
       solution: integrationInstanceGroup.solution,
@@ -136,6 +140,11 @@ export let integrationInstanceGroupUpdatedQueue = createQueue<{
 
 export let integrationInstanceGroupUpdatedQueueProcessor =
   integrationInstanceGroupUpdatedQueue.process(async data => {
+    let integrationInstanceGroup = await db.integrationInstanceGroup.findUnique({
+      where: { id: data.integrationInstanceGroupId }
+    });
+    if (!integrationInstanceGroup || integrationInstanceGroup.isMagicMcpBacking) return;
+
     await enqueueSyncIntegrationInstanceGroupSessionTemplates({
       integrationInstanceGroupId: data.integrationInstanceGroupId
     });

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/magicMcpBackingReconcile.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/magicMcpBackingReconcile.ts
@@ -1,0 +1,217 @@
+import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import {
+  db,
+  type Environment,
+  type Solution,
+  type Tenant,
+  withTransaction
+} from '@metorial-subspace/db';
+import { sessionTemplateProviderService } from '@metorial-subspace/module-session';
+import { enqueueSessionTemplateSyncHash } from '@metorial-subspace/module-session/src/queues/lifecycle/sessionTemplateProvider';
+import { env } from '../../env';
+import { integrationInstanceGroupProviderService } from '../../services/integrationInstanceGroupProvider';
+import { reconcileMagicMcpServerProvidersForBackingWithoutLock } from '../../services/magicMcpBacking/serverProvider';
+
+export type MagicMcpBackingReconcileInput = {
+  tenantId: string;
+  solutionId: string;
+  environmentId: string;
+} & (
+  | { kind: 'server'; magicMcpServerBackingId: string }
+  | { kind: 'endpoint'; magicMcpEndpointBackingId: string }
+);
+
+export let magicMcpBackingReconcileQueue = createQueue<MagicMcpBackingReconcileInput>({
+  name: 'sub/int/magicMcpBacking/reconcile',
+  redisUrl: env.service.REDIS_URL
+});
+
+let loadScope = async (d: { tenantId: string; solutionId: string; environmentId: string }) => {
+  let environment = await db.environment.findFirst({
+    where: {
+      id: d.environmentId,
+      tenant: { OR: [{ id: d.tenantId }, { identifier: d.tenantId }] }
+    },
+    include: {
+      tenant: true
+    }
+  });
+  if (!environment) throw new QueueRetryError();
+  let solution = await db.solution.findFirst({
+    where: {
+      OR: [{ id: d.solutionId }, { identifier: d.solutionId }]
+    }
+  });
+  if (!solution) throw new QueueRetryError();
+
+  return {
+    tenant: environment.tenant,
+    solution,
+    environment
+  };
+};
+
+export let enqueueMagicMcpServerBackingReconcile = async (d: {
+  tenant: Tenant;
+  solution: Solution;
+  environment: Environment;
+  magicMcpServerBackingId: string;
+}) => {
+  await magicMcpBackingReconcileQueue.add({
+    kind: 'server',
+    tenantId: d.tenant.id,
+    solutionId: d.solution.id,
+    environmentId: d.environment.id,
+    magicMcpServerBackingId: d.magicMcpServerBackingId
+  });
+};
+
+export let enqueueMagicMcpEndpointBackingReconcile = async (d: {
+  tenant: Tenant;
+  solution: Solution;
+  environment: Environment;
+  magicMcpEndpointBackingId: string;
+}) => {
+  await magicMcpBackingReconcileQueue.add({
+    kind: 'endpoint',
+    tenantId: d.tenant.id,
+    solutionId: d.solution.id,
+    environmentId: d.environment.id,
+    magicMcpEndpointBackingId: d.magicMcpEndpointBackingId
+  });
+};
+
+export let reconcileMagicMcpServerBacking = async (d: {
+  tenant: Tenant;
+  solution: Solution;
+  environment: Environment;
+  magicMcpServerBackingId: string;
+}) => {
+  let backing = await db.magicMcpServerBacking.findFirst({
+    where: {
+      id: d.magicMcpServerBackingId,
+      integrationInstance: {
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid
+      }
+    },
+    include: {
+      integrationInstance: true,
+      sessionTemplate: true,
+      ephemeralManagedSession: true
+    }
+  });
+  if (!backing) throw new QueueRetryError();
+
+  try {
+    await sessionTemplateProviderService.syncForIntegrationInstance({
+      sessionTemplate: backing.sessionTemplate,
+      integrationInstance: backing.integrationInstance
+    });
+    await enqueueSessionTemplateSyncHash(backing.sessionTemplate.id);
+
+    await reconcileMagicMcpServerProvidersForBackingWithoutLock({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      magicMcpServerBackingId: d.magicMcpServerBackingId
+    });
+  } finally {
+    await db.ephemeralManagedSession.update({
+      where: { oid: backing.ephemeralManagedSessionOid },
+      data: { isReconciling: false }
+    });
+  }
+};
+
+export let reconcileMagicMcpEndpointBacking = async (d: {
+  tenant: Tenant;
+  solution: Solution;
+  environment: Environment;
+  magicMcpEndpointBackingId: string;
+}) => {
+  let backing = await db.magicMcpEndpointBacking.findFirst({
+    where: {
+      id: d.magicMcpEndpointBackingId,
+      integrationGroup: {
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid
+      }
+    },
+    include: {
+      integrationGroup: true,
+      sessionTemplate: true,
+      ephemeralManagedSession: true,
+      servers: {
+        include: {
+          magicMcpServerBacking: {
+            include: {
+              integrationInstance: {
+                include: {
+                  integrationInstanceProviders: {
+                    where: { status: 'active', isParentDeleted: false },
+                    include: { currentVersion: true }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+  if (!backing) throw new QueueRetryError();
+
+  try {
+    let input = backing.servers.flatMap(serverBacking => {
+      return serverBacking.magicMcpServerBacking.integrationInstance.integrationInstanceProviders
+        .filter(provider => provider.currentVersion?.configOid)
+        .map(provider => ({
+          integrationInstanceProviderId: provider.id,
+          toolFilters: serverBacking.toolFilters as PrismaJson.ToolFilter | null
+        }));
+    });
+
+    await integrationInstanceGroupProviderService.syncMagicMcpIntegrationInstanceGroupProviders(
+      {
+        tenant: d.tenant,
+        solution: d.solution,
+        environment: d.environment,
+        integrationInstanceGroup: backing.integrationGroup,
+        input
+      }
+    );
+
+    await sessionTemplateProviderService.syncForIntegrationInstanceGroup({
+      sessionTemplate: backing.sessionTemplate,
+      integrationInstanceGroup: backing.integrationGroup
+    });
+    await enqueueSessionTemplateSyncHash(backing.sessionTemplate.id);
+  } finally {
+    await db.ephemeralManagedSession.update({
+      where: { oid: backing.ephemeralManagedSessionOid },
+      data: { isReconciling: false }
+    });
+  }
+};
+
+export let magicMcpBackingReconcileQueueProcessor = magicMcpBackingReconcileQueue.process(
+  async data => {
+    let scope = await loadScope(data);
+
+    if (data.kind === 'server') {
+      await reconcileMagicMcpServerBacking({
+        ...scope,
+        magicMcpServerBackingId: data.magicMcpServerBackingId
+      });
+      return;
+    }
+
+    await reconcileMagicMcpEndpointBacking({
+      ...scope,
+      magicMcpEndpointBackingId: data.magicMcpEndpointBackingId
+    });
+  }
+);

--- a/src/systems/subspace/modules/integration/src/services/integration.ts
+++ b/src/systems/subspace/modules/integration/src/services/integration.ts
@@ -54,6 +54,12 @@ export let integrationInclude = {
   magicMcpServerBacking: true
 };
 
+export let magicMcpBackingIntegrationInclude = {
+  currentVersion: {
+    include: integrationVersionInclude
+  }
+};
+
 let getSlug = (input: { name: string }) =>
   `${slugify(input.name)}-${generatePlainId(7).toLowerCase()}`.toLowerCase();
 
@@ -284,7 +290,7 @@ class integrationServiceImpl {
             environmentOid: d.environment.oid
           },
           data: this.integrationUpdateData({ ...d.input, isMagicMcpBacking: true }),
-          include: integrationInclude
+          include: magicMcpBackingIntegrationInclude
         });
 
         await addAfterTransactionHook(async () =>
@@ -307,7 +313,7 @@ class integrationServiceImpl {
           isMagicMcpBacking: true
         }),
         update: this.integrationUpdateData({ ...d.input, isMagicMcpBacking: true }),
-        include: integrationInclude
+        include: magicMcpBackingIntegrationInclude
       });
       let isNew = integration.id === newId.id;
 
@@ -315,7 +321,7 @@ class integrationServiceImpl {
         await createIntegrationVersion({ integrationOid: integration.oid });
         integration = await db.integration.findUniqueOrThrow({
           where: { oid: integration.oid },
-          include: integrationInclude
+          include: magicMcpBackingIntegrationInclude
         });
       }
 

--- a/src/systems/subspace/modules/integration/src/services/integrationInstance.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstance.ts
@@ -92,6 +92,12 @@ export let integrationInstanceInclude = {
   magicMcpServerBacking: true
 } as const;
 
+export let magicMcpBackingIntegrationInstanceInclude = {
+  integration: true,
+  identityActor: true,
+  identity: true
+} as const;
+
 type IntegrationIdentityInput = {
   identityActorId?: string | null;
   identityId?: string | null;
@@ -224,6 +230,7 @@ class integrationInstanceServiceImpl {
     integrationInstance: IntegrationInstance;
     input: IntegrationInstanceWriteInput;
     current?: Parameters<typeof mergeIntegrationIdentityInput>[0]['current'];
+    isMagicMcpBacking?: boolean;
   }) {
     let mergedIdentityInput = mergeIntegrationIdentityInput({
       current: d.current,
@@ -657,7 +664,7 @@ class integrationInstanceServiceImpl {
               input: d.input,
               isMagicMcpBacking: true
             }),
-            include: integrationInstanceInclude
+            include: magicMcpBackingIntegrationInstanceInclude
           })
         : await db.integrationInstance.create({
             data: this.integrationInstanceCreateData({
@@ -669,7 +676,7 @@ class integrationInstanceServiceImpl {
               input: d.input,
               isMagicMcpBacking: true
             }),
-            include: integrationInstanceInclude
+            include: magicMcpBackingIntegrationInstanceInclude
           });
       let isNew = integrationInstance.id === newId.id;
 

--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/endpoint.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/endpoint.ts
@@ -3,6 +3,7 @@ import { Service } from '@lowerdeck/service';
 import {
   db,
   type Environment,
+  Prisma,
   snowflake,
   type Solution,
   type Tenant,
@@ -10,13 +11,14 @@ import {
 } from '@metorial-subspace/db';
 import {
   ephemeralManagedSessionService,
-  sessionTemplateProviderService,
   sessionTemplateService
 } from '@metorial-subspace/module-session';
-import { enqueueSessionTemplateSyncHash } from '@metorial-subspace/module-session/src/queues/lifecycle/sessionTemplateProvider';
 import { checkTenant } from '@metorial-subspace/module-tenant';
+import {
+  enqueueMagicMcpEndpointBackingReconcile,
+  reconcileMagicMcpEndpointBacking
+} from '../../queues/lifecycle/magicMcpBackingReconcile';
 import { integrationInstanceGroupService } from '../integrationInstanceGroup';
-import { integrationInstanceGroupProviderService } from '../integrationInstanceGroupProvider';
 import {
   type MagicMcpBackingInputBase,
   magicMcpEndpointBackingInclude,
@@ -35,6 +37,7 @@ type UpsertMagicMcpEndpointBackingInput = {
       toolFilters?: PrismaJson.ToolFilter | null;
     }[];
     isReconciliation?: boolean;
+    deferReconcile?: boolean;
   };
 };
 
@@ -46,6 +49,7 @@ class magicMcpEndpointBackingServiceImpl {
       identityId: d.input.identityId
     });
 
+    let shouldDeferReconcile = d.input.deferReconcile !== false;
     let syncTarget = await withMagicMcpBackingLock(
       [`endpoint:${d.input.id}`],
       async () =>
@@ -62,10 +66,8 @@ class magicMcpEndpointBackingServiceImpl {
             include: {
               integrationInstance: {
                 include: {
-                  integrationInstanceProviders: {
-                    where: { status: 'active', isParentDeleted: false },
-                    include: { currentVersion: true }
-                  }
+                  identityActor: true,
+                  identity: true
                 }
               }
             }
@@ -84,7 +86,11 @@ class magicMcpEndpointBackingServiceImpl {
 
           let existing = await db.magicMcpEndpointBacking.findUnique({
             where: { id: d.input.id },
-            include: magicMcpEndpointBackingInclude
+            include: {
+              integrationGroup: true,
+              sessionTemplate: true,
+              ephemeralManagedSession: true
+            }
           });
 
           let group =
@@ -130,11 +136,12 @@ class magicMcpEndpointBackingServiceImpl {
               sessionTemplate,
               input: {
                 maxSessionDurationInMinutes: d.input.maxSessionDurationInMinutes,
-                actorOid
+                actorOid,
+                isReconciling: shouldDeferReconcile
               }
             });
 
-          await db.magicMcpEndpointBacking.upsert({
+          let backing = await db.magicMcpEndpointBacking.upsert({
             where: { id: d.input.id },
             create: {
               oid: snowflake.nextId(),
@@ -152,69 +159,66 @@ class magicMcpEndpointBackingServiceImpl {
             }
           });
 
-          let backing = await db.magicMcpEndpointBacking.findUniqueOrThrow({
+          let persistedBacking = await db.magicMcpEndpointBacking.findUniqueOrThrow({
             where: { id: d.input.id }
           });
           let requestedJoinIds = new Set(d.input.servers.map(server => server.id));
           await db.magicMcpEndpointServerBacking.deleteMany({
             where: {
-              magicMcpEndpointBackingOid: backing.oid,
+              magicMcpEndpointBackingOid: persistedBacking.oid,
               id: { notIn: Array.from(requestedJoinIds) }
             }
           });
 
+          let servers = [];
           for (let serverInput of d.input.servers) {
             let serverBacking = serverBackingsById.get(serverInput.magicMcpServerBackingId)!;
-            await db.magicMcpEndpointServerBacking.upsert({
+            let server = await db.magicMcpEndpointServerBacking.upsert({
               where: { id: serverInput.id },
               create: {
                 oid: snowflake.nextId(),
                 id: serverInput.id,
-                magicMcpEndpointBackingOid: backing.oid,
-                magicMcpServerBackingOid: serverBacking.oid
+                magicMcpEndpointBackingOid: persistedBacking.oid,
+                magicMcpServerBackingOid: serverBacking.oid,
+                toolFilters: serverInput.toolFilters ?? Prisma.JsonNull
               },
               update: {
-                magicMcpEndpointBackingOid: backing.oid,
-                magicMcpServerBackingOid: serverBacking.oid
+                magicMcpEndpointBackingOid: persistedBacking.oid,
+                magicMcpServerBackingOid: serverBacking.oid,
+                toolFilters: serverInput.toolFilters ?? Prisma.JsonNull
               }
             });
+            servers.push({ ...server, magicMcpServerBacking: serverBacking });
           }
 
-          let groupProviderInput = d.input.servers.flatMap(serverInput => {
-            let serverBacking = serverBackingsById.get(serverInput.magicMcpServerBackingId)!;
-            return serverBacking.integrationInstance.integrationInstanceProviders
-              .filter(provider => provider.currentVersion?.configOid)
-              .map(provider => ({
-                integrationInstanceProviderId: provider.id,
-                toolFilters: serverInput.toolFilters
-              }));
-          });
-
-          return { group, sessionTemplate, groupProviderInput };
+          return { backing, group, sessionTemplate, ephemeralManagedSession, servers };
         })
     );
 
-    await integrationInstanceGroupProviderService.syncMagicMcpIntegrationInstanceGroupProviders(
-      {
+    if (shouldDeferReconcile) {
+      await enqueueMagicMcpEndpointBackingReconcile({
         tenant: d.tenant,
         solution: d.solution,
         environment: d.environment,
-        integrationInstanceGroup: syncTarget.group,
-        isReconciliation: d.input.isReconciliation,
-        input: syncTarget.groupProviderInput
-      }
-    );
+        magicMcpEndpointBackingId: d.input.id
+      });
+    } else {
+      await reconcileMagicMcpEndpointBacking({
+        tenant: d.tenant,
+        solution: d.solution,
+        environment: d.environment,
+        magicMcpEndpointBackingId: d.input.id
+      });
+    }
 
-    await sessionTemplateProviderService.syncForIntegrationInstanceGroup({
+    return {
+      ...syncTarget.backing,
+      integrationGroup: syncTarget.group,
       sessionTemplate: syncTarget.sessionTemplate,
-      integrationInstanceGroup: syncTarget.group
-    });
-    await enqueueSessionTemplateSyncHash(syncTarget.sessionTemplate.id);
-
-    return await db.magicMcpEndpointBacking.findUniqueOrThrow({
-      where: { id: d.input.id },
-      include: magicMcpEndpointBackingInclude
-    });
+      ephemeralManagedSession: syncTarget.ephemeralManagedSession,
+      actor: null,
+      servers: syncTarget.servers
+    };
   }
 
   async getMagicMcpEndpointBackingById(d: {

--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/server.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/server.ts
@@ -10,15 +10,16 @@ import {
 } from '@metorial-subspace/db';
 import {
   ephemeralManagedSessionService,
-  sessionTemplateProviderService,
   sessionTemplateService
 } from '@metorial-subspace/module-session';
-import { enqueueSessionTemplateSyncHash } from '@metorial-subspace/module-session/src/queues/lifecycle/sessionTemplateProvider';
 import { checkTenant } from '@metorial-subspace/module-tenant';
 import { integrationService } from '../integration';
 import { integrationInstanceService } from '../integrationInstance';
 import { integrationInstanceProviderService } from '../integrationInstanceProvider';
-import { reconcileMagicMcpServerProvidersForBackingWithoutLock } from './serverProvider';
+import {
+  enqueueMagicMcpServerBackingReconcile,
+  reconcileMagicMcpServerBacking
+} from '../../queues/lifecycle/magicMcpBackingReconcile';
 import {
   type BackingProviderInput,
   getMagicMcpOwnerType,
@@ -40,6 +41,7 @@ type UpsertMagicMcpServerBackingInput = {
     providers?: BackingProviderInput[];
     legacySessionTemplateId?: string | null;
     isReconciliation?: boolean;
+    deferReconcile?: boolean;
   };
 };
 
@@ -184,13 +186,22 @@ class magicMcpServerBackingServiceImpl {
           })
         : []);
 
+    let shouldRunReconcile =
+      providers.length > 0 || ownerType !== 'server_owned' || d.input.deferReconcile === false;
+    let shouldDeferReconcile = d.input.deferReconcile !== false && shouldRunReconcile;
+
     let syncTarget = await withMagicMcpBackingLock(
       `server:${d.input.id}`,
       async () =>
         await withTransaction(async db => {
           let existing = await db.magicMcpServerBacking.findUnique({
             where: { id: d.input.id },
-            include: magicMcpServerBackingInclude
+            include: {
+              integration: true,
+              integrationInstance: true,
+              sessionTemplate: true,
+              ephemeralManagedSession: true
+            }
           });
 
           let integration =
@@ -263,11 +274,12 @@ class magicMcpServerBackingServiceImpl {
               sessionTemplate,
               input: {
                 maxSessionDurationInMinutes: d.input.maxSessionDurationInMinutes,
-                actorOid
+                actorOid,
+                isReconciling: shouldDeferReconcile
               }
             });
 
-          await db.magicMcpServerBacking.upsert({
+          let backing = await db.magicMcpServerBacking.upsert({
             where: { id: d.input.id },
             create: {
               oid: snowflake.nextId(),
@@ -293,7 +305,13 @@ class magicMcpServerBackingServiceImpl {
             }
           });
 
-          return { integration, integrationInstance, sessionTemplate };
+          return {
+            backing,
+            integration,
+            integrationInstance,
+            sessionTemplate,
+            ephemeralManagedSession
+          };
         })
     );
 
@@ -309,23 +327,32 @@ class magicMcpServerBackingServiceImpl {
       });
     }
 
-    await sessionTemplateProviderService.syncForIntegrationInstance({
+    if (shouldDeferReconcile) {
+      await enqueueMagicMcpServerBackingReconcile({
+        tenant: d.tenant,
+        solution: d.solution,
+        environment: d.environment,
+        magicMcpServerBackingId: d.input.id
+      });
+    } else if (shouldRunReconcile) {
+      await reconcileMagicMcpServerBacking({
+        tenant: d.tenant,
+        solution: d.solution,
+        environment: d.environment,
+        magicMcpServerBackingId: d.input.id
+      });
+    }
+
+    return {
+      ...syncTarget.backing,
+      providerTemplateBacking,
+      ownerIntegration: ownerType === 'integration' ? syncTarget.integration : null,
+      integration: ownerType === 'server_owned' ? syncTarget.integration : null,
+      integrationInstance: syncTarget.integrationInstance,
       sessionTemplate: syncTarget.sessionTemplate,
-      integrationInstance: syncTarget.integrationInstance
-    });
-    await enqueueSessionTemplateSyncHash(syncTarget.sessionTemplate.id);
-
-    await reconcileMagicMcpServerProvidersForBackingWithoutLock({
-      tenant: d.tenant,
-      solution: d.solution,
-      environment: d.environment,
-      magicMcpServerBackingId: d.input.id
-    });
-
-    return await db.magicMcpServerBacking.findUniqueOrThrow({
-      where: { id: d.input.id },
-      include: magicMcpServerBackingInclude
-    });
+      ephemeralManagedSession: syncTarget.ephemeralManagedSession,
+      actor: null
+    };
   }
 
   async getMagicMcpServerBackingById(d: {

--- a/src/systems/subspace/modules/session/src/services/ephemeralManagedSession.ts
+++ b/src/systems/subspace/modules/session/src/services/ephemeralManagedSession.ts
@@ -24,6 +24,11 @@ let ephemeralManagedSessionResolveLock = createLock({
   redisUrl: env.service.REDIS_URL
 });
 
+let EPHEMERAL_MANAGED_SESSION_RECONCILE_POLL_INTERVAL_MS = 100;
+let EPHEMERAL_MANAGED_SESSION_RECONCILE_POLL_ATTEMPTS = 20;
+
+let wait = async (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
 type ResolvedBackingSession = Session & {
   tenant: Tenant;
   solution: Solution;
@@ -94,6 +99,27 @@ let shouldRotateBackingSession = (ephemeralManagedSession: EphemeralManagedSessi
   if (maxDurationInMinutes <= 0) return false;
 
   return Date.now() - currentSession.createdAt.getTime() >= maxDurationInMinutes * 60 * 1000;
+};
+
+let waitForEphemeralManagedSessionReconcile = async (d: {
+  sessionId: string;
+  tenantId: string;
+  solutionId: string;
+}) => {
+  let latest: EphemeralManagedSessionRecord | null = null;
+
+  for (
+    let attempt = 0;
+    attempt < EPHEMERAL_MANAGED_SESSION_RECONCILE_POLL_ATTEMPTS;
+    attempt++
+  ) {
+    latest = await getEphemeralManagedSessionById(d);
+    if (!latest || !latest.isReconciling) return latest;
+
+    await wait(EPHEMERAL_MANAGED_SESSION_RECONCILE_POLL_INTERVAL_MS);
+  }
+
+  return latest;
 };
 
 let getWillRotateAt = (d: { session: Session; maxSessionDurationInMinutes: number }) => {
@@ -201,6 +227,7 @@ class ephemeralManagedSessionServiceImpl {
     input: {
       maxSessionDurationInMinutes: number;
       actorOid?: bigint | null;
+      isReconciling?: boolean;
     };
   }) {
     return withTransaction(async db => {
@@ -210,7 +237,8 @@ class ephemeralManagedSessionServiceImpl {
         maxSessionDurationInMinutes: d.input.maxSessionDurationInMinutes,
         sessionTemplateOid: d.sessionTemplate.oid,
         actorOid: d.input.actorOid ?? d.sessionTemplate.identityActorOid ?? null,
-        identityOid: d.sessionTemplate.identityOid ?? null
+        identityOid: d.sessionTemplate.identityOid ?? null,
+        isReconciling: d.input.isReconciling ?? false
       };
 
       if (d.ephemeralManagedSession) {
@@ -325,6 +353,15 @@ class ephemeralManagedSessionServiceImpl {
     let existing = await getEphemeralManagedSessionById(d);
     if (!existing) return null;
 
+    if (existing.isReconciling) {
+      let resolved = await waitForEphemeralManagedSessionReconcile(d);
+      if (!resolved) return null;
+      if (resolved.isReconciling && resolved.currentSession?.status === 'active') {
+        return resolved.currentSession;
+      }
+      existing = resolved;
+    }
+
     if (!shouldRotateBackingSession(existing)) {
       return existing.currentSession!;
     }
@@ -332,6 +369,15 @@ class ephemeralManagedSessionServiceImpl {
     return await ephemeralManagedSessionResolveLock.usingLock(existing.id, async () => {
       let ephemeralManagedSession = await getEphemeralManagedSessionById(d);
       if (!ephemeralManagedSession) return null;
+
+      if (ephemeralManagedSession.isReconciling) {
+        let resolved = await waitForEphemeralManagedSessionReconcile(d);
+        if (!resolved) return null;
+        if (resolved.isReconciling && resolved.currentSession?.status === 'active') {
+          return resolved.currentSession;
+        }
+        ephemeralManagedSession = resolved;
+      }
 
       if (!shouldRotateBackingSession(ephemeralManagedSession)) {
         return ephemeralManagedSession.currentSession!;

--- a/src/systems/subspace/packages/presenters/src/magicMcpBacking.ts
+++ b/src/systems/subspace/packages/presenters/src/magicMcpBacking.ts
@@ -60,13 +60,16 @@ export let providerTemplateBackingPresenter = (
 
 export let magicMcpServerBackingPresenter = (
   backing: MagicMcpServerBacking & {
-    providerTemplateBacking: ProviderTemplateBacking | null;
-    ownerIntegration: Integration | null;
-    integration: Integration | null;
-    integrationInstance: IntegrationInstance;
-    sessionTemplate: SessionTemplate;
-    ephemeralManagedSession: EphemeralManagedSession;
-    actor: IdentityActor | null;
+    providerTemplateBacking: Pick<ProviderTemplateBacking, 'id'> | null;
+    ownerIntegration: Pick<Integration, 'id'> | null;
+    integration: Pick<Integration, 'id'> | null;
+    integrationInstance: Pick<IntegrationInstance, 'id'>;
+    sessionTemplate: Pick<SessionTemplate, 'id'>;
+    ephemeralManagedSession: Pick<
+      EphemeralManagedSession,
+      'id' | 'willRotateAt' | 'isReconciling'
+    >;
+    actor: Pick<IdentityActor, 'id'> | null;
   }
 ) => ({
   object: 'magic_mcp.server_backing',
@@ -78,6 +81,7 @@ export let magicMcpServerBackingPresenter = (
   integrationInstanceId: backing.integrationInstance.id,
   sessionTemplateId: backing.sessionTemplate.id,
   ephemeralManagedSessionId: backing.ephemeralManagedSession.id,
+  isReconciling: backing.ephemeralManagedSession.isReconciling,
   willRotateAt: backing.ephemeralManagedSession.willRotateAt,
   identityActorId: backing.actor?.id ?? null,
   createdAt: backing.createdAt
@@ -85,7 +89,7 @@ export let magicMcpServerBackingPresenter = (
 
 export let magicMcpEndpointServerBackingPresenter = (
   backing: MagicMcpEndpointServerBacking & {
-    magicMcpServerBacking: MagicMcpServerBacking;
+    magicMcpServerBacking: Pick<MagicMcpServerBacking, 'id'>;
   }
 ) => ({
   object: 'magic_mcp.endpoint_server_backing',
@@ -96,12 +100,15 @@ export let magicMcpEndpointServerBackingPresenter = (
 
 export let magicMcpEndpointBackingPresenter = (
   backing: MagicMcpEndpointBacking & {
-    integrationGroup: IntegrationInstanceGroup;
-    sessionTemplate: SessionTemplate;
-    ephemeralManagedSession: EphemeralManagedSession;
-    actor: IdentityActor | null;
+    integrationGroup: Pick<IntegrationInstanceGroup, 'id'>;
+    sessionTemplate: Pick<SessionTemplate, 'id'>;
+    ephemeralManagedSession: Pick<
+      EphemeralManagedSession,
+      'id' | 'willRotateAt' | 'isReconciling'
+    >;
+    actor: Pick<IdentityActor, 'id'> | null;
     servers: (MagicMcpEndpointServerBacking & {
-      magicMcpServerBacking: MagicMcpServerBacking;
+      magicMcpServerBacking: Pick<MagicMcpServerBacking, 'id'>;
     })[];
   }
 ) => ({
@@ -110,6 +117,7 @@ export let magicMcpEndpointBackingPresenter = (
   integrationInstanceGroupId: backing.integrationGroup.id,
   sessionTemplateId: backing.sessionTemplate.id,
   ephemeralManagedSessionId: backing.ephemeralManagedSession.id,
+  isReconciling: backing.ephemeralManagedSession.isReconciling,
   willRotateAt: backing.ephemeralManagedSession.willRotateAt,
   identityActorId: backing.actor?.id ?? null,
   servers: backing.servers.map(magicMcpEndpointServerBackingPresenter),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Magic MCP backing/session creation and introduces deferred reconciliation via queues, which can affect connect-time readiness and session resolution if the new reconciling state isn’t updated correctly. Includes schema changes and new polling logic that could impact performance/latency under load.
> 
> **Overview**
> **Hardens Magic MCP backing lifecycle by making reconciliation explicit and asynchronous.** Adds `isSubspaceBackingReconciling` to Magic MCP servers/endpoints and propagates a `deferReconcile` flag through backing upserts so resources can be created immediately while reconciliation runs later.
> 
> Connect/session resolution now **waits/polls for backing readiness** (`waitForMagicMcp*BackingReady`) and forces synchronous reconciliation when needed (`deferReconcile: false`). Creation/update flows for Magic MCP servers/endpoints stop doing inline backing work and instead mark reconciling and rely on lifecycle queues.
> 
> On the Subspace side, adds `EphemeralManagedSession.isReconciling`, persists endpoint-server `toolFilters`, and introduces a new `magicMcpBackingReconcile` queue to run session-template/provider reconciliation and then clear `isReconciling`. Lifecycle processors skip session-template work for `isMagicMcpBacking` integration instances/groups, and presenters/controllers expose the reconciling state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59d3efacb37cecfc0e6de110e0552d32e0b295c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->