### PR TITLE
Harden slate rediscovery queue

### DIFF
--- a/src/systems/slates/apps/hub/src/queues/deployment/deploy.ts
+++ b/src/systems/slates/apps/hub/src/queues/deployment/deploy.ts
@@ -428,7 +428,7 @@ export let deploySlateVersionCompletedQueueProcessor =
 
         await discoverSlateQueue.add(
           { versionId: deployment.slateVersion.id },
-          { delay: 10_000 }
+          { delay: 10_000, id: deployment.slateVersion.id }
         );
       });
     })

--- a/src/systems/slates/apps/hub/src/queues/discovery/rediscover.ts
+++ b/src/systems/slates/apps/hub/src/queues/discovery/rediscover.ts
@@ -36,9 +36,10 @@ export let rediscoverSlatesQueueProcessor = rediscoverSlatesQueue.process(async 
   });
   if (versions.length === 0) return;
 
-  await rediscoverSlateQueue.addMany(
+  await rediscoverSlateQueue.addManyWithOps(
     versions.map(v => ({
-      slateVersionId: v.id
+      data: { slateVersionId: v.id },
+      opts: { id: v.id }
     }))
   );
 
@@ -51,10 +52,10 @@ let rediscoverSlateQueue = createQueue<{ slateVersionId: string }>({
   name: 'shub/rds/sing',
   redisUrl: env.service.REDIS_URL,
   workerOpts: {
-    limiter: {
-      max: 5,
-      duration: 60_000
-    },
+    // limiter: {
+    //   max: 5,
+    //   duration: 60_000
+    // },
     concurrency: 5
   }
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes background job enqueue semantics and removes a rate limit on rediscovery, which can alter discovery throughput and how duplicate work is coalesced without touching auth or data models directly.
> 
> **Overview**
> This PR **deduplicates slate discovery work** by assigning stable BullMQ job `id`s keyed on slate version id whenever jobs are enqueued on `discoverSlateQueue` (after successful deploy and from the rediscover worker).
> 
> The scheduled rediscover fan-out now uses **`addManyWithOps`** so each per-version rediscover job also gets that same id, and the per-minute **limiter on `rediscoverSlateQueue` is disabled** (commented out) while **concurrency stays at 5**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa76454b88874eacbd1aa41d0d50ac7f540d3aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->