### PR TITLE
Harden auth method discovery

### DIFF
--- a/src/systems/subspace/modules/auth/src/services/providerAuthConfigInternal.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthConfigInternal.ts
@@ -91,7 +91,12 @@ class providerAuthConfigInternalServiceImpl {
           specificationOid,
           authMethodId: d.authMethodId
         });
-        if (!requestedAuthMethod || requestedAuthMethod.oid !== authMethod.oid) {
+        if (
+          !requestedAuthMethod ||
+          (requestedAuthMethod.oid !== authMethod.oid &&
+            requestedAuthMethod.globalOid !== authMethod.globalOid &&
+            requestedAuthMethod.callableId !== authMethod.callableId)
+        ) {
           throw new ServiceError(
             badRequestError({
               message:
@@ -100,6 +105,8 @@ class providerAuthConfigInternalServiceImpl {
             })
           );
         }
+
+        authMethod = requestedAuthMethod;
       }
 
       return {
@@ -152,7 +159,7 @@ class providerAuthConfigInternalServiceImpl {
     specificationOid: bigint;
     authMethodId: string;
   }) {
-    return await db.providerAuthMethod.findFirst({
+    let authMethodForSpec = await db.providerAuthMethod.findFirst({
       where: {
         providerOid: d.provider.oid,
         specificationOid: d.specificationOid,
@@ -172,6 +179,56 @@ class providerAuthConfigInternalServiceImpl {
       },
       orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }]
     });
+    if (authMethodForSpec) return authMethodForSpec;
+
+    // This is likely because a version mismatch - an integration or other resource is
+    // locked to a specific auth method id, but the spec has changed and that auth method
+    // is not part of the new spec. We now need to find a fallback that matches the locked
+    // auth method id, but is part of the new spec.
+    let oldAuthMethod = await db.providerAuthMethod.findFirst({
+      where: {
+        providerOid: d.provider.oid,
+        id: d.authMethodId
+      }
+    });
+
+    // There is no such auth method in the old spec,
+    // nothing we can do to resolve this
+    if (!oldAuthMethod) return null;
+
+    // Now we need to find an auth method in the new spec that matches the old auth method
+    let fallbackAuthMethod = await db.providerAuthMethod.findFirst({
+      where: {
+        providerOid: d.provider.oid,
+        specificationOid: d.specificationOid,
+        OR: [
+          { specId: oldAuthMethod.specId },
+          { specUniqueIdentifier: oldAuthMethod.specUniqueIdentifier },
+          { key: oldAuthMethod.key },
+          { callableId: oldAuthMethod.callableId }
+        ]
+      },
+      include: {
+        specification: true
+      },
+      orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }]
+    });
+    if (fallbackAuthMethod) return fallbackAuthMethod;
+
+    fallbackAuthMethod = await db.providerAuthMethod.findFirst({
+      where: {
+        providerOid: d.provider.oid,
+        specificationOid: d.specificationOid,
+        type: oldAuthMethod.type
+      },
+      include: {
+        specification: true
+      },
+      orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }]
+    });
+    if (fallbackAuthMethod) return fallbackAuthMethod;
+
+    return null;
   }
 
   private async findPreferredAuthMethodForVersion(d: {
@@ -231,9 +288,7 @@ class providerAuthConfigInternalServiceImpl {
       authMethod = result as ProviderAuthMethodWithSpecification | null;
     }
 
-    if (authMethod) {
-      return authMethod;
-    }
+    if (authMethod) return authMethod;
 
     throw new ServiceError(
       badRequestError({

--- a/src/systems/subspace/modules/auth/src/services/providerAuthConfigInternal.ts
+++ b/src/systems/subspace/modules/auth/src/services/providerAuthConfigInternal.ts
@@ -201,6 +201,20 @@ class providerAuthConfigInternalServiceImpl {
       where: {
         providerOid: d.provider.oid,
         specificationOid: d.specificationOid,
+        globalOid: oldAuthMethod.globalOid
+      },
+      include: {
+        specification: true
+      },
+      orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }]
+    });
+    if (fallbackAuthMethod) return fallbackAuthMethod;
+
+    // Now we need to find an auth method in the new spec that matches the old auth method
+    fallbackAuthMethod = await db.providerAuthMethod.findFirst({
+      where: {
+        providerOid: d.provider.oid,
+        specificationOid: d.specificationOid,
         OR: [
           { specId: oldAuthMethod.specId },
           { specUniqueIdentifier: oldAuthMethod.specUniqueIdentifier },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, additive change to fallback ordering in auth method lookup; improves correctness without altering credential validation rules.
> 
> **Overview**
> When a locked **auth method id** no longer exists on the current provider spec, resolution in `findAuthMethodForVersion` now tries a **`globalOid`** match on the new spec **before** the existing fallback that matches `specId`, `specUniqueIdentifier`, `key`, or `callableId`.
> 
> That ordering aligns version-mismatch fallback with how managed credentials already identify auth methods, so integrations pinned to an old method id are more likely to map to the correct method after a spec change instead of a weaker identifier match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6cdf51f15d41b41c41a7c9d19b836a8d32bd0e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->