### PR TITLE
Fix brand image upload

### DIFF
--- a/src/backend/apis/core/src/controllers/management/organization/project.ts
+++ b/src/backend/apis/core/src/controllers/management/organization/project.ts
@@ -3,7 +3,7 @@ import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
 import { accessService } from '@metorial/module-access';
 import { projectBrandService, projectService } from '@metorial/module-organization';
-import { Controller, Path } from '@metorial/rest';
+import { Controller } from '@metorial/rest';
 import { normalizeArrayParam } from '../../../lib/normalizeArrayParam';
 import { checkAccess } from '../../../middleware/checkAccess';
 import {
@@ -224,7 +224,8 @@ export let projectManagementController = Controller.create(
         organizationManagementPath('projects/:projectId/branding', 'projects.branding.update'),
         {
           name: 'Update project branding',
-          description: 'Update branding information for a specific project'
+          description: 'Update branding information for a specific project',
+          hideInDocs: true
         }
       )
       .use(checkAccess({ possibleScopes: ['organization.project:write'] }))

--- a/src/backend/modules/file/src/services/fileReference.ts
+++ b/src/backend/modules/file/src/services/fileReference.ts
@@ -7,8 +7,7 @@ import {
   cargo,
   ensureCargoScope,
   reconcileCargoPurposes,
-  resolveCargoScopeDescriptorForOwner,
-  resolveCargoScopeDescriptorForProject
+  resolveCargoScopeDescriptorForOwner
 } from '../cargo';
 import type { FileOwner } from './file';
 import { resolveCargoScopeForOwner } from './scope';
@@ -59,24 +58,21 @@ class FileReferenceServiceImpl {
   }): Promise<EntityImage> {
     await reconcileCargoPurposes();
 
-    let descriptor =
-      d.entityType === 'project_brand'
-        ? await resolveCargoScopeDescriptorForProject(d.entityId)
-        : await resolveCargoScopeDescriptorForOwner(
-            d.owner.type === 'user'
-              ? {
-                  type: 'user',
-                  user: {
-                    id: d.owner.userId
-                  }
-                }
-              : {
-                  type: 'organization',
-                  organization: {
-                    id: d.owner.organizationId
-                  }
-                }
-          );
+    let descriptor = await resolveCargoScopeDescriptorForOwner(
+      d.owner.type === 'user'
+        ? {
+            type: 'user',
+            user: {
+              id: d.owner.userId
+            }
+          }
+        : {
+            type: 'organization',
+            organization: {
+              id: d.owner.organizationId
+            }
+          }
+    );
     if (!descriptor) {
       throw new ServiceError(notFoundError('file.scope', d.fileId));
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, targeted change to file reference scope resolution for branding images plus a docs visibility flag; no auth or broad API behavior changes.
> 
> **Overview**
> Fixes **project brand image uploads** by resolving Cargo file scope from the **organization (or user) owner** when creating image links, instead of branching on `project_brand` and using **project** scope. That aligns linking with how `project_brand_image` files are stored and should stop scope/not-found failures when attaching an uploaded file to branding.
> 
> The management **update project branding** route is marked **`hideInDocs: true`**, and an unused `Path` import is removed from the project controller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 075777c37339ee94fe1cf505e0b3342d0544ebe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->