### PR TITLE
Improve root direct

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/index/pages/rootRedirect.tsx
+++ b/src/frontend/apps/dashboard/src/slices/index/pages/rootRedirect.tsx
@@ -82,7 +82,7 @@ export let RootRedirect = () => {
 
         navigate(path, { replace: true });
       });
-  }, [boot.data, path, intent]);
+  }, [boot.data, path, intent, organizationId]);
 
   return null;
 };

--- a/src/frontend/config/src/paths.ts
+++ b/src/frontend/config/src/paths.ts
@@ -903,6 +903,49 @@ let OrganizationPaths = Object.assign(
   }
 );
 
+export let PLACEHOLDER_INSTANCE_ENTITY = { id: 'a', slug: 'a' };
+
+export let PLACEHOLDER_INSTANCE_PARAMS = [
+  PLACEHOLDER_INSTANCE_ENTITY,
+  PLACEHOLDER_INSTANCE_ENTITY,
+  PLACEHOLDER_INSTANCE_ENTITY
+] as const;
+
+let dashboardInstanceRedirect = (
+  dashboardUrl: string,
+  fullInstancePath: string,
+  opts?: { organizationId?: string }
+) => {
+  if (!fullInstancePath || fullInstancePath === '#' || !fullInstancePath.startsWith('/i/')) {
+    return fullInstancePath;
+  }
+
+  let queryIndex = fullInstancePath.indexOf('?');
+  let pathname = queryIndex >= 0 ? fullInstancePath.slice(0, queryIndex) : fullInstancePath;
+  let query = queryIndex >= 0 ? fullInstancePath.slice(queryIndex + 1) : '';
+
+  let segments = pathname.split('/').filter(Boolean);
+  if (segments[0] !== 'i' || segments.length < 4) return fullInstancePath;
+
+  let prefix = InstancePaths.home(
+    { slug: segments[1] },
+    { slug: segments[2] },
+    { slug: segments[3] }
+  );
+
+  let resPath = pathname.slice(prefix.length);
+
+  if (query) {
+    resPath = resPath ? `${resPath}?${query}` : `?${query}`;
+  }
+
+  let dashUrl = new URL(dashboardUrl);
+  if (resPath.length > 0) dashUrl.searchParams.set('path', resPath);
+  if (opts?.organizationId) dashUrl.searchParams.set('organization_id', opts.organizationId);
+
+  return dashUrl.toString();
+};
+
 export let WelcomePaths = Object.assign(
   (...subPages: SubPages) => joinPaths('welcome', ...subPages),
   {
@@ -939,5 +982,6 @@ export let Paths = {
   project: ProjectPaths,
   account: AccountPaths,
   organization: OrganizationPaths,
-  welcome: WelcomePaths
+  welcome: WelcomePaths,
+  dashboardInstanceRedirect
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small routing and URL-building changes with no auth or data-layer impact; main risk is incorrect navigation if redirect parsing is wrong.
> 
> **Overview**
> Improves **root redirect** behavior when the dashboard entry URL carries **`organization_id`** (and related query params) by re-running navigation when that param changes, not only when boot data, `path`, or `intent` change.
> 
> Adds shared path utilities: **`Paths.dashboardInstanceRedirect`** turns a full `/i/{org}/{project}/{instance}/…` instance URL into a dashboard URL with the instance tail in a **`path`** query param and optional **`organization_id`**, plus exported **placeholder** instance entity/params for building instance-shaped paths before real slugs are known.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b7b1fdfbbcb456c46d06ce16ea5aff221aa99ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->