### PR TITLE
Harden custom providers

### DIFF
--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/custom-providers.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/custom-providers.ts
@@ -6,6 +6,7 @@ import {
 import {
   mapDashboardInstanceCustomProvidersCreateBody,
   mapDashboardInstanceCustomProvidersCreateOutput,
+  mapDashboardInstanceCustomProvidersGetEnvOutput,
   mapDashboardInstanceCustomProvidersGetOutput,
   mapDashboardInstanceCustomProvidersListOutput,
   mapDashboardInstanceCustomProvidersListQuery,
@@ -13,6 +14,7 @@ import {
   mapDashboardInstanceCustomProvidersUpdateOutput,
   type DashboardInstanceCustomProvidersCreateBody,
   type DashboardInstanceCustomProvidersCreateOutput,
+  type DashboardInstanceCustomProvidersGetEnvOutput,
   type DashboardInstanceCustomProvidersGetOutput,
   type DashboardInstanceCustomProvidersListOutput,
   type DashboardInstanceCustomProvidersListQuery,
@@ -101,6 +103,33 @@ export class MetorialCustomProvidersEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstanceCustomProvidersGetOutput
+    );
+  }
+
+  /**
+   * @name Get custom provider environment
+   * @description Retrieves the environment variables for a specific custom provider by ID.
+   *
+   * @param `customProviderId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceCustomProvidersGetEnvOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  getEnv(
+    customProviderId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceCustomProvidersGetEnvOutput> {
+    let path = `custom-providers/${customProviderId}/env`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardInstanceCustomProvidersGetEnvOutput
     );
   }
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/custom-providers_versions.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/custom-providers_versions.ts
@@ -6,11 +6,13 @@ import {
 import {
   mapDashboardInstanceCustomProvidersVersionsCreateBody,
   mapDashboardInstanceCustomProvidersVersionsCreateOutput,
+  mapDashboardInstanceCustomProvidersVersionsGetEnvOutput,
   mapDashboardInstanceCustomProvidersVersionsGetOutput,
   mapDashboardInstanceCustomProvidersVersionsListOutput,
   mapDashboardInstanceCustomProvidersVersionsListQuery,
   type DashboardInstanceCustomProvidersVersionsCreateBody,
   type DashboardInstanceCustomProvidersVersionsCreateOutput,
+  type DashboardInstanceCustomProvidersVersionsGetEnvOutput,
   type DashboardInstanceCustomProvidersVersionsGetOutput,
   type DashboardInstanceCustomProvidersVersionsListOutput,
   type DashboardInstanceCustomProvidersVersionsListQuery
@@ -99,6 +101,33 @@ export class MetorialCustomProvidersVersionsEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstanceCustomProvidersVersionsGetOutput
+    );
+  }
+
+  /**
+   * @name Get custom provider version environment
+   * @description Retrieves the environment variables for a specific version of a custom provider.
+   *
+   * @param `customProviderVersionId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceCustomProvidersVersionsGetEnvOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  getEnv(
+    customProviderVersionId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceCustomProvidersVersionsGetEnvOutput> {
+    let path = `custom-provider-versions/${customProviderVersionId}/env`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardInstanceCustomProvidersVersionsGetEnvOutput
     );
   }
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_custom-providers.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_custom-providers.ts
@@ -6,6 +6,7 @@ import {
 import {
   mapDashboardInstanceCustomProvidersCreateBody,
   mapDashboardInstanceCustomProvidersCreateOutput,
+  mapDashboardInstanceCustomProvidersGetEnvOutput,
   mapDashboardInstanceCustomProvidersGetOutput,
   mapDashboardInstanceCustomProvidersListOutput,
   mapDashboardInstanceCustomProvidersListQuery,
@@ -13,6 +14,7 @@ import {
   mapDashboardInstanceCustomProvidersUpdateOutput,
   type DashboardInstanceCustomProvidersCreateBody,
   type DashboardInstanceCustomProvidersCreateOutput,
+  type DashboardInstanceCustomProvidersGetEnvOutput,
   type DashboardInstanceCustomProvidersGetOutput,
   type DashboardInstanceCustomProvidersListOutput,
   type DashboardInstanceCustomProvidersListQuery,
@@ -105,6 +107,35 @@ export class MetorialDashboardInstanceCustomProvidersEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstanceCustomProvidersGetOutput
+    );
+  }
+
+  /**
+   * @name Get custom provider environment
+   * @description Retrieves the environment variables for a specific custom provider by ID.
+   *
+   * @param `instanceId` - string
+   * @param `customProviderId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceCustomProvidersGetEnvOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  getEnv(
+    instanceId: string,
+    customProviderId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceCustomProvidersGetEnvOutput> {
+    let path = `dashboard/instances/${instanceId}/custom-providers/${customProviderId}/env`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardInstanceCustomProvidersGetEnvOutput
     );
   }
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_custom-providers_versions.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_custom-providers_versions.ts
@@ -6,11 +6,13 @@ import {
 import {
   mapDashboardInstanceCustomProvidersVersionsCreateBody,
   mapDashboardInstanceCustomProvidersVersionsCreateOutput,
+  mapDashboardInstanceCustomProvidersVersionsGetEnvOutput,
   mapDashboardInstanceCustomProvidersVersionsGetOutput,
   mapDashboardInstanceCustomProvidersVersionsListOutput,
   mapDashboardInstanceCustomProvidersVersionsListQuery,
   type DashboardInstanceCustomProvidersVersionsCreateBody,
   type DashboardInstanceCustomProvidersVersionsCreateOutput,
+  type DashboardInstanceCustomProvidersVersionsGetEnvOutput,
   type DashboardInstanceCustomProvidersVersionsGetOutput,
   type DashboardInstanceCustomProvidersVersionsListOutput,
   type DashboardInstanceCustomProvidersVersionsListQuery
@@ -103,6 +105,35 @@ export class MetorialDashboardInstanceCustomProvidersVersionsEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstanceCustomProvidersVersionsGetOutput
+    );
+  }
+
+  /**
+   * @name Get custom provider version environment
+   * @description Retrieves the environment variables for a specific version of a custom provider.
+   *
+   * @param `instanceId` - string
+   * @param `customProviderVersionId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceCustomProvidersVersionsGetEnvOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  getEnv(
+    instanceId: string,
+    customProviderVersionId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceCustomProvidersVersionsGetEnvOutput> {
+    let path = `dashboard/instances/${instanceId}/custom-provider-versions/${customProviderVersionId}/env`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardInstanceCustomProvidersVersionsGetEnvOutput
     );
   }
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_projects_configure_auth-config.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_projects_configure_auth-config.ts
@@ -1,0 +1,102 @@
+import {
+  BaseMetorialEndpoint,
+  MetorialEndpointManager
+} from '@metorial/util-endpoint';
+
+import {
+  mapDashboardProjectsConfigureAuthConfigGetOutput,
+  mapDashboardProjectsConfigureAuthConfigUpdateBody,
+  mapDashboardProjectsConfigureAuthConfigUpdateOutput,
+  type DashboardProjectsConfigureAuthConfigGetOutput,
+  type DashboardProjectsConfigureAuthConfigUpdateBody,
+  type DashboardProjectsConfigureAuthConfigUpdateOutput
+} from '../resources';
+
+/**
+ * @name Project configuration controller
+ * @description Configure project-level settings
+ *
+ * @see https://metorial.com/api
+ * @see https://metorial.com/docs
+ */
+export class MetorialDashboardProjectsConfigureAuthConfigEndpoint {
+  constructor(private readonly _manager: MetorialEndpointManager<any>) {}
+
+  // thin proxies so method bodies stay unchanged
+  private _get(request: any) {
+    return this._manager._get(request);
+  }
+  private _post(request: any) {
+    return this._manager._post(request);
+  }
+  private _put(request: any) {
+    return this._manager._put(request);
+  }
+  private _patch(request: any) {
+    return this._manager._patch(request);
+  }
+  private _delete(request: any) {
+    return this._manager._delete(request);
+  }
+
+  /**
+   * @name Get project auth config configuration
+   * @description Get auth config export/import settings for a project
+   *
+   * @param `organizationId` - string
+   * @param `projectId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardProjectsConfigureAuthConfigGetOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  get(
+    organizationId: string,
+    projectId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardProjectsConfigureAuthConfigGetOutput> {
+    let path = `dashboard/organizations/${organizationId}/projects/${projectId}/configure/auth-config`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardProjectsConfigureAuthConfigGetOutput
+    );
+  }
+
+  /**
+   * @name Update project auth config configuration
+   * @description Update auth config export/import settings for a project
+   *
+   * @param `organizationId` - string
+   * @param `projectId` - string
+   * @param `body` - DashboardProjectsConfigureAuthConfigUpdateBody
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardProjectsConfigureAuthConfigUpdateOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  update(
+    organizationId: string,
+    projectId: string,
+    body: DashboardProjectsConfigureAuthConfigUpdateBody,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardProjectsConfigureAuthConfigUpdateOutput> {
+    let path = `dashboard/organizations/${organizationId}/projects/${projectId}/configure/auth-config`;
+
+    let request = {
+      path,
+      body: mapDashboardProjectsConfigureAuthConfigUpdateBody.transformTo(body),
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._patch(request).transform(
+      mapDashboardProjectsConfigureAuthConfigUpdateOutput
+    );
+  }
+}

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/index.ts
@@ -164,6 +164,7 @@ export * from './dashboard_organizations_service-accounts_policies';
 export * from './dashboard_organizations_teams';
 export * from './dashboard_organizations_teams_members';
 export * from './dashboard_organizations_teams_policies';
+export * from './dashboard_projects_configure_auth-config';
 export * from './dashboard_projects_configure_retention';
 export * from './dashboard_usage';
 export * from './documents';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/management_instance_custom-providers.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/management_instance_custom-providers.ts
@@ -6,6 +6,7 @@ import {
 import {
   mapDashboardInstanceCustomProvidersCreateBody,
   mapDashboardInstanceCustomProvidersCreateOutput,
+  mapDashboardInstanceCustomProvidersGetEnvOutput,
   mapDashboardInstanceCustomProvidersGetOutput,
   mapDashboardInstanceCustomProvidersListOutput,
   mapDashboardInstanceCustomProvidersListQuery,
@@ -13,6 +14,7 @@ import {
   mapDashboardInstanceCustomProvidersUpdateOutput,
   type DashboardInstanceCustomProvidersCreateBody,
   type DashboardInstanceCustomProvidersCreateOutput,
+  type DashboardInstanceCustomProvidersGetEnvOutput,
   type DashboardInstanceCustomProvidersGetOutput,
   type DashboardInstanceCustomProvidersListOutput,
   type DashboardInstanceCustomProvidersListQuery,
@@ -105,6 +107,35 @@ export class MetorialManagementInstanceCustomProvidersEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstanceCustomProvidersGetOutput
+    );
+  }
+
+  /**
+   * @name Get custom provider environment
+   * @description Retrieves the environment variables for a specific custom provider by ID.
+   *
+   * @param `instanceId` - string
+   * @param `customProviderId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceCustomProvidersGetEnvOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  getEnv(
+    instanceId: string,
+    customProviderId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceCustomProvidersGetEnvOutput> {
+    let path = `instances/${instanceId}/custom-providers/${customProviderId}/env`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardInstanceCustomProvidersGetEnvOutput
     );
   }
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/management_instance_custom-providers_versions.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/management_instance_custom-providers_versions.ts
@@ -6,11 +6,13 @@ import {
 import {
   mapDashboardInstanceCustomProvidersVersionsCreateBody,
   mapDashboardInstanceCustomProvidersVersionsCreateOutput,
+  mapDashboardInstanceCustomProvidersVersionsGetEnvOutput,
   mapDashboardInstanceCustomProvidersVersionsGetOutput,
   mapDashboardInstanceCustomProvidersVersionsListOutput,
   mapDashboardInstanceCustomProvidersVersionsListQuery,
   type DashboardInstanceCustomProvidersVersionsCreateBody,
   type DashboardInstanceCustomProvidersVersionsCreateOutput,
+  type DashboardInstanceCustomProvidersVersionsGetEnvOutput,
   type DashboardInstanceCustomProvidersVersionsGetOutput,
   type DashboardInstanceCustomProvidersVersionsListOutput,
   type DashboardInstanceCustomProvidersVersionsListQuery
@@ -103,6 +105,35 @@ export class MetorialManagementInstanceCustomProvidersVersionsEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstanceCustomProvidersVersionsGetOutput
+    );
+  }
+
+  /**
+   * @name Get custom provider version environment
+   * @description Retrieves the environment variables for a specific version of a custom provider.
+   *
+   * @param `instanceId` - string
+   * @param `customProviderVersionId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceCustomProvidersVersionsGetEnvOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  getEnv(
+    instanceId: string,
+    customProviderVersionId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceCustomProvidersVersionsGetEnvOutput> {
+    let path = `instances/${instanceId}/custom-provider-versions/${customProviderVersionId}/env`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardInstanceCustomProvidersVersionsGetEnvOutput
     );
   }
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/custom-providers/get-env.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/custom-providers/get-env.ts
@@ -1,0 +1,13 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type CustomProvidersGetEnvOutput = {
+  object: 'custom_provider.env';
+  env: Record<string, any> | null;
+};
+
+export let mapCustomProvidersGetEnvOutput =
+  mtMap.object<CustomProvidersGetEnvOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    env: mtMap.objectField('env', mtMap.passthrough())
+  });
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/custom-providers/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/custom-providers/index.ts
@@ -3,6 +3,7 @@ export * from './commits';
 export * from './create';
 export * from './deployments';
 export * from './environments';
+export * from './get-env';
 export * from './get';
 export * from './list';
 export * from './update';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/custom-providers/versions/get-env.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/custom-providers/versions/get-env.ts
@@ -1,0 +1,13 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type CustomProvidersVersionsGetEnvOutput = {
+  object: 'custom_provider.env';
+  env: Record<string, any> | null;
+};
+
+export let mapCustomProvidersVersionsGetEnvOutput =
+  mtMap.object<CustomProvidersVersionsGetEnvOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    env: mtMap.objectField('env', mtMap.passthrough())
+  });
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/custom-providers/versions/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/custom-providers/versions/index.ts
@@ -1,3 +1,4 @@
 export * from './create';
+export * from './get-env';
 export * from './get';
 export * from './list';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/custom-providers/get-env.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/custom-providers/get-env.ts
@@ -1,0 +1,13 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type DashboardInstanceCustomProvidersGetEnvOutput = {
+  object: 'custom_provider.env';
+  env: Record<string, any> | null;
+};
+
+export let mapDashboardInstanceCustomProvidersGetEnvOutput =
+  mtMap.object<DashboardInstanceCustomProvidersGetEnvOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    env: mtMap.objectField('env', mtMap.passthrough())
+  });
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/custom-providers/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/custom-providers/index.ts
@@ -3,6 +3,7 @@ export * from './commits';
 export * from './create';
 export * from './deployments';
 export * from './environments';
+export * from './get-env';
 export * from './get';
 export * from './list';
 export * from './update';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/custom-providers/versions/get-env.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/custom-providers/versions/get-env.ts
@@ -1,0 +1,13 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type DashboardInstanceCustomProvidersVersionsGetEnvOutput = {
+  object: 'custom_provider.env';
+  env: Record<string, any> | null;
+};
+
+export let mapDashboardInstanceCustomProvidersVersionsGetEnvOutput =
+  mtMap.object<DashboardInstanceCustomProvidersVersionsGetEnvOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    env: mtMap.objectField('env', mtMap.passthrough())
+  });
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/custom-providers/versions/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/custom-providers/versions/index.ts
@@ -1,3 +1,4 @@
 export * from './create';
+export * from './get-env';
 export * from './get';
 export * from './list';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/instance-groups/create-session-template.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/instance-groups/create-session-template.ts
@@ -79,6 +79,11 @@ export let mapDashboardInstanceIntegrationsInstanceGroupsCreateSessionTemplateOu
         'integration_instance_group_id',
         mtMap.passthrough()
       ),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
       providers: mtMap.objectField(
         'providers',
         mtMap.array(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/instance-groups/create-session.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/instance-groups/create-session.ts
@@ -224,7 +224,10 @@ export let mapDashboardInstanceIntegrationsInstanceGroupsCreateSessionOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/instances/create-session-template.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/instances/create-session-template.ts
@@ -79,6 +79,11 @@ export let mapDashboardInstanceIntegrationsInstancesCreateSessionTemplateOutput 
         'integration_instance_group_id',
         mtMap.passthrough()
       ),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
       providers: mtMap.objectField(
         'providers',
         mtMap.array(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/instances/create-session.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/integrations/instances/create-session.ts
@@ -224,7 +224,10 @@ export let mapDashboardInstanceIntegrationsInstancesCreateSessionOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/magic-mcp-servers/session/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/magic-mcp-servers/session/create.ts
@@ -224,7 +224,10 @@ export let mapDashboardInstanceMagicMcpServersSessionCreateOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/session-templates/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/session-templates/create.ts
@@ -77,7 +77,10 @@ export let mapDashboardInstanceSessionTemplatesCreateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/session-templates/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/session-templates/delete.ts
@@ -77,7 +77,10 @@ export let mapDashboardInstanceSessionTemplatesDeleteOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/session-templates/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/session-templates/get.ts
@@ -77,7 +77,10 @@ export let mapDashboardInstanceSessionTemplatesGetOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/session-templates/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/session-templates/list.ts
@@ -84,6 +84,11 @@ export let mapDashboardInstanceSessionTemplatesListOutput =
             'integration_instance_group_id',
             mtMap.passthrough()
           ),
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
           providers: mtMap.objectField(
             'providers',
             mtMap.array(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/session-templates/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/session-templates/update.ts
@@ -77,7 +77,10 @@ export let mapDashboardInstanceSessionTemplatesUpdateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/connections/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/connections/get.ts
@@ -100,6 +100,8 @@ export let mapDashboardInstanceSessionsConnectionsGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/connections/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/connections/list.ts
@@ -28,8 +28,8 @@ export type DashboardInstanceSessionsConnectionsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -114,6 +114,11 @@ export let mapDashboardInstanceSessionsConnectionsListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/create.ts
@@ -224,7 +224,10 @@ export let mapDashboardInstanceSessionsCreateOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/delete.ts
@@ -224,7 +224,10 @@ export let mapDashboardInstanceSessionsDeleteOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/events/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/events/get.ts
@@ -44,8 +44,8 @@ export type DashboardInstanceSessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -125,8 +125,8 @@ export type DashboardInstanceSessionsEventsGetOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -143,8 +143,8 @@ export type DashboardInstanceSessionsEventsGetOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -202,8 +202,8 @@ export type DashboardInstanceSessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -220,8 +220,8 @@ export type DashboardInstanceSessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -343,6 +343,11 @@ export let mapDashboardInstanceSessionsEventsGetOutput =
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(
@@ -507,6 +512,14 @@ export let mapDashboardInstanceSessionsEventsGetOutput =
                   'identity_actor_id',
                   mtMap.passthrough()
                 ),
+                identityId: mtMap.objectField(
+                  'identity_id',
+                  mtMap.passthrough()
+                ),
+                agentActorId: mtMap.objectField(
+                  'agent_actor_id',
+                  mtMap.passthrough()
+                ),
                 agentClientId: mtMap.objectField(
                   'agent_client_id',
                   mtMap.passthrough()
@@ -554,6 +567,14 @@ export let mapDashboardInstanceSessionsEventsGetOutput =
                 ),
                 identityActorId: mtMap.objectField(
                   'identity_actor_id',
+                  mtMap.passthrough()
+                ),
+                identityId: mtMap.objectField(
+                  'identity_id',
+                  mtMap.passthrough()
+                ),
+                agentActorId: mtMap.objectField(
+                  'agent_actor_id',
                   mtMap.passthrough()
                 ),
                 agentClientId: mtMap.objectField(
@@ -692,6 +713,11 @@ export let mapDashboardInstanceSessionsEventsGetOutput =
               'identity_actor_id',
               mtMap.passthrough()
             ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
+              mtMap.passthrough()
+            ),
             agentClientId: mtMap.objectField(
               'agent_client_id',
               mtMap.passthrough()
@@ -730,6 +756,11 @@ export let mapDashboardInstanceSessionsEventsGetOutput =
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/events/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/events/list.ts
@@ -45,8 +45,8 @@ export type DashboardInstanceSessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -126,8 +126,8 @@ export type DashboardInstanceSessionsEventsListOutput = {
           agentId: string | null;
           agentInstanceId: string | null;
           identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+          identityId: string | null;
+          agentActorId: string | null;
           agentClientId: string | null;
           consumerId: string | null;
           createdAt: Date;
@@ -144,8 +144,8 @@ export type DashboardInstanceSessionsEventsListOutput = {
           agentId: string | null;
           agentInstanceId: string | null;
           identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+          identityId: string | null;
+          agentActorId: string | null;
           agentClientId: string | null;
           consumerId: string | null;
           createdAt: Date;
@@ -206,8 +206,8 @@ export type DashboardInstanceSessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -224,8 +224,8 @@ export type DashboardInstanceSessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -359,6 +359,14 @@ export let mapDashboardInstanceSessionsEventsListOutput =
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(
@@ -550,6 +558,14 @@ export let mapDashboardInstanceSessionsEventsListOutput =
                         'identity_actor_id',
                         mtMap.passthrough()
                       ),
+                      identityId: mtMap.objectField(
+                        'identity_id',
+                        mtMap.passthrough()
+                      ),
+                      agentActorId: mtMap.objectField(
+                        'agent_actor_id',
+                        mtMap.passthrough()
+                      ),
                       agentClientId: mtMap.objectField(
                         'agent_client_id',
                         mtMap.passthrough()
@@ -600,6 +616,14 @@ export let mapDashboardInstanceSessionsEventsListOutput =
                       ),
                       identityActorId: mtMap.objectField(
                         'identity_actor_id',
+                        mtMap.passthrough()
+                      ),
+                      identityId: mtMap.objectField(
+                        'identity_id',
+                        mtMap.passthrough()
+                      ),
+                      agentActorId: mtMap.objectField(
+                        'agent_actor_id',
                         mtMap.passthrough()
                       ),
                       agentClientId: mtMap.objectField(
@@ -759,6 +783,14 @@ export let mapDashboardInstanceSessionsEventsListOutput =
                     'identity_actor_id',
                     mtMap.passthrough()
                   ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
+                    mtMap.passthrough()
+                  ),
                   agentClientId: mtMap.objectField(
                     'agent_client_id',
                     mtMap.passthrough()
@@ -806,6 +838,14 @@ export let mapDashboardInstanceSessionsEventsListOutput =
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/get.ts
@@ -224,7 +224,10 @@ export let mapDashboardInstanceSessionsGetOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/list.ts
@@ -258,8 +258,11 @@ export let mapDashboardInstanceSessionsListOutput =
           ),
           hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
           hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
           updatedAt: mtMap.objectField('updated_at', mtMap.date())
         })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/messages/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/messages/get.ts
@@ -57,8 +57,8 @@ export type DashboardInstanceSessionsMessagesGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -75,8 +75,8 @@ export type DashboardInstanceSessionsMessagesGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -285,6 +285,11 @@ export let mapDashboardInstanceSessionsMessagesGetOutput =
               'identity_actor_id',
               mtMap.passthrough()
             ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
+              mtMap.passthrough()
+            ),
             agentClientId: mtMap.objectField(
               'agent_client_id',
               mtMap.passthrough()
@@ -323,6 +328,11 @@ export let mapDashboardInstanceSessionsMessagesGetOutput =
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(
@@ -446,6 +456,8 @@ export let mapDashboardInstanceSessionsMessagesGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()
@@ -483,6 +495,8 @@ export let mapDashboardInstanceSessionsMessagesGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/messages/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/messages/list.ts
@@ -58,8 +58,8 @@ export type DashboardInstanceSessionsMessagesListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -76,8 +76,8 @@ export type DashboardInstanceSessionsMessagesListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -135,8 +135,8 @@ export type DashboardInstanceSessionsMessagesListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -153,8 +153,8 @@ export type DashboardInstanceSessionsMessagesListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -310,6 +310,14 @@ export let mapDashboardInstanceSessionsMessagesListOutput =
                     'identity_actor_id',
                     mtMap.passthrough()
                   ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
+                    mtMap.passthrough()
+                  ),
                   agentClientId: mtMap.objectField(
                     'agent_client_id',
                     mtMap.passthrough()
@@ -357,6 +365,14 @@ export let mapDashboardInstanceSessionsMessagesListOutput =
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(
@@ -498,6 +514,11 @@ export let mapDashboardInstanceSessionsMessagesListOutput =
                 'identity_actor_id',
                 mtMap.passthrough()
               ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
+                mtMap.passthrough()
+              ),
               agentClientId: mtMap.objectField(
                 'agent_client_id',
                 mtMap.passthrough()
@@ -536,6 +557,11 @@ export let mapDashboardInstanceSessionsMessagesListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/participants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/participants/list.ts
@@ -54,6 +54,11 @@ export let mapDashboardInstanceSessionsParticipantsListOutput =
             'identity_actor_id',
             mtMap.passthrough()
           ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          agentActorId: mtMap.objectField(
+            'agent_actor_id',
+            mtMap.passthrough()
+          ),
           agentClientId: mtMap.objectField(
             'agent_client_id',
             mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/sessions/update.ts
@@ -224,7 +224,10 @@ export let mapDashboardInstanceSessionsUpdateOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/tool-calls/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/tool-calls/create.ts
@@ -131,6 +131,8 @@ export let mapDashboardInstanceToolCallsCreateOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()
@@ -168,6 +170,8 @@ export let mapDashboardInstanceToolCallsCreateOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/tool-calls/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/tool-calls/get.ts
@@ -131,6 +131,8 @@ export let mapDashboardInstanceToolCallsGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()
@@ -168,6 +170,8 @@ export let mapDashboardInstanceToolCallsGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/tool-calls/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/tool-calls/list.ts
@@ -26,8 +26,8 @@ export type DashboardInstanceToolCallsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -44,8 +44,8 @@ export type DashboardInstanceToolCallsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -144,6 +144,11 @@ export let mapDashboardInstanceToolCallsListOutput =
                 'identity_actor_id',
                 mtMap.passthrough()
               ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
+                mtMap.passthrough()
+              ),
               agentClientId: mtMap.objectField(
                 'agent_client_id',
                 mtMap.passthrough()
@@ -182,6 +187,11 @@ export let mapDashboardInstanceToolCallsListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/auth-config/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/auth-config/get.ts
@@ -1,0 +1,25 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type DashboardProjectsConfigureAuthConfigGetOutput = {
+  object: 'organization.project.auth_config_configuration';
+  projectId: string;
+  allowAuthConfigExport: boolean;
+  allowAuthConfigImport: boolean;
+  updatedAt: Date;
+};
+
+export let mapDashboardProjectsConfigureAuthConfigGetOutput =
+  mtMap.object<DashboardProjectsConfigureAuthConfigGetOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    projectId: mtMap.objectField('project_id', mtMap.passthrough()),
+    allowAuthConfigExport: mtMap.objectField(
+      'allow_auth_config_export',
+      mtMap.passthrough()
+    ),
+    allowAuthConfigImport: mtMap.objectField(
+      'allow_auth_config_import',
+      mtMap.passthrough()
+    ),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+  });
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/auth-config/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/auth-config/index.ts
@@ -1,0 +1,2 @@
+export * from './get';
+export * from './update';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/auth-config/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/auth-config/update.ts
@@ -1,0 +1,42 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type DashboardProjectsConfigureAuthConfigUpdateOutput = {
+  object: 'organization.project.auth_config_configuration';
+  projectId: string;
+  allowAuthConfigExport: boolean;
+  allowAuthConfigImport: boolean;
+  updatedAt: Date;
+};
+
+export let mapDashboardProjectsConfigureAuthConfigUpdateOutput =
+  mtMap.object<DashboardProjectsConfigureAuthConfigUpdateOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    projectId: mtMap.objectField('project_id', mtMap.passthrough()),
+    allowAuthConfigExport: mtMap.objectField(
+      'allow_auth_config_export',
+      mtMap.passthrough()
+    ),
+    allowAuthConfigImport: mtMap.objectField(
+      'allow_auth_config_import',
+      mtMap.passthrough()
+    ),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+  });
+
+export type DashboardProjectsConfigureAuthConfigUpdateBody = {
+  allowAuthConfigExport?: boolean | undefined;
+  allowAuthConfigImport?: boolean | undefined;
+};
+
+export let mapDashboardProjectsConfigureAuthConfigUpdateBody =
+  mtMap.object<DashboardProjectsConfigureAuthConfigUpdateBody>({
+    allowAuthConfigExport: mtMap.objectField(
+      'allow_auth_config_export',
+      mtMap.passthrough()
+    ),
+    allowAuthConfigImport: mtMap.objectField(
+      'allow_auth_config_import',
+      mtMap.passthrough()
+    )
+  });
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/projects/configure/index.ts
@@ -1,1 +1,2 @@
+export * from './auth-config';
 export * from './retention';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/instance-groups/create-session-template.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/instance-groups/create-session-template.ts
@@ -77,7 +77,10 @@ export let mapIntegrationsInstanceGroupsCreateSessionTemplateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/instance-groups/create-session.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/instance-groups/create-session.ts
@@ -224,7 +224,10 @@ export let mapIntegrationsInstanceGroupsCreateSessionOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/instances/create-session-template.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/instances/create-session-template.ts
@@ -77,7 +77,10 @@ export let mapIntegrationsInstancesCreateSessionTemplateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/instances/create-session.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/integrations/instances/create-session.ts
@@ -224,7 +224,10 @@ export let mapIntegrationsInstancesCreateSessionOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/magic-mcp-servers/session/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/magic-mcp-servers/session/create.ts
@@ -224,7 +224,10 @@ export let mapMagicMcpServersSessionCreateOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/custom-providers/get-env.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/custom-providers/get-env.ts
@@ -1,0 +1,13 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type ManagementInstanceCustomProvidersGetEnvOutput = {
+  object: 'custom_provider.env';
+  env: Record<string, any> | null;
+};
+
+export let mapManagementInstanceCustomProvidersGetEnvOutput =
+  mtMap.object<ManagementInstanceCustomProvidersGetEnvOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    env: mtMap.objectField('env', mtMap.passthrough())
+  });
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/custom-providers/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/custom-providers/index.ts
@@ -3,6 +3,7 @@ export * from './commits';
 export * from './create';
 export * from './deployments';
 export * from './environments';
+export * from './get-env';
 export * from './get';
 export * from './list';
 export * from './update';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/custom-providers/versions/get-env.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/custom-providers/versions/get-env.ts
@@ -1,0 +1,13 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type ManagementInstanceCustomProvidersVersionsGetEnvOutput = {
+  object: 'custom_provider.env';
+  env: Record<string, any> | null;
+};
+
+export let mapManagementInstanceCustomProvidersVersionsGetEnvOutput =
+  mtMap.object<ManagementInstanceCustomProvidersVersionsGetEnvOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    env: mtMap.objectField('env', mtMap.passthrough())
+  });
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/custom-providers/versions/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/custom-providers/versions/index.ts
@@ -1,3 +1,4 @@
 export * from './create';
+export * from './get-env';
 export * from './get';
 export * from './list';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/instance-groups/create-session-template.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/instance-groups/create-session-template.ts
@@ -79,6 +79,11 @@ export let mapManagementInstanceIntegrationsInstanceGroupsCreateSessionTemplateO
         'integration_instance_group_id',
         mtMap.passthrough()
       ),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
       providers: mtMap.objectField(
         'providers',
         mtMap.array(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/instance-groups/create-session.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/instance-groups/create-session.ts
@@ -234,8 +234,11 @@ export let mapManagementInstanceIntegrationsInstanceGroupsCreateSessionOutput =
       ),
       hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
       hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
       updatedAt: mtMap.objectField('updated_at', mtMap.date())
     }

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/instances/create-session-template.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/instances/create-session-template.ts
@@ -79,6 +79,11 @@ export let mapManagementInstanceIntegrationsInstancesCreateSessionTemplateOutput
         'integration_instance_group_id',
         mtMap.passthrough()
       ),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
       providers: mtMap.objectField(
         'providers',
         mtMap.array(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/instances/create-session.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/integrations/instances/create-session.ts
@@ -224,7 +224,10 @@ export let mapManagementInstanceIntegrationsInstancesCreateSessionOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/magic-mcp-servers/session/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/magic-mcp-servers/session/create.ts
@@ -224,7 +224,10 @@ export let mapManagementInstanceMagicMcpServersSessionCreateOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/session-templates/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/session-templates/create.ts
@@ -77,7 +77,10 @@ export let mapManagementInstanceSessionTemplatesCreateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/session-templates/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/session-templates/delete.ts
@@ -77,7 +77,10 @@ export let mapManagementInstanceSessionTemplatesDeleteOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/session-templates/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/session-templates/get.ts
@@ -77,7 +77,10 @@ export let mapManagementInstanceSessionTemplatesGetOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/session-templates/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/session-templates/list.ts
@@ -84,6 +84,11 @@ export let mapManagementInstanceSessionTemplatesListOutput =
             'integration_instance_group_id',
             mtMap.passthrough()
           ),
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
           providers: mtMap.objectField(
             'providers',
             mtMap.array(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/session-templates/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/session-templates/update.ts
@@ -77,7 +77,10 @@ export let mapManagementInstanceSessionTemplatesUpdateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/connections/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/connections/get.ts
@@ -100,6 +100,8 @@ export let mapManagementInstanceSessionsConnectionsGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/connections/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/connections/list.ts
@@ -28,8 +28,8 @@ export type ManagementInstanceSessionsConnectionsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -114,6 +114,11 @@ export let mapManagementInstanceSessionsConnectionsListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/create.ts
@@ -224,7 +224,10 @@ export let mapManagementInstanceSessionsCreateOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/delete.ts
@@ -224,7 +224,10 @@ export let mapManagementInstanceSessionsDeleteOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/events/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/events/get.ts
@@ -44,8 +44,8 @@ export type ManagementInstanceSessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -125,8 +125,8 @@ export type ManagementInstanceSessionsEventsGetOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -143,8 +143,8 @@ export type ManagementInstanceSessionsEventsGetOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -202,8 +202,8 @@ export type ManagementInstanceSessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -220,8 +220,8 @@ export type ManagementInstanceSessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -343,6 +343,11 @@ export let mapManagementInstanceSessionsEventsGetOutput =
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(
@@ -507,6 +512,14 @@ export let mapManagementInstanceSessionsEventsGetOutput =
                   'identity_actor_id',
                   mtMap.passthrough()
                 ),
+                identityId: mtMap.objectField(
+                  'identity_id',
+                  mtMap.passthrough()
+                ),
+                agentActorId: mtMap.objectField(
+                  'agent_actor_id',
+                  mtMap.passthrough()
+                ),
                 agentClientId: mtMap.objectField(
                   'agent_client_id',
                   mtMap.passthrough()
@@ -554,6 +567,14 @@ export let mapManagementInstanceSessionsEventsGetOutput =
                 ),
                 identityActorId: mtMap.objectField(
                   'identity_actor_id',
+                  mtMap.passthrough()
+                ),
+                identityId: mtMap.objectField(
+                  'identity_id',
+                  mtMap.passthrough()
+                ),
+                agentActorId: mtMap.objectField(
+                  'agent_actor_id',
                   mtMap.passthrough()
                 ),
                 agentClientId: mtMap.objectField(
@@ -692,6 +713,11 @@ export let mapManagementInstanceSessionsEventsGetOutput =
               'identity_actor_id',
               mtMap.passthrough()
             ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
+              mtMap.passthrough()
+            ),
             agentClientId: mtMap.objectField(
               'agent_client_id',
               mtMap.passthrough()
@@ -730,6 +756,11 @@ export let mapManagementInstanceSessionsEventsGetOutput =
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/events/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/events/list.ts
@@ -45,8 +45,8 @@ export type ManagementInstanceSessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -126,8 +126,8 @@ export type ManagementInstanceSessionsEventsListOutput = {
           agentId: string | null;
           agentInstanceId: string | null;
           identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+          identityId: string | null;
+          agentActorId: string | null;
           agentClientId: string | null;
           consumerId: string | null;
           createdAt: Date;
@@ -144,8 +144,8 @@ export type ManagementInstanceSessionsEventsListOutput = {
           agentId: string | null;
           agentInstanceId: string | null;
           identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+          identityId: string | null;
+          agentActorId: string | null;
           agentClientId: string | null;
           consumerId: string | null;
           createdAt: Date;
@@ -206,8 +206,8 @@ export type ManagementInstanceSessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -224,8 +224,8 @@ export type ManagementInstanceSessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -359,6 +359,14 @@ export let mapManagementInstanceSessionsEventsListOutput =
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(
@@ -550,6 +558,14 @@ export let mapManagementInstanceSessionsEventsListOutput =
                         'identity_actor_id',
                         mtMap.passthrough()
                       ),
+                      identityId: mtMap.objectField(
+                        'identity_id',
+                        mtMap.passthrough()
+                      ),
+                      agentActorId: mtMap.objectField(
+                        'agent_actor_id',
+                        mtMap.passthrough()
+                      ),
                       agentClientId: mtMap.objectField(
                         'agent_client_id',
                         mtMap.passthrough()
@@ -600,6 +616,14 @@ export let mapManagementInstanceSessionsEventsListOutput =
                       ),
                       identityActorId: mtMap.objectField(
                         'identity_actor_id',
+                        mtMap.passthrough()
+                      ),
+                      identityId: mtMap.objectField(
+                        'identity_id',
+                        mtMap.passthrough()
+                      ),
+                      agentActorId: mtMap.objectField(
+                        'agent_actor_id',
                         mtMap.passthrough()
                       ),
                       agentClientId: mtMap.objectField(
@@ -759,6 +783,14 @@ export let mapManagementInstanceSessionsEventsListOutput =
                     'identity_actor_id',
                     mtMap.passthrough()
                   ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
+                    mtMap.passthrough()
+                  ),
                   agentClientId: mtMap.objectField(
                     'agent_client_id',
                     mtMap.passthrough()
@@ -806,6 +838,14 @@ export let mapManagementInstanceSessionsEventsListOutput =
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/get.ts
@@ -224,7 +224,10 @@ export let mapManagementInstanceSessionsGetOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/list.ts
@@ -258,8 +258,11 @@ export let mapManagementInstanceSessionsListOutput =
           ),
           hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
           hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
           updatedAt: mtMap.objectField('updated_at', mtMap.date())
         })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/messages/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/messages/get.ts
@@ -57,8 +57,8 @@ export type ManagementInstanceSessionsMessagesGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -75,8 +75,8 @@ export type ManagementInstanceSessionsMessagesGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -285,6 +285,11 @@ export let mapManagementInstanceSessionsMessagesGetOutput =
               'identity_actor_id',
               mtMap.passthrough()
             ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
+              mtMap.passthrough()
+            ),
             agentClientId: mtMap.objectField(
               'agent_client_id',
               mtMap.passthrough()
@@ -323,6 +328,11 @@ export let mapManagementInstanceSessionsMessagesGetOutput =
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(
@@ -446,6 +456,8 @@ export let mapManagementInstanceSessionsMessagesGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()
@@ -483,6 +495,8 @@ export let mapManagementInstanceSessionsMessagesGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/messages/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/messages/list.ts
@@ -58,8 +58,8 @@ export type ManagementInstanceSessionsMessagesListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -76,8 +76,8 @@ export type ManagementInstanceSessionsMessagesListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -135,8 +135,8 @@ export type ManagementInstanceSessionsMessagesListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -153,8 +153,8 @@ export type ManagementInstanceSessionsMessagesListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -310,6 +310,14 @@ export let mapManagementInstanceSessionsMessagesListOutput =
                     'identity_actor_id',
                     mtMap.passthrough()
                   ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
+                    mtMap.passthrough()
+                  ),
                   agentClientId: mtMap.objectField(
                     'agent_client_id',
                     mtMap.passthrough()
@@ -357,6 +365,14 @@ export let mapManagementInstanceSessionsMessagesListOutput =
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(
@@ -498,6 +514,11 @@ export let mapManagementInstanceSessionsMessagesListOutput =
                 'identity_actor_id',
                 mtMap.passthrough()
               ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
+                mtMap.passthrough()
+              ),
               agentClientId: mtMap.objectField(
                 'agent_client_id',
                 mtMap.passthrough()
@@ -536,6 +557,11 @@ export let mapManagementInstanceSessionsMessagesListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/participants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/participants/list.ts
@@ -54,6 +54,11 @@ export let mapManagementInstanceSessionsParticipantsListOutput =
             'identity_actor_id',
             mtMap.passthrough()
           ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          agentActorId: mtMap.objectField(
+            'agent_actor_id',
+            mtMap.passthrough()
+          ),
           agentClientId: mtMap.objectField(
             'agent_client_id',
             mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/sessions/update.ts
@@ -224,7 +224,10 @@ export let mapManagementInstanceSessionsUpdateOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/tool-calls/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/tool-calls/create.ts
@@ -131,6 +131,8 @@ export let mapManagementInstanceToolCallsCreateOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()
@@ -168,6 +170,8 @@ export let mapManagementInstanceToolCallsCreateOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/tool-calls/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/tool-calls/get.ts
@@ -131,6 +131,8 @@ export let mapManagementInstanceToolCallsGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()
@@ -168,6 +170,8 @@ export let mapManagementInstanceToolCallsGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/tool-calls/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/tool-calls/list.ts
@@ -26,8 +26,8 @@ export type ManagementInstanceToolCallsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -44,8 +44,8 @@ export type ManagementInstanceToolCallsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -144,6 +144,11 @@ export let mapManagementInstanceToolCallsListOutput =
                 'identity_actor_id',
                 mtMap.passthrough()
               ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
+                mtMap.passthrough()
+              ),
               agentClientId: mtMap.objectField(
                 'agent_client_id',
                 mtMap.passthrough()
@@ -182,6 +187,11 @@ export let mapManagementInstanceToolCallsListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/session-templates/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/session-templates/create.ts
@@ -77,7 +77,10 @@ export let mapSessionTemplatesCreateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/session-templates/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/session-templates/delete.ts
@@ -77,7 +77,10 @@ export let mapSessionTemplatesDeleteOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/session-templates/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/session-templates/get.ts
@@ -77,7 +77,10 @@ export let mapSessionTemplatesGetOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/session-templates/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/session-templates/list.ts
@@ -84,6 +84,11 @@ export let mapSessionTemplatesListOutput =
             'integration_instance_group_id',
             mtMap.passthrough()
           ),
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
           providers: mtMap.objectField(
             'providers',
             mtMap.array(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/session-templates/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/session-templates/update.ts
@@ -77,7 +77,10 @@ export let mapSessionTemplatesUpdateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
     identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/connections/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/connections/get.ts
@@ -100,6 +100,8 @@ export let mapSessionsConnectionsGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/connections/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/connections/list.ts
@@ -28,8 +28,8 @@ export type SessionsConnectionsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -114,6 +114,11 @@ export let mapSessionsConnectionsListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/events/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/events/get.ts
@@ -44,8 +44,8 @@ export type SessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -125,8 +125,8 @@ export type SessionsEventsGetOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -143,8 +143,8 @@ export type SessionsEventsGetOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -202,8 +202,8 @@ export type SessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -220,8 +220,8 @@ export type SessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -336,6 +336,11 @@ export let mapSessionsEventsGetOutput = mtMap.object<SessionsEventsGetOutput>({
           ),
           identityActorId: mtMap.objectField(
             'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          agentActorId: mtMap.objectField(
+            'agent_actor_id',
             mtMap.passthrough()
           ),
           agentClientId: mtMap.objectField(
@@ -488,6 +493,11 @@ export let mapSessionsEventsGetOutput = mtMap.object<SessionsEventsGetOutput>({
                 'identity_actor_id',
                 mtMap.passthrough()
               ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
+                mtMap.passthrough()
+              ),
               agentClientId: mtMap.objectField(
                 'agent_client_id',
                 mtMap.passthrough()
@@ -526,6 +536,11 @@ export let mapSessionsEventsGetOutput = mtMap.object<SessionsEventsGetOutput>({
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(
@@ -652,6 +667,11 @@ export let mapSessionsEventsGetOutput = mtMap.object<SessionsEventsGetOutput>({
             'identity_actor_id',
             mtMap.passthrough()
           ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          agentActorId: mtMap.objectField(
+            'agent_actor_id',
+            mtMap.passthrough()
+          ),
           agentClientId: mtMap.objectField(
             'agent_client_id',
             mtMap.passthrough()
@@ -687,6 +707,11 @@ export let mapSessionsEventsGetOutput = mtMap.object<SessionsEventsGetOutput>({
           ),
           identityActorId: mtMap.objectField(
             'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          agentActorId: mtMap.objectField(
+            'agent_actor_id',
             mtMap.passthrough()
           ),
           agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/events/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/events/list.ts
@@ -45,8 +45,8 @@ export type SessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -126,8 +126,8 @@ export type SessionsEventsListOutput = {
           agentId: string | null;
           agentInstanceId: string | null;
           identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+          identityId: string | null;
+          agentActorId: string | null;
           agentClientId: string | null;
           consumerId: string | null;
           createdAt: Date;
@@ -144,8 +144,8 @@ export type SessionsEventsListOutput = {
           agentId: string | null;
           agentInstanceId: string | null;
           identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+          identityId: string | null;
+          agentActorId: string | null;
           agentClientId: string | null;
           consumerId: string | null;
           createdAt: Date;
@@ -206,8 +206,8 @@ export type SessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -224,8 +224,8 @@ export type SessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -359,6 +359,14 @@ export let mapSessionsEventsListOutput = mtMap.object<SessionsEventsListOutput>(
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(
@@ -550,6 +558,14 @@ export let mapSessionsEventsListOutput = mtMap.object<SessionsEventsListOutput>(
                         'identity_actor_id',
                         mtMap.passthrough()
                       ),
+                      identityId: mtMap.objectField(
+                        'identity_id',
+                        mtMap.passthrough()
+                      ),
+                      agentActorId: mtMap.objectField(
+                        'agent_actor_id',
+                        mtMap.passthrough()
+                      ),
                       agentClientId: mtMap.objectField(
                         'agent_client_id',
                         mtMap.passthrough()
@@ -600,6 +616,14 @@ export let mapSessionsEventsListOutput = mtMap.object<SessionsEventsListOutput>(
                       ),
                       identityActorId: mtMap.objectField(
                         'identity_actor_id',
+                        mtMap.passthrough()
+                      ),
+                      identityId: mtMap.objectField(
+                        'identity_id',
+                        mtMap.passthrough()
+                      ),
+                      agentActorId: mtMap.objectField(
+                        'agent_actor_id',
                         mtMap.passthrough()
                       ),
                       agentClientId: mtMap.objectField(
@@ -759,6 +783,14 @@ export let mapSessionsEventsListOutput = mtMap.object<SessionsEventsListOutput>(
                     'identity_actor_id',
                     mtMap.passthrough()
                   ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
+                    mtMap.passthrough()
+                  ),
                   agentClientId: mtMap.objectField(
                     'agent_client_id',
                     mtMap.passthrough()
@@ -806,6 +838,14 @@ export let mapSessionsEventsListOutput = mtMap.object<SessionsEventsListOutput>(
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/list.ts
@@ -245,8 +245,11 @@ export let mapSessionsListOutput = mtMap.object<SessionsListOutput>({
         ),
         hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
         hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
-    identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
-    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        identityActorId: mtMap.objectField(
+          'identity_actor_id',
+          mtMap.passthrough()
+        ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date())
       })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/messages/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/messages/get.ts
@@ -57,8 +57,8 @@ export type SessionsMessagesGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -75,8 +75,8 @@ export type SessionsMessagesGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -285,6 +285,11 @@ export let mapSessionsMessagesGetOutput =
               'identity_actor_id',
               mtMap.passthrough()
             ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
+              mtMap.passthrough()
+            ),
             agentClientId: mtMap.objectField(
               'agent_client_id',
               mtMap.passthrough()
@@ -323,6 +328,11 @@ export let mapSessionsMessagesGetOutput =
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(
@@ -446,6 +456,8 @@ export let mapSessionsMessagesGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()
@@ -483,6 +495,8 @@ export let mapSessionsMessagesGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/messages/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/messages/list.ts
@@ -58,8 +58,8 @@ export type SessionsMessagesListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -76,8 +76,8 @@ export type SessionsMessagesListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -135,8 +135,8 @@ export type SessionsMessagesListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -153,8 +153,8 @@ export type SessionsMessagesListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -310,6 +310,14 @@ export let mapSessionsMessagesListOutput =
                     'identity_actor_id',
                     mtMap.passthrough()
                   ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
+                    mtMap.passthrough()
+                  ),
                   agentClientId: mtMap.objectField(
                     'agent_client_id',
                     mtMap.passthrough()
@@ -357,6 +365,14 @@ export let mapSessionsMessagesListOutput =
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(
@@ -498,6 +514,11 @@ export let mapSessionsMessagesListOutput =
                 'identity_actor_id',
                 mtMap.passthrough()
               ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
+                mtMap.passthrough()
+              ),
               agentClientId: mtMap.objectField(
                 'agent_client_id',
                 mtMap.passthrough()
@@ -536,6 +557,11 @@ export let mapSessionsMessagesListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/participants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/sessions/participants/list.ts
@@ -54,6 +54,11 @@ export let mapSessionsParticipantsListOutput =
             'identity_actor_id',
             mtMap.passthrough()
           ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          agentActorId: mtMap.objectField(
+            'agent_actor_id',
+            mtMap.passthrough()
+          ),
           agentClientId: mtMap.objectField(
             'agent_client_id',
             mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/tool-calls/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/tool-calls/create.ts
@@ -127,6 +127,8 @@ export let mapToolCallsCreateOutput = mtMap.object<ToolCallsCreateOutput>({
         'identity_actor_id',
         mtMap.passthrough()
       ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
       agentClientId: mtMap.objectField('agent_client_id', mtMap.passthrough()),
       consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date())
@@ -158,6 +160,8 @@ export let mapToolCallsCreateOutput = mtMap.object<ToolCallsCreateOutput>({
         'identity_actor_id',
         mtMap.passthrough()
       ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
       agentClientId: mtMap.objectField('agent_client_id', mtMap.passthrough()),
       consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/tool-calls/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/tool-calls/get.ts
@@ -127,6 +127,8 @@ export let mapToolCallsGetOutput = mtMap.object<ToolCallsGetOutput>({
         'identity_actor_id',
         mtMap.passthrough()
       ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
       agentClientId: mtMap.objectField('agent_client_id', mtMap.passthrough()),
       consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date())
@@ -158,6 +160,8 @@ export let mapToolCallsGetOutput = mtMap.object<ToolCallsGetOutput>({
         'identity_actor_id',
         mtMap.passthrough()
       ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
       agentClientId: mtMap.objectField('agent_client_id', mtMap.passthrough()),
       consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/tool-calls/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/tool-calls/list.ts
@@ -26,8 +26,8 @@ export type ToolCallsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -44,8 +44,8 @@ export type ToolCallsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
-    identityId: string | null;
-    agentActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -143,6 +143,11 @@ export let mapToolCallsListOutput = mtMap.object<ToolCallsListOutput>({
               'identity_actor_id',
               mtMap.passthrough()
             ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
+              mtMap.passthrough()
+            ),
             agentClientId: mtMap.objectField(
               'agent_client_id',
               mtMap.passthrough()
@@ -181,6 +186,11 @@ export let mapToolCallsListOutput = mtMap.object<ToolCallsListOutput>({
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/sdk.ts
+++ b/clients/metorial-dashboard/src/sdk.ts
@@ -151,6 +151,7 @@ import {
   MetorialDashboardOrganizationsTeamsEndpoint,
   MetorialDashboardOrganizationsTeamsMembersEndpoint,
   MetorialDashboardOrganizationsTeamsPoliciesEndpoint,
+  MetorialDashboardProjectsConfigureAuthConfigEndpoint,
   MetorialDashboardProjectsConfigureRetentionEndpoint,
   MetorialDashboardUsageEndpoint,
   MetorialManagementUserEndpoint,
@@ -431,6 +432,7 @@ export let createMetorialDashboardSDK = sdkBuilder.build(
   instances: new MetorialDashboardOrganizationsInstancesEndpoint(manager),
   projects: Object.assign(new MetorialDashboardOrganizationsProjectsEndpoint(manager), {
     branding: new MetorialDashboardOrganizationsProjectsBrandingEndpoint(manager),
+    configureAuthConfig: new MetorialDashboardProjectsConfigureAuthConfigEndpoint(manager),
     configureRetention: new MetorialDashboardProjectsConfigureRetentionEndpoint(manager)
   }),
   user: new MetorialManagementUserEndpoint(manager),

--- a/src/backend/apis/core/src/controllers/dashboard/projectConfiguration.ts
+++ b/src/backend/apis/core/src/controllers/dashboard/projectConfiguration.ts
@@ -1,12 +1,16 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { v } from '@lowerdeck/validation';
 import { accessService } from '@metorial/module-access';
-import { projectRetentionService, projectService } from '@metorial/module-organization';
+import {
+  projectAuthConfigConfigurationService,
+  projectRetentionService,
+  projectService
+} from '@metorial/module-organization';
 import { Controller, Path } from '@metorial/rest';
 import { checkAccess } from '../../middleware/checkAccess';
 import { isDashboardGroup } from '../../middleware/isDashboard';
 import { organizationGroup } from '../../middleware/organizationGroup';
-import { projectRetentionPresenter } from '../../presenters';
+import { projectAuthConfigConfigurationPresenter, projectRetentionPresenter } from '../../presenters';
 
 let logRetentionInDaysValidator = v.optional(
   v.number({ modifiers: [v.positive(), v.integer(), v.minValue(1), v.maxValue(365)] })
@@ -113,6 +117,120 @@ export let dashboardProjectConfigurationController = Controller.create(
         });
 
         return projectRetentionPresenter.present({ project });
+      }),
+
+    getAuthConfig: organizationGroup
+      .use(isDashboardGroup())
+      .get(
+        Path(
+          '/dashboard/organizations/:organizationId/projects/:projectId/configure/auth-config',
+          'dashboard.projects.configure.auth_config.get'
+        ),
+        {
+          name: 'Get project auth config configuration',
+          description: 'Get auth config export/import settings for a project'
+        }
+      )
+      .use(checkAccess({ possibleScopes: ['organization.project:read'] }))
+      .output(projectAuthConfigConfigurationPresenter)
+      .do(async ctx => {
+        let project = await projectService.getProjectById({
+          organization: ctx.organization,
+          projectId: ctx.params.projectId,
+          member: ctx.member,
+          actor: ctx.actor
+        });
+
+        await accessService.checkTargetAccess({
+          authInfo: ctx.auth,
+          organization: ctx.organization,
+          member: ctx.member,
+          project,
+          possibleScopes: ['organization.project:read']
+        });
+
+        let configuration =
+          await projectAuthConfigConfigurationService.getProjectAuthConfigConfiguration({
+            project
+          });
+
+        return projectAuthConfigConfigurationPresenter.present({
+          project,
+          ...configuration
+        });
+      }),
+
+    updateAuthConfig: organizationGroup
+      .use(isDashboardGroup())
+      .patch(
+        Path(
+          '/dashboard/organizations/:organizationId/projects/:projectId/configure/auth-config',
+          'dashboard.projects.configure.auth_config.update'
+        ),
+        {
+          name: 'Update project auth config configuration',
+          description: 'Update auth config export/import settings for a project'
+        }
+      )
+      .use(checkAccess({ possibleScopes: ['organization.project:write'] }))
+      .body(
+        'default',
+        v.object({
+          allow_auth_config_export: v.optional(v.boolean()),
+          allow_auth_config_import: v.optional(v.boolean())
+        })
+      )
+      .output(projectAuthConfigConfigurationPresenter)
+      .do(async ctx => {
+        if (
+          ctx.body.allow_auth_config_export === undefined &&
+          ctx.body.allow_auth_config_import === undefined
+        ) {
+          throw new ServiceError(
+            badRequestError({
+              message: 'At least one auth config configuration field must be provided'
+            })
+          );
+        }
+
+        let project = await projectService.getProjectById({
+          organization: ctx.organization,
+          projectId: ctx.params.projectId,
+          member: ctx.member,
+          actor: ctx.actor
+        });
+
+        await accessService.checkTargetAccess({
+          authInfo: ctx.auth,
+          organization: ctx.organization,
+          member: ctx.member,
+          project,
+          possibleScopes: ['organization.project:write']
+        });
+
+        let configuration =
+          await projectAuthConfigConfigurationService.updateProjectAuthConfigConfiguration({
+            project,
+            organization: ctx.organization,
+            performedBy: ctx.actor,
+            context: ctx.context,
+            input: {
+              allowAuthConfigExport: ctx.body.allow_auth_config_export,
+              allowAuthConfigImport: ctx.body.allow_auth_config_import
+            }
+          });
+
+        project = await projectService.getProjectById({
+          organization: ctx.organization,
+          projectId: project.id,
+          member: ctx.member,
+          actor: ctx.actor
+        });
+
+        return projectAuthConfigConfigurationPresenter.present({
+          project,
+          ...configuration
+        });
       })
   }
 );

--- a/src/backend/apis/core/src/controllers/instance/custom-provider/customProvider.ts
+++ b/src/backend/apis/core/src/controllers/instance/custom-provider/customProvider.ts
@@ -9,7 +9,10 @@ import { normalizeArrayParam } from '../../../lib/normalizeArrayParam';
 import { checkAccess } from '../../../middleware/checkAccess';
 import { hasFlags } from '../../../middleware/hasFlags';
 import { instanceGroup, instancePath } from '../../../middleware/instanceGroup';
-import { subspaceCustomProviderPresenter } from '../../../presenters';
+import {
+  subspaceCustomProviderEnvPresenter,
+  subspaceCustomProviderPresenter
+} from '../../../presenters';
 
 export let customProviderGroup = instanceGroup.use(async ctx => {
   if (!ctx.params.customProviderId) {
@@ -23,7 +26,8 @@ export let customProviderGroup = instanceGroup.use(async ctx => {
 
   let customProvider = await subspaceCustomProviderService.get({
     instance: ctx.instance,
-    customProviderId: ctx.params.customProviderId
+    customProviderId: ctx.params.customProviderId,
+    includeEnv: false
   });
 
   return { customProvider };
@@ -259,6 +263,27 @@ export let customProviderController = Controller.create(
       .do(async ctx => {
         return subspaceCustomProviderPresenter.present({
           customProvider: ctx.customProvider
+        });
+      }),
+
+    getEnv: customProviderGroup
+      .get(instancePath('custom-providers/:customProviderId/env', 'customProviders.getEnv'), {
+        name: 'Get custom provider environment',
+        description:
+          'Retrieves the environment variables for a specific custom provider by ID.'
+      })
+      .use(checkAccess({ possibleScopes: ['instance.provider.custom:read'] }))
+      .use(hasFlags(['custom-providers-enabled', 'paid-custom-providers']))
+      .output(subspaceCustomProviderEnvPresenter)
+      .do(async ctx => {
+        let customProvider = await subspaceCustomProviderService.get({
+          instance: ctx.instance,
+          customProviderId: ctx.params.customProviderId,
+          includeEnv: true
+        });
+
+        return subspaceCustomProviderEnvPresenter.present({
+          customProviderFrom: customProvider.draft.from
         });
       }),
 

--- a/src/backend/apis/core/src/controllers/instance/custom-provider/customProviderVersion.ts
+++ b/src/backend/apis/core/src/controllers/instance/custom-provider/customProviderVersion.ts
@@ -9,7 +9,10 @@ import { normalizeArrayParam } from '../../../lib/normalizeArrayParam';
 import { checkAccess } from '../../../middleware/checkAccess';
 import { hasFlags } from '../../../middleware/hasFlags';
 import { instanceGroup, instancePath } from '../../../middleware/instanceGroup';
-import { subspaceCustomProviderVersionPresenter } from '../../../presenters';
+import {
+  subspaceCustomProviderEnvPresenter,
+  subspaceCustomProviderVersionPresenter
+} from '../../../presenters';
 import {
   customProviderConfigValidator,
   customProviderFromValidator,
@@ -28,7 +31,8 @@ let customProviderVersionGroup = instanceGroup.use(async ctx => {
 
   let customProviderVersion = await subspaceCustomProviderVersionService.get({
     instance: ctx.instance,
-    customProviderVersionId: ctx.params.customProviderVersionId
+    customProviderVersionId: ctx.params.customProviderVersionId,
+    includeEnv: false
   });
 
   return { customProviderVersion };
@@ -144,6 +148,33 @@ export let customProviderVersionController = Controller.create(
       .do(async ctx => {
         return subspaceCustomProviderVersionPresenter.present({
           customProviderVersion: ctx.customProviderVersion
+        });
+      }),
+
+    getEnv: customProviderVersionGroup
+      .get(
+        instancePath(
+          'custom-provider-versions/:customProviderVersionId/env',
+          'customProviders.versions.getEnv'
+        ),
+        {
+          name: 'Get custom provider version environment',
+          description:
+            'Retrieves the environment variables for a specific version of a custom provider.'
+        }
+      )
+      .use(checkAccess({ possibleScopes: ['instance.provider.custom.version:read'] }))
+      .use(hasFlags(['custom-providers-enabled', 'paid-custom-providers']))
+      .output(subspaceCustomProviderEnvPresenter)
+      .do(async ctx => {
+        let customProviderVersion = await subspaceCustomProviderVersionService.get({
+          instance: ctx.instance,
+          customProviderVersionId: ctx.params.customProviderVersionId,
+          includeEnv: true
+        });
+
+        return subspaceCustomProviderEnvPresenter.present({
+          customProviderFrom: customProviderVersion.from
         });
       }),
 

--- a/src/backend/apis/core/src/presenters/implementation/organization/index.ts
+++ b/src/backend/apis/core/src/presenters/implementation/organization/index.ts
@@ -7,5 +7,6 @@ export * from './profile';
 export * from './project';
 export * from './projectBrand';
 export * from './projectRetention';
+export * from './projectAuthConfigConfiguration';
 export * from './team';
 export * from './user';

--- a/src/backend/apis/core/src/presenters/implementation/organization/projectAuthConfigConfiguration.ts
+++ b/src/backend/apis/core/src/presenters/implementation/organization/projectAuthConfigConfiguration.ts
@@ -1,0 +1,25 @@
+import { v } from '@lowerdeck/validation';
+import { Presenter } from '@metorial/presenter';
+import { projectAuthConfigConfigurationType } from '../../types';
+
+export let v1ProjectAuthConfigConfigurationPresenter = Presenter.create(
+  projectAuthConfigConfigurationType
+)
+  .presenter(async ({ project, allowAuthConfigExport, allowAuthConfigImport }) => ({
+    object: 'organization.project.auth_config_configuration' as const,
+
+    project_id: project.id,
+    allow_auth_config_export: allowAuthConfigExport,
+    allow_auth_config_import: allowAuthConfigImport,
+    updated_at: project.updatedAt
+  }))
+  .schema(
+    v.object({
+      object: v.literal('organization.project.auth_config_configuration'),
+      project_id: v.string(),
+      allow_auth_config_export: v.boolean(),
+      allow_auth_config_import: v.boolean(),
+      updated_at: v.date()
+    })
+  )
+  .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/customProvider/customProviderEnv.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/customProvider/customProviderEnv.ts
@@ -1,0 +1,23 @@
+import { v } from '@lowerdeck/validation';
+import { Presenter } from '@metorial/presenter';
+import { customProviderEnvType } from '../../../types';
+
+export let v1CustomProviderEnvPresenter = Presenter.create(customProviderEnvType)
+  .presenter(async ({ customProviderFrom }, opts) => ({
+    object: 'custom_provider.env' as const,
+
+    env: customProviderFrom?.type === 'function' ? customProviderFrom.env : null
+  }))
+  .schema(
+    v.object({
+      object: v.literal('custom_provider.env', {
+        description: "String representing the object's type"
+      }),
+      env: v.nullable(
+        v.record(v.any(), {
+          description: 'Key-value pairs representing the custom provider environment variables'
+        })
+      )
+    })
+  )
+  .build();

--- a/src/backend/apis/core/src/presenters/implementation/provider/customProvider/index.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/customProvider/index.ts
@@ -4,5 +4,6 @@ export * from './bucketEditorToken';
 export * from './customProvider';
 export * from './customProviderCommit';
 export * from './customProviderDeployment';
+export * from './customProviderEnv';
 export * from './customProviderEnvironment';
 export * from './customProviderVersion';

--- a/src/backend/apis/core/src/presenters/index.ts
+++ b/src/backend/apis/core/src/presenters/index.ts
@@ -57,6 +57,7 @@ import {
   v1CustomProviderCommitPresenter,
   v1CustomProviderDeploymentLogsPresenter,
   v1CustomProviderDeploymentPresenter,
+  v1CustomProviderEnvPresenter,
   v1CustomProviderEnvironmentPresenter,
   // Custom Provider presenters
   v1CustomProviderPresenter,
@@ -112,6 +113,7 @@ import {
   v1ProjectBrandPresenter,
   v1ProjectPresenter,
   v1ProjectRetentionPresenter,
+  v1ProjectAuthConfigConfigurationPresenter,
   v1ProviderAuthConfigErrorGroupPresenter,
   v1ProviderAuthConfigErrorPresenter,
   v1ProviderAuthConfigEventPresenter,
@@ -234,6 +236,7 @@ import {
   customProviderCommitType,
   customProviderDeploymentLogsType,
   customProviderDeploymentType,
+  customProviderEnvType,
   customProviderEnvironmentType,
   // Custom Provider types
   customProviderType,
@@ -289,6 +292,7 @@ import {
   profileType,
   projectBrandType,
   projectRetentionType,
+  projectAuthConfigConfigurationType,
   projectType,
   providerAuthConfigErrorGroupType,
   providerAuthConfigErrorType,
@@ -520,6 +524,13 @@ export let projectRetentionPresenter = declarePresenter(projectRetentionType, {
   mt_2025_01_01_dashboard: v1ProjectRetentionPresenter,
   mt_2026_01_01_magnetar: v1ProjectRetentionPresenter
 });
+
+export let projectAuthConfigConfigurationPresenter = declarePresenter(
+  projectAuthConfigConfigurationType,
+  {
+    mt_2025_01_01_dashboard: v1ProjectAuthConfigConfigurationPresenter
+  }
+);
 
 export let userPresenter = declarePresenter(userType, {
   mt_2025_01_01_dashboard: v1UserPresenter,
@@ -1207,6 +1218,11 @@ export let bucketEditorTokenPresenter = declarePresenter(bucketEditorTokenType, 
 export let subspaceCustomProviderPresenter = declarePresenter(customProviderType, {
   mt_2025_01_01_dashboard: dashboardCustomProviderPresenter,
   mt_2026_01_01_magnetar: v1CustomProviderPresenter
+});
+
+export let subspaceCustomProviderEnvPresenter = declarePresenter(customProviderEnvType, {
+  mt_2025_01_01_dashboard: v1CustomProviderEnvPresenter,
+  mt_2026_01_01_magnetar: v1CustomProviderEnvPresenter
 });
 
 export let subspaceCustomProviderVersionPresenter = declarePresenter(

--- a/src/backend/apis/core/src/presenters/types.ts
+++ b/src/backend/apis/core/src/presenters/types.ts
@@ -85,25 +85,25 @@ import {
 import type {
   CargoDocumentPermissions,
   CargoFileLink,
-  CargoStore,
-  CargoStorePermissions,
   CargoSkillAgent,
   CargoSkillConfiguration,
-  EnrichedCargoSkillExport,
-  EnrichedCargoSkillMarketplace,
-  EnrichedCargoSkillMarketplacePlugin,
-  EnrichedCargoSkillMarketplaceRepository,
+  CargoSkillVersion,
+  CargoSkillVersionSnapshot,
+  CargoStore,
+  CargoStorePermissions,
   EnrichedCargoDocument,
   EnrichedCargoDocumentParticipant,
   EnrichedCargoDocumentVersion,
   EnrichedCargoFile,
+  EnrichedCargoSkillExport,
+  EnrichedCargoSkillMarketplace,
+  EnrichedCargoSkillMarketplacePlugin,
+  EnrichedCargoSkillMarketplaceRepository,
   EnrichedCargoSkillParticipant,
   EnrichedCargoSkillPlugin,
   EnrichedCargoSkillPluginRepository,
   EnrichedCargoSkillPluginSkill,
   EnrichedCargoSkillSync,
-  CargoSkillVersion,
-  CargoSkillVersionSnapshot,
   EnrichedCargoStoreItem,
   EnrichedCargoStoreParticipant
 } from '@metorial/module-file';
@@ -240,6 +240,12 @@ export let projectType = PresentableType.create<{
 export let projectRetentionType = PresentableType.create<{
   project: Project;
 }>()('project_retention');
+
+export let projectAuthConfigConfigurationType = PresentableType.create<{
+  project: Project;
+  allowAuthConfigExport: boolean;
+  allowAuthConfigImport: boolean;
+}>()('project_auth_config_configuration');
 
 export let tokenType = PresentableType.create<{
   token: {
@@ -1283,6 +1289,12 @@ export let customProviderType = PresentableType.create<{
 export let customProviderVersionType = PresentableType.create<{
   customProviderVersion: SubspaceCustomProviderVersion;
 }>()('customProviderVersion');
+
+export let customProviderEnvType = PresentableType.create<{
+  customProviderFrom:
+    | SubspaceCustomProviderVersion['from']
+    | SubspaceCustomProvider['draft']['from'];
+}>()('customProviderEnv');
 
 export let customProviderDeploymentType = PresentableType.create<{
   customProviderDeployment: SubspaceCustomProviderDeployment;

--- a/src/backend/modules/organization/src/services/index.ts
+++ b/src/backend/modules/organization/src/services/index.ts
@@ -13,4 +13,5 @@ export * from './organizationMember';
 export * from './project';
 export * from './projectBrand';
 export * from './projectRetention';
+export * from './projectAuthConfigConfiguration';
 export * from './team';

--- a/src/backend/modules/organization/src/services/projectAuthConfigConfiguration.ts
+++ b/src/backend/modules/organization/src/services/projectAuthConfigConfiguration.ts
@@ -1,0 +1,106 @@
+import { forbiddenError, ServiceError } from '@lowerdeck/error';
+import { Service } from '@lowerdeck/service';
+import { Context } from '@metorial/context';
+import { db, Organization, OrganizationActor, Project } from '@metorial/db';
+import { Fabric } from '@metorial/fabric';
+import {
+  getTenantForSubspace,
+  subspaceTenantService,
+  syncSubspaceTenantForProject
+} from '@metorial/module-subspace';
+
+class ProjectAuthConfigConfigurationService {
+  private async ensureProjectActive(project: Project) {
+    if (project.status !== 'active') {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Cannot perform this action on a deleted project'
+        })
+      );
+    }
+  }
+
+  private async getSubspaceTenantForProject(project: Project) {
+    await syncSubspaceTenantForProject(project);
+
+    let instance = await db.instance.findFirst({
+      where: { projectOid: project.oid },
+      orderBy: { createdAt: 'asc' }
+    });
+    if (!instance) {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Project has no instances'
+        })
+      );
+    }
+
+    let { tenant, environmentId } = await getTenantForSubspace(instance);
+
+    return subspaceTenantService.get({
+      tenantId: tenant.id,
+      environmentId
+    });
+  }
+
+  async getProjectAuthConfigConfiguration(d: { project: Project }) {
+    await this.ensureProjectActive(d.project);
+
+    let tenant = await this.getSubspaceTenantForProject(d.project);
+
+    return {
+      allowAuthConfigExport: tenant.allowAuthConfigExport,
+      allowAuthConfigImport: tenant.allowAuthConfigImport
+    };
+  }
+
+  async updateProjectAuthConfigConfiguration(d: {
+    project: Project;
+    organization: Organization;
+    performedBy: OrganizationActor;
+    context: Context;
+    input: {
+      allowAuthConfigExport?: boolean;
+      allowAuthConfigImport?: boolean;
+    };
+  }) {
+    await this.ensureProjectActive(d.project);
+
+    await Fabric.fire('organization.project.auth_config_configuration.updated:before', d);
+
+    let tenant = await this.getSubspaceTenantForProject(d.project);
+
+    let updatedTenant = await subspaceTenantService.upsert({
+      name: tenant.name,
+      identifier: tenant.identifier,
+      environments: [],
+      allowAuthConfigExport:
+        d.input.allowAuthConfigExport ?? tenant.allowAuthConfigExport,
+      allowAuthConfigImport:
+        d.input.allowAuthConfigImport ?? tenant.allowAuthConfigImport
+    });
+
+    await db.project.update({
+      where: { oid: d.project.oid },
+      data: { updatedAt: new Date() }
+    });
+
+    await Fabric.fire('organization.project.auth_config_configuration.updated:after', {
+      ...d,
+      configuration: {
+        allowAuthConfigExport: updatedTenant.allowAuthConfigExport,
+        allowAuthConfigImport: updatedTenant.allowAuthConfigImport
+      }
+    });
+
+    return {
+      allowAuthConfigExport: updatedTenant.allowAuthConfigExport,
+      allowAuthConfigImport: updatedTenant.allowAuthConfigImport
+    };
+  }
+}
+
+export let projectAuthConfigConfigurationService = Service.create(
+  'projectAuthConfigConfigurationService',
+  () => new ProjectAuthConfigConfigurationService()
+).build();

--- a/src/backend/modules/subspace/src/proxy/index.ts
+++ b/src/backend/modules/subspace/src/proxy/index.ts
@@ -60,7 +60,7 @@ export let proxyMcpRequestToSubspace = async (
   headers.set(
     'Metorial-Proxy-URL',
     process.env.NODE_ENV == 'production'
-      ? `https://${inputUrl.hostname}${inputUrl.pathname}${inputUrl.search}`
+      ? `https://${finalHostName}${inputUrl.pathname}${inputUrl.search}`
       : `http://${inputUrl.host}${inputUrl.pathname}${inputUrl.search}`
   );
 

--- a/src/backend/modules/subspace/src/services/index.ts
+++ b/src/backend/modules/subspace/src/services/index.ts
@@ -80,3 +80,4 @@ export * from './skillItem';
 export * from './skillTemplate';
 export * from './skillTemplateItem';
 export * from './toolCall';
+export * from './tenant';

--- a/src/backend/modules/subspace/src/services/tenant.ts
+++ b/src/backend/modules/subspace/src/services/tenant.ts
@@ -1,0 +1,10 @@
+import { createSubspacePublicService } from '../lib/subspaceService';
+import { subspace } from '../subspace';
+
+export let subspaceTenantService = createSubspacePublicService(
+  subspace.tenant,
+  ['get', 'upsert'],
+  () => ({})
+);
+
+export type SubspaceTenant = Awaited<ReturnType<typeof subspace.tenant.get>>;

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/code.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/code.tsx
@@ -5,16 +5,22 @@ import {
   useCreateCustomProviderVersion,
   useCurrentInstance,
   useCustomProvider,
-  useCustomProviderCodeEditorToken
+  useCustomProviderCodeEditorToken,
+  useCustomProviderEnv
 } from '@metorial/state';
-import { Button, Dialog, Flex, Input, showModal, Spacer, Text, theme } from '@metorial/ui';
+import { Button, Dialog, Flex, Input, showModal, Spacer, Text, theme, toast } from '@metorial/ui';
 import { SideBox } from '@metorial/ui-product';
 import { RiArrowRightSLine, RiExpandDiagonal2Line, RiUpload2Line } from '@remixicon/react';
 import { motion } from 'framer-motion';
 import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
-import { getCustomProviderLinkedRepo } from '../../../scenes/customProvider/utils';
+import {
+  getCustomProviderLinkedRepo,
+  getFunctionProviderVersionFrom,
+  normalizeEnvRecord,
+  normalizeRepoPath
+} from '../../../scenes/customProvider/utils';
 import { SelectRepo } from '../../../scenes/customProvider/selectRepo';
 
 let Wrapper = styled.div`
@@ -57,16 +63,12 @@ let Iframe = styled.iframe`
   background: #fff;
 `;
 
-let normalizeRepoPath = (path: string | null | undefined) => {
-  let trimmed = path?.trim();
-  return trimmed ? trimmed : undefined;
-};
-
 export let CustomProviderCodePage = () => {
   let instance = useCurrentInstance();
 
   let { customProviderId } = useParams();
   let customProvider = useCustomProvider(instance.data?.id, customProviderId);
+  let customProviderEnv = useCustomProviderEnv(instance.data?.id, customProvider.data?.id);
 
   let editorToken = useCustomProviderCodeEditorToken(
     instance.data?.id,
@@ -93,28 +95,22 @@ export let CustomProviderCodePage = () => {
     Boolean(customProvider.data?.draft?.containerImage);
 
   let publishFrom = useMemo(() => {
-    if (linkedRepo?.id) {
-      return {
-        type: 'function' as const,
-        env: {},
-        runtime: { identifier: 'nodejs' as const, version: '22.x' as const },
-        repository: {
-          repositoryId: linkedRepo.id,
-          branch: linkedRepo.defaultBranch || 'main',
-          path: normalizeRepoPath(linkedRepo.path)
-        }
-      };
-    }
+    if (!customProvider.data) return null;
+    let env = normalizeEnvRecord(customProviderEnv.data?.env);
+    return getFunctionProviderVersionFrom(customProvider.data, env);
+  }, [customProvider.data, customProviderEnv.data?.env]);
 
-    return {
-      type: 'function' as const,
-      files: [],
-      env: {},
-      runtime: { identifier: 'nodejs' as const, version: '22.x' as const }
-    };
-  }, [linkedRepo]);
+  let canPublish =
+    Boolean(publishFrom) && !customProviderEnv.isLoading && !customProviderEnv.error;
 
   let publishNewVersion = async () => {
+    if (!canPublish || !publishFrom) {
+      if (customProviderEnv.error) {
+        toast.error('Could not load environment variables. Try again from Settings.');
+      }
+      return;
+    }
+
     let [version] = await createVersion.mutate({
       instanceId: instance.data!.id,
       customProviderId: customProvider.data!.id,
@@ -153,7 +149,14 @@ export let CustomProviderCodePage = () => {
             description="Code is managed through the connected repository."
           >
             <Flex align="center" gap={10}>
-              <Button as="span" size="2" variant="outline" onClick={publishNewVersion}>
+              <Button
+                as="span"
+                size="2"
+                variant="outline"
+                disabled={!canPublish}
+                loading={customProviderEnv.isLoading || createVersion.isLoading}
+                onClick={publishNewVersion}
+              >
                 Publish New Version
               </Button>
 
@@ -269,6 +272,8 @@ export let CustomProviderCodePage = () => {
               size="1"
               variant="outline"
               iconLeft={<RiUpload2Line />}
+              disabled={!canPublish}
+              loading={customProviderEnv.isLoading || createVersion.isLoading}
               onClick={publishNewVersion}
             >
               Publish New Version

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/updateForm.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/updateForm.tsx
@@ -1,18 +1,86 @@
+import { RiDeleteBinLine } from '@remixicon/react';
 import { CustomProvidersGetOutput } from '@metorial/dashboard-sdk';
 import { useForm } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import {
   useCreateCustomProviderVersion,
   useCurrentInstance,
-  useCustomProvider
+  useCustomProvider,
+  useCustomProviderEnv
 } from '@metorial/state';
-import { Button, Group, Input, Select, Spacer, toast } from '@metorial/ui';
+import { Button, Group, Input, Select, Spacer, Text, theme, toast } from '@metorial/ui';
+import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import { FormPage } from '../form/page';
 import {
   type CustomProviderRemoteProtocol,
-  getCustomProviderRemoteProtocolFromUrl
+  getCustomProviderRemoteProtocolFromUrl,
+  getFunctionProviderVersionFrom,
+  normalizeEnvRecord
 } from './utils';
+
+type EnvVarRow = {
+  id: string;
+  key: string;
+  value: string;
+};
+
+let EnvRows = styled.div`
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding-bottom: 12px;
+  gap: 10px;
+`;
+
+let EnvRow = styled.div`
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(220px, 1.2fr) auto;
+  gap: 12px;
+  align-items: end;
+`;
+
+let EnvActions = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+`;
+
+let SaveActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+let envRecordToRows = (env: Record<string, string>): EnvVarRow[] =>
+  Object.entries(env).map(([key, value]) => ({
+    id: `env-${key}`,
+    key,
+    value
+  }));
+
+let rowsToEnvRecord = (rows: EnvVarRow[]) => {
+  let env: Record<string, string> = {};
+
+  for (let row of rows) {
+    let key = row.key.trim();
+    if (!key) continue;
+    env[key] = String(row.value ?? '');
+  }
+
+  return env;
+};
+
+let stringifyEnvRecord = (env: Record<string, string>) =>
+  JSON.stringify(
+    Object.keys(env)
+      .sort()
+      .reduce<Record<string, string>>((acc, key) => {
+        acc[key] = env[key];
+        return acc;
+      }, {})
+  );
 
 export let CustomProviderUpdateForm = (p: { customProvider?: CustomProvidersGetOutput }) => {
   let instance = useCurrentInstance();
@@ -21,6 +89,11 @@ export let CustomProviderUpdateForm = (p: { customProvider?: CustomProvidersGetO
   let updateMutator = customProvider.useUpdateMutator();
   let createVersionMutator = useCreateCustomProviderVersion();
   let customProviderData = customProvider.data ?? p.customProvider;
+  let isFunctionProvider = customProviderData?.type === 'function';
+  let customProviderEnv = useCustomProviderEnv(
+    isFunctionProvider ? instance.data?.id : null,
+    isFunctionProvider ? customProviderData?.id : null
+  );
   let isExternalProvider = Boolean(customProviderData?.draft?.remoteMcpServer);
   let currentRemoteUrl = customProviderData?.draft?.remoteMcpServer?.url ?? '';
   let currentRemoteProtocol =
@@ -28,27 +101,34 @@ export let CustomProviderUpdateForm = (p: { customProvider?: CustomProvidersGetO
     getCustomProviderRemoteProtocolFromUrl(currentRemoteUrl);
   let isSaving = updateMutator.isLoading || createVersionMutator.isLoading;
   let isSaved = !isSaving && (updateMutator.isSuccess || createVersionMutator.isSuccess);
+  let currentEnv = useMemo(
+    () => normalizeEnvRecord(customProviderEnv.data?.env),
+    [customProviderEnv.data?.env]
+  );
+  let initialEnvRows = useMemo(() => envRecordToRows(currentEnv), [currentEnv]);
 
   let form = useForm({
     initialValues: {
       name: customProviderData?.name ?? '',
       description: customProviderData?.description ?? '',
       remoteUrl: currentRemoteUrl,
-      remoteProtocol: currentRemoteProtocol
+      remoteProtocol: currentRemoteProtocol,
+      envRows: initialEnvRows
     },
     updateInitialValues: true,
     onSubmit: async values => {
-      console.log('Submitting with values:', values);
-
       if (!instance.data) return;
       if (!customProviderData) return;
 
       let nextRemoteUrl = values.remoteUrl.trim();
       let nextRemoteProtocol: 'sse' | 'streamable_http' =
         values.remoteProtocol == 'sse' ? 'sse' : 'streamable_http';
+      let nextEnv = rowsToEnvRecord(values.envRows);
       let didUpdateRemote =
         isExternalProvider &&
         (nextRemoteUrl !== currentRemoteUrl || nextRemoteProtocol !== currentRemoteProtocol);
+      let didUpdateEnv =
+        isFunctionProvider && stringifyEnvRecord(nextEnv) !== stringifyEnvRecord(currentEnv);
 
       await updateMutator.mutate({
         name: values.name.trim(),
@@ -87,9 +167,51 @@ export let CustomProviderUpdateForm = (p: { customProvider?: CustomProvidersGetO
           );
         }
       }
+
+      if (didUpdateEnv) {
+        let [version] = await createVersionMutator.mutate({
+          instanceId: instance.data.id,
+          customProviderId: customProviderData.id,
+          from: getFunctionProviderVersionFrom(customProviderData, nextEnv)
+        });
+
+        if (version) {
+          toast.success('Environment variable update started');
+          await customProvider.refetch();
+          await customProviderEnv.refetch();
+
+          navigate(
+            Paths.instance.customProvider(
+              instance.data.organization,
+              instance.data.project,
+              instance.data,
+              customProviderData.id,
+              'versions',
+              { version_id: version.id }
+            )
+          );
+        }
+      }
     },
-    schema: yup =>
-      isExternalProvider
+    schema: yup => {
+      let envRows = yup
+        .array()
+        .of(
+          yup.object({
+            id: yup.string().required(),
+            key: yup.string(),
+            value: yup.string()
+          })
+        )
+        .test('env-keys', 'Environment variables need unique names.', rows => {
+          let keys = (rows ?? []).map(row => row.key?.trim()).filter(Boolean);
+          return keys.length === new Set(keys).size;
+        })
+        .test('env-key-required', 'Add a variable name or remove the empty row.', rows => {
+          return (rows ?? []).every(row => row.key?.trim() || !row.value);
+        });
+
+      return isExternalProvider
         ? yup.object({
             name: yup.string().trim().required('Name is required'),
             description: yup.string(),
@@ -103,30 +225,54 @@ export let CustomProviderUpdateForm = (p: { customProvider?: CustomProvidersGetO
             remoteProtocol: yup
               .mixed<CustomProviderRemoteProtocol>()
               .oneOf(['sse', 'streamable_http'])
-              .required('Transport protocol is required')
+              .required('Transport protocol is required'),
+            envRows
           })
         : (yup.object({
             name: yup.string().trim().required('Name is required'),
             description: yup.string(),
             remoteUrl: yup.string().optional(),
-            remoteProtocol: yup.mixed<CustomProviderRemoteProtocol>().optional()
-          }) as any)
+            remoteProtocol: yup.mixed<CustomProviderRemoteProtocol>().optional(),
+            envRows
+          }) as any);
+    }
   });
+
+  let addEnvRow = () => {
+    form.setFieldValue('envRows', [
+      ...form.values.envRows,
+      { id: `env-${Date.now()}`, key: '', value: '' }
+    ]);
+  };
+
+  let updateEnvRow = (id: string, values: Partial<EnvVarRow>) => {
+    form.setFieldValue(
+      'envRows',
+      form.values.envRows.map(row => (row.id === id ? { ...row, ...values } : row))
+    );
+  };
+
+  let removeEnvRow = (id: string) => {
+    form.setFieldValue(
+      'envRows',
+      form.values.envRows.filter(row => row.id !== id)
+    );
+  };
 
   return (
     <FormPage>
-      <Group.Wrapper>
-        <Group.Header
-          title="General"
-          description={
-            isExternalProvider
-              ? 'Update the details of your external provider. Changing the remote URL publishes a new version.'
-              : 'Update the details of your custom provider.'
-          }
-        />
+      <form onSubmit={form.handleSubmit}>
+        <Group.Wrapper>
+          <Group.Header
+            title="General"
+            description={
+              isExternalProvider
+                ? 'Update the details of your external provider. Changing the remote URL publishes a new version.'
+                : 'Update the details of your custom provider.'
+            }
+          />
 
-        <Group.Content>
-          <form onSubmit={form.handleSubmit}>
+          <Group.Content>
             <Input label="Name" {...form.getFieldProps('name')} />
             <form.RenderError field="name" />
 
@@ -161,20 +307,89 @@ export let CustomProviderUpdateForm = (p: { customProvider?: CustomProvidersGetO
                 <form.RenderError field="remoteProtocol" />
               </>
             )}
+          </Group.Content>
+        </Group.Wrapper>
 
+        {isFunctionProvider && (
+          <>
             <Spacer size={15} />
 
-            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-              <Button size="2" type="submit" loading={isSaving} success={isSaved}>
-                Save
-              </Button>
-            </div>
+            <Group.Wrapper>
+              <Group.Header
+                title="Environment Variables"
+                description="Set custom environment variables for your provider. Use configs and auth configs for sensitive and user-specific data."
+              />
 
-            {updateMutator.error && <updateMutator.RenderError />}
-            {createVersionMutator.error && <createVersionMutator.RenderError />}
-          </form>
-        </Group.Content>
-      </Group.Wrapper>
+              <Group.Content>
+                {customProviderEnv.isLoading ? (
+                  <Text size="2" color="gray600">
+                    Loading environment variables...
+                  </Text>
+                ) : (
+                  <>
+                    {form.values.envRows.length > 0 && (
+                      <EnvRows>
+                        {form.values.envRows.map((row, idx) => (
+                          <EnvRow key={row.id}>
+                            <Input
+                              label="Name"
+                              hideLabel={idx !== 0}
+                              placeholder="DATABASE_URL"
+                              value={row.key}
+                              onChange={e => updateEnvRow(row.id, { key: e.target.value })}
+                            />
+
+                            <Input
+                              label="Value"
+                              hideLabel={idx !== 0}
+                              placeholder="Enter value"
+                              type="password"
+                              value={row.value}
+                              onChange={e => updateEnvRow(row.id, { value: e.target.value })}
+                            />
+
+                            <Button
+                              variant="soft"
+                              color="red"
+                              type="button"
+                              onClick={() => removeEnvRow(row.id)}
+                              iconRight={<RiDeleteBinLine />}
+                            />
+                          </EnvRow>
+                        ))}
+                      </EnvRows>
+                    )}
+
+                    <EnvActions>
+                      <Button size="2" variant="outline" type="button" onClick={addEnvRow}>
+                        Add variable
+                      </Button>
+                    </EnvActions>
+                  </>
+                )}
+
+                <form.RenderError field="envRows" />
+                {customProviderEnv.error && (
+                  <Text size="2" color="red600">
+                    {customProviderEnv.error.message}
+                  </Text>
+                )}
+              </Group.Content>
+            </Group.Wrapper>
+          </>
+        )}
+
+        <Spacer size={15} />
+
+        <SaveActions>
+          <Button size="2" type="submit" loading={isSaving} success={isSaved}>
+            Save
+          </Button>
+        </SaveActions>
+
+        {updateMutator.error && <updateMutator.RenderError />}
+        {createVersionMutator.error && <createVersionMutator.RenderError />}
+      </form>
     </FormPage>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/utils.ts
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/utils.ts
@@ -1,6 +1,55 @@
-import type { DashboardInstanceCustomProvidersGetOutput } from '@metorial/dashboard-sdk';
+import type {
+  CustomProvidersGetOutput,
+  DashboardInstanceCustomProvidersGetOutput,
+  DashboardInstanceCustomProvidersVersionsCreateBody
+} from '@metorial/dashboard-sdk';
 
 export type CustomProviderRemoteProtocol = 'sse' | 'streamable_http';
+
+export let normalizeRepoPath = (path: string | null | undefined) => {
+  let trimmed = path?.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+export let normalizeEnvRecord = (env: Record<string, any> | null | undefined) => {
+  let normalized: Record<string, string> = {};
+
+  for (let [key, value] of Object.entries(env ?? {})) {
+    let normalizedKey = key.trim();
+    if (!normalizedKey) continue;
+    normalized[normalizedKey] = String(value ?? '');
+  }
+
+  return normalized;
+};
+
+export let getFunctionProviderVersionFrom = (
+  customProvider: CustomProvidersGetOutput | DashboardInstanceCustomProvidersGetOutput,
+  env: Record<string, string>
+): DashboardInstanceCustomProvidersVersionsCreateBody['from'] => {
+  let linkedRepo = getCustomProviderLinkedRepo(customProvider);
+  let runtime = { identifier: 'nodejs' as const, version: '22.x' as const };
+
+  if (linkedRepo?.id) {
+    return {
+      type: 'function',
+      env,
+      runtime,
+      repository: {
+        repositoryId: linkedRepo.id,
+        branch: linkedRepo.defaultBranch || 'main',
+        path: normalizeRepoPath(linkedRepo.path)
+      }
+    };
+  }
+
+  return {
+    type: 'function',
+    files: [],
+    env,
+    runtime
+  };
+};
 
 export let normalizeTrackedBranch = (branch: string | null | undefined) => {
   let normalizedBranch = branch?.trim();

--- a/src/frontend/state/src/custom-provider/loaders/customProviders.ts
+++ b/src/frontend/state/src/custom-provider/loaders/customProviders.ts
@@ -85,3 +85,24 @@ export let useCustomProvider = (
     useUpdateMutator: data.useMutator('update')
   };
 };
+
+export let customProviderEnvLoader = createLoader({
+  name: 'customProviderEnv',
+  parents: [customProviderLoader],
+  fetch: (i: { instanceId: string; customProviderId: string }) =>
+    withAuth(sdk => sdk.customProviders.getEnv(i.instanceId, i.customProviderId)),
+  mutators: {}
+});
+
+export let useCustomProviderEnv = (
+  instanceId: string | null | undefined,
+  customProviderId: string | null | undefined
+) => {
+  let data = customProviderEnvLoader.use(
+    instanceId && customProviderId ? { instanceId, customProviderId } : null
+  );
+
+  return {
+    ...data
+  };
+};

--- a/src/frontend/state/src/organization/index.ts
+++ b/src/frontend/state/src/organization/index.ts
@@ -10,6 +10,7 @@ export * from './loaders/organizationMember';
 export * from './loaders/project';
 export * from './loaders/projectBrand';
 export * from './loaders/projectRetention';
+export * from './loaders/projectAuthConfigConfiguration';
 export * from './loaders/team';
 
 export * from './current';

--- a/src/frontend/state/src/organization/loaders/projectAuthConfigConfiguration.ts
+++ b/src/frontend/state/src/organization/loaders/projectAuthConfigConfiguration.ts
@@ -1,0 +1,40 @@
+import type { DashboardProjectsConfigureAuthConfigUpdateBody } from '@metorial/dashboard-sdk';
+import { createLoader } from '@metorial/data-hooks';
+import { withAuth } from '../../user';
+import { projectLoader } from './project';
+
+export let projectAuthConfigConfigurationLoader = createLoader({
+  name: 'projectAuthConfigConfiguration',
+  parents: [projectLoader],
+  fetch: (i: { organizationId: string; projectId: string }) =>
+    withAuth(sdk =>
+      sdk.projects.configureAuthConfig.get(i.organizationId, i.projectId)
+    ),
+  mutators: {
+    update: (
+      i: DashboardProjectsConfigureAuthConfigUpdateBody,
+      { input }: { input: { organizationId: string; projectId: string } }
+    ) =>
+      withAuth(sdk =>
+        sdk.projects.configureAuthConfig.update(
+          input.organizationId,
+          input.projectId,
+          i
+        )
+      )
+  }
+});
+
+export let useProjectAuthConfigConfiguration = (
+  organizationId: string | null | undefined,
+  projectId: string | null | undefined
+) => {
+  let authConfigConfiguration = projectAuthConfigConfigurationLoader.use(
+    organizationId && projectId ? { organizationId, projectId } : null
+  );
+
+  return {
+    ...authConfigConfiguration,
+    updateMutator: authConfigConfiguration.useMutator('update')
+  };
+};

--- a/src/systems/shuttle/sdk/packages/mcp-server/server.ts
+++ b/src/systems/shuttle/sdk/packages/mcp-server/server.ts
@@ -12,7 +12,7 @@ let config = createConfig(
 let authConfig = createOAuth({
   getAuthorizationUrl: async ctx => {
     // Google OAuth 2.0 endpoint for requesting an authorization code
-    let url = new URL('https://accounts.google.com/o/oauth2/v2/auth');
+    let url = new URL('https://mock-oauth.metorial.net/authorize');
     url.searchParams.set('client_id', ctx.clientId);
     url.searchParams.set('redirect_uri', ctx.redirectUri);
     url.searchParams.set('response_type', 'code');
@@ -21,7 +21,7 @@ let authConfig = createOAuth({
   },
   handleCallback: async ctx => {
     // Exchange authorization code for access token
-    let tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+    let tokenResponse = await fetch('https://mock-oauth.metorial.net/token', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'

--- a/src/systems/subspace/apps/controller/src/controllers/customProvider.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/customProvider.ts
@@ -22,6 +22,33 @@ export let customProviderApp = tenantApp.use(async ctx => {
   return { customProvider };
 });
 
+let functionRuntimeValidator = v.union([
+  v.object({
+    identifier: v.literal('nodejs'),
+    version: v.enumOf(['24.x', '22.x'])
+  }),
+  v.object({
+    identifier: v.literal('python'),
+    version: v.enumOf(['3.14', '3.13', '3.12'])
+  })
+]);
+
+let functionRepositoryValidator = v.optional(
+  v.union([
+    v.object({
+      repositoryId: v.string(),
+      branch: v.string(),
+      path: v.optional(v.string())
+    }),
+    v.object({
+      type: v.literal('git'),
+      repositoryUrl: v.string(),
+      branch: v.string(),
+      path: v.optional(v.string())
+    })
+  ])
+);
+
 export let customProviderFromValidator = v.union([
   v.object({
     type: v.literal('container'),
@@ -47,31 +74,42 @@ export let customProviderFromValidator = v.union([
       })
     ),
     env: v.record(v.string()),
-    runtime: v.union([
-      v.object({
-        identifier: v.literal('nodejs'),
-        version: v.enumOf(['24.x', '22.x'])
-      }),
-      v.object({
-        identifier: v.literal('python'),
-        version: v.enumOf(['3.14', '3.13', '3.12'])
-      })
-    ]),
+    runtime: functionRuntimeValidator,
+    repository: functionRepositoryValidator
+  })
+]);
+
+export let customProviderFromUpdateValidator = v.union([
+  v.object({
+    type: v.literal('container'),
     repository: v.optional(
-      v.union([
-        v.object({
-          repositoryId: v.string(),
-          branch: v.string(),
-          path: v.optional(v.string())
-        }),
-        v.object({
-          type: v.literal('git'),
-          repositoryUrl: v.string(),
-          branch: v.string(),
-          path: v.optional(v.string())
-        })
-      ])
+      v.object({
+        imageRef: v.optional(v.string()),
+        username: v.optional(v.string()),
+        password: v.optional(v.string())
+      })
     )
+  }),
+  v.object({
+    type: v.literal('remote'),
+    remoteUrl: v.optional(v.string()),
+    oauthConfig: v.optional(v.record(v.any())),
+    protocol: v.optional(v.enumOf(['sse', 'streamable_http']))
+  }),
+  v.object({
+    type: v.literal('function'),
+    files: v.optional(
+      v.array(
+        v.object({
+          filename: v.string(),
+          content: v.string(),
+          encoding: v.optional(v.enumOf(['utf-8', 'base64']))
+        })
+      )
+    ),
+    env: v.optional(v.record(v.string())),
+    runtime: v.optional(functionRuntimeValidator),
+    repository: functionRepositoryValidator
   })
 ]);
 
@@ -101,7 +139,9 @@ export let customProviderController = app.controller({
           providerIds: v.optional(v.array(v.string())),
 
           createdAt: createdAtValidator,
-          updatedAt: updatedAtValidator
+          updatedAt: updatedAtValidator,
+
+          includeEnv: v.optional(v.boolean())
         })
       )
     )
@@ -126,7 +166,12 @@ export let customProviderController = app.controller({
 
       let list = await paginator.run(ctx.input);
 
-      return Paginator.presentLight(list, v => customProviderPresenter(v, ctx));
+      return Paginator.presentLight(list, v =>
+        customProviderPresenter(v, {
+          tenant: ctx.tenant,
+          includeEnv: ctx.input.includeEnv
+        })
+      );
     }),
 
   get: customProviderApp
@@ -136,10 +181,17 @@ export let customProviderController = app.controller({
         tenantId: v.string(),
         environmentId: v.string(),
         customProviderId: v.string(),
-        allowDeleted: v.optional(v.boolean())
+        allowDeleted: v.optional(v.boolean()),
+
+        includeEnv: v.optional(v.boolean())
       })
     )
-    .do(async ctx => await customProviderPresenter(ctx.customProvider, ctx)),
+    .do(async ctx =>
+      customProviderPresenter(ctx.customProvider, {
+        tenant: ctx.tenant,
+        includeEnv: ctx.input.includeEnv
+      })
+    ),
 
   create: tenantApp
     .handler()
@@ -179,7 +231,7 @@ export let customProviderController = app.controller({
         }
       });
 
-      return await customProviderPresenter(customProvider, ctx);
+      return await customProviderPresenter(customProvider, { tenant: ctx.tenant });
     }),
 
   update: customProviderApp
@@ -223,6 +275,6 @@ export let customProviderController = app.controller({
         }
       });
 
-      return await customProviderPresenter(customProvider, ctx);
+      return await customProviderPresenter(customProvider, { tenant: ctx.tenant });
     })
 });

--- a/src/systems/subspace/apps/controller/src/controllers/customProviderCommit.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/customProviderCommit.ts
@@ -41,7 +41,9 @@ export let customProviderCommitController = app.controller({
           customProviderEnvironmentIds: v.optional(v.array(v.string())),
 
           createdAt: createdAtValidator,
-          updatedAt: updatedAtValidator
+          updatedAt: updatedAtValidator,
+
+          includeEnv: v.optional(v.boolean())
         })
       )
     )
@@ -63,7 +65,9 @@ export let customProviderCommitController = app.controller({
 
       let list = await paginator.run(ctx.input);
 
-      return Paginator.presentLight(list, customProviderCommitPresenter);
+      return Paginator.presentLight(list, v =>
+        customProviderCommitPresenter(v, { includeEnv: ctx.input.includeEnv })
+      );
     }),
 
   get: customProviderCommitApp
@@ -72,10 +76,16 @@ export let customProviderCommitController = app.controller({
       v.object({
         tenantId: v.string(),
         environmentId: v.string(),
-        customProviderCommitId: v.string()
+        customProviderCommitId: v.string(),
+
+        includeEnv: v.optional(v.boolean())
       })
     )
-    .do(async ctx => customProviderCommitPresenter(ctx.customProviderCommit)),
+    .do(async ctx =>
+      customProviderCommitPresenter(ctx.customProviderCommit, {
+        includeEnv: ctx.input.includeEnv
+      })
+    ),
 
   create: tenantApp
     .handler()

--- a/src/systems/subspace/apps/controller/src/controllers/customProviderVersion.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/customProviderVersion.ts
@@ -8,7 +8,10 @@ import { actorService } from '@metorial-subspace/module-tenant';
 import { customProviderVersionPresenter } from '@metorial-subspace/presenters';
 import { app } from './_app';
 import { createdAtValidator, updatedAtValidator } from './_dateFilter';
-import { customProviderConfigValidator, customProviderFromValidator } from './customProvider';
+import {
+  customProviderConfigValidator,
+  customProviderFromUpdateValidator
+} from './customProvider';
 import { tenantApp } from './tenant';
 
 export let customProviderVersionApp = tenantApp.use(async ctx => {
@@ -48,7 +51,9 @@ export let customProviderVersionController = app.controller({
           customProviderEnvironmentIds: v.optional(v.array(v.string())),
 
           createdAt: createdAtValidator,
-          updatedAt: updatedAtValidator
+          updatedAt: updatedAtValidator,
+
+          includeEnv: v.optional(v.boolean())
         })
       )
     )
@@ -73,7 +78,9 @@ export let customProviderVersionController = app.controller({
 
       let list = await paginator.run(ctx.input);
 
-      return Paginator.presentLight(list, customProviderVersionPresenter);
+      return Paginator.presentLight(list, v =>
+        customProviderVersionPresenter(v, { includeEnv: ctx.input.includeEnv })
+      );
     }),
 
   get: customProviderVersionApp
@@ -82,10 +89,16 @@ export let customProviderVersionController = app.controller({
       v.object({
         tenantId: v.string(),
         environmentId: v.string(),
-        customProviderVersionId: v.string()
+        customProviderVersionId: v.string(),
+
+        includeEnv: v.optional(v.boolean())
       })
     )
-    .do(async ctx => customProviderVersionPresenter(ctx.customProviderVersion)),
+    .do(async ctx =>
+      customProviderVersionPresenter(ctx.customProviderVersion, {
+        includeEnv: ctx.input.includeEnv
+      })
+    ),
 
   create: tenantApp
     .handler()
@@ -99,8 +112,10 @@ export let customProviderVersionController = app.controller({
 
         message: v.optional(v.string()),
 
-        from: customProviderFromValidator,
-        config: customProviderConfigValidator
+        from: v.optional(customProviderFromUpdateValidator),
+        config: customProviderConfigValidator,
+
+        includeEnv: v.optional(v.boolean())
       })
     )
     .do(async ctx => {
@@ -132,6 +147,8 @@ export let customProviderVersionController = app.controller({
           }
         });
 
-      return customProviderVersionPresenter(customProviderVersion);
+      return customProviderVersionPresenter(customProviderVersion, {
+        includeEnv: ctx.input.includeEnv
+      });
     })
 });

--- a/src/systems/subspace/apps/controller/src/controllers/tenant.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/tenant.ts
@@ -61,6 +61,8 @@ export let tenantController = app.controller({
         isWhitelabel: v.optional(v.boolean()),
         logRetentionInDays: v.optional(v.number()),
         enforceSessionExpiry: v.optional(v.boolean()),
+        allowAuthConfigExport: v.optional(v.boolean()),
+        allowAuthConfigImport: v.optional(v.boolean()),
         environments: v.array(
           v.object({
             name: v.string(),
@@ -79,7 +81,9 @@ export let tenantController = app.controller({
           onlyAllowTrustedProviders: ctx.input.onlyAllowTrustedProviders,
           isWhitelabel: ctx.input.isWhitelabel,
           logRetentionInDays: ctx.input.logRetentionInDays,
-          enforceSessionExpiry: ctx.input.enforceSessionExpiry
+          enforceSessionExpiry: ctx.input.enforceSessionExpiry,
+          allowAuthConfigExport: ctx.input.allowAuthConfigExport,
+          allowAuthConfigImport: ctx.input.allowAuthConfigImport
         }
       });
       return tenantPresenter(tenant);

--- a/src/systems/subspace/apps/controller/src/controllers/tests/tenant.e2e.test.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/tests/tenant.e2e.test.ts
@@ -38,7 +38,22 @@ describe('tenant.e2e', () => {
       identifier: 'test-tenant',
       name: 'Test Tenant',
       logRetentionInDays: 14,
+      allowAuthConfigExport: false,
+      allowAuthConfigImport: false,
       createdAt: expect.any(Date)
+    });
+
+    let updated = await client.tenant.upsert({
+      name: 'Test Tenant',
+      identifier: 'test-tenant',
+      allowAuthConfigExport: true,
+      allowAuthConfigImport: true,
+      environments: []
+    });
+
+    expect(updated).toMatchObject({
+      allowAuthConfigExport: true,
+      allowAuthConfigImport: true
     });
 
     let fetched = await client.tenant.get({
@@ -50,7 +65,9 @@ describe('tenant.e2e', () => {
       id: tenant.id,
       identifier: tenant.identifier,
       name: tenant.name,
-      logRetentionInDays: 14
+      logRetentionInDays: 14,
+      allowAuthConfigExport: true,
+      allowAuthConfigImport: true
     });
   });
 });

--- a/src/systems/subspace/db/prisma/schema/custom-provider/upcoming.prisma
+++ b/src/systems/subspace/db/prisma/schema/custom-provider/upcoming.prisma
@@ -35,7 +35,7 @@ model UpcomingCustomProvider {
   errorCode    String?
   errorMessage String?
 
-  /// [CustomProviderPayload]
+  /// [UpcomingCustomProviderPayload]
   payload Json
 
   createdAt DateTime @default(now())

--- a/src/systems/subspace/db/prisma/schema/tenant.prisma
+++ b/src/systems/subspace/db/prisma/schema/tenant.prisma
@@ -24,6 +24,9 @@ model Tenant {
   logRetentionInDays     Int     @default(30)
   enforceSessionExpiry Boolean @default(false)
 
+  allowAuthConfigExport Boolean @default(false)
+  allowAuthConfigImport Boolean @default(false)
+
   providers                                Provider[]
   providerListingGroups                    ProviderListingGroup[]
   providerListings                         ProviderListing[]

--- a/src/systems/subspace/db/src/db.ts
+++ b/src/systems/subspace/db/src/db.ts
@@ -11,7 +11,11 @@ import type { InitializeRequest, JSONRPCMessage } from '@modelcontextprotocol/sd
 import { PrismaPg } from '@prisma/adapter-pg';
 import { readReplicas } from '@prisma/extension-read-replicas';
 import { PrismaClient } from '../prisma/generated/client';
-import type { CustomProviderConfig, CustomProviderFrom } from './types';
+import type {
+  CustomProviderConfig,
+  CustomProviderFrom,
+  CustomProviderFromUpdate
+} from './types';
 export type { EntityImage } from '../../../_shared/entityImage';
 
 let mainAdapter = new PrismaPg({
@@ -161,6 +165,11 @@ declare global {
     type CustomProviderPayload = {
       from: CustomProviderFrom;
       config: CustomProviderConfig | undefined;
+    };
+
+    type UpcomingCustomProviderPayload = {
+      from?: CustomProviderFromUpdate;
+      config?: CustomProviderConfig;
     };
 
     type ProviderTypeAttributes = {

--- a/src/systems/subspace/db/src/types/customProvider.ts
+++ b/src/systems/subspace/db/src/types/customProvider.ts
@@ -1,42 +1,57 @@
-export type CustomProviderFrom =
-  | {
-      type: 'container';
-      repository: {
-        imageRef: string;
-        username?: string;
-        password?: string;
+export type CustomProviderFromContainer = {
+  type: 'container';
+  repository: {
+    imageRef: string;
+    username?: string;
+    password?: string;
+  };
+};
+
+export type CustomProviderFromRemote = {
+  type: 'remote';
+  remoteUrl: string;
+  protocol: 'sse' | 'streamable_http';
+  oauthConfig?: Record<string, any>;
+};
+
+export type CustomProviderFromFunction = {
+  type: 'function';
+  env: Record<string, string>;
+  runtime:
+    | { identifier: 'nodejs'; version: '24.x' | '22.x' }
+    | { identifier: 'python'; version: '3.14' | '3.13' | '3.12' };
+
+  files?: {
+    filename: string;
+    content: string;
+    encoding?: 'utf-8' | 'base64';
+  }[];
+
+  repository?:
+    | {
+        repositoryId: string;
+        branch: string;
+      }
+    | {
+        type: 'git';
+        repositoryUrl: string;
+        branch: string;
       };
-    }
-  | {
-      type: 'remote';
-      remoteUrl: string;
-      protocol: 'sse' | 'streamable_http';
-      oauthConfig?: Record<string, any>;
-    }
-  | {
-      type: 'function';
-      env: Record<string, string>;
-      runtime:
-        | { identifier: 'nodejs'; version: '24.x' | '22.x' }
-        | { identifier: 'python'; version: '3.14' | '3.13' | '3.12' };
+};
 
-      files?: {
-        filename: string;
-        content: string;
-        encoding?: 'utf-8' | 'base64';
-      }[];
+export type CustomProviderFrom =
+  | CustomProviderFromContainer
+  | CustomProviderFromRemote
+  | CustomProviderFromFunction;
 
-      repository?:
-        | {
-            repositoryId: string;
-            branch: string;
-          }
-        | {
-            type: 'git';
-            repositoryUrl: string;
-            branch: string;
-          };
-    };
+export type CustomProviderFromUpdate =
+  | CustomProviderFromContainer
+  | CustomProviderFromRemote
+  | (Omit<CustomProviderFromFunction, 'files' | 'env' | 'runtime'> & {
+      runtime?: CustomProviderFromFunction['runtime'];
+      env?: CustomProviderFromFunction['env'];
+      files?: CustomProviderFromFunction['files'];
+    });
 
 export type CustomProviderConfig = {
   schema: Record<string, any>;

--- a/src/systems/subspace/modules/auth/src/services/providerAuthExport.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthExport.ts
@@ -1,4 +1,4 @@
-import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { forbiddenError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import {
@@ -120,6 +120,14 @@ class providerAuthExportServiceImpl {
     checkTenant(d, d.authConfig);
     checkDeletedRelation(d.authConfig);
     await checkManagedCredentialsBlocked(d.authConfig);
+
+    if (!d.tenant.allowAuthConfigExport) {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Auth config export is not enabled for this project'
+        })
+      );
+    }
 
     let backend = await getBackend({ entity: d.authConfig });
 

--- a/src/systems/subspace/modules/auth/src/services/providerAuthImport.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthImport.ts
@@ -1,4 +1,4 @@
-import { notFoundError, ServiceError, badRequestError } from '@lowerdeck/error';
+import { notFoundError, ServiceError, badRequestError, forbiddenError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import {
@@ -134,6 +134,14 @@ class providerAuthImportServiceImpl {
       input: { authMethodId?: string };
     }
   ) {
+    if (!d.tenant.allowAuthConfigImport) {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Auth config import is not enabled for this project'
+        })
+      );
+    }
+
     checkTenant(d, d.providerAuthConfig);
     checkTenant(d, d.providerDeployment);
 
@@ -180,6 +188,14 @@ class providerAuthImportServiceImpl {
       };
     }
   ) {
+    if (!d.tenant.allowAuthConfigImport) {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Auth config import is not enabled for this project'
+        })
+      );
+    }
+
     let checkRes = await this.check(d);
 
     checkProviderMatch(checkRes.provider, checkRes.providerAuthConfig);

--- a/src/systems/subspace/modules/custom-provider/src/internal/files.ts
+++ b/src/systems/subspace/modules/custom-provider/src/internal/files.ts
@@ -12,6 +12,7 @@ import {
 } from '@metorial-subspace/db';
 import { getTenantForOrigin, origin } from '../origin';
 import { linkRepo } from './linkRepo';
+import { synthesizeRepositoryFromScmRepo } from './resolveFrom';
 
 let getImmutableBucketForRepoVersion = async (d: {
   provider: CustomProvider;
@@ -182,9 +183,11 @@ let getImmutableBucketForFiles = async (d: {
     where: { oid: d.version.customProviderOid },
     include: { draftCodeBucket: true }
   });
-  if (d.from.type !== 'function' || !d.from.files) {
+  if (d.from.type !== 'function') {
     throw new Error('Can only get files for function providers');
   }
+
+  let files = d.from.files ?? [];
 
   let originTenant = await getTenantForOrigin(d.tenant);
 
@@ -221,11 +224,11 @@ let getImmutableBucketForFiles = async (d: {
     });
   }
 
-  if (d.from.files.length) {
+  if (files.length) {
     await origin.codeBucket.setFiles({
       tenantId: originTenant.id,
       codeBucketId: provider.draftCodeBucket!.id,
-      files: d.from.files.map(f => ({
+      files: files.map(f => ({
         path: f.filename,
         data: f.content,
         encoding: f.encoding ?? 'utf-8'
@@ -233,12 +236,12 @@ let getImmutableBucketForFiles = async (d: {
     });
   }
 
-  let immutableBucketOrigin = d.from.files.length
+  let immutableBucketOrigin = files.length
     ? await origin.codeBucket.create({
         tenantId: originTenant.id,
         purpose: 'subspace.custom_provider_files',
         isReadOnly: true,
-        files: d.from.files.map(f => ({
+        files: files.map(f => ({
           path: f.filename,
           data: f.content,
           encoding: f.encoding ?? 'utf-8'
@@ -302,8 +305,34 @@ export let getImmutableBucketForCustomProviderVersion = async (d: {
       return await getImmutableBucketForRepoVersion(d);
     }
 
-    if (d.from.files) {
+    if (d.from.files !== undefined) {
       return await getImmutableBucketForFiles(d);
+    }
+
+    if (d.provider.scmRepoOid) {
+      let provider = await db.customProvider.findUniqueOrThrow({
+        where: { oid: d.provider.oid },
+        include: { scmRepo: true }
+      });
+      if (provider.scmRepo) {
+        return await getImmutableBucketForRepoVersion({
+          ...d,
+          from: {
+            ...d.from,
+            repository: synthesizeRepositoryFromScmRepo(provider.scmRepo)
+          }
+        });
+      }
+    }
+
+    if (d.provider.draftCodeBucketOid) {
+      return await getImmutableBucketForFiles({
+        ...d,
+        from: {
+          ...d.from,
+          files: []
+        }
+      });
     }
   }
 

--- a/src/systems/subspace/modules/custom-provider/src/internal/resolveFrom.ts
+++ b/src/systems/subspace/modules/custom-provider/src/internal/resolveFrom.ts
@@ -1,0 +1,166 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
+import type {
+  CustomProvider,
+  CustomProviderConfig,
+  CustomProviderFrom,
+  CustomProviderFromFunction,
+  CustomProviderFromUpdate,
+  ScmRepo
+} from '@metorial-subspace/db';
+
+export let mergeCustomProviderFromUpdate = (
+  base: CustomProviderFrom,
+  update?: CustomProviderFromUpdate
+): CustomProviderFrom => {
+  if (!update) return base;
+
+  if (base.type !== update.type) {
+    throw new ServiceError(
+      badRequestError({
+        message: `Cannot change custom provider type from '${base.type}' to '${update.type}'`,
+        hint: 'The deployment from type must match the custom provider type.'
+      })
+    );
+  }
+
+  if (base.type === 'function' && update.type === 'function') {
+    return {
+      type: 'function',
+      env: update.env ?? base.env,
+      runtime: update.runtime ?? base.runtime,
+      repository: update.repository !== undefined ? update.repository : base.repository,
+      files: update.files !== undefined ? update.files : base.files
+    };
+  }
+
+  if (base.type === 'container' && update.type === 'container') {
+    return {
+      type: 'container',
+      repository: {
+        ...base.repository,
+        ...update.repository
+      }
+    };
+  }
+
+  if (base.type === 'remote' && update.type === 'remote') {
+    return {
+      type: 'remote',
+      remoteUrl: update.remoteUrl ?? base.remoteUrl,
+      protocol: update.protocol ?? base.protocol,
+      oauthConfig: update.oauthConfig !== undefined ? update.oauthConfig : base.oauthConfig
+    };
+  }
+
+  return base;
+};
+
+export let synthesizeRepositoryFromScmRepo = (
+  scmRepo: ScmRepo
+): CustomProviderFromFunction['repository'] => {
+  if (scmRepo.fromRepoUrl) {
+    return {
+      type: 'git',
+      repositoryUrl: scmRepo.fromRepoUrl,
+      branch: scmRepo.defaultBranch
+    };
+  }
+
+  return {
+    repositoryId: scmRepo.id,
+    branch: scmRepo.defaultBranch
+  };
+};
+
+let assertFunctionDeployable = (
+  from: CustomProviderFromFunction,
+  provider: CustomProvider
+) => {
+  let hasFiles = from.files !== undefined;
+  let hasRepository = !!from.repository;
+  let hasScmRepo = !!provider.scmRepoOid;
+  let hasDraftBucket = !!provider.draftCodeBucketOid;
+
+  if (!hasFiles && !hasRepository && !hasScmRepo && !hasDraftBucket) {
+    throw new ServiceError(
+      badRequestError({
+        message:
+          'No deployment source provided. Either files, an SCM repository, or an existing linked source must be available to create a deployment.',
+        hint: 'Please provide deployment files, link an SCM repository, or ensure the custom provider has a linked repo or draft code bucket.'
+      })
+    );
+  }
+
+  if (!from.env || !from.runtime) {
+    throw new ServiceError(
+      badRequestError({
+        message: 'Function deployment requires env and runtime.',
+        hint: 'Provide env and runtime in the request or ensure they are set on the custom provider.'
+      })
+    );
+  }
+};
+
+export let resolveCustomProviderFromForDeployment = (d: {
+  partial?: CustomProviderFromUpdate;
+  provider: CustomProvider & { scmRepo?: ScmRepo | null };
+}): CustomProviderFrom => {
+  let merged = mergeCustomProviderFromUpdate(d.provider.payload.from, d.partial);
+
+  if (merged.type === 'function') {
+    if (!merged.repository && !merged.files?.length && d.provider.scmRepoOid && d.provider.scmRepo) {
+      merged = {
+        ...merged,
+        repository: synthesizeRepositoryFromScmRepo(d.provider.scmRepo)
+      };
+    }
+
+    if (
+      !merged.repository &&
+      merged.files === undefined &&
+      d.provider.draftCodeBucketOid &&
+      !d.provider.scmRepoOid
+    ) {
+      merged = {
+        ...merged,
+        files: []
+      };
+    }
+
+    assertFunctionDeployable(merged, d.provider);
+    return merged;
+  }
+
+  if (merged.type === 'container') {
+    if (!merged.repository?.imageRef) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Container deployment requires an image reference.',
+          hint: 'Provide repository.imageRef in the request or ensure it is set on the custom provider.'
+        })
+      );
+    }
+    return merged;
+  }
+
+  if (merged.type === 'remote') {
+    if (!merged.remoteUrl || !merged.protocol) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Remote deployment requires remoteUrl and protocol.',
+          hint: 'Provide remoteUrl and protocol in the request or ensure they are set on the custom provider.'
+        })
+      );
+    }
+    return merged;
+  }
+
+  return merged;
+};
+
+export let resolveCustomProviderConfig = (
+  partial?: CustomProviderConfig,
+  base?: CustomProviderConfig
+): CustomProviderConfig | undefined => {
+  return partial ?? base;
+};

--- a/src/systems/subspace/modules/custom-provider/src/queues/commit/apply.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/commit/apply.ts
@@ -58,6 +58,7 @@ export let commitApplyQueueProcessor = commitApplyQueue.process(async data => {
     ) {
       // Re-enqueue until the target version is deployed
       await commitApplyQueue.add(data, { delay: 2500 });
+      return;
     }
 
     await withTransaction(async db => {
@@ -120,6 +121,22 @@ export let commitApplyQueueProcessor = commitApplyQueue.process(async data => {
       await db.providerVersion.updateMany({
         where: { oid: targetVersion.providerVersionOid! },
         data: { isEnvironmentLocked: true }
+      });
+
+      await db.providerVariant.updateMany({
+        where: { oid: customProvider.providerVariantOid! },
+        data: { currentVersionOid: targetVersion.providerVersionOid! }
+      });
+      await db.providerVersion.updateMany({
+        where: {
+          providerVariantOid: customProvider.providerVariantOid!,
+          oid: { not: targetVersion.providerVersionOid! }
+        },
+        data: { isCurrent: false }
+      });
+      await db.providerVersion.updateMany({
+        where: { oid: targetVersion.providerVersionOid! },
+        data: { isCurrent: true }
       });
 
       await db.provider.updateMany({

--- a/src/systems/subspace/modules/custom-provider/src/queues/deployment/monitor.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/deployment/monitor.ts
@@ -30,7 +30,9 @@ export let customDeploymentMonitorQueueProcessor = customDeploymentMonitorQueue.
     let shuttleDeploymentRecord = deployment.shuttleCustomServerDeployment;
     let shuttleCustomServerRecord = deployment.shuttleCustomServer;
     let shuttleServerRecord = shuttleCustomServerRecord?.server;
-    if (!shuttleDeploymentRecord || !shuttleCustomServerRecord || !shuttleServerRecord) return;
+    if (!shuttleDeploymentRecord || !shuttleCustomServerRecord || !shuttleServerRecord) {
+      throw new QueueRetryError();
+    }
 
     let shuttleTenant = await getTenantForShuttle(deployment.tenant);
     let shuttleDeployment = await shuttle.serverDeployment.get({
@@ -98,7 +100,7 @@ export let customDeploymentMonitorQueueProcessor = customDeploymentMonitorQueue.
             customProviderDeploymentId: deployment.id
           });
           return;
-        } catch (err) {
+        } catch {
           throw new QueueRetryError();
         }
       }

--- a/src/systems/subspace/modules/custom-provider/src/queues/deployment/succeeded.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/deployment/succeeded.ts
@@ -35,14 +35,35 @@ export let customDeploymentSucceededQueueProcessor = customDeploymentSucceededQu
     let commit = deployment?.commit;
 
     if (!deployment) throw new QueueRetryError();
+
     if (
       !customProviderVersion ||
       !shuttleServerRecord ||
       !shuttleServerVersionRecord ||
       !sourceEnvironment ||
       !commit
-    )
+    ) {
+      throw new QueueRetryError();
+    }
+
+    if (customProviderVersion.providerVersionOid) {
+      if (deployment.status !== 'succeeded') {
+        await db.customProviderDeployment.updateMany({
+          where: { id: deployment.id },
+          data: {
+            status: 'succeeded',
+            startedAt: deployment.startedAt ?? new Date(),
+            endedAt: deployment.endedAt ?? new Date()
+          }
+        });
+      }
+
+      if (commit.status !== 'applied') {
+        await commitApplyQueue.add({ customProviderCommitId: commit.id });
+      }
+
       return;
+    }
 
     let tenant = await getTenantForShuttle(deployment.tenant);
 
@@ -56,61 +77,61 @@ export let customDeploymentSucceededQueueProcessor = customDeploymentSucceededQu
     });
 
     await withTransaction(async db => {
-      let versionRes = await upsertShuttleServerVersion({
-        shuttleServer,
-        shuttleServerVersion,
+        let versionRes = await upsertShuttleServerVersion({
+          shuttleServer,
+          shuttleServerVersion,
 
-        shuttleServerRecord,
-        shuttleServerVersionRecord
-      });
+          shuttleServerRecord,
+          shuttleServerVersionRecord
+        });
 
-      await linkNewShuttleVersionToCustomProvider({
-        ...versionRes,
-        customProviderVersion
-      });
+        await linkNewShuttleVersionToCustomProvider({
+          ...versionRes,
+          customProviderVersion
+        });
 
-      await ensureEnvironments(customProviderVersion);
+        await ensureEnvironments(customProviderVersion);
 
-      let sourceEnvFull = await db.customProviderEnvironment.findUniqueOrThrow({
-        where: { oid: sourceEnvironment.oid },
-        include: {
-          providerEnvironment: {
-            include: {
-              currentVersion: {
-                include: { customProviderVersion: true }
+        let sourceEnvFull = await db.customProviderEnvironment.findUniqueOrThrow({
+          where: { oid: sourceEnvironment.oid },
+          include: {
+            providerEnvironment: {
+              include: {
+                currentVersion: {
+                  include: { customProviderVersion: true }
+                }
               }
             }
           }
-        }
+        });
+
+        await db.customProviderCommit.updateMany({
+          where: { oid: commit.oid },
+          data: {
+            toEnvironmentOid: sourceEnvFull.oid,
+            toEnvironmentVersionBeforeOid:
+              sourceEnvFull.providerEnvironment?.currentVersion?.customProviderVersion?.oid
+          }
+        });
+
+        await addAfterTransactionHook(() =>
+          commitApplyQueue.add({ customProviderCommitId: commit.id })
+        );
+
+        await addAfterTransactionHook(() =>
+          customDeploymentPropagateToOtherEnvironmentsQueue.add({
+            customProviderDeploymentId: deployment.id
+          })
+        );
+
+        await db.customProviderDeployment.updateMany({
+          where: { id: deployment.id },
+          data: {
+            status: 'succeeded',
+            startedAt: deployment.startedAt ?? new Date(),
+            endedAt: deployment.endedAt ?? new Date()
+          }
+        });
       });
-
-      await db.customProviderCommit.updateMany({
-        where: { oid: commit.oid },
-        data: {
-          toEnvironmentOid: sourceEnvFull.oid,
-          toEnvironmentVersionBeforeOid:
-            sourceEnvFull.providerEnvironment?.currentVersion?.customProviderVersion?.oid
-        }
-      });
-
-      await addAfterTransactionHook(() =>
-        commitApplyQueue.add({ customProviderCommitId: commit.id })
-      );
-
-      await addAfterTransactionHook(() =>
-        customDeploymentPropagateToOtherEnvironmentsQueue.add({
-          customProviderDeploymentId: deployment.id
-        })
-      );
-
-      await db.customProviderDeployment.updateMany({
-        where: { id: deployment.id },
-        data: {
-          status: 'succeeded',
-          startedAt: deployment.startedAt ?? new Date(),
-          endedAt: deployment.endedAt ?? new Date()
-        }
-      });
-    });
   }
 );

--- a/src/systems/subspace/modules/custom-provider/src/queues/upcoming/handle.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/upcoming/handle.ts
@@ -17,6 +17,10 @@ import { env } from '../../env';
 import { createVersion } from '../../internal/createVersion';
 import { ensureEnvironments } from '../../internal/ensureEnvironments';
 import { getImmutableBucketForCustomProviderVersion } from '../../internal/files';
+import {
+  resolveCustomProviderConfig,
+  resolveCustomProviderFromForDeployment
+} from '../../internal/resolveFrom';
 import { origin } from '../../origin';
 import { customDeploymentFailedQueue } from '../deployment/failed';
 import { customProviderCreatedQueue } from '../lifecycle/customProvider';
@@ -87,20 +91,29 @@ export let handleUpcomingCustomProviderQueueProcessor =
         solution: true,
         environment: true,
         actor: true,
-        customProvider: true,
+        customProvider: { include: { scmRepo: true } },
         customProviderDeployment: true,
         customProviderVersion: true
       }
     });
     if (!upcoming) throw new QueueRetryError();
     try {
+      let resolvedFrom = resolveCustomProviderFromForDeployment({
+        partial: upcoming.payload.from,
+        provider: upcoming.customProvider
+      });
+      let resolvedConfig = resolveCustomProviderConfig(
+        upcoming.payload.config,
+        upcoming.customProvider.payload.config
+      );
+
       let from = await mapFrom({
-        isInitial: false,
+        isInitial: upcoming.type === 'create_custom_provider',
 
         deployment: upcoming.customProviderDeployment,
         version: upcoming.customProviderVersion,
         provider: upcoming.customProvider,
-        from: upcoming.payload.from,
+        from: resolvedFrom,
 
         tenant: upcoming.tenant,
         solution: upcoming.solution,
@@ -116,14 +129,14 @@ export let handleUpcomingCustomProviderQueueProcessor =
               name: upcoming.customProvider.name,
               description: upcoming.customProvider.description ?? undefined,
 
-              config: upcoming.payload.config,
+              config: resolvedConfig,
               from
             })
           : await backend.createCustomProviderVersion({
               tenant: upcoming.tenant,
               customProvider: upcoming.customProvider,
 
-              config: upcoming.payload.config,
+              config: resolvedConfig,
               from
             });
 

--- a/src/systems/subspace/modules/custom-provider/src/services/customProvider.ts
+++ b/src/systems/subspace/modules/custom-provider/src/services/customProvider.ts
@@ -163,7 +163,11 @@ class customProviderServiceImpl {
   }) {
     let customProvider = await db.customProvider.findFirst({
       where: {
-        id: d.customProviderId,
+        OR: [
+          { id: d.customProviderId },
+          { provider: { id: d.customProviderId } },
+          { provider: { slug: d.customProviderId } }
+        ],
         tenantOid: d.tenant.oid,
         solutionOid: d.solution.oid,
         ...normalizeStatusForGet(d).noParent

--- a/src/systems/subspace/modules/custom-provider/src/services/customProviderVersion.ts
+++ b/src/systems/subspace/modules/custom-provider/src/services/customProviderVersion.ts
@@ -3,7 +3,7 @@ import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import type {
   CustomProviderConfig,
-  CustomProviderFrom,
+  CustomProviderFromUpdate,
   CustomProviderVersion,
   ProviderVersion
 } from '@metorial-subspace/db';
@@ -21,18 +21,22 @@ import {
 } from '@metorial-subspace/db';
 import {
   checkDeletedRelation,
-  type DateFilter,
   normalizeDateFilter,
   resolveCustomProviderDeployments,
   resolveCustomProviderEnvironments,
   resolveCustomProviders,
+  resolveProviders,
   resolveProviderVersions,
-  resolveProviders
+  type DateFilter
 } from '@metorial-subspace/list-utils';
-import type { ProviderVersionEnrichment } from '@metorial-subspace/provider-utils';
 import { providerVersionInternalService } from '@metorial-subspace/module-provider-internal';
 import { checkTenant } from '@metorial-subspace/module-tenant';
+import type { ProviderVersionEnrichment } from '@metorial-subspace/provider-utils';
 import { prepareVersion } from '../internal/createVersion';
+import {
+  resolveCustomProviderConfig,
+  resolveCustomProviderFromForDeployment
+} from '../internal/resolveFrom';
 import { handleUpcomingCustomProviderQueue } from '../queues/upcoming/handle';
 
 let include = {
@@ -106,26 +110,36 @@ class customProviderVersionServiceImpl {
     customProvider: CustomProvider;
     input: {
       message?: string;
-      from?: CustomProviderFrom;
+      from?: CustomProviderFromUpdate;
       config?: CustomProviderConfig;
     };
   }) {
     checkTenant(d, d.customProvider);
     checkDeletedRelation(d.customProvider);
 
-    let from = d.input.from || d.customProvider.payload.from;
-    let config = d.input.config || d.customProvider.payload.config;
+    let resolvedFrom = resolveCustomProviderFromForDeployment({
+      partial: d.input.from,
+      provider: d.customProvider
+    });
+    let resolvedConfig = resolveCustomProviderConfig(
+      d.input.config,
+      d.customProvider.payload.config
+    );
 
-    if (d.customProvider.type !== from.type) {
+    if (d.customProvider.type !== resolvedFrom.type) {
       throw new ServiceError(
         badRequestError({
-          message: `Custom provider type '${d.customProvider.type}' does not match deployment from type '${from.type}'`,
+          message: `Custom provider type '${d.customProvider.type}' does not match deployment from type '${resolvedFrom.type}'`,
           hint: 'Please ensure the deployment from type matches the custom provider type.'
         })
       );
     }
 
-    if (from.type === 'function' && from.files?.length && from.repository) {
+    if (
+      resolvedFrom.type === 'function' &&
+      resolvedFrom.files?.length &&
+      (resolvedFrom.repository || d.customProvider.scmRepoOid)
+    ) {
       throw new ServiceError(
         badRequestError({
           message:
@@ -135,23 +149,16 @@ class customProviderVersionServiceImpl {
       );
     }
 
-    if (from.type === 'function' && !from.files && !from.repository) {
-      throw new ServiceError(
-        badRequestError({
-          message:
-            'No deployment source provided. Either files or an SCM repository must be set to create a deployment.',
-          hint: 'Please provide either deployment files or link an SCM repository.'
-        })
-      );
-    }
-
     let customProvider = await withTransaction(async db => {
       let updatedProvider = await db.customProvider.update({
         where: { oid: d.customProvider.oid },
         data: {
           payload: {
-            from: from.type === 'function' ? { ...from, files: undefined } : from,
-            config
+            from:
+              resolvedFrom.type === 'function'
+                ? { ...resolvedFrom, files: undefined }
+                : resolvedFrom,
+            config: resolvedConfig
           }
         }
       });
@@ -183,9 +190,9 @@ class customProviderVersionServiceImpl {
           customProviderDeploymentOid: versionPrep.deployment.oid,
 
           payload: {
-            from,
-            config
-          }
+            ...(d.input.from !== undefined ? { from: d.input.from } : {}),
+            ...(d.input.config !== undefined ? { config: d.input.config } : {})
+          } satisfies PrismaJson.UpcomingCustomProviderPayload
         }
       });
 

--- a/src/systems/subspace/modules/tenant/src/services/tenant.ts
+++ b/src/systems/subspace/modules/tenant/src/services/tenant.ts
@@ -16,6 +16,8 @@ class tenantServiceImpl {
       isWhitelabel?: boolean;
       logRetentionInDays?: number;
       enforceSessionExpiry?: boolean;
+      allowAuthConfigExport?: boolean;
+      allowAuthConfigImport?: boolean;
       environments: {
         name: string;
         identifier: string;
@@ -39,7 +41,9 @@ class tenantServiceImpl {
           onlyAllowTrustedProviders: d.input.onlyAllowTrustedProviders,
           isWhitelabel: d.input.isWhitelabel,
           logRetentionInDays: d.input.logRetentionInDays,
-          enforceSessionExpiry: d.input.enforceSessionExpiry
+          enforceSessionExpiry: d.input.enforceSessionExpiry,
+          allowAuthConfigExport: d.input.allowAuthConfigExport,
+          allowAuthConfigImport: d.input.allowAuthConfigImport
         },
         create: {
           ...getId('tenant'),
@@ -49,6 +53,8 @@ class tenantServiceImpl {
           isWhitelabel: d.input.isWhitelabel,
           logRetentionInDays: d.input.logRetentionInDays ?? 30,
           enforceSessionExpiry: d.input.enforceSessionExpiry ?? false,
+          allowAuthConfigExport: d.input.allowAuthConfigExport ?? false,
+          allowAuthConfigImport: d.input.allowAuthConfigImport ?? false,
 
           urlKey: generatePlainId(10).toLowerCase()
         }

--- a/src/systems/subspace/packages/presenters/src/customProvider.ts
+++ b/src/systems/subspace/packages/presenters/src/customProvider.ts
@@ -17,6 +17,7 @@ import type {
   ShuttleContainerTag
 } from '@metorial-subspace/provider-shuttle';
 import { bucketPresenter } from './bucket';
+import { presentCustomProviderFrom } from './presentCustomProviderFrom';
 import { providerPresenter } from './provider';
 import { scmRepositoryPresenter } from './scmRepository';
 
@@ -53,7 +54,7 @@ export let customProviderPresenter = async (
     remoteUrl?: string;
     remoteProtocol?: 'sse' | 'streamable_http';
   },
-  d: { tenant: Tenant }
+  d: { tenant: Tenant; includeEnv?: boolean }
 ) => ({
   object: 'custom_provider',
 
@@ -91,11 +92,9 @@ export let customProviderPresenter = async (
       : null,
 
     from: customProvider.payload?.from
-      ? {
-          object: 'custom_provider.from',
-          ...customProvider.payload.from,
-          env: {}
-        }
+      ? presentCustomProviderFrom(customProvider.payload.from, {
+          includeEnv: d.includeEnv
+        })
       : null
   },
 

--- a/src/systems/subspace/packages/presenters/src/customProviderCommit.ts
+++ b/src/systems/subspace/packages/presenters/src/customProviderCommit.ts
@@ -16,6 +16,7 @@ import type {
 } from '@metorial-subspace/db';
 import { actorPresenter } from './actor';
 import { customProviderEnvironmentPresenter } from './customProviderEnvironment';
+import { type CustomProviderPresenterOptions } from './presentCustomProviderFrom';
 import { customProviderVersionPresenter } from './customProviderVersion';
 import { scmPushPresenter } from './scmPush';
 
@@ -100,7 +101,8 @@ export let customProviderCommitPresenter = (
     creatorActor: TenantActor;
 
     scmRepoPush: (ScmRepoPush & { repo: ScmRepo }) | null;
-  }
+  },
+  opts?: CustomProviderPresenterOptions
 ) => ({
   object: 'custom_provider.commit',
 
@@ -132,15 +134,21 @@ export let customProviderCommitPresenter = (
       })
     : null,
 
-  targetCustomProviderVersion: customProviderVersionPresenter({
-    ...customProviderCommit.targetCustomProviderVersion,
-    customProvider: customProviderCommit.customProvider
-  }),
+  targetCustomProviderVersion: customProviderVersionPresenter(
+    {
+      ...customProviderCommit.targetCustomProviderVersion,
+      customProvider: customProviderCommit.customProvider
+    },
+    opts
+  ),
   previousCustomProviderVersion: customProviderCommit.toEnvironmentVersionBefore
-    ? customProviderVersionPresenter({
-        ...customProviderCommit.toEnvironmentVersionBefore,
-        customProvider: customProviderCommit.customProvider
-      })
+    ? customProviderVersionPresenter(
+        {
+          ...customProviderCommit.toEnvironmentVersionBefore,
+          customProvider: customProviderCommit.customProvider
+        },
+        opts
+      )
     : null,
 
   actor: actorPresenter(customProviderCommit.creatorActor),

--- a/src/systems/subspace/packages/presenters/src/customProviderVersion.ts
+++ b/src/systems/subspace/packages/presenters/src/customProviderVersion.ts
@@ -24,6 +24,10 @@ import { actorPresenter } from './actor';
 import { bucketPresenter } from './bucket';
 import { customProviderDeploymentPresenter } from './customProviderDeployment';
 import { customProviderEnvironmentPresenter } from './customProviderEnvironment';
+import {
+  type CustomProviderPresenterOptions,
+  presentCustomProviderFrom
+} from './presentCustomProviderFrom';
 
 export let customProviderVersionPresenter = (
   customProviderVersion: CustomProviderVersion & {
@@ -65,7 +69,8 @@ export let customProviderVersionPresenter = (
 
     remoteUrl?: string;
     remoteProtocol?: 'sse' | 'streamable_http';
-  }
+  },
+  opts?: CustomProviderPresenterOptions
 ) => {
   let customEnvironments = customProviderVersion.customProviderEnvironmentVersions.map(
     v => v.customProviderEnvironment
@@ -128,11 +133,7 @@ export let customProviderVersionPresenter = (
       : null,
 
     from: customProviderVersion.payload?.from
-      ? {
-          object: 'custom_provider.from',
-          ...customProviderVersion.payload.from,
-          env: {}
-        }
+      ? presentCustomProviderFrom(customProviderVersion.payload.from, opts)
       : null,
 
     createdAt: customProviderVersion.createdAt,

--- a/src/systems/subspace/packages/presenters/src/index.ts
+++ b/src/systems/subspace/packages/presenters/src/index.ts
@@ -16,6 +16,7 @@ export * from './callbackDestination';
 export * from './callbackEvent';
 export * from './callbackInstance';
 export * from './customProvider';
+export * from './presentCustomProviderFrom';
 export * from './customProviderCommit';
 export * from './customProviderDeployment';
 export * from './customProviderEnvironment';

--- a/src/systems/subspace/packages/presenters/src/presentCustomProviderFrom.ts
+++ b/src/systems/subspace/packages/presenters/src/presentCustomProviderFrom.ts
@@ -1,0 +1,33 @@
+import type { CustomProviderFrom } from '@metorial-subspace/db';
+
+export type CustomProviderPresenterOptions = {
+  includeEnv?: boolean;
+};
+
+export let presentCustomProviderFrom = (
+  from: CustomProviderFrom,
+  opts?: CustomProviderPresenterOptions
+) => {
+  if (from.type !== 'function') {
+    return {
+      object: 'custom_provider.from' as const,
+      ...from
+    };
+  }
+
+  let { env, ...rest } = from;
+
+  if (opts?.includeEnv) {
+    return {
+      object: 'custom_provider.from' as const,
+      ...rest,
+      env
+    };
+  }
+
+  return {
+    object: 'custom_provider.from' as const,
+    ...rest,
+    env: {}
+  };
+};

--- a/src/systems/subspace/packages/presenters/src/tenant.ts
+++ b/src/systems/subspace/packages/presenters/src/tenant.ts
@@ -12,5 +12,8 @@ export let tenantPresenter = (tenant: Tenant) => ({
   onlyAllowTrustedProviders: tenant.onlyAllowTrustedProviders,
   isWhitelabel: tenant.isWhitelabel,
 
+  allowAuthConfigExport: tenant.allowAuthConfigExport,
+  allowAuthConfigImport: tenant.allowAuthConfigImport,
+
   createdAt: tenant.createdAt
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new dashboard API endpoints that control auth-config export/import settings and exposes custom provider environment variables; incorrect access checks or response handling could leak sensitive configuration data. Most other changes are generated SDK/schema updates with low behavioral complexity.
> 
> **Overview**
> **Adds new configuration surface for project auth-config settings.** The backend dashboard controller now exposes `GET`/`PATCH /dashboard/organizations/:organizationId/projects/:projectId/configure/auth-config` to read/update `allow_auth_config_export` and `allow_auth_config_import`, including validation that at least one field is provided and enforcing `organization.project:read`/`write` access.
> 
> **Extends generated dashboard SDK.** New client endpoint `MetorialDashboardProjectsConfigureAuthConfigEndpoint` is exported and wired into `sdk.ts`, and custom provider endpoints gain `getEnv` methods (plus new `custom_provider.env` resource mappers) to retrieve environment variables for providers and provider versions across dashboard/management instance routes.
> 
> **Schema/mapping updates.** Session/session-template/message/event/connection/tool-call resource mappers are updated to include additional identity fields (`identity_id`, `identity_actor_id`) and agent actor IDs where present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 776414a83987c9d184b0170f08214c1664008f26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->