### PR TITLE
Revert deploy changes and add transpileOnly

### DIFF
--- a/src/systems/function-bay/packages/nodejs/src/index.ts
+++ b/src/systems/function-bay/packages/nodejs/src/index.ts
@@ -147,7 +147,7 @@ export let build = async (): Promise<void> => {
   }
 
   let outputTempDir = await tempDir();
-  await $`ncc build ${launcher.entrypoint} -o ${outputTempDir} --minify --source-map --debug --target es2020`.env(
+  await $`ncc build ${launcher.entrypoint} -o ${outputTempDir} --minify --source-map --debug --target es2020 --transpile-only`.env(
     env
   );
 

--- a/src/systems/function-bay/service/src/providers/aws-lambda/deploy.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/deploy.ts
@@ -155,64 +155,30 @@ let nodeProxyWrapper = (originalHandler: string, bootstrapCode: string) => `
 ${bootstrapCode}
 const originalHandler = ${JSON.stringify(originalHandler)};
 const [modulePath, exportName = 'handler'] = originalHandler.split(/\\.([^.]*)$/).filter(Boolean);
-const fs = require('fs');
 const path = require('path');
 const { pathToFileURL } = require('url');
 let loaded;
 
-function getModuleCandidates() {
-  if (/\\.[cm]?js$/.test(modulePath)) return [modulePath];
-  return [modulePath, modulePath + '.js', modulePath + '.cjs', modulePath + '.mjs'];
-}
-
-function resolveOriginalModulePath() {
-  const candidates = getModuleCandidates();
-  for (const candidate of candidates) {
-    const resolved = path.resolve(__dirname, candidate);
-    if (fs.existsSync(resolved)) return resolved;
-  }
-
-  let availableFiles = [];
-  try {
-    availableFiles = fs.readdirSync(__dirname).sort();
-  } catch {}
-
-  throw new Error(
-    'Original handler module not found. Handler=' +
-      originalHandler +
-      '; tried=' +
-      candidates.join(', ') +
-      '; available=' +
-      availableFiles.join(', ')
-  );
-}
-
 async function loadOriginalModule() {
-  const resolvedModulePath = resolveOriginalModulePath();
-
   try {
-    return await import(pathToFileURL(resolvedModulePath).href);
+    return require('./' + modulePath);
   } catch (err) {
-    if (err && err.code === 'ERR_UNKNOWN_FILE_EXTENSION') {
-      return require(resolvedModulePath);
+    const candidates = [
+      modulePath,
+      /\\.[cm]?js$/.test(modulePath) ? undefined : modulePath + '.js',
+      /\\.[cm]?js$/.test(modulePath) ? undefined : modulePath + '.mjs'
+    ].filter(Boolean);
+
+    let lastError = err;
+    for (const candidate of candidates) {
+      try {
+        return await import(pathToFileURL(path.resolve(__dirname, candidate)).href);
+      } catch (importErr) {
+        lastError = importErr;
+      }
     }
-
-    throw err;
+    throw lastError;
   }
-}
-
-function getHandler(moduleExports) {
-  if (typeof moduleExports[exportName] === 'function') return moduleExports[exportName];
-
-  if (moduleExports.default && typeof moduleExports.default[exportName] === 'function') {
-    return moduleExports.default[exportName];
-  }
-
-  if (exportName === 'default' && typeof moduleExports.default === 'function') {
-    return moduleExports.default;
-  }
-
-  return undefined;
 }
 
 exports.handler = async (event, context) => {
@@ -220,7 +186,7 @@ exports.handler = async (event, context) => {
   if (!loaded) {
     loaded = await loadOriginalModule();
   }
-  const handler = getHandler(loaded);
+  const handler = loaded[exportName];
   if (typeof handler !== 'function') throw new Error('Original handler export not found');
   return await handler(event, context);
 };
@@ -306,10 +272,7 @@ let prepareZip = async (d: {
   }
 
   let zip = await JSZip.loadAsync(zipBytes);
-  zip.file(
-    'metorial_deflector_wrapper.cjs',
-    await buildNodeProxyWrapper(d.runtimeConfig.handler)
-  );
+  zip.file('metorial_deflector_wrapper.cjs', await buildNodeProxyWrapper(d.runtimeConfig.handler));
 
   return {
     zipBytes: Buffer.from(await zip.generateAsync({ type: 'uint8array' })),

--- a/src/systems/slates/apps/hub/src/queues/deployment/packageFiles.test.ts
+++ b/src/systems/slates/apps/hub/src/queues/deployment/packageFiles.test.ts
@@ -61,6 +61,37 @@ describe('buildSlateDeploymentFiles', () => {
     expect(result.files.some(file => file.filename === 'logo.png')).toBe(false);
   });
 
+  it('runs ncc slate build scripts without type checking', () => {
+    let result = buildSlateDeploymentFiles([
+      {
+        path: 'package.json',
+        buffer: Buffer.from(
+          JSON.stringify({
+            name: '@scope/unbuilt-slate',
+            version: '1.0.0',
+            scripts: {
+              build: 'bunx @vercel/ncc build src/index.ts -o dist -m -s'
+            }
+          })
+        )
+      },
+      {
+        path: 'src/index.ts',
+        buffer: Buffer.from('export let provider = {};')
+      }
+    ]);
+
+    expect(result.slateEntrypoint).toBe('src/index.ts');
+
+    let packageJson = JSON.parse(getFile(result.files, 'package.json').content);
+    expect(packageJson.scripts.build).toBe(
+      'bunx @vercel/ncc build src/index.ts -o dist -m -s --transpile-only'
+    );
+
+    let functionBayJson = JSON.parse(getFile(result.files, 'function-bay.json').content);
+    expect(functionBayJson.scripts).toBeUndefined();
+  });
+
   it('prefers the prebuilt dist entrypoint and keeps sourcemap files', () => {
     let result = buildSlateDeploymentFiles([
       {
@@ -105,44 +136,5 @@ describe('buildSlateDeploymentFiles', () => {
     expect(Buffer.from(mapFile.content, 'base64').toString('utf-8')).toContain(
       '"file":"index.js"'
     );
-  });
-
-  it('uses packed dist output instead of rebuilding a source main', () => {
-    let result = buildSlateDeploymentFiles([
-      {
-        path: 'package.json',
-        buffer: Buffer.from(
-          JSON.stringify({
-            name: '@scope/prebuilt-slate-with-source-main',
-            version: '3.0.0',
-            main: 'src/index.ts',
-            scripts: {
-              build: 'bunx @vercel/ncc build src/index.ts -o dist -m -s'
-            }
-          })
-        )
-      },
-      {
-        path: 'src/index.ts',
-        buffer: Buffer.from('export let provider = "source";')
-      },
-      {
-        path: 'dist/index.js',
-        buffer: Buffer.from('export let provider = "dist";')
-      }
-    ]);
-
-    expect(result.slateEntrypoint).toBe('dist/index.js');
-    expect(getFile(result.files, 'slates_entry_point.js').content).toContain(
-      "import { provider } from './dist/index.js';"
-    );
-
-    let functionBayJson = JSON.parse(getFile(result.files, 'function-bay.json').content);
-    expect(functionBayJson).toMatchObject({
-      entrypoint: 'slates_entry_point.js',
-      scripts: {
-        build: expect.stringContaining('Skipping slate build')
-      }
-    });
   });
 });

--- a/src/systems/slates/apps/hub/src/queues/deployment/packageFiles.ts
+++ b/src/systems/slates/apps/hub/src/queues/deployment/packageFiles.ts
@@ -3,6 +3,13 @@ type DeploymentArchiveFile = {
   buffer: Buffer;
 };
 
+type SlatePackageJson = {
+  [key: string]: any;
+  main?: string;
+  dependencies?: Record<string, any>;
+  scripts?: Record<string, string | undefined>;
+};
+
 let logoFiles = ['png', 'jpg', 'jpeg', 'svg'].map(ext => `logo.${ext}`);
 let wrapperDependencies = {
   '@slates/provider-handler': 'latest',
@@ -54,7 +61,7 @@ let getEntrypointCandidates = (value: string) => {
 
 let getSlateEntrypoint = (
   files: DeploymentArchiveFile[],
-  packageJson: { main?: string } | null
+  packageJson: Pick<SlatePackageJson, 'main'> | null
 ): string => {
   if (packageJson?.main) {
     for (let candidate of getEntrypointCandidates(packageJson.main)) {
@@ -71,8 +78,8 @@ let getSlateEntrypoint = (
   );
 };
 
-let getMergedPackageJson = (packageJson: Record<string, any> | null) => {
-  let mergedPackageJson = {
+let getMergedPackageJson = (packageJson: SlatePackageJson | null) => {
+  let mergedPackageJson: SlatePackageJson = {
     ...(packageJson ?? {
       name: 'slate-version-function',
       version: '1.0.0'
@@ -108,7 +115,7 @@ let getFunctionBayConfig = (slateEntrypoint: string) => ({
 
 export let buildSlateDeploymentFiles = (files: DeploymentArchiveFile[]) => {
   let packageJsonFile = getArchiveFile(files, 'package.json');
-  let packageJson: Record<string, any> | null = null;
+  let packageJson: SlatePackageJson | null = null;
 
   if (packageJsonFile) {
     try {

--- a/src/systems/slates/apps/hub/src/queues/deployment/packageFiles.ts
+++ b/src/systems/slates/apps/hub/src/queues/deployment/packageFiles.ts
@@ -11,19 +11,29 @@ let wrapperDependencies = {
   '@lowerdeck/serialize': 'latest'
 };
 let entrypointExtensions = ['.ts', '.js', '.cjs', '.mjs'];
-let prebuiltEntrypoints = ['dist/index.js', 'dist/index.cjs', 'dist/index.mjs'];
 let fallbackEntrypoints = [
-  ...prebuiltEntrypoints,
   'src/index.ts',
   'src/index.js',
   'index.ts',
-  'index.js'
+  'index.js',
+  'dist/index.js'
 ];
 
 let getArchiveFile = (files: DeploymentArchiveFile[], path: string) =>
   files.find(file => file.path === path);
 
 let normalizeArchivePath = (value: string) => value.replace(/^\.\/+/, '').replace(/^\/+/, '');
+
+let nccBuildPattern = /(^|\s)(?:@vercel\/)?ncc\s+build(\s|$)/;
+let nccTranspileOnlyPattern = /(^|\s)--transpile-only(\s|$)/;
+
+let ensureNccTranspileOnly = (buildScript: string | undefined) => {
+  if (!buildScript) return buildScript;
+  if (!nccBuildPattern.test(buildScript)) return buildScript;
+  if (nccTranspileOnlyPattern.test(buildScript)) return buildScript;
+
+  return `${buildScript} --transpile-only`;
+};
 
 let getEntrypointCandidates = (value: string) => {
   let normalized = normalizeArchivePath(value);
@@ -48,15 +58,7 @@ let getSlateEntrypoint = (
 ): string => {
   if (packageJson?.main) {
     for (let candidate of getEntrypointCandidates(packageJson.main)) {
-      if (getArchiveFile(files, candidate)) {
-        if (candidate.startsWith('src/') || candidate.endsWith('.ts')) {
-          for (let prebuiltEntrypoint of prebuiltEntrypoints) {
-            if (getArchiveFile(files, prebuiltEntrypoint)) return prebuiltEntrypoint;
-          }
-        }
-
-        return candidate;
-      }
+      if (getArchiveFile(files, candidate)) return candidate;
     }
   }
 
@@ -69,16 +71,29 @@ let getSlateEntrypoint = (
   );
 };
 
-let getMergedPackageJson = (packageJson: Record<string, any> | null) => ({
-  ...(packageJson ?? {
-    name: 'slate-version-function',
-    version: '1.0.0'
-  }),
-  dependencies: {
-    ...(packageJson?.dependencies ?? {}),
-    ...wrapperDependencies
-  }
-});
+let getMergedPackageJson = (packageJson: Record<string, any> | null) => {
+  let mergedPackageJson = {
+    ...(packageJson ?? {
+      name: 'slate-version-function',
+      version: '1.0.0'
+    }),
+    dependencies: {
+      ...(packageJson?.dependencies ?? {}),
+      ...wrapperDependencies
+    }
+  };
+
+  let buildScript = ensureNccTranspileOnly(mergedPackageJson.scripts?.build);
+  if (!buildScript) return mergedPackageJson;
+
+  return {
+    ...mergedPackageJson,
+    scripts: {
+      ...mergedPackageJson.scripts,
+      build: buildScript
+    }
+  };
+};
 
 let getFunctionBayConfig = (slateEntrypoint: string) => ({
   entrypoint: 'slates_entry_point.js',


### PR DESCRIPTION
Revert deploy changes and add transpileOnly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Node.js build/bundling flags and AWS Lambda handler resolution logic, which can affect runtime module loading and deploy-time packaging behavior.
> 
> **Overview**
> Updates Node.js bundling to run `ncc build` with `--transpile-only`, avoiding TypeScript type-checking during packaging.
> 
> Simplifies the AWS Lambda deflector wrapper’s handler loader to prefer `require()` and fall back to ESM `import()` with a smaller set of candidates, and drops the previous explicit file-existence resolution and export-detection logic.
> 
> Adjusts slate deployment packaging to stop auto-preferring `dist/` when `main` points at `src/`, and to automatically append `--transpile-only` to `ncc build` scripts found in `package.json`; related tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60dd58e18fb9c0442444bdbc6c67d3354d13405f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->