### PR TITLE
Add nebula service

### DIFF
--- a/.github/workflows/nebula.yml
+++ b/.github/workflows/nebula.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -68,6 +70,7 @@ jobs:
     secrets: inherit
     with:
       service_directory: src/systems/nebula/service
+      checkout_submodules: true
       compose_project_prefix: nebula-ci
       compose_profiles: 'infra service'
       wait_services: |

--- a/.github/workflows/nebula.yml
+++ b/.github/workflows/nebula.yml
@@ -1,0 +1,78 @@
+name: 'Nebula'
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build:
+    name: 'Nebula Build'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/metorial/nebula
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./src/systems/nebula/service/Dockerfile
+          platforms: linux/amd64
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+
+  test:
+    name: 'Nebula Test'
+    permissions:
+      contents: read
+      packages: read
+    uses: metorial/.github/.github/workflows/reusable-e2e-tests.yml@main
+    secrets: inherit
+    with:
+      service_directory: src/systems/nebula/service
+      compose_project_prefix: nebula-ci
+      compose_profiles: 'infra service'
+      wait_services: |
+        nebula-postgres
+        nebula-redis
+        nebula-service
+      test_container: nebula-service
+      test_command: cd /app && bun run test

--- a/bun.lock
+++ b/bun.lock
@@ -1594,6 +1594,20 @@
         "vitest": "^3.1.2",
       },
     },
+    "src/systems/_clients/nebula": {
+      "name": "@metorial-platform-systems/nebula-client",
+      "version": "1.0.0",
+      "dependencies": {
+        "@lowerdeck/rpc-client": "^1.1.4",
+        "@lowerdeck/validation": "^1.0.10",
+        "@types/bun": "^1.3.7",
+      },
+      "devDependencies": {
+        "tsup": "^8.5.1",
+        "typescript": "^5.8.3",
+        "vitest": "^3.1.2",
+      },
+    },
     "src/systems/_clients/origin-client": {
       "name": "@metorial-platform-systems/origin-client",
       "version": "1.0.0",
@@ -2135,6 +2149,46 @@
         "@metorial-platform-systems/function-bay-client": "workspace:*",
         "@types/bun": "latest",
         "@types/lodash": "^4.17.23",
+        "@vercel/ncc": "^0.38.1",
+        "vitest": "4.0.17",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+    "src/systems/nebula/service": {
+      "name": "@metorial/nebula",
+      "dependencies": {
+        "@aws-sdk/client-kms": "^3.957.0",
+        "@lowerdeck/api-mux": "^1.0.4",
+        "@lowerdeck/canonicalize": "^1.0.4",
+        "@lowerdeck/cron": "^1.1.3",
+        "@lowerdeck/env": "^1.0.6",
+        "@lowerdeck/error": "^1.2.3",
+        "@lowerdeck/hash": "^1.0.4",
+        "@lowerdeck/id": "^1.0.8",
+        "@lowerdeck/jwt": "^1.0.4",
+        "@lowerdeck/lock": "^1.0.6",
+        "@lowerdeck/pagination": "^1.0.8",
+        "@lowerdeck/queue": "^1.0.11",
+        "@lowerdeck/rpc-client": "^1.1.4",
+        "@lowerdeck/rpc-server": "^1.0.11",
+        "@lowerdeck/sentry": "^1.0.2",
+        "@lowerdeck/service": "^1.0.7",
+        "@lowerdeck/snowflake": "^1.0.2",
+        "@lowerdeck/validation": "^1.0.10",
+        "@prisma/adapter-pg": "^7.2.0",
+        "@prisma/client": "^7.2.0",
+        "@prisma/extension-read-replicas": "^0.5.0",
+        "@sentry/bun": "^10.38.0",
+        "@sentry/cli": "^3.2.0",
+        "date-fns": "^4.1.0",
+        "prisma": "^7.2.0",
+      },
+      "devDependencies": {
+        "@lowerdeck/testing-tools": "^1.0.1",
+        "@types/bun": "latest",
+        "@types/node": "^25.0.3",
         "@vercel/ncc": "^0.38.1",
         "vitest": "4.0.17",
       },
@@ -4217,6 +4271,8 @@
 
     "@lowerdeck/join-paths": ["@lowerdeck/join-paths@1.0.4", "", {}, "sha512-nLPDXdg6gsybw6WwtkjHOvBoQySMFsD7+/4ch52e5fLaJbkMbNXOyRfV+gjimGrfUNP7EA05SXtzuFJfIpsB0g=="],
 
+    "@lowerdeck/jwt": ["@lowerdeck/jwt@1.0.4", "", { "dependencies": { "jose": "^5.6.3" } }, "sha512-F/Ov9NRFWNO/cPmEH3Evc0GIpMVqUxhbQYbDqxUdbBljCseqEE0GYP+b3krqccEpOAYxs4HDpCiNjmxHAk4IdA=="],
+
     "@lowerdeck/lock": ["@lowerdeck/lock@1.0.6", "", { "dependencies": { "@lowerdeck/delay": "^1.0.4", "@lowerdeck/redis": "^1.0.6", "@types/bun": "^1.2.11", "ioredis": "^5.4.1", "redlock": "^5.0.0-beta.2", "superjson": "^2.2.5" } }, "sha512-nf8P6FuWgSQ+hQEVSBGXTPVvFxezoemUtMOXuWP9uVEbAxvtWIKA2SzQoo4XsS3sHHQ2BlCc/8sSCzUzsPPyEQ=="],
 
     "@lowerdeck/memo": ["@lowerdeck/memo@1.0.4", "", {}, "sha512-Fyhi14j1EocQeAjZ6sqeYZaydPlCt23P+CEv99QVPb46Y6n77RGrslbHE7HDPgV0f9CJi4UWxSbfhk+Spmmj5g=="],
@@ -4302,6 +4358,8 @@
     "@metorial-platform-systems/forge-client": ["@metorial-platform-systems/forge-client@workspace:src/systems/_clients/forge"],
 
     "@metorial-platform-systems/function-bay-client": ["@metorial-platform-systems/function-bay-client@workspace:src/systems/_clients/function-bay"],
+
+    "@metorial-platform-systems/nebula-client": ["@metorial-platform-systems/nebula-client@workspace:src/systems/_clients/nebula"],
 
     "@metorial-platform-systems/origin-client": ["@metorial-platform-systems/origin-client@workspace:src/systems/_clients/origin-client"],
 
@@ -4520,6 +4578,8 @@
     "@metorial/module-user": ["@metorial/module-user@workspace:src/backend/modules/user"],
 
     "@metorial/multi-region": ["@metorial/multi-region@workspace:src/backend/multi-region"],
+
+    "@metorial/nebula": ["@metorial/nebula@workspace:src/systems/nebula/service"],
 
     "@metorial/origin": ["@metorial/origin@workspace:src/systems/origin/apps/service"],
 
@@ -8711,6 +8771,8 @@
 
     "@lowerdeck/id/@lowerdeck/error": ["@lowerdeck/error@1.2.2", "", { "dependencies": { "@lowerdeck/case": "^1.0.9", "@lowerdeck/validation": "^1.0.8" } }, "sha512-elbVMzRrKlN+/hk4s9sh0Sysc7Sxtmt7qj+qOWSH0U7h9gwfkFDCPSkJkhuNtHYUvDwe5LyoXPXO+o0LpBaRqw=="],
 
+    "@lowerdeck/jwt/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
     "@lowerdeck/lock/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@lowerdeck/sentry/@sentry/core": ["@sentry/core@10.42.0", "", {}, "sha512-L4rMrXMqUKBanpjpMT+TuAVk6xAijz6AWM6RiEYpohAr7SGcCEc1/T0+Ep1eLV8+pwWacfU27OvELIyNeOnGzA=="],
@@ -8742,6 +8804,8 @@
     "@metorial-platform-systems/forge-client/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@metorial-platform-systems/function-bay-client/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@metorial-platform-systems/nebula-client/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@metorial-platform-systems/origin-client/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
@@ -8870,6 +8934,10 @@
     "@metorial/multi-region/@prisma/adapter-pg": ["@prisma/adapter-pg@6.19.0", "", { "dependencies": { "@prisma/driver-adapter-utils": "6.19.0", "pg": "^8.11.3", "postgres-array": "3.0.4" } }, "sha512-F8f2kvU+igmxERA9oM+D2maMaxrST1P6vO7ayvdlAdcJI47nKNPdkLBGZKic9otghfA9CQnjNOGB56q2VXqnHw=="],
 
     "@metorial/multi-region/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@metorial/nebula/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@metorial/nebula/vitest": ["vitest@4.0.17", "", { "dependencies": { "@vitest/expect": "4.0.17", "@vitest/mocker": "4.0.17", "@vitest/pretty-format": "4.0.17", "@vitest/runner": "4.0.17", "@vitest/snapshot": "4.0.17", "@vitest/spy": "4.0.17", "@vitest/utils": "4.0.17", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.17", "@vitest/browser-preview": "4.0.17", "@vitest/browser-webdriverio": "4.0.17", "@vitest/ui": "4.0.17", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg=="],
 
     "@metorial/origin/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
@@ -10303,6 +10371,28 @@
 
     "@metorial/multi-region/@prisma/adapter-pg/@prisma/driver-adapter-utils": ["@prisma/driver-adapter-utils@6.19.0", "", { "dependencies": { "@prisma/debug": "6.19.0" } }, "sha512-VAC/wFebV569Jk7iEqzLxekM2A5toKYAr6cPM2KWVHiRHgyjsh/IHf++Xo67q8uor/JxY8mwOuyQyuxkstSf5w=="],
 
+    "@metorial/nebula/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@metorial/nebula/vitest/@vitest/expect": ["@vitest/expect@4.0.17", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.17", "@vitest/utils": "4.0.17", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ=="],
+
+    "@metorial/nebula/vitest/@vitest/mocker": ["@vitest/mocker@4.0.17", "", { "dependencies": { "@vitest/spy": "4.0.17", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ=="],
+
+    "@metorial/nebula/vitest/@vitest/pretty-format": ["@vitest/pretty-format@4.0.17", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw=="],
+
+    "@metorial/nebula/vitest/@vitest/runner": ["@vitest/runner@4.0.17", "", { "dependencies": { "@vitest/utils": "4.0.17", "pathe": "^2.0.3" } }, "sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ=="],
+
+    "@metorial/nebula/vitest/@vitest/snapshot": ["@vitest/snapshot@4.0.17", "", { "dependencies": { "@vitest/pretty-format": "4.0.17", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ=="],
+
+    "@metorial/nebula/vitest/@vitest/spy": ["@vitest/spy@4.0.17", "", {}, "sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew=="],
+
+    "@metorial/nebula/vitest/@vitest/utils": ["@vitest/utils@4.0.17", "", { "dependencies": { "@vitest/pretty-format": "4.0.17", "tinyrainbow": "^3.0.3" } }, "sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w=="],
+
+    "@metorial/nebula/vitest/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+
+    "@metorial/nebula/vitest/tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "@metorial/nebula/vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
     "@metorial/origin/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@metorial/origin/vitest/@vitest/expect": ["@vitest/expect@4.0.17", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.17", "@vitest/utils": "4.0.17", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ=="],
@@ -11243,6 +11333,12 @@
 
     "@metorial/multi-region/@prisma/adapter-pg/@prisma/driver-adapter-utils/@prisma/debug": ["@prisma/debug@6.19.0", "", {}, "sha512-8hAdGG7JmxrzFcTzXZajlQCidX0XNkMJkpqtfbLV54wC6LSSX6Vni25W/G+nAANwLnZ2TmwkfIuWetA7jJxJFA=="],
 
+    "@metorial/nebula/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "@metorial/nebula/vitest/@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "@metorial/nebula/vitest/vite/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
     "@metorial/origin/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "@metorial/origin/vitest/@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
@@ -11648,6 +11744,58 @@
     "@metorial/function-bay/vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
 
     "@metorial/function-bay/vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "@metorial/nebula/vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
     "@metorial/origin/vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 

--- a/scripts/dev-tools/scripts/dbInit.sh
+++ b/scripts/dev-tools/scripts/dbInit.sh
@@ -19,6 +19,7 @@ export SLATES_REGISTRY_DATABASE_URL="postgres://postgres:postgres@localhost:3543
 export SUBSPACE_DATABASE_URL="postgres://postgres:postgres@localhost:35432/subspace"
 export SHUTTLE_DATABASE_URL="postgres://postgres:postgres@localhost:35432/shuttle"
 export FORGE_DATABASE_URL="postgres://postgres:postgres@localhost:35432/forge"
+export NEBULA_DATABASE_URL="postgres://postgres:postgres@localhost:35432/nebula"
 export FUNCTION_BAY_DATABASE_URL="postgres://postgres:postgres@localhost:35432/function-bay"
 export HORIZON_DATABASE_URL="postgres://postgres:postgres@localhost:35432/horizon"
 export ARES_DATABASE_URL="postgres://postgres:postgres@localhost:35432/ares"

--- a/scripts/dev-tools/src/env/destinations.ts
+++ b/scripts/dev-tools/src/env/destinations.ts
@@ -6,6 +6,7 @@ import {
   forgeServiceEnv,
   functionBayServiceEnv,
   horizonServiceEnv,
+  nebulaServiceEnv,
   originCodeBucketEnv,
   originServiceEnv,
   signalServiceEnv,
@@ -110,6 +111,11 @@ export let destinations: Destination[] = [
     type: 'oss',
     env: forgeServiceEnv,
     path: 'src/systems/forge/service'
+  },
+  {
+    type: 'oss',
+    env: nebulaServiceEnv,
+    path: 'src/systems/nebula/service'
   },
   {
     type: 'oss',

--- a/scripts/dev-tools/src/env/services.ts
+++ b/scripts/dev-tools/src/env/services.ts
@@ -497,6 +497,49 @@ export let forgeServiceEnv: Env = [
   // }
 ];
 
+export let nebulaServiceEnv: Env = [
+  {
+    key: 'DATABASE_URL',
+    defaultValue: 'postgresql://postgres:postgres@localhost:35432/nebula'
+  },
+  {
+    key: 'REDIS_URL',
+    defaultValue: 'redis://localhost:36379/0'
+  },
+  {
+    key: 'DEFAULT_PROVIDER',
+    defaultValue: 'local'
+  },
+  {
+    key: 'LOCAL_MASTER_SECRET',
+    defaultValue: 'local-dev-nebula-master-secret-with-enough-entropy'
+  },
+  {
+    key: 'KMS_AWS_REGION',
+    defaultValue: 'us-east-1'
+  },
+  {
+    key: 'KMS_CREATE_DEFAULT_KEY',
+    defaultValue: 'false'
+  },
+  {
+    key: 'CONSUMER_INSTANCE_TOKEN_SECRET',
+    defaultValue: 'local-dev-nebula-consumer-token-secret-with-enough-entropy'
+  },
+  {
+    key: 'CONSUMER_INSTANCE_TOKEN_TTL_SECONDS',
+    defaultValue: '3600'
+  },
+  {
+    key: 'CONSUMER_REGISTRATION_SLATES',
+    defaultValue: 'local-dev-nebula-slates-registration-secret'
+  },
+  {
+    key: 'CONSUMER_REGISTRATION_SHUTTLE',
+    defaultValue: 'local-dev-nebula-shuttle-registration-secret'
+  }
+];
+
 export let functionBayServiceEnv: Env = [
   {
     key: 'DATABASE_URL',

--- a/src/systems/_clients/nebula/package.json
+++ b/src/systems/_clients/nebula/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@metorial-platform-systems/nebula-client",
+  "version": "1.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "src/**",
+    "dist/**",
+    "README.md",
+    "package.json"
+  ],
+  "author": "Tobias Herber",
+  "license": "FSL 1.1",
+  "type": "module",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "require": "./dist/index.cjs",
+    "import": "./dist/index.js",
+    "default": "./dist/index.js"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "test": "vitest run --passWithNoTests",
+    "lint": "prettier src/**/*.ts --check",
+    "build": "tsup",
+    "prepublish": "bun run build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@lowerdeck/rpc-client": "^1.1.4",
+    "@lowerdeck/validation": "^1.0.10",
+    "@types/bun": "^1.3.7"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.2"
+  }
+}

--- a/src/systems/_clients/nebula/src/index.ts
+++ b/src/systems/_clients/nebula/src/index.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@lowerdeck/rpc-client';
+import type { NebulaClient } from '../../../nebula/service/src/controllers';
+
+type ClientOpts = Parameters<typeof createClient>[0];
+
+export let createNebulaClient = (o: ClientOpts): NebulaClient => createClient<NebulaClient>(o);

--- a/src/systems/_clients/nebula/src/index.ts
+++ b/src/systems/_clients/nebula/src/index.ts
@@ -3,4 +3,110 @@ import type { NebulaClient } from '../../../nebula/service/src/controllers';
 
 type ClientOpts = Parameters<typeof createClient>[0];
 
-export let createNebulaClient = (o: ClientOpts): NebulaClient => createClient<NebulaClient>(o);
+type SecretClient = NebulaClient['secret'];
+type SecretCreateInput = Parameters<SecretClient['create']>[0];
+type SecretUpdateInput = Parameters<SecretClient['update']>[0];
+type SecretUseInput = Parameters<SecretClient['use']>[0];
+
+type WithInjectedConsumerToken<T> = Omit<T, 'consumerToken'>;
+
+export type AuthenticatedNebulaClient = Omit<NebulaClient, 'secret'> & {
+  secret: Omit<SecretClient, 'create' | 'update' | 'use'> & {
+    create: (
+      input: WithInjectedConsumerToken<SecretCreateInput>
+    ) => ReturnType<SecretClient['create']>;
+    update: (
+      input: WithInjectedConsumerToken<SecretUpdateInput>
+    ) => ReturnType<SecretClient['update']>;
+    use: (input: WithInjectedConsumerToken<SecretUseInput>) => ReturnType<SecretClient['use']>;
+  };
+};
+
+export type NebulaClientOpts = ClientOpts & {
+  consumerToken: string;
+  identifier: string;
+  refreshSkewMs?: number;
+};
+
+type ConsumerInstanceToken = {
+  token: string;
+  consumerInstanceId: string;
+  expiresAt: Date | string;
+};
+
+let toDate = (value: Date | string) => (value instanceof Date ? value : new Date(value));
+
+export let createRawNebulaClient = (o: ClientOpts): NebulaClient => createClient<NebulaClient>(o);
+
+export let createNebulaClient = (o: NebulaClientOpts): AuthenticatedNebulaClient => {
+  let { consumerToken, identifier, refreshSkewMs = 60_000, ...clientOpts } = o;
+  let client = createRawNebulaClient(clientOpts);
+  let current: ConsumerInstanceToken | null = null;
+  let inFlight: Promise<ConsumerInstanceToken> | null = null;
+
+  let register = async () => {
+    let next = await client.consumer.register({
+      secret: consumerToken,
+      identifier
+    });
+    current = next;
+    return next;
+  };
+
+  let refresh = async () => {
+    if (!current) return await register();
+
+    try {
+      let next = await client.consumer.refresh({
+        secret: consumerToken,
+        token: current.token
+      });
+      current = next;
+      return next;
+    } catch {
+      return await register();
+    }
+  };
+
+  let getToken = async () => {
+    if (
+      current &&
+      toDate(current.expiresAt).getTime() - refreshSkewMs > Date.now()
+    ) {
+      return current.token;
+    }
+
+    inFlight ??= refresh().finally(() => {
+      inFlight = null;
+    });
+
+    return (await inFlight).token;
+  };
+
+  return {
+    tenant: client.tenant,
+    consumer: client.consumer,
+    keyProvider: client.keyProvider,
+    keyProviderError: client.keyProviderError,
+    secret: {
+      list: client.secret.list,
+      get: client.secret.get,
+      listVersions: client.secret.listVersions,
+      create: async input =>
+        await client.secret.create({
+          ...input,
+          consumerToken: await getToken()
+        }),
+      update: async input =>
+        await client.secret.update({
+          ...input,
+          consumerToken: await getToken()
+        }),
+      use: async input =>
+        await client.secret.use({
+          ...input,
+          consumerToken: await getToken()
+        })
+    }
+  };
+};

--- a/src/systems/_clients/nebula/tsconfig.json
+++ b/src/systems/_clients/nebula/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Default",
+  "include": [
+    "src"
+  ],
+  "compilerOptions": {
+    "outDir": "dist",
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": false,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "module": "esnext",
+    "lib": [
+      "ESNext",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "target": "ESNext",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "downlevelIteration": true,
+    "resolveJsonModule": true
+  },
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/src/systems/_clients/nebula/tsup.config.ts
+++ b/src/systems/_clients/nebula/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  outDir: 'dist'
+});

--- a/src/systems/nebula/service/.dockerignore
+++ b/src/systems/nebula/service/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.env.test

--- a/src/systems/nebula/service/.env.ci
+++ b/src/systems/nebula/service/.env.ci
@@ -1,0 +1,18 @@
+# CI environment
+# Points to Docker container hostnames
+
+DATABASE_URL=postgresql://nebula:nebula@postgres:5432/nebula-test
+REDIS_URL=redis://redis:6379/0
+
+DEFAULT_PROVIDER=local
+LOCAL_MASTER_SECRET=please-change-this-local-development-secret-with-32-bytes
+
+KMS_AWS_REGION=us-east-1
+KMS_CREATE_DEFAULT_KEY=false
+KMS_DEFAULT_KEY_ID=
+KMS_EXTERNAL_KEY_ROLE_ARN=arn:aws:iam::123456789012:role/nebula-test-kms-role
+
+CONSUMER_INSTANCE_TOKEN_SECRET=please-change-this-consumer-token-signing-secret
+CONSUMER_INSTANCE_TOKEN_TTL_SECONDS=3600
+CONSUMER_REGISTRATION_SLATES=slates-registration-secret
+CONSUMER_REGISTRATION_SHUTTLE=shuttle-registration-secret

--- a/src/systems/nebula/service/.env.example
+++ b/src/systems/nebula/service/.env.example
@@ -1,0 +1,16 @@
+# Service configuration
+DATABASE_URL=postgresql://nebula:nebula@postgres:5432/nebula
+REDIS_URL=redis://redis:6379
+
+# Provider defaults
+DEFAULT_PROVIDER=local
+
+# Local adapter
+LOCAL_MASTER_SECRET=please-change-this-local-development-secret-with-32-bytes
+
+# AWS KMS adapter
+KMS_AWS_REGION=us-east-1
+# KMS_AWS_ACCESS_KEY_ID=
+# KMS_AWS_SECRET_ACCESS_KEY=
+# KMS_DEFAULT_KEY_ID=
+# KMS_CREATE_DEFAULT_KEY=false

--- a/src/systems/nebula/service/.env.example
+++ b/src/systems/nebula/service/.env.example
@@ -14,3 +14,8 @@ KMS_AWS_REGION=us-east-1
 # KMS_AWS_SECRET_ACCESS_KEY=
 # KMS_DEFAULT_KEY_ID=
 # KMS_CREATE_DEFAULT_KEY=false
+
+# Consumer instance auth
+CONSUMER_INSTANCE_TOKEN_SECRET=please-change-this-consumer-token-signing-secret
+CONSUMER_INSTANCE_TOKEN_TTL_SECONDS=3600
+CONSUMER_REGISTRATION_worker=please-change-this-worker-registration-secret

--- a/src/systems/nebula/service/.gitignore
+++ b/src/systems/nebula/service/.gitignore
@@ -1,0 +1,4 @@
+dist
+generated
+.env
+.env.test

--- a/src/systems/nebula/service/Dockerfile
+++ b/src/systems/nebula/service/Dockerfile
@@ -1,10 +1,45 @@
-FROM oven/bun:1 AS base
+# Build stage
+FROM oven/bun:1 AS builder
+
 WORKDIR /app
 
-COPY package.json bun.lock* ./
-RUN bun install --frozen-lockfile || bun install
+ARG SENTRY_AUTH_TOKEN
+ENV SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
 
+# Copy repository contents from the OSS root context
 COPY . .
-RUN bun run db:generate && bun run server:build
 
-CMD ["bun", "run", "server:start"]
+# Install CA certificates for Sentry CLI uploads
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
+# Install dependencies from the OSS workspace
+RUN bun install --linker=hoisted
+
+# Generate Prisma client and build the service from the monorepo path
+WORKDIR /app/src/systems/nebula/service
+RUN bun prisma generate
+RUN bun run server:build
+
+# Production stage
+FROM oven/bun:1-alpine AS runner
+
+WORKDIR /app
+
+# Install curl for health checks
+RUN apk add --no-cache curl
+
+# Copy built output, Prisma assets, and hoisted dependencies
+COPY --from=builder /app/src/systems/nebula/service/dist /app/dist
+COPY --from=builder /app/src/systems/nebula/service/prisma /app/prisma
+COPY --from=builder /app/src/systems/nebula/service/prisma.config.ts /app/prisma.config.ts
+COPY --from=builder /app/node_modules /app/node_modules
+
+# Expose port
+EXPOSE 52170
+
+# Health check using curl
+HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
+    CMD curl -f http://localhost:52170/ping && curl -f http://localhost:12121/ || exit 1
+
+# Start command: push schema and start service
+CMD ["sh", "-c", "bun prisma db push --accept-data-loss && bun /app/dist/index.js"]

--- a/src/systems/nebula/service/Dockerfile
+++ b/src/systems/nebula/service/Dockerfile
@@ -1,0 +1,10 @@
+FROM oven/bun:1 AS base
+WORKDIR /app
+
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile || bun install
+
+COPY . .
+RUN bun run db:generate && bun run server:build
+
+CMD ["bun", "run", "server:start"]

--- a/src/systems/nebula/service/dev.Dockerfile
+++ b/src/systems/nebula/service/dev.Dockerfile
@@ -1,0 +1,18 @@
+FROM oven/bun:1
+
+WORKDIR /app
+
+# Copy package files
+COPY package.json bun.lock* ./
+
+# Install dependencies
+RUN bun install
+
+# Copy source code
+COPY . .
+
+# Expose port
+EXPOSE 52170
+
+# Run in dev mode with hot reloading
+CMD ["sh", "-c", "bun prisma generate && bun prisma db push --accept-data-loss && bun --watch src/server.ts"]

--- a/src/systems/nebula/service/docker-compose.dev.yml
+++ b/src/systems/nebula/service/docker-compose.dev.yml
@@ -61,6 +61,15 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          "bun -e \"fetch('http://localhost:52170/').then(()=>process.exit(0)).catch(()=>process.exit(1))\""
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
     networks:
       - nebula-network
 

--- a/src/systems/nebula/service/docker-compose.dev.yml
+++ b/src/systems/nebula/service/docker-compose.dev.yml
@@ -1,0 +1,69 @@
+services:
+  postgres:
+    profiles: ['infra']
+    image: postgres:16-alpine
+    container_name: nebula-postgres
+    restart: unless-stopped
+    ports:
+      - '56432:5432'
+    environment:
+      POSTGRES_USER: nebula
+      POSTGRES_PASSWORD: nebula
+      POSTGRES_DB: nebula
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./init-test-db.sh:/docker-entrypoint-initdb.d/init-test-db.sh
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U nebula']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - nebula-network
+
+  redis:
+    profiles: ['infra']
+    image: redis:7-alpine
+    container_name: nebula-redis
+    restart: unless-stopped
+    ports:
+      - '57379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - nebula-network
+
+  nebula:
+    profiles: ['service']
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: nebula-service
+    restart: unless-stopped
+    ports:
+      - '55060:52060'
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://nebula:nebula@postgres:5432/nebula}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      DEFAULT_PROVIDER: ${DEFAULT_PROVIDER:-local}
+      LOCAL_MASTER_SECRET: ${LOCAL_MASTER_SECRET:-please-change-this-local-development-secret-with-32-bytes}
+      KMS_AWS_REGION: ${KMS_AWS_REGION:-us-east-1}
+      KMS_DEFAULT_KEY_ID: ${KMS_DEFAULT_KEY_ID:-}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - nebula-network
+
+volumes:
+  postgres_data:
+    driver: local
+
+networks:
+  nebula-network:
+    driver: bridge

--- a/src/systems/nebula/service/docker-compose.dev.yml
+++ b/src/systems/nebula/service/docker-compose.dev.yml
@@ -40,7 +40,7 @@ services:
     profiles: ['service']
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: dev.Dockerfile
     container_name: nebula-service
     restart: unless-stopped
     ports:

--- a/src/systems/nebula/service/docker-compose.dev.yml
+++ b/src/systems/nebula/service/docker-compose.dev.yml
@@ -44,7 +44,7 @@ services:
     container_name: nebula-service
     restart: unless-stopped
     ports:
-      - '55060:52060'
+      - '55170:52170'
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://nebula:nebula@postgres:5432/nebula}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
@@ -52,6 +52,10 @@ services:
       LOCAL_MASTER_SECRET: ${LOCAL_MASTER_SECRET:-please-change-this-local-development-secret-with-32-bytes}
       KMS_AWS_REGION: ${KMS_AWS_REGION:-us-east-1}
       KMS_DEFAULT_KEY_ID: ${KMS_DEFAULT_KEY_ID:-}
+      CONSUMER_INSTANCE_TOKEN_SECRET: ${CONSUMER_INSTANCE_TOKEN_SECRET:-please-change-this-consumer-token-signing-secret}
+      CONSUMER_INSTANCE_TOKEN_TTL_SECONDS: ${CONSUMER_INSTANCE_TOKEN_TTL_SECONDS:-3600}
+      CONSUMER_REGISTRATION_SLATES: ${CONSUMER_REGISTRATION_SLATES:-slates-registration-secret}
+      CONSUMER_REGISTRATION_SHUTTLE: ${CONSUMER_REGISTRATION_SHUTTLE:-shuttle-registration-secret}
     depends_on:
       postgres:
         condition: service_healthy

--- a/src/systems/nebula/service/init-test-db.sh
+++ b/src/systems/nebula/service/init-test-db.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+psql postgres://postgres:postgres@localhost:5432/postgres -c "DROP DATABASE IF EXISTS \"nebula-test\";"
+psql postgres://postgres:postgres@localhost:5432/postgres -c "CREATE DATABASE \"nebula-test\";"

--- a/src/systems/nebula/service/init-test-db.sh
+++ b/src/systems/nebula/service/init-test-db.sh
@@ -1,5 +1,15 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -e
 
-psql postgres://postgres:postgres@localhost:5432/postgres -c "DROP DATABASE IF EXISTS \"nebula-test\";"
-psql postgres://postgres:postgres@localhost:5432/postgres -c "CREATE DATABASE \"nebula-test\";"
+# Create databases for CI/local-compose services if they don't exist
+dbs="nebula-test"
+for db in $dbs; do
+  exists=$(psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
+    -tAc "SELECT 1 FROM pg_database WHERE datname='${db}'")
+  if [ "$exists" != "1" ]; then
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
+      -c "CREATE DATABASE \"${db}\";"
+  fi
+done
+
+echo "Database initialization complete"

--- a/src/systems/nebula/service/package.json
+++ b/src/systems/nebula/service/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@metorial/nebula",
+  "module": "index.ts",
+  "type": "commonjs",
+  "private": true,
+  "scripts": {
+    "start": "bun run server:start",
+    "server:build": "ncc build ./src/server.ts -o ./dist --source-map --transpile-only && bun run sentry:sourcemaps:if-token",
+    "sentry:sourcemaps": "sentry-cli sourcemaps inject --org metorial --project mte-nebula ./dist && sentry-cli sourcemaps upload --org metorial --project mte-nebula ./dist",
+    "sentry:sourcemaps:if-token": "sh -c 'if [ -n \"$SENTRY_AUTH_TOKEN\" ]; then bun run sentry:sourcemaps; else echo \"Skipping Sentry sourcemap upload\"; fi'",
+    "server:start": "bun ./dist/index.js",
+    "dev": "bun --watch ./src/server.ts",
+    "enterprise:dev": "bun run dev",
+    "prisma:generate": "bun run db:generate",
+    "prisma:push": "bun run db:push:dev",
+    "db:generate": "bun prisma generate",
+    "db:push:dev": "sh -c 'set -a; . .env; set +a; bun prisma db push --accept-data-loss'",
+    "db:push:test": "sh -c 'set -a; . .env.test; set +a; bun prisma db push --accept-data-loss'",
+    "db:push": "bun run db:push:dev && bun run db:push:test",
+    "test": "bunx vitest run --passWithNoTests",
+    "test:watch": "bunx vitest watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@lowerdeck/testing-tools": "^1.0.1",
+    "@types/bun": "latest",
+    "@types/node": "^25.0.3",
+    "@vercel/ncc": "^0.38.1",
+    "vitest": "4.0.17"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  },
+  "dependencies": {
+    "@aws-sdk/client-kms": "^3.957.0",
+    "@lowerdeck/api-mux": "^1.0.4",
+    "@lowerdeck/canonicalize": "^1.0.4",
+    "@lowerdeck/cron": "^1.1.3",
+    "@lowerdeck/env": "^1.0.6",
+    "@lowerdeck/error": "^1.2.3",
+    "@lowerdeck/hash": "^1.0.4",
+    "@lowerdeck/id": "^1.0.8",
+    "@lowerdeck/lock": "^1.0.6",
+    "@lowerdeck/pagination": "^1.0.8",
+    "@lowerdeck/queue": "^1.0.11",
+    "@lowerdeck/rpc-client": "^1.1.4",
+    "@lowerdeck/rpc-server": "^1.0.11",
+    "@lowerdeck/sentry": "^1.0.2",
+    "@lowerdeck/service": "^1.0.7",
+    "@lowerdeck/snowflake": "^1.0.2",
+    "@lowerdeck/validation": "^1.0.10",
+    "@prisma/adapter-pg": "^7.2.0",
+    "@prisma/client": "^7.2.0",
+    "@prisma/extension-read-replicas": "^0.5.0",
+    "@sentry/bun": "^10.38.0",
+    "@sentry/cli": "^3.2.0",
+    "date-fns": "^4.1.0",
+    "prisma": "^7.2.0"
+  }
+}

--- a/src/systems/nebula/service/package.json
+++ b/src/systems/nebula/service/package.json
@@ -40,6 +40,7 @@
     "@lowerdeck/error": "^1.2.3",
     "@lowerdeck/hash": "^1.0.4",
     "@lowerdeck/id": "^1.0.8",
+    "@lowerdeck/jwt": "^1.0.4",
     "@lowerdeck/lock": "^1.0.6",
     "@lowerdeck/pagination": "^1.0.8",
     "@lowerdeck/queue": "^1.0.11",

--- a/src/systems/nebula/service/prisma.config.ts
+++ b/src/systems/nebula/service/prisma.config.ts
@@ -1,0 +1,26 @@
+import 'dotenv/config';
+import { defineConfig } from 'prisma/config';
+
+let databaseUrl = process.env.NEBULA_DATABASE_URL ?? process.env.DATABASE_URL;
+
+if (
+  !databaseUrl &&
+  process.env.DATABASE_USERNAME &&
+  process.env.DATABASE_PASSWORD &&
+  process.env.DATABASE_HOST &&
+  process.env.DATABASE_PORT &&
+  process.env.DATABASE_NAME
+) {
+  databaseUrl = `postgres://${process.env.DATABASE_USERNAME}:${process.env.DATABASE_PASSWORD}@${process.env.DATABASE_HOST}:${process.env.DATABASE_PORT}/${process.env.DATABASE_NAME}?schema=public&sslmode=no-verify&connection_limit=20`;
+}
+
+export default defineConfig({
+  schema: 'prisma/schema',
+  migrations: {
+    path: 'prisma/migrations'
+  },
+  datasource: {
+    url: databaseUrl,
+    shadowDatabaseUrl: process.env['SHADOW_DATABASE_URL']
+  }
+});

--- a/src/systems/nebula/service/prisma/schema/_connection.prisma
+++ b/src/systems/nebula/service/prisma/schema/_connection.prisma
@@ -1,0 +1,8 @@
+generator client {
+  provider = "prisma-client"
+  output   = "../generated"
+}
+
+datasource db {
+  provider = "postgresql"
+}

--- a/src/systems/nebula/service/prisma/schema/consumer.prisma
+++ b/src/systems/nebula/service/prisma/schema/consumer.prisma
@@ -3,23 +3,50 @@ enum ConsumerStatus {
   inactive
 }
 
+enum ConsumerInstanceStatus {
+  active
+  revoked
+  expired
+}
+
 model Consumer {
   oid BigInt @id
   id  String @unique
 
-  tenantOid BigInt
-  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
-
-  identifier String
+  identifier String @unique
   name       String
   status     ConsumerStatus
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
+  instances  ConsumerInstance[]
   secrets    Secret[]
   secretUses SecretUse[]
 
-  @@unique([tenantOid, identifier])
-  @@index([tenantOid, status])
+  @@index([status])
+}
+
+model ConsumerInstance {
+  oid BigInt @id
+  id  String @unique
+
+  consumerOid BigInt
+  consumer    Consumer @relation(fields: [consumerOid], references: [oid])
+
+  identifier String
+  tokenNonce String
+  status     ConsumerInstanceStatus
+
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @default(now()) @updatedAt
+  expiresAt  DateTime
+  lastUsedAt DateTime?
+  revokedAt  DateTime?
+
+  secretUses SecretUse[]
+
+  @@index([consumerOid, status])
+  @@index([expiresAt])
+  @@index([identifier])
 }

--- a/src/systems/nebula/service/prisma/schema/consumer.prisma
+++ b/src/systems/nebula/service/prisma/schema/consumer.prisma
@@ -1,0 +1,25 @@
+enum ConsumerStatus {
+  active
+  inactive
+}
+
+model Consumer {
+  oid BigInt @id
+  id  String @unique
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  identifier String
+  name       String
+  status     ConsumerStatus
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  secrets    Secret[]
+  secretUses SecretUse[]
+
+  @@unique([tenantOid, identifier])
+  @@index([tenantOid, status])
+}

--- a/src/systems/nebula/service/prisma/schema/key.prisma
+++ b/src/systems/nebula/service/prisma/schema/key.prisma
@@ -1,0 +1,21 @@
+model Key {
+  oid BigInt @id
+  id  String @unique
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  keyProviderOid BigInt
+  keyProvider    KeyProvider @relation(fields: [keyProviderOid], references: [oid])
+
+  encryptedDataKey Bytes
+  keyInfo          Json
+
+  currentUntil DateTime
+  createdAt    DateTime  @default(now())
+  retiredAt    DateTime?
+
+  secretVersions SecretVersion[]
+
+  @@index([tenantOid, keyProviderOid, currentUntil])
+}

--- a/src/systems/nebula/service/prisma/schema/keyProvider.prisma
+++ b/src/systems/nebula/service/prisma/schema/keyProvider.prisma
@@ -1,0 +1,77 @@
+enum KeyProviderType {
+  aws_kms
+  local
+}
+
+enum KeyProviderOwner {
+  tenant
+  system
+}
+
+enum KeyProviderStatus {
+  active
+  inactive
+  degraded
+}
+
+enum KeyProviderErrorOperation {
+  create_system_provider
+  validate_provider
+  generate_data_key
+  decrypt_data_key
+}
+
+model KeyProvider {
+  oid BigInt @id
+  id  String @unique
+
+  systemIdentifier String @unique
+  name       String
+  type       KeyProviderType
+  owner      KeyProviderOwner
+  status     KeyProviderStatus
+
+  keyInfo Json
+
+  keyReuseTimeSeconds Int?
+
+  tenantOid BigInt?
+  tenant    Tenant? @relation("TenantKeyProviders", fields: [tenantOid], references: [oid])
+
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @default(now()) @updatedAt
+  deletedAt DateTime?
+
+  defaultForTenants Tenant[]        @relation("TenantDefaultKeyProvider")
+  keys              Key[]
+  keyErrors         KeyError[]
+  secretVersions    SecretVersion[]
+
+  @@index([tenantOid])
+}
+
+model KeyError {
+  oid BigInt @id
+  id  String @unique
+
+  keyProviderOid BigInt
+  keyProvider    KeyProvider @relation(fields: [keyProviderOid], references: [oid])
+
+  tenantOid BigInt?
+  tenant    Tenant? @relation(fields: [tenantOid], references: [oid])
+
+  day         DateTime
+  operation   KeyProviderErrorOperation
+  code        String
+  messageHash String
+  count       Int                       @default(1)
+
+  sampleMessage String?
+
+  firstSeenAt DateTime @default(now())
+  lastSeenAt  DateTime @default(now())
+
+  @@unique([keyProviderOid, day, operation, code, messageHash])
+  @@index([tenantOid, day])
+  @@index([day])
+}

--- a/src/systems/nebula/service/prisma/schema/secret.prisma
+++ b/src/systems/nebula/service/prisma/schema/secret.prisma
@@ -1,0 +1,90 @@
+enum SecretStatus {
+  active
+  inactive
+  deleted
+}
+
+enum SecretAlgorithm {
+  aes_256_gcm
+}
+
+model Secret {
+  oid BigInt @id
+  id  String @unique
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  consumerOid BigInt
+  consumer    Consumer @relation(fields: [consumerOid], references: [oid])
+
+  purpose String
+  status  SecretStatus
+
+  currentVersionOid BigInt?
+  currentVersion    SecretVersion? @relation("CurrentSecretVersion", fields: [currentVersionOid], references: [oid])
+
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @default(now()) @updatedAt
+  deletedAt DateTime?
+
+  versions   SecretVersion[]
+  secretUses SecretUse[]
+
+  @@index([tenantOid, status])
+  @@index([consumerOid, status])
+}
+
+model SecretVersion {
+  oid BigInt @id
+  id  String @unique
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  secretOid BigInt
+  secret    Secret @relation(fields: [secretOid], references: [oid])
+
+  keyOid BigInt
+  key    Key    @relation(fields: [keyOid], references: [oid])
+
+  keyProviderOid BigInt
+  keyProvider    KeyProvider @relation(fields: [keyProviderOid], references: [oid])
+
+  proofHash         String
+  encryptionContext Json
+  alg               SecretAlgorithm
+  iv                Bytes
+  ciphertext        Bytes
+  authTag           Bytes
+  aadHash           String?
+
+  createdAt DateTime @default(now())
+
+  currentForSecrets Secret[] @relation("CurrentSecretVersion")
+
+  @@index([tenantOid, secretOid])
+  @@index([keyOid])
+}
+
+model SecretUse {
+  oid BigInt @id
+  id  String @unique
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  secretOid BigInt
+  secret    Secret @relation(fields: [secretOid], references: [oid])
+
+  consumerOid BigInt
+  consumer    Consumer @relation(fields: [consumerOid], references: [oid])
+
+  note String
+
+  ts DateTime @default(now())
+
+  @@index([ts])
+  @@index([tenantOid, secretOid, ts])
+  @@index([consumerOid, ts])
+}

--- a/src/systems/nebula/service/prisma/schema/secret.prisma
+++ b/src/systems/nebula/service/prisma/schema/secret.prisma
@@ -80,6 +80,9 @@ model SecretUse {
   consumerOid BigInt
   consumer    Consumer @relation(fields: [consumerOid], references: [oid])
 
+  consumerInstanceOid BigInt
+  consumerInstance    ConsumerInstance @relation(fields: [consumerInstanceOid], references: [oid])
+
   note String
 
   ts DateTime @default(now())
@@ -87,4 +90,5 @@ model SecretUse {
   @@index([ts])
   @@index([tenantOid, secretOid, ts])
   @@index([consumerOid, ts])
+  @@index([consumerInstanceOid, ts])
 }

--- a/src/systems/nebula/service/prisma/schema/tenant.prisma
+++ b/src/systems/nebula/service/prisma/schema/tenant.prisma
@@ -18,6 +18,5 @@ model Tenant {
   keyErrors      KeyError[]
   secrets        Secret[]
   secretVersions SecretVersion[]
-  consumers      Consumer[]
   secretUses     SecretUse[]
 }

--- a/src/systems/nebula/service/prisma/schema/tenant.prisma
+++ b/src/systems/nebula/service/prisma/schema/tenant.prisma
@@ -1,0 +1,23 @@
+model Tenant {
+  oid BigInt @id
+  id  String @unique
+
+  identifier String @unique
+  name       String
+
+  keyReuseTimeSeconds Int?
+
+  defaultKeyProviderOid BigInt?
+  defaultKeyProvider    KeyProvider? @relation("TenantDefaultKeyProvider", fields: [defaultKeyProviderOid], references: [oid])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  keyProviders   KeyProvider[]   @relation("TenantKeyProviders")
+  keys           Key[]
+  keyErrors      KeyError[]
+  secrets        Secret[]
+  secretVersions SecretVersion[]
+  consumers      Consumer[]
+  secretUses     SecretUse[]
+}

--- a/src/systems/nebula/service/src/adapters/_lib/adapter.ts
+++ b/src/systems/nebula/service/src/adapters/_lib/adapter.ts
@@ -3,20 +3,12 @@ import type { KeyProvider } from '../../../prisma/generated/client';
 export type AdapterKeyProviderInput =
   | {
       type: 'aws_kms';
-      name: string;
       keyId?: string;
       region?: string;
     }
   | {
       type: 'local';
-      name: string;
     };
-
-export type KeyProviderCreateInput = {
-  name: string;
-  keyId?: string;
-  region?: string;
-};
 
 export type DataKeyContext = {
   tenantId: string;
@@ -32,6 +24,40 @@ export type DataKeyResult = {
   keyInfo: any;
 };
 
+export type KeyProviderSetupInfoInput = {
+  tenantId: string;
+  tenantIdentifier: string;
+  region?: string;
+  keyId?: string;
+  roleArn?: string;
+};
+
+export type KeyProviderSetupInfo = {
+  steps: {
+    title: string;
+    description: string;
+    markdown?: string;
+    inputs?: {
+      type: 'text' | 'json';
+      key: string;
+      label: string;
+      description: string;
+    }[];
+  }[];
+  markdown: string;
+};
+
+export let detag = (strings: TemplateStringsArray, ...values: any[]) => {
+  let raw = strings.reduce((out, str, idx) => `${out}${str}${values[idx] ?? ''}`, '');
+  let lines = raw.replace(/^\n/, '').replace(/\n\s*$/, '').split('\n');
+  let indents = lines
+    .filter(line => line.trim().length > 0)
+    .map(line => line.match(/^\s*/)?.[0].length ?? 0);
+  let indent = indents.length ? Math.min(...indents) : 0;
+
+  return lines.map(line => line.slice(indent)).join('\n');
+};
+
 export abstract class NebulaKeyProviderAdapter {
   abstract readonly type: KeyProvider['type'];
 
@@ -45,15 +71,17 @@ export abstract class NebulaKeyProviderAdapter {
     tenantIdentifier: string;
     name: string;
     systemIdentifier: string;
-    region?: string;
   }): Promise<{
     name: string;
     keyInfo: any;
   }>;
 
-  abstract validateKeyProvider(input: AdapterKeyProviderInput): Promise<{
+  abstract validateKeyProvider(input: Record<string, any>): Promise<{
+    name: string;
     keyInfo: any;
   }>;
+
+  abstract getSetupInfo(input: KeyProviderSetupInfoInput): Promise<KeyProviderSetupInfo>;
 
   abstract generateDataKey(keyProvider: KeyProvider, context: DataKeyContext): Promise<DataKeyResult>;
 

--- a/src/systems/nebula/service/src/adapters/_lib/adapter.ts
+++ b/src/systems/nebula/service/src/adapters/_lib/adapter.ts
@@ -1,0 +1,68 @@
+import type { KeyProvider } from '../../../prisma/generated/client';
+
+export type AdapterKeyProviderInput =
+  | {
+      type: 'aws_kms';
+      name: string;
+      keyId?: string;
+      region?: string;
+    }
+  | {
+      type: 'local';
+      name: string;
+    };
+
+export type KeyProviderCreateInput = {
+  name: string;
+  keyId?: string;
+  region?: string;
+};
+
+export type DataKeyContext = {
+  tenantId: string;
+  tenantOid: bigint;
+  keyProviderId: string;
+  keyProviderOid: bigint;
+  keyId?: string;
+};
+
+export type DataKeyResult = {
+  plaintextDataKey: Uint8Array;
+  encryptedDataKey: Uint8Array;
+  keyInfo: any;
+};
+
+export abstract class NebulaKeyProviderAdapter {
+  abstract readonly type: KeyProvider['type'];
+
+  abstract createSystemKeyProvider(): Promise<{
+    name: string;
+    keyInfo: any;
+  }>;
+
+  abstract createTenantManagedKeyProvider(input: {
+    tenantId: string;
+    tenantIdentifier: string;
+    name: string;
+    systemIdentifier: string;
+    region?: string;
+  }): Promise<{
+    name: string;
+    keyInfo: any;
+  }>;
+
+  abstract validateKeyProvider(input: AdapterKeyProviderInput): Promise<{
+    keyInfo: any;
+  }>;
+
+  abstract generateDataKey(keyProvider: KeyProvider, context: DataKeyContext): Promise<DataKeyResult>;
+
+  abstract decryptDataKey(
+    keyProvider: KeyProvider,
+    encryptedDataKey: Uint8Array,
+    keyInfo: any,
+    context: DataKeyContext
+  ): Promise<Uint8Array>;
+
+  abstract describeKeyProvider(keyProvider: KeyProvider): Promise<Record<string, any>>;
+}

--- a/src/systems/nebula/service/src/adapters/_lib/errors.ts
+++ b/src/systems/nebula/service/src/adapters/_lib/errors.ts
@@ -1,0 +1,23 @@
+export class NebulaAdapterError extends Error {
+  readonly code: string;
+  readonly safeMessage: string;
+  override readonly cause: unknown;
+
+  constructor(code: string, safeMessage: string, cause?: unknown) {
+    super(safeMessage);
+    this.name = 'NebulaAdapterError';
+    this.code = code;
+    this.safeMessage = safeMessage;
+    this.cause = cause;
+  }
+}
+
+export let normalizeAdapterError = (err: unknown) => {
+  if (err instanceof NebulaAdapterError) return err;
+
+  let anyErr = err as any;
+  let code = String(anyErr?.name ?? anyErr?.code ?? 'provider_error');
+  let message = String(anyErr?.message ?? 'Provider operation failed');
+
+  return new NebulaAdapterError(code, message, err);
+};

--- a/src/systems/nebula/service/src/adapters/aws-kms/index.ts
+++ b/src/systems/nebula/service/src/adapters/aws-kms/index.ts
@@ -1,0 +1,216 @@
+import {
+  CreateKeyCommand,
+  DecryptCommand,
+  DescribeKeyCommand,
+  GenerateDataKeyCommand,
+  KMSClient
+} from '@aws-sdk/client-kms';
+import type { KeyProvider } from '../../../prisma/generated/client';
+import { env } from '../../env';
+import type {
+  AdapterKeyProviderInput,
+  DataKeyContext,
+  DataKeyResult
+} from '../_lib/adapter';
+import { NebulaKeyProviderAdapter } from '../_lib/adapter';
+import { NebulaAdapterError, normalizeAdapterError } from '../_lib/errors';
+
+let getKmsClient = (region?: string) =>
+  new KMSClient({
+    region: region ?? env.kms.KMS_AWS_REGION,
+    credentials:
+      env.kms.KMS_AWS_ACCESS_KEY_ID && env.kms.KMS_AWS_SECRET_ACCESS_KEY
+        ? {
+            accessKeyId: env.kms.KMS_AWS_ACCESS_KEY_ID,
+            secretAccessKey: env.kms.KMS_AWS_SECRET_ACCESS_KEY
+          }
+        : undefined
+  });
+
+let getEncryptionContext = (context: DataKeyContext) => ({
+  tenantId: context.tenantId,
+  tenantOid: String(context.tenantOid),
+  keyProviderId: context.keyProviderId,
+  keyProviderOid: String(context.keyProviderOid)
+});
+
+export class AwsKmsKeyProviderAdapter extends NebulaKeyProviderAdapter {
+  readonly type = 'aws_kms' as const;
+
+  async createSystemKeyProvider() {
+    let region = env.kms.KMS_AWS_REGION;
+    if (!region) throw new NebulaAdapterError('kms_region_missing', 'KMS region is missing');
+
+    let keyId = env.kms.KMS_DEFAULT_KEY_ID;
+
+    try {
+      if (!keyId && env.kms.KMS_CREATE_DEFAULT_KEY === 'true') {
+        let created = await getKmsClient(region).send(
+          new CreateKeyCommand({
+            Description: 'Nebula default data-key KMS key',
+            KeyUsage: 'ENCRYPT_DECRYPT',
+            KeySpec: 'SYMMETRIC_DEFAULT',
+            Tags: [{ TagKey: 'metorial-system', TagValue: 'nebula' }]
+          })
+        );
+        keyId = created.KeyMetadata?.Arn ?? created.KeyMetadata?.KeyId;
+      }
+
+      if (!keyId) {
+        throw new NebulaAdapterError('kms_default_key_missing', 'Default KMS key is missing');
+      }
+
+      return {
+        name: 'Nebula AWS KMS Default',
+        keyInfo: await this.describeKeyId({ keyId, region })
+      };
+    } catch (err) {
+      throw normalizeAdapterError(err);
+    }
+  }
+
+  async validateKeyProvider(input: AdapterKeyProviderInput) {
+    if (input.type !== 'aws_kms') {
+      throw new NebulaAdapterError('invalid_provider_type', 'Invalid AWS KMS provider input');
+    }
+
+    let region = input.region ?? env.kms.KMS_AWS_REGION;
+    if (!input.keyId) throw new NebulaAdapterError('kms_key_missing', 'KMS key is missing');
+    if (!region) throw new NebulaAdapterError('kms_region_missing', 'KMS region is missing');
+
+    try {
+      return {
+        keyInfo: await this.describeKeyId({ keyId: input.keyId, region })
+      };
+    } catch (err) {
+      throw normalizeAdapterError(err);
+    }
+  }
+
+  async createTenantManagedKeyProvider(input: {
+    tenantId: string;
+    tenantIdentifier: string;
+    name: string;
+    systemIdentifier: string;
+    region?: string;
+  }) {
+    let region = input.region ?? env.kms.KMS_AWS_REGION;
+    if (!region) throw new NebulaAdapterError('kms_region_missing', 'KMS region is missing');
+
+    try {
+      let created = await getKmsClient(region).send(
+        new CreateKeyCommand({
+          Description: `Nebula tenant data-key KMS key for ${input.tenantIdentifier}`,
+          KeyUsage: 'ENCRYPT_DECRYPT',
+          KeySpec: 'SYMMETRIC_DEFAULT',
+          Tags: [
+            { TagKey: 'metorial-system', TagValue: 'nebula' },
+            { TagKey: 'nebula-managed', TagValue: 'true' },
+            { TagKey: 'nebula-tenant-id', TagValue: input.tenantId },
+            { TagKey: 'nebula-key-provider', TagValue: input.systemIdentifier }
+          ]
+        })
+      );
+
+      let keyId = created.KeyMetadata?.Arn ?? created.KeyMetadata?.KeyId;
+      if (!keyId) throw new NebulaAdapterError('kms_key_missing', 'KMS key is missing');
+
+      return {
+        name: input.name,
+        keyInfo: {
+          ...(await this.describeKeyId({ keyId, region })),
+          managedByNebula: true,
+          tenantId: input.tenantId
+        }
+      };
+    } catch (err) {
+      throw normalizeAdapterError(err);
+    }
+  }
+
+  async generateDataKey(keyProvider: KeyProvider, context: DataKeyContext): Promise<DataKeyResult> {
+    let keyInfo = keyProvider.keyInfo as any;
+
+    try {
+      let result = await getKmsClient(keyInfo.region).send(
+        new GenerateDataKeyCommand({
+          KeyId: keyInfo.keyArn ?? keyInfo.keyId,
+          KeySpec: 'AES_256',
+          EncryptionContext: getEncryptionContext(context)
+        })
+      );
+
+      if (!result.Plaintext || !result.CiphertextBlob) {
+        throw new NebulaAdapterError('kms_data_key_missing', 'KMS did not return a data key');
+      }
+
+      return {
+        plaintextDataKey: result.Plaintext,
+        encryptedDataKey: result.CiphertextBlob,
+        keyInfo: {
+          variant: 'aws_kms',
+          region: keyInfo.region,
+          keyId: keyInfo.keyId,
+          keyArn: keyInfo.keyArn
+        }
+      };
+    } catch (err) {
+      throw normalizeAdapterError(err);
+    }
+  }
+
+  async decryptDataKey(
+    keyProvider: KeyProvider,
+    encryptedDataKey: Uint8Array,
+    keyInfo: any,
+    context: DataKeyContext
+  ) {
+    if (keyInfo?.variant !== 'aws_kms') {
+      throw new NebulaAdapterError('invalid_key_info', 'Invalid AWS KMS key info');
+    }
+
+    try {
+      let result = await getKmsClient(keyInfo.region).send(
+        new DecryptCommand({
+          KeyId: keyInfo.keyArn ?? keyInfo.keyId ?? (keyProvider.keyInfo as any).keyArn,
+          CiphertextBlob: encryptedDataKey,
+          EncryptionContext: getEncryptionContext(context)
+        })
+      );
+
+      if (!result.Plaintext) {
+        throw new NebulaAdapterError('kms_plaintext_missing', 'KMS did not return plaintext');
+      }
+
+      return result.Plaintext;
+    } catch (err) {
+      throw normalizeAdapterError(err);
+    }
+  }
+
+  async describeKeyProvider(keyProvider: KeyProvider) {
+    let keyInfo = keyProvider.keyInfo as any;
+    return {
+      type: 'aws_kms',
+      region: keyInfo.region,
+      keyId: keyInfo.keyId,
+      keyArn: keyInfo.keyArn
+    };
+  }
+
+  private async describeKeyId(d: { keyId: string; region: string }) {
+    let described = await getKmsClient(d.region).send(
+      new DescribeKeyCommand({
+        KeyId: d.keyId
+      })
+    );
+
+    return {
+      variant: 'aws_kms',
+      region: d.region,
+      keyId: described.KeyMetadata?.KeyId ?? d.keyId,
+      keyArn: described.KeyMetadata?.Arn ?? d.keyId,
+      accountId: described.KeyMetadata?.AWSAccountId
+    };
+  }
+}

--- a/src/systems/nebula/service/src/adapters/aws-kms/index.ts
+++ b/src/systems/nebula/service/src/adapters/aws-kms/index.ts
@@ -5,15 +5,22 @@ import {
   GenerateDataKeyCommand,
   KMSClient
 } from '@aws-sdk/client-kms';
+import { v } from '@lowerdeck/validation';
 import type { KeyProvider } from '../../../prisma/generated/client';
 import { env } from '../../env';
 import type {
-  AdapterKeyProviderInput,
   DataKeyContext,
-  DataKeyResult
+  DataKeyResult,
+  KeyProviderSetupInfoInput
 } from '../_lib/adapter';
+import { detag } from '../_lib/adapter';
 import { NebulaKeyProviderAdapter } from '../_lib/adapter';
 import { NebulaAdapterError, normalizeAdapterError } from '../_lib/errors';
+
+let importKeyInputSchema = v.object({
+  keyId: v.string(),
+  region: v.optional(v.string())
+});
 
 let getKmsClient = (region?: string) =>
   new KMSClient({
@@ -69,17 +76,18 @@ export class AwsKmsKeyProviderAdapter extends NebulaKeyProviderAdapter {
     }
   }
 
-  async validateKeyProvider(input: AdapterKeyProviderInput) {
-    if (input.type !== 'aws_kms') {
-      throw new NebulaAdapterError('invalid_provider_type', 'Invalid AWS KMS provider input');
-    }
+  async validateKeyProvider(rawInput: Record<string, any>) {
+    let parsed = importKeyInputSchema.validate(rawInput);
+    if (!parsed.success) throw new NebulaAdapterError('invalid_key_input', 'Invalid AWS KMS key input');
 
+    let input = parsed.value;
     let region = input.region ?? env.kms.KMS_AWS_REGION;
     if (!input.keyId) throw new NebulaAdapterError('kms_key_missing', 'KMS key is missing');
     if (!region) throw new NebulaAdapterError('kms_region_missing', 'KMS region is missing');
 
     try {
       return {
+        name: 'AWS KMS KeyProvider',
         keyInfo: await this.describeKeyId({ keyId: input.keyId, region })
       };
     } catch (err) {
@@ -87,14 +95,105 @@ export class AwsKmsKeyProviderAdapter extends NebulaKeyProviderAdapter {
     }
   }
 
+  async getSetupInfo(input: KeyProviderSetupInfoInput) {
+    let region = input.region ?? env.kms.KMS_AWS_REGION ?? '<aws-region>';
+    let keyId = input.keyId ?? '<kms-key-arn-or-alias>';
+    let roleArn = input.roleArn ?? env.kms.KMS_EXTERNAL_KEY_ROLE_ARN ?? '<nebula-role-arn>';
+    let policyStatement = {
+      Sid: 'AllowNebulaUseOfConsumerKey',
+      Effect: 'Allow',
+      Principal: {
+        AWS: roleArn
+      },
+      Action: ['kms:DescribeKey', 'kms:GenerateDataKey', 'kms:Decrypt'],
+      Resource: '*'
+    };
+    let policyJson = JSON.stringify(policyStatement, null, 2);
+    let importKeyProviderPayload = {
+      tenantId: input.tenantId,
+      keyInput: {
+        keyId,
+        region
+      }
+    };
+    let optionalTags = {
+      'metorial-system': 'nebula',
+      'nebula-tenant-id': input.tenantId
+    };
+
+    let steps = [
+      {
+        title: 'Create or choose a symmetric KMS key',
+        description: `Choose a symmetric ENCRYPT_DECRYPT KMS key in ${region}. It can be in your AWS account or any account that can grant Nebula access.`
+      },
+      {
+        title: 'Grant the Nebula role access to the key',
+        description: `Allow Nebula's AWS role to describe the key, generate data keys, and decrypt wrapped data keys.`,
+        markdown: detag`
+          Add this statement to the KMS key policy, or create an equivalent KMS grant:
+
+          \`\`\`json
+          ${policyJson}
+          \`\`\`
+        `
+      },
+      {
+        title: 'Create the Nebula KeyProvider',
+        description: 'Create the KeyProvider after the key policy is updated. Nebula validates KMS access before storing it.',
+        markdown: detag`
+          Call \`keyProvider.import\` with this payload:
+
+          \`\`\`json
+          ${JSON.stringify(importKeyProviderPayload, null, 2)}
+          \`\`\`
+        `,
+        inputs: [
+          {
+            type: 'text' as const,
+            key: 'keyId',
+            label: 'KMS key ARN, key ID, or alias',
+            description: 'The customer-managed KMS key identifier that Nebula should use.'
+          },
+          {
+            type: 'text' as const,
+            key: 'region',
+            label: 'AWS region',
+            description: 'The AWS region where the KMS key exists.'
+          }
+        ]
+      },
+      {
+        title: 'Optional: tag the customer key',
+        description: 'Tags are optional for customer-managed keys, but they help with inventory. Nebula-managed keys always use metorial-system=nebula.',
+        markdown: detag`
+          Suggested optional tags:
+
+          \`\`\`json
+          ${JSON.stringify(optionalTags, null, 2)}
+          \`\`\`
+        `
+      }
+    ];
+
+    let markdown = detag`
+      Tenant: \`${input.tenantIdentifier}\`
+      Region: \`${region}\`
+      Key ID or ARN: \`${keyId}\`
+      Nebula role ARN: \`${roleArn}\`
+
+      ${steps.flatMap(step => step.markdown ?? []).join('\n\n')}
+    `;
+
+    return { steps, markdown };
+  }
+
   async createTenantManagedKeyProvider(input: {
     tenantId: string;
     tenantIdentifier: string;
     name: string;
     systemIdentifier: string;
-    region?: string;
   }) {
-    let region = input.region ?? env.kms.KMS_AWS_REGION;
+    let region = env.kms.KMS_AWS_REGION;
     if (!region) throw new NebulaAdapterError('kms_region_missing', 'KMS region is missing');
 
     try {

--- a/src/systems/nebula/service/src/adapters/index.ts
+++ b/src/systems/nebula/service/src/adapters/index.ts
@@ -1,0 +1,11 @@
+import type { KeyProvider } from '../../prisma/generated/client';
+import { AwsKmsKeyProviderAdapter } from './aws-kms';
+import type { NebulaKeyProviderAdapter } from './_lib/adapter';
+import { LocalKeyProviderAdapter } from './local';
+
+let adapters: Record<KeyProvider['type'], NebulaKeyProviderAdapter> = {
+  aws_kms: new AwsKmsKeyProviderAdapter(),
+  local: new LocalKeyProviderAdapter()
+};
+
+export let getKeyProviderAdapter = (type: KeyProvider['type']) => adapters[type];

--- a/src/systems/nebula/service/src/adapters/local/index.ts
+++ b/src/systems/nebula/service/src/adapters/local/index.ts
@@ -2,10 +2,11 @@ import type { KeyProvider } from '../../../prisma/generated/client';
 import { env } from '../../env';
 import { decryptAes256Gcm, deriveSha256Key, encryptAes256Gcm } from '../../lib/crypto';
 import type {
-  AdapterKeyProviderInput,
   DataKeyContext,
-  DataKeyResult
+  DataKeyResult,
+  KeyProviderSetupInfoInput
 } from '../_lib/adapter';
+import { detag } from '../_lib/adapter';
 import { NebulaKeyProviderAdapter } from '../_lib/adapter';
 import { NebulaAdapterError } from '../_lib/errors';
 
@@ -39,16 +40,13 @@ export class LocalKeyProviderAdapter extends NebulaKeyProviderAdapter {
     };
   }
 
-  async validateKeyProvider(input: AdapterKeyProviderInput) {
+  async validateKeyProvider(_input: Record<string, any>) {
     assertLocalAllowed();
-
-    if (input.type !== 'local') {
-      throw new NebulaAdapterError('invalid_provider_type', 'Invalid local provider input');
-    }
 
     getMasterKey();
 
     return {
+      name: 'Nebula Local KeyProvider',
       keyInfo: {
         variant: 'local',
         version: 1
@@ -72,6 +70,80 @@ export class LocalKeyProviderAdapter extends NebulaKeyProviderAdapter {
         managedByNebula: true,
         secret: Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString('base64url')
       }
+    };
+  }
+
+  async getSetupInfo(input: KeyProviderSetupInfoInput) {
+    let importKeyProviderPayload = {
+      tenantId: input.tenantId,
+      keyInput: {
+        testKeyId: 'local-test-key',
+        environment: 'development',
+        owner: input.tenantIdentifier
+      }
+    };
+    let createProviderMarkdown = detag`
+      Example \`keyProvider.import\` payload:
+
+      \`\`\`json
+      ${JSON.stringify(importKeyProviderPayload, null, 2)}
+      \`\`\`
+    `;
+    let steps = [
+      {
+        title: 'Choose a local test key identifier',
+        description:
+          'Pick a stable identifier for this local test key. Nebula accepts these values for a realistic setup flow, but the local adapter does not use them for encryption.',
+        inputs: [
+          {
+            type: 'text' as const,
+            key: 'testKeyId',
+            label: 'Test key ID',
+            description: 'A local-only key identifier to help you recognize this test KeyProvider.'
+          },
+          {
+            type: 'text' as const,
+            key: 'environment',
+            label: 'Environment',
+            description: 'A label such as development, test, or ci.'
+          }
+        ]
+      },
+      {
+        title: 'Configure the local master secret',
+        description:
+          'Set LOCAL_MASTER_SECRET to a high-entropy value with at least 32 characters before starting Nebula locally. Local mode is blocked in production.',
+        inputs: [
+          {
+            type: 'text' as const,
+            key: 'localMasterSecretRef',
+            label: 'Local master secret reference',
+            description: 'A note or reference for where your local LOCAL_MASTER_SECRET is configured. Do not send the actual secret value.'
+          }
+        ]
+      },
+      {
+        title: 'Create the local KeyProvider',
+        description: `Create the local KeyProvider for tenant ${input.tenantIdentifier}. No external cloud setup is required.`,
+        markdown: createProviderMarkdown,
+        inputs: [
+          {
+            type: 'json' as const,
+            key: 'keyInput',
+            label: 'Local test key input',
+            description: 'Testing metadata to send as keyInput. The local adapter accepts it but ignores it for cryptographic operations.'
+          }
+        ]
+      }
+    ];
+
+    return {
+      steps,
+      markdown: detag`
+        Tenant: \`${input.tenantIdentifier}\`
+
+        ${steps.flatMap(step => step.markdown ?? []).join('\n\n')}
+      `
     };
   }
 

--- a/src/systems/nebula/service/src/adapters/local/index.ts
+++ b/src/systems/nebula/service/src/adapters/local/index.ts
@@ -1,0 +1,136 @@
+import type { KeyProvider } from '../../../prisma/generated/client';
+import { env } from '../../env';
+import { decryptAes256Gcm, deriveSha256Key, encryptAes256Gcm } from '../../lib/crypto';
+import type {
+  AdapterKeyProviderInput,
+  DataKeyContext,
+  DataKeyResult
+} from '../_lib/adapter';
+import { NebulaKeyProviderAdapter } from '../_lib/adapter';
+import { NebulaAdapterError } from '../_lib/errors';
+
+let assertLocalAllowed = () => {
+  if (process.env.NODE_ENV === 'production') {
+    throw new NebulaAdapterError('local_provider_in_production', 'Local provider cannot be used in production');
+  }
+};
+
+let getMasterKey = (keyProvider?: KeyProvider) => {
+  assertLocalAllowed();
+
+  let secret = (keyProvider?.keyInfo as any)?.secret ?? env.local.LOCAL_MASTER_SECRET;
+  if (!secret) throw new NebulaAdapterError('local_secret_missing', 'Local master secret is missing');
+  return deriveSha256Key(secret);
+};
+
+export class LocalKeyProviderAdapter extends NebulaKeyProviderAdapter {
+  readonly type = 'local' as const;
+
+  async createSystemKeyProvider() {
+    assertLocalAllowed();
+    getMasterKey();
+
+    return {
+      name: 'Nebula Local Default',
+      keyInfo: {
+        variant: 'local',
+        version: 1
+      }
+    };
+  }
+
+  async validateKeyProvider(input: AdapterKeyProviderInput) {
+    assertLocalAllowed();
+
+    if (input.type !== 'local') {
+      throw new NebulaAdapterError('invalid_provider_type', 'Invalid local provider input');
+    }
+
+    getMasterKey();
+
+    return {
+      keyInfo: {
+        variant: 'local',
+        version: 1
+      }
+    };
+  }
+
+  async createTenantManagedKeyProvider(input: {
+    name: string;
+  }): Promise<{
+    name: string;
+    keyInfo: any;
+  }> {
+    assertLocalAllowed();
+
+    return {
+      name: input.name,
+      keyInfo: {
+        variant: 'local',
+        version: 1,
+        managedByNebula: true,
+        secret: Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString('base64url')
+      }
+    };
+  }
+
+  async generateDataKey(keyProvider: KeyProvider, context: DataKeyContext): Promise<DataKeyResult> {
+    let plaintextDataKey = crypto.getRandomValues(new Uint8Array(32));
+    let wrapped = encryptAes256Gcm({
+      key: getMasterKey(keyProvider),
+      plaintext: plaintextDataKey,
+      aad: Buffer.from(this.getAad(context), 'utf8')
+    });
+
+    return {
+      plaintextDataKey,
+      encryptedDataKey: Buffer.concat([
+        Buffer.from(wrapped.iv),
+        Buffer.from(wrapped.authTag),
+        Buffer.from(wrapped.ciphertext)
+      ]),
+      keyInfo: {
+        variant: 'local',
+        version: 1,
+        providerId: keyProvider.id,
+        managedByNebula: (keyProvider.keyInfo as any)?.managedByNebula === true
+      }
+    };
+  }
+
+  async decryptDataKey(
+    keyProvider: KeyProvider,
+    encryptedDataKey: Uint8Array,
+    keyInfo: any,
+    context: DataKeyContext
+  ) {
+    if (keyInfo?.variant !== 'local') {
+      throw new NebulaAdapterError('invalid_key_info', 'Invalid local key info');
+    }
+
+    let buffer = Buffer.from(encryptedDataKey);
+    if (buffer.length < 29) {
+      throw new NebulaAdapterError('invalid_encrypted_data_key', 'Invalid encrypted data key');
+    }
+
+    return decryptAes256Gcm({
+      key: getMasterKey(keyProvider),
+      iv: buffer.subarray(0, 12),
+      authTag: buffer.subarray(12, 28),
+      ciphertext: buffer.subarray(28),
+      aad: Buffer.from(this.getAad(context), 'utf8')
+    });
+  }
+
+  async describeKeyProvider() {
+    return {
+      type: 'local',
+      managed: true
+    };
+  }
+
+  private getAad(context: DataKeyContext) {
+    return `nebula:data-key:${context.tenantId}:${context.keyProviderId}`;
+  }
+}

--- a/src/systems/nebula/service/src/controllers/_app.ts
+++ b/src/systems/nebula/service/src/controllers/_app.ts
@@ -1,0 +1,3 @@
+import { Group } from '@lowerdeck/rpc-server';
+
+export let app = new Group();

--- a/src/systems/nebula/service/src/controllers/consumer.ts
+++ b/src/systems/nebula/service/src/controllers/consumer.ts
@@ -1,0 +1,59 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import { consumerPresenter } from '../presenters';
+import { consumerService } from '../services';
+import { app } from './_app';
+import { tenantApp } from './tenant';
+
+export let consumerApp = tenantApp.use(async ctx => {
+  let consumerId = ctx.body.consumerId;
+  if (!consumerId) throw new Error('Consumer ID is required');
+
+  let consumer = await consumerService.getConsumerById({
+    tenant: ctx.tenant,
+    id: consumerId
+  });
+
+  return { consumer };
+});
+
+export let consumerController = app.controller({
+  upsert: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        name: v.string(),
+        identifier: v.string()
+      })
+    )
+    .do(async ctx => {
+      let consumer = await consumerService.upsertConsumer({
+        tenant: ctx.tenant,
+        input: {
+          name: ctx.input.name,
+          identifier: ctx.input.identifier
+        }
+      });
+      return consumerPresenter(consumer);
+    }),
+
+  list: tenantApp
+    .handler()
+    .input(Paginator.validate(v.object({ tenantId: v.string() })))
+    .do(async ctx => {
+      let paginator = await consumerService.listConsumers({ tenant: ctx.tenant });
+      let list = await paginator.run(ctx.input);
+      return Paginator.presentLight(list, consumerPresenter);
+    }),
+
+  get: consumerApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        consumerId: v.string()
+      })
+    )
+    .do(async ctx => consumerPresenter(ctx.consumer))
+});

--- a/src/systems/nebula/service/src/controllers/consumer.ts
+++ b/src/systems/nebula/service/src/controllers/consumer.ts
@@ -1,3 +1,4 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
 import { consumerPresenter } from '../presenters';
@@ -5,55 +6,68 @@ import { consumerService } from '../services';
 import { app } from './_app';
 import { tenantApp } from './tenant';
 
-export let consumerApp = tenantApp.use(async ctx => {
-  let consumerId = ctx.body.consumerId;
-  if (!consumerId) throw new Error('Consumer ID is required');
+export let consumerInstanceApp = tenantApp.use(async ctx => {
+  let token = ctx.body.consumerToken ?? ctx.body.token;
+  try {
+    let { consumer, consumerInstance } = await consumerService.authenticateConsumerInstanceToken({
+      token: typeof token === 'string' ? token : ''
+    });
 
-  let consumer = await consumerService.getConsumerById({
-    tenant: ctx.tenant,
-    id: consumerId
-  });
-
-  return { consumer };
+    return { consumer, consumerInstance };
+  } catch {
+    throw new ServiceError(badRequestError({ message: 'Unable to use secret' }));
+  }
 });
 
 export let consumerController = app.controller({
-  upsert: tenantApp
+  register: app
     .handler()
     .input(
       v.object({
-        tenantId: v.string(),
-        name: v.string(),
+        secret: v.string(),
         identifier: v.string()
       })
     )
     .do(async ctx => {
-      let consumer = await consumerService.upsertConsumer({
-        tenant: ctx.tenant,
-        input: {
-          name: ctx.input.name,
-          identifier: ctx.input.identifier
-        }
+      return await consumerService.registerConsumerInstance({
+        secret: ctx.input.secret,
+        identifier: ctx.input.identifier
       });
-      return consumerPresenter(consumer);
     }),
 
-  list: tenantApp
+  refresh: app
     .handler()
-    .input(Paginator.validate(v.object({ tenantId: v.string() })))
+    .input(
+      v.object({
+        secret: v.string(),
+        token: v.string()
+      })
+    )
     .do(async ctx => {
-      let paginator = await consumerService.listConsumers({ tenant: ctx.tenant });
+      return await consumerService.refreshConsumerInstance({
+        secret: ctx.input.secret,
+        token: ctx.input.token
+      });
+    }),
+
+  list: app
+    .handler()
+    .input(Paginator.validate(v.object({})))
+    .do(async ctx => {
+      let paginator = await consumerService.listConsumers();
       let list = await paginator.run(ctx.input);
       return Paginator.presentLight(list, consumerPresenter);
     }),
 
-  get: consumerApp
+  get: app
     .handler()
     .input(
       v.object({
-        tenantId: v.string(),
         consumerId: v.string()
       })
     )
-    .do(async ctx => consumerPresenter(ctx.consumer))
+    .do(async ctx => {
+      let consumer = await consumerService.getConsumerById({ id: ctx.input.consumerId });
+      return consumerPresenter(consumer);
+    })
 });

--- a/src/systems/nebula/service/src/controllers/index.ts
+++ b/src/systems/nebula/service/src/controllers/index.ts
@@ -1,0 +1,21 @@
+import { apiMux } from '@lowerdeck/api-mux';
+import { createServer, rpcMux, type InferClient } from '@lowerdeck/rpc-server';
+import { app } from './_app';
+import { consumerController } from './consumer';
+import { keyProviderController } from './keyProvider';
+import { keyProviderErrorController } from './keyProviderError';
+import { secretController } from './secret';
+import { tenantController } from './tenant';
+
+export let rootController = app.controller({
+  tenant: tenantController,
+  consumer: consumerController,
+  keyProvider: keyProviderController,
+  keyProviderError: keyProviderErrorController,
+  secret: secretController
+});
+
+export let nebulaRPC = createServer({})(rootController);
+export let nebulaApi = apiMux([{ endpoint: rpcMux({ path: '/metorial-nebula' }, [nebulaRPC]) }]);
+
+export type NebulaClient = InferClient<typeof rootController>;

--- a/src/systems/nebula/service/src/controllers/keyProvider.ts
+++ b/src/systems/nebula/service/src/controllers/keyProvider.ts
@@ -18,47 +18,35 @@ export let keyProviderApp = tenantApp.use(async ctx => {
 });
 
 export let keyProviderController = app.controller({
-  create: tenantApp
+  import: tenantApp
     .handler()
     .input(
       v.object({
         tenantId: v.string(),
-        name: v.string(),
-        keyId: v.optional(v.string()),
-        region: v.optional(v.string()),
-        keyReuseTimeSeconds: v.optional(v.number())
+        keyInput: v.record(v.any())
       })
     )
     .do(async ctx => {
-      let keyProvider = await keyProviderService.createKeyProvider({
+      let keyProvider = await keyProviderService.importKeyProvider({
         tenant: ctx.tenant,
-        input: {
-          name: ctx.input.name,
-          keyId: ctx.input.keyId,
-          region: ctx.input.region,
-          keyReuseTimeSeconds: ctx.input.keyReuseTimeSeconds
-        } as any
+        keyInput: ctx.input.keyInput
       });
       return keyProviderPresenter(keyProvider);
     }),
 
-  createManagedKms: tenantApp
+  createManaged: tenantApp
     .handler()
     .input(
       v.object({
         tenantId: v.string(),
-        name: v.string(),
-        region: v.optional(v.string()),
-        keyReuseTimeSeconds: v.optional(v.number())
+        name: v.string()
       })
     )
     .do(async ctx => {
-      let keyProvider = await keyProviderService.createManagedKmsKeyProvider({
+      let keyProvider = await keyProviderService.createManaged({
         tenant: ctx.tenant,
         input: {
-          name: ctx.input.name,
-          region: ctx.input.region,
-          keyReuseTimeSeconds: ctx.input.keyReuseTimeSeconds
+          name: ctx.input.name
         }
       });
       return keyProviderPresenter(keyProvider);
@@ -82,6 +70,31 @@ export let keyProviderController = app.controller({
       })
     )
     .do(async ctx => keyProviderPresenter(ctx.keyProvider)),
+
+  getSetupInfo: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        region: v.optional(v.string()),
+        keyId: v.optional(v.string())
+      })
+    )
+    .do(async ctx => {
+      let setupInfo = await keyProviderService.getSetupInfo({
+        tenant: ctx.tenant,
+        input: {
+          region: ctx.input.region,
+          keyId: ctx.input.keyId
+        }
+      });
+
+      return {
+        object: 'nebula#key_provider_setup_info',
+        steps: setupInfo.steps,
+        markdown: setupInfo.markdown
+      };
+    }),
 
   setDefault: keyProviderApp
     .handler()

--- a/src/systems/nebula/service/src/controllers/keyProvider.ts
+++ b/src/systems/nebula/service/src/controllers/keyProvider.ts
@@ -1,0 +1,122 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import { keyProviderPresenter, tenantPresenter } from '../presenters';
+import { keyProviderService } from '../services';
+import { app } from './_app';
+import { tenantApp } from './tenant';
+
+export let keyProviderApp = tenantApp.use(async ctx => {
+  let keyProviderId = ctx.body.keyProviderId;
+  if (!keyProviderId) throw new Error('Key provider ID is required');
+
+  let keyProvider = await keyProviderService.getKeyProviderById({
+    tenant: ctx.tenant,
+    id: keyProviderId
+  });
+
+  return { keyProvider };
+});
+
+export let keyProviderController = app.controller({
+  create: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        name: v.string(),
+        keyId: v.optional(v.string()),
+        region: v.optional(v.string()),
+        keyReuseTimeSeconds: v.optional(v.number())
+      })
+    )
+    .do(async ctx => {
+      let keyProvider = await keyProviderService.createKeyProvider({
+        tenant: ctx.tenant,
+        input: {
+          name: ctx.input.name,
+          keyId: ctx.input.keyId,
+          region: ctx.input.region,
+          keyReuseTimeSeconds: ctx.input.keyReuseTimeSeconds
+        } as any
+      });
+      return keyProviderPresenter(keyProvider);
+    }),
+
+  createManagedKms: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        name: v.string(),
+        region: v.optional(v.string()),
+        keyReuseTimeSeconds: v.optional(v.number())
+      })
+    )
+    .do(async ctx => {
+      let keyProvider = await keyProviderService.createManagedKmsKeyProvider({
+        tenant: ctx.tenant,
+        input: {
+          name: ctx.input.name,
+          region: ctx.input.region,
+          keyReuseTimeSeconds: ctx.input.keyReuseTimeSeconds
+        }
+      });
+      return keyProviderPresenter(keyProvider);
+    }),
+
+  list: tenantApp
+    .handler()
+    .input(Paginator.validate(v.object({ tenantId: v.string() })))
+    .do(async ctx => {
+      let paginator = await keyProviderService.listKeyProviders({ tenant: ctx.tenant });
+      let list = await paginator.run(ctx.input);
+      return Paginator.presentLight(list, keyProviderPresenter);
+    }),
+
+  get: keyProviderApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        keyProviderId: v.string()
+      })
+    )
+    .do(async ctx => keyProviderPresenter(ctx.keyProvider)),
+
+  setDefault: keyProviderApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        keyProviderId: v.string()
+      })
+    )
+    .do(async ctx => {
+      let tenant = await keyProviderService.setDefaultKeyProvider({
+        tenant: ctx.tenant,
+        keyProviderId: ctx.keyProvider.id
+      });
+      return tenantPresenter(tenant);
+    }),
+
+  validate: keyProviderApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        keyProviderId: v.string()
+      })
+    )
+    .do(async ctx => {
+      let description = await keyProviderService.validateKeyProvider({
+        tenant: ctx.tenant,
+        keyProviderId: ctx.keyProvider.id
+      });
+
+      return {
+        object: 'nebula#key_provider_validation',
+        keyProviderId: ctx.keyProvider.id,
+        description
+      };
+    })
+});

--- a/src/systems/nebula/service/src/controllers/keyProviderError.ts
+++ b/src/systems/nebula/service/src/controllers/keyProviderError.ts
@@ -1,0 +1,27 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import { keyProviderErrorPresenter } from '../presenters';
+import { keyProviderErrorService } from '../services';
+import { app } from './_app';
+import { keyProviderApp } from './keyProvider';
+
+export let keyProviderErrorController = app.controller({
+  list: keyProviderApp
+    .handler()
+    .input(
+      Paginator.validate(
+        v.object({
+          tenantId: v.string(),
+          keyProviderId: v.string()
+        })
+      )
+    )
+    .do(async ctx => {
+      let paginator = await keyProviderErrorService.listKeyProviderErrors({
+        tenant: ctx.tenant,
+        keyProvider: ctx.keyProvider
+      });
+      let list = await paginator.run(ctx.input);
+      return Paginator.presentLight(list, keyProviderErrorPresenter);
+    })
+});

--- a/src/systems/nebula/service/src/controllers/secret.ts
+++ b/src/systems/nebula/service/src/controllers/secret.ts
@@ -1,9 +1,9 @@
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
 import { secretPresenter, secretUsePresenter, secretVersionPresenter } from '../presenters';
-import { consumerService, secretService } from '../services';
+import { secretService } from '../services';
 import { app } from './_app';
-import { consumerApp } from './consumer';
+import { consumerInstanceApp } from './consumer';
 import { tenantApp } from './tenant';
 
 export let secretApp = tenantApp.use(async ctx => {
@@ -19,12 +19,12 @@ export let secretApp = tenantApp.use(async ctx => {
 });
 
 export let secretController = app.controller({
-  create: consumerApp
+  create: consumerInstanceApp
     .handler()
     .input(
       v.object({
         tenantId: v.string(),
-        consumerId: v.string(),
+        consumerToken: v.string(),
         purpose: v.string(),
         secret: v.string(),
         proof: v.any(),
@@ -47,13 +47,13 @@ export let secretController = app.controller({
       return secretPresenter(secret);
     }),
 
-  update: secretApp
+  update: consumerInstanceApp
     .handler()
     .input(
       v.object({
         tenantId: v.string(),
         secretId: v.string(),
-        consumerId: v.string(),
+        consumerToken: v.string(),
         secret: v.string(),
         proof: v.any(),
         encryptionContext: v.optional(v.any()),
@@ -61,15 +61,15 @@ export let secretController = app.controller({
       })
     )
     .do(async ctx => {
-      let consumer = await consumerService.getConsumerById({
+      let currentSecret = await secretService.getSecretById({
         tenant: ctx.tenant,
-        id: ctx.input.consumerId
+        id: ctx.input.secretId
       });
 
       let secret = await secretService.updateSecret({
         tenant: ctx.tenant,
-        consumer,
-        secret: ctx.secret,
+        consumer: ctx.consumer,
+        secret: currentSecret,
         input: {
           secret: ctx.input.secret,
           proof: ctx.input.proof,
@@ -99,12 +99,12 @@ export let secretController = app.controller({
     )
     .do(async ctx => secretPresenter(ctx.secret)),
 
-  use: consumerApp
+  use: consumerInstanceApp
     .handler()
     .input(
       v.object({
         tenantId: v.string(),
-        consumerId: v.string(),
+        consumerToken: v.string(),
         secretId: v.string(),
         proof: v.any(),
         note: v.string()
@@ -118,6 +118,7 @@ export let secretController = app.controller({
       let used = await secretService.useSecret({
         tenant: ctx.tenant,
         consumer: ctx.consumer,
+        consumerInstance: ctx.consumerInstance,
         secret,
         proof: ctx.input.proof,
         note: ctx.input.note

--- a/src/systems/nebula/service/src/controllers/secret.ts
+++ b/src/systems/nebula/service/src/controllers/secret.ts
@@ -1,0 +1,146 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import { secretPresenter, secretUsePresenter, secretVersionPresenter } from '../presenters';
+import { consumerService, secretService } from '../services';
+import { app } from './_app';
+import { consumerApp } from './consumer';
+import { tenantApp } from './tenant';
+
+export let secretApp = tenantApp.use(async ctx => {
+  let secretId = ctx.body.secretId;
+  if (!secretId) throw new Error('Secret ID is required');
+
+  let secret = await secretService.getSecretById({
+    tenant: ctx.tenant,
+    id: secretId
+  });
+
+  return { secret };
+});
+
+export let secretController = app.controller({
+  create: consumerApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        consumerId: v.string(),
+        purpose: v.string(),
+        secret: v.string(),
+        proof: v.any(),
+        encryptionContext: v.optional(v.any()),
+        keyProviderId: v.optional(v.string())
+      })
+    )
+    .do(async ctx => {
+      let secret = await secretService.createSecret({
+        tenant: ctx.tenant,
+        consumer: ctx.consumer,
+        input: {
+          purpose: ctx.input.purpose,
+          secret: ctx.input.secret,
+          proof: ctx.input.proof,
+          encryptionContext: ctx.input.encryptionContext,
+          keyProviderId: ctx.input.keyProviderId
+        }
+      });
+      return secretPresenter(secret);
+    }),
+
+  update: secretApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        secretId: v.string(),
+        consumerId: v.string(),
+        secret: v.string(),
+        proof: v.any(),
+        encryptionContext: v.optional(v.any()),
+        keyProviderId: v.optional(v.string())
+      })
+    )
+    .do(async ctx => {
+      let consumer = await consumerService.getConsumerById({
+        tenant: ctx.tenant,
+        id: ctx.input.consumerId
+      });
+
+      let secret = await secretService.updateSecret({
+        tenant: ctx.tenant,
+        consumer,
+        secret: ctx.secret,
+        input: {
+          secret: ctx.input.secret,
+          proof: ctx.input.proof,
+          encryptionContext: ctx.input.encryptionContext,
+          keyProviderId: ctx.input.keyProviderId
+        }
+      });
+      return secretPresenter(secret);
+    }),
+
+  list: tenantApp
+    .handler()
+    .input(Paginator.validate(v.object({ tenantId: v.string() })))
+    .do(async ctx => {
+      let paginator = await secretService.listSecrets({ tenant: ctx.tenant });
+      let list = await paginator.run(ctx.input);
+      return Paginator.presentLight(list, secretPresenter);
+    }),
+
+  get: secretApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        secretId: v.string()
+      })
+    )
+    .do(async ctx => secretPresenter(ctx.secret)),
+
+  use: consumerApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        consumerId: v.string(),
+        secretId: v.string(),
+        proof: v.any(),
+        note: v.string()
+      })
+    )
+    .do(async ctx => {
+      let secret = await secretService.getSecretById({
+        tenant: ctx.tenant,
+        id: ctx.input.secretId
+      });
+      let used = await secretService.useSecret({
+        tenant: ctx.tenant,
+        consumer: ctx.consumer,
+        secret,
+        proof: ctx.input.proof,
+        note: ctx.input.note
+      });
+      return secretUsePresenter(used);
+    }),
+
+  listVersions: secretApp
+    .handler()
+    .input(
+      Paginator.validate(
+        v.object({
+          tenantId: v.string(),
+          secretId: v.string()
+        })
+      )
+    )
+    .do(async ctx => {
+      let paginator = await secretService.listSecretVersions({
+        tenant: ctx.tenant,
+        secret: ctx.secret
+      });
+      let list = await paginator.run(ctx.input);
+      return Paginator.presentLight(list, secretVersionPresenter);
+    })
+});

--- a/src/systems/nebula/service/src/controllers/tenant.ts
+++ b/src/systems/nebula/service/src/controllers/tenant.ts
@@ -1,0 +1,44 @@
+import { v } from '@lowerdeck/validation';
+import { tenantPresenter } from '../presenters';
+import { tenantService } from '../services';
+import { app } from './_app';
+
+export let tenantApp = app.use(async ctx => {
+  let tenantId = ctx.body.tenantId;
+  if (!tenantId) throw new Error('Tenant ID is required');
+
+  let tenant = await tenantService.getTenantById({ id: tenantId });
+
+  return { tenant };
+});
+
+export let tenantController = app.controller({
+  upsert: app
+    .handler()
+    .input(
+      v.object({
+        name: v.string(),
+        identifier: v.string(),
+        keyReuseTimeSeconds: v.optional(v.number())
+      })
+    )
+    .do(async ctx => {
+      let tenant = await tenantService.upsertTenant({
+        input: {
+          name: ctx.input.name,
+          identifier: ctx.input.identifier,
+          keyReuseTimeSeconds: ctx.input.keyReuseTimeSeconds
+        }
+      });
+      return tenantPresenter(tenant);
+    }),
+
+  get: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string()
+      })
+    )
+    .do(async ctx => tenantPresenter(ctx.tenant))
+});

--- a/src/systems/nebula/service/src/controllers/tests/keyProviderError.e2e.test.ts
+++ b/src/systems/nebula/service/src/controllers/tests/keyProviderError.e2e.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { keyProviderErrorService } from '../../services';
+import { nebulaClient } from '../../test/client';
+import { cleanDatabase, testDb } from '../../test/setup';
+
+describe('key provider errors', () => {
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  it('dedupes provider errors per day and increments count', async () => {
+    let tenant = await nebulaClient.tenant.upsert({
+      identifier: 'tenant-errors',
+      name: 'Tenant Errors'
+    });
+    let provider = await nebulaClient.keyProvider.create({
+      tenantId: tenant.id,
+      name: 'Local Errors'
+    });
+
+    let dbTenant = await testDb.tenant.findUniqueOrThrow({ where: { id: tenant.id } });
+    let dbProvider = await testDb.keyProvider.findUniqueOrThrow({ where: { id: provider.id } });
+
+    await keyProviderErrorService.recordKeyProviderError({
+      tenant: dbTenant,
+      keyProvider: dbProvider,
+      operation: 'decrypt_data_key',
+      code: 'DisabledException',
+      message: 'KMS key is disabled'
+    });
+    await keyProviderErrorService.recordKeyProviderError({
+      tenant: dbTenant,
+      keyProvider: dbProvider,
+      operation: 'decrypt_data_key',
+      code: 'DisabledException',
+      message: 'KMS key is disabled'
+    });
+
+    let errors = await testDb.keyError.findMany();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      count: 2,
+      code: 'DisabledException',
+      sampleMessage: 'KMS key is disabled'
+    });
+  });
+});

--- a/src/systems/nebula/service/src/controllers/tests/keyProviderError.e2e.test.ts
+++ b/src/systems/nebula/service/src/controllers/tests/keyProviderError.e2e.test.ts
@@ -13,9 +13,9 @@ describe('key provider errors', () => {
       identifier: 'tenant-errors',
       name: 'Tenant Errors'
     });
-    let provider = await nebulaClient.keyProvider.create({
+    let provider = await nebulaClient.keyProvider.import({
       tenantId: tenant.id,
-      name: 'Local Errors'
+      keyInput: {}
     });
 
     let dbTenant = await testDb.tenant.findUniqueOrThrow({ where: { id: tenant.id } });

--- a/src/systems/nebula/service/src/controllers/tests/keyProviderSetupInfo.e2e.test.ts
+++ b/src/systems/nebula/service/src/controllers/tests/keyProviderSetupInfo.e2e.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { AwsKmsKeyProviderAdapter } from '../../adapters/aws-kms';
+import { nebulaClient } from '../../test/client';
+import { cleanDatabase } from '../../test/setup';
+
+describe('key provider setup info', () => {
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  it('returns local setup info without a consumer token', async () => {
+    let tenant = await nebulaClient.tenant.upsert({
+      identifier: 'tenant-setup-local',
+      name: 'Tenant Setup Local'
+    });
+
+    let setupInfo = await nebulaClient.keyProvider.getSetupInfo({
+      tenantId: tenant.id
+    });
+
+    expect(setupInfo).toMatchObject({
+      object: 'nebula#key_provider_setup_info'
+    });
+    expect(setupInfo.steps.length).toBeGreaterThan(0);
+    expect(setupInfo.steps.some(step => step.markdown?.includes('keyProvider.import'))).toBe(true);
+    expect(setupInfo.steps.every(step => !step.inputs || step.inputs.length === 0)).toBe(true);
+    expect(setupInfo.markdown).toContain('LOCAL_MASTER_SECRET');
+    expect(setupInfo.markdown).toContain('development only');
+  });
+
+  it('generates AWS KMS setup info with role ARN and required actions', async () => {
+    let adapter = new AwsKmsKeyProviderAdapter();
+    let roleArn = 'arn:aws:iam::123456789012:role/metorial-test-nebula-task-role';
+    let setupInfo = await adapter.getSetupInfo({
+      tenantId: 'ntn_test',
+      tenantIdentifier: 'tenant-setup-aws',
+      region: 'us-east-1',
+      keyId: 'arn:aws:kms:us-east-1:123456789012:key/example',
+      roleArn
+    });
+
+    expect(setupInfo.steps.length).toBeGreaterThan(0);
+    expect(setupInfo.steps.some(step => (step.markdown?.length ?? 0) > 0)).toBe(true);
+    expect(setupInfo.steps.some(step => step.inputs?.some(input => input.key === 'keyId'))).toBe(true);
+    expect(
+      setupInfo.steps.some(step => step.inputs?.some(input => input.key === 'region'))
+    ).toBe(true);
+    expect(setupInfo.markdown).toContain(roleArn);
+    expect(setupInfo.markdown).toContain('kms:DescribeKey');
+    expect(setupInfo.markdown).toContain('kms:GenerateDataKey');
+    expect(setupInfo.markdown).toContain('kms:Decrypt');
+    expect(setupInfo.markdown).toContain('metorial-system=nebula');
+  });
+});

--- a/src/systems/nebula/service/src/controllers/tests/keyProviderSetupInfo.e2e.test.ts
+++ b/src/systems/nebula/service/src/controllers/tests/keyProviderSetupInfo.e2e.test.ts
@@ -23,9 +23,12 @@ describe('key provider setup info', () => {
     });
     expect(setupInfo.steps.length).toBeGreaterThan(0);
     expect(setupInfo.steps.some(step => step.markdown?.includes('keyProvider.import'))).toBe(true);
-    expect(setupInfo.steps.every(step => !step.inputs || step.inputs.length === 0)).toBe(true);
-    expect(setupInfo.markdown).toContain('LOCAL_MASTER_SECRET');
-    expect(setupInfo.markdown).toContain('development only');
+    expect(setupInfo.steps.some(step => step.inputs?.some(input => input.key === 'testKeyId'))).toBe(true);
+    expect(
+      setupInfo.steps.some(step => step.inputs?.some(input => input.key === 'localMasterSecretRef'))
+    ).toBe(true);
+    expect(setupInfo.steps.some(step => step.description.includes('LOCAL_MASTER_SECRET'))).toBe(true);
+    expect(setupInfo.steps.some(step => step.description.includes('production'))).toBe(true);
   });
 
   it('generates AWS KMS setup info with role ARN and required actions', async () => {
@@ -49,6 +52,6 @@ describe('key provider setup info', () => {
     expect(setupInfo.markdown).toContain('kms:DescribeKey');
     expect(setupInfo.markdown).toContain('kms:GenerateDataKey');
     expect(setupInfo.markdown).toContain('kms:Decrypt');
-    expect(setupInfo.markdown).toContain('metorial-system=nebula');
+    expect(setupInfo.markdown).toContain('"metorial-system": "nebula"');
   });
 });

--- a/src/systems/nebula/service/src/controllers/tests/secret.e2e.test.ts
+++ b/src/systems/nebula/service/src/controllers/tests/secret.e2e.test.ts
@@ -121,9 +121,9 @@ describe('secret E2E', () => {
     let tenantB = await createTenant('tenant-provider-b');
     let registration = await registerWorker();
 
-    let provider = await nebulaClient.keyProvider.create({
+    let provider = await nebulaClient.keyProvider.import({
       tenantId: tenantA.id,
-      name: 'Local BYOK'
+      keyInput: {}
     });
 
     await expect(

--- a/src/systems/nebula/service/src/controllers/tests/secret.e2e.test.ts
+++ b/src/systems/nebula/service/src/controllers/tests/secret.e2e.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { nebulaClient } from '../../test/client';
+import { cleanDatabase, testDb } from '../../test/setup';
+
+let createTenant = (identifier = 'tenant-a') =>
+  nebulaClient.tenant.upsert({
+    identifier,
+    name: identifier
+  });
+
+describe('secret E2E', () => {
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  it('stores and uses a secret with the correct proof', async () => {
+    let tenant = await createTenant();
+    let consumer = await nebulaClient.consumer.upsert({
+      tenantId: tenant.id,
+      identifier: 'worker',
+      name: 'Worker'
+    });
+
+    let secret = await nebulaClient.secret.create({
+      tenantId: tenant.id,
+      consumerId: consumer.id,
+      purpose: 'database_password',
+      secret: 'high-entropy-secret-value-1',
+      proof: { binding: 'db', nonce: 'proof-1' },
+      encryptionContext: { service: 'database' }
+    });
+
+    let used = await nebulaClient.secret.use({
+      tenantId: tenant.id,
+      consumerId: consumer.id,
+      secretId: secret.id,
+      proof: { binding: 'db', nonce: 'proof-1' },
+      note: 'Read database password for connection test'
+    });
+
+    expect(used).toMatchObject({
+      object: 'nebula#secret_use',
+      secretId: secret.id,
+      plaintext: 'high-entropy-secret-value-1'
+    });
+
+    await expect(
+      nebulaClient.secret.use({
+        tenantId: tenant.id,
+        consumerId: consumer.id,
+        secretId: secret.id,
+        proof: { binding: 'db', nonce: 'wrong' },
+        note: 'Attempt with wrong proof'
+      })
+    ).rejects.toThrow('Unable to use secret');
+  });
+
+  it('locks a secret to the creating consumer', async () => {
+    let tenant = await createTenant('tenant-consumer-lock');
+    let owner = await nebulaClient.consumer.upsert({
+      tenantId: tenant.id,
+      identifier: 'owner',
+      name: 'Owner'
+    });
+    let other = await nebulaClient.consumer.upsert({
+      tenantId: tenant.id,
+      identifier: 'other',
+      name: 'Other'
+    });
+
+    let secret = await nebulaClient.secret.create({
+      tenantId: tenant.id,
+      consumerId: owner.id,
+      purpose: 'locked_secret',
+      secret: 'high-entropy-secret-value-locked',
+      proof: { binding: 'owner' }
+    });
+
+    expect(secret.consumerId).toBe(owner.id);
+
+    await expect(
+      nebulaClient.secret.use({
+        tenantId: tenant.id,
+        consumerId: other.id,
+        secretId: secret.id,
+        proof: { binding: 'owner' },
+        note: 'Attempt access from other consumer'
+      })
+    ).rejects.toThrow('Unable to use secret');
+  });
+
+  it('reuses the current data key for multiple writes in the reuse window', async () => {
+    let tenant = await createTenant('tenant-reuse');
+    let consumer = await nebulaClient.consumer.upsert({
+      tenantId: tenant.id,
+      identifier: 'worker',
+      name: 'Worker'
+    });
+
+    await nebulaClient.secret.create({
+      tenantId: tenant.id,
+      consumerId: consumer.id,
+      purpose: 'first',
+      secret: 'high-entropy-secret-value-2',
+      proof: { p: 1 }
+    });
+
+    await nebulaClient.secret.create({
+      tenantId: tenant.id,
+      consumerId: consumer.id,
+      purpose: 'second',
+      secret: 'high-entropy-secret-value-3',
+      proof: { p: 2 }
+    });
+
+    let keys = await testDb.key.findMany();
+    expect(keys).toHaveLength(1);
+  });
+
+  it('does not allow a tenant to use another tenant key provider', async () => {
+    let tenantA = await createTenant('tenant-provider-a');
+    let tenantB = await createTenant('tenant-provider-b');
+    let consumerB = await nebulaClient.consumer.upsert({
+      tenantId: tenantB.id,
+      identifier: 'worker',
+      name: 'Worker'
+    });
+
+    let provider = await nebulaClient.keyProvider.create({
+      tenantId: tenantA.id,
+      name: 'Local BYOK'
+    });
+
+    await expect(
+      nebulaClient.secret.create({
+        tenantId: tenantB.id,
+        consumerId: consumerB.id,
+        purpose: 'cross_tenant',
+        secret: 'high-entropy-secret-value-4',
+        proof: { p: 1 },
+        keyProviderId: provider.id
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/src/systems/nebula/service/src/controllers/tests/secret.e2e.test.ts
+++ b/src/systems/nebula/service/src/controllers/tests/secret.e2e.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { nebulaClient } from '../../test/client';
 import { cleanDatabase, testDb } from '../../test/setup';
+import { consumerService } from '../../services';
 
 let createTenant = (identifier = 'tenant-a') =>
   nebulaClient.tenant.upsert({
@@ -8,22 +9,26 @@ let createTenant = (identifier = 'tenant-a') =>
     name: identifier
   });
 
+let registerWorker = (secret = 'worker-secret', identifier = 'WORKER-INSTANCE') =>
+  nebulaClient.consumer.register({
+    secret,
+    identifier
+  });
+
 describe('secret E2E', () => {
   beforeEach(async () => {
     await cleanDatabase();
+    await consumerService.ensureEnvConsumers();
   });
 
   it('stores and uses a secret with the correct proof', async () => {
     let tenant = await createTenant();
-    let consumer = await nebulaClient.consumer.upsert({
-      tenantId: tenant.id,
-      identifier: 'worker',
-      name: 'Worker'
-    });
+    let registration = await registerWorker();
+    let consumer = await testDb.consumer.findUniqueOrThrow({ where: { identifier: 'worker' } });
 
     let secret = await nebulaClient.secret.create({
       tenantId: tenant.id,
-      consumerId: consumer.id,
+      consumerToken: registration.token,
       purpose: 'database_password',
       secret: 'high-entropy-secret-value-1',
       proof: { binding: 'db', nonce: 'proof-1' },
@@ -32,7 +37,7 @@ describe('secret E2E', () => {
 
     let used = await nebulaClient.secret.use({
       tenantId: tenant.id,
-      consumerId: consumer.id,
+      consumerToken: registration.token,
       secretId: secret.id,
       proof: { binding: 'db', nonce: 'proof-1' },
       note: 'Read database password for connection test'
@@ -43,11 +48,16 @@ describe('secret E2E', () => {
       secretId: secret.id,
       plaintext: 'high-entropy-secret-value-1'
     });
+    let useRecord = await testDb.secretUse.findFirstOrThrow();
+    let instance = await testDb.consumerInstance.findUniqueOrThrow({
+      where: { id: registration.consumerInstanceId }
+    });
+    expect(useRecord.consumerInstanceOid).toBe(instance.oid);
 
     await expect(
       nebulaClient.secret.use({
         tenantId: tenant.id,
-        consumerId: consumer.id,
+        consumerToken: registration.token,
         secretId: secret.id,
         proof: { binding: 'db', nonce: 'wrong' },
         note: 'Attempt with wrong proof'
@@ -57,20 +67,13 @@ describe('secret E2E', () => {
 
   it('locks a secret to the creating consumer', async () => {
     let tenant = await createTenant('tenant-consumer-lock');
-    let owner = await nebulaClient.consumer.upsert({
-      tenantId: tenant.id,
-      identifier: 'owner',
-      name: 'Owner'
-    });
-    let other = await nebulaClient.consumer.upsert({
-      tenantId: tenant.id,
-      identifier: 'other',
-      name: 'Other'
-    });
+    let ownerRegistration = await registerWorker('owner-secret', 'OWNER-INSTANCE');
+    let otherRegistration = await registerWorker('other-secret', 'OTHER-INSTANCE');
+    let owner = await testDb.consumer.findUniqueOrThrow({ where: { identifier: 'owner' } });
 
     let secret = await nebulaClient.secret.create({
       tenantId: tenant.id,
-      consumerId: owner.id,
+      consumerToken: ownerRegistration.token,
       purpose: 'locked_secret',
       secret: 'high-entropy-secret-value-locked',
       proof: { binding: 'owner' }
@@ -81,7 +84,7 @@ describe('secret E2E', () => {
     await expect(
       nebulaClient.secret.use({
         tenantId: tenant.id,
-        consumerId: other.id,
+        consumerToken: otherRegistration.token,
         secretId: secret.id,
         proof: { binding: 'owner' },
         note: 'Attempt access from other consumer'
@@ -91,15 +94,11 @@ describe('secret E2E', () => {
 
   it('reuses the current data key for multiple writes in the reuse window', async () => {
     let tenant = await createTenant('tenant-reuse');
-    let consumer = await nebulaClient.consumer.upsert({
-      tenantId: tenant.id,
-      identifier: 'worker',
-      name: 'Worker'
-    });
+    let registration = await registerWorker();
 
     await nebulaClient.secret.create({
       tenantId: tenant.id,
-      consumerId: consumer.id,
+      consumerToken: registration.token,
       purpose: 'first',
       secret: 'high-entropy-secret-value-2',
       proof: { p: 1 }
@@ -107,7 +106,7 @@ describe('secret E2E', () => {
 
     await nebulaClient.secret.create({
       tenantId: tenant.id,
-      consumerId: consumer.id,
+      consumerToken: registration.token,
       purpose: 'second',
       secret: 'high-entropy-secret-value-3',
       proof: { p: 2 }
@@ -120,11 +119,7 @@ describe('secret E2E', () => {
   it('does not allow a tenant to use another tenant key provider', async () => {
     let tenantA = await createTenant('tenant-provider-a');
     let tenantB = await createTenant('tenant-provider-b');
-    let consumerB = await nebulaClient.consumer.upsert({
-      tenantId: tenantB.id,
-      identifier: 'worker',
-      name: 'Worker'
-    });
+    let registration = await registerWorker();
 
     let provider = await nebulaClient.keyProvider.create({
       tenantId: tenantA.id,
@@ -134,12 +129,107 @@ describe('secret E2E', () => {
     await expect(
       nebulaClient.secret.create({
         tenantId: tenantB.id,
-        consumerId: consumerB.id,
+        consumerToken: registration.token,
         purpose: 'cross_tenant',
         secret: 'high-entropy-secret-value-4',
         proof: { p: 1 },
         keyProviderId: provider.id
       })
     ).rejects.toThrow();
+  });
+
+  it('registers lowercased consumer instances and refreshes by rotating the nonce', async () => {
+    let first = await registerWorker('worker-secret', 'WORKER-RUNTIME-A');
+    let instance = await testDb.consumerInstance.findUniqueOrThrow({
+      where: { id: first.consumerInstanceId },
+      include: { consumer: true }
+    });
+
+    expect(instance.identifier).toBe('worker-runtime-a');
+    expect(instance.consumer.identifier).toBe('worker');
+
+    let originalNonce = instance.tokenNonce;
+    let refreshed = await nebulaClient.consumer.refresh({
+      secret: 'worker-secret',
+      token: first.token
+    });
+    let updated = await testDb.consumerInstance.findUniqueOrThrow({
+      where: { id: first.consumerInstanceId }
+    });
+
+    expect(refreshed.consumerInstanceId).toBe(first.consumerInstanceId);
+    expect(updated.tokenNonce).not.toBe(originalNonce);
+
+    await expect(
+      nebulaClient.consumer.refresh({
+        secret: 'worker-secret',
+        token: first.token
+      })
+    ).rejects.toThrow('Consumer token has been rotated or revoked');
+  });
+
+  it('keeps metadata and key provider operations open without consumer tokens', async () => {
+    let tenant = await createTenant('tenant-open-metadata');
+    let registration = await registerWorker();
+    let secret = await nebulaClient.secret.create({
+      tenantId: tenant.id,
+      consumerToken: registration.token,
+      purpose: 'metadata',
+      secret: 'high-entropy-secret-value-5',
+      proof: { p: 'metadata' }
+    });
+
+    await expect(
+      nebulaClient.secret.list({ tenantId: tenant.id, limit: 10 })
+    ).resolves.toBeDefined();
+    await expect(
+      nebulaClient.secret.get({ tenantId: tenant.id, secretId: secret.id })
+    ).resolves.toMatchObject({ id: secret.id });
+    await expect(
+      nebulaClient.keyProvider.list({ tenantId: tenant.id, limit: 10 })
+    ).resolves.toBeDefined();
+  });
+
+  it('rejects bad, expired, revoked, and wrong-secret consumer tokens generically', async () => {
+    let registration = await registerWorker();
+
+    await expect(
+      nebulaClient.consumer.refresh({
+        secret: 'wrong-secret',
+        token: registration.token
+      })
+    ).rejects.toThrow('Registration secret does not match consumer');
+
+    await expect(
+      nebulaClient.consumer.refresh({
+        secret: 'worker-secret',
+        token: `${registration.token}x`
+      })
+    ).rejects.toThrow('Consumer token is invalid');
+
+    await testDb.consumerInstance.update({
+      where: { id: registration.consumerInstanceId },
+      data: { expiresAt: new Date(Date.now() - 1000) }
+    });
+
+    await expect(
+      nebulaClient.consumer.refresh({
+        secret: 'worker-secret',
+        token: registration.token
+      })
+    ).rejects.toThrow('Consumer token has expired');
+
+    let revoked = await registerWorker('worker-secret', 'revoked-worker');
+    await testDb.consumerInstance.update({
+      where: { id: revoked.consumerInstanceId },
+      data: { status: 'revoked', revokedAt: new Date() }
+    });
+
+    await expect(
+      nebulaClient.consumer.refresh({
+        secret: 'worker-secret',
+        token: revoked.token
+      })
+    ).rejects.toThrow('Consumer instance is not active');
   });
 });

--- a/src/systems/nebula/service/src/db.ts
+++ b/src/systems/nebula/service/src/db.ts
@@ -1,0 +1,31 @@
+import { PrismaPg } from '@prisma/adapter-pg';
+import { readReplicas } from '@prisma/extension-read-replicas';
+import { PrismaClient } from '../prisma/generated/client';
+
+let mainAdapter = new PrismaPg({
+  connectionString: process.env.NEBULA_DATABASE_URL ?? process.env.DATABASE_URL
+});
+
+let replicaAdapter = process.env.DATABASE_URL_READER
+  ? new PrismaPg({
+      connectionString: process.env.DATABASE_URL_READER
+    })
+  : undefined;
+
+let replicaClient = replicaAdapter ? new PrismaClient({ adapter: replicaAdapter }) : undefined;
+
+let baseClient = new PrismaClient({
+  adapter: mainAdapter,
+  transactionOptions: {
+    maxWait: 10000,
+    timeout: 12000
+  }
+});
+
+if (replicaClient) {
+  baseClient = baseClient.$extends(
+    readReplicas({ replicas: [replicaClient] })
+  ) as any as PrismaClient;
+}
+
+export let db = baseClient;

--- a/src/systems/nebula/service/src/endpoints.ts
+++ b/src/systems/nebula/service/src/endpoints.ts
@@ -8,7 +8,7 @@ await keyProviderService.ensureSystemDefaultProvider();
 
 let server = Bun.serve({
   fetch: nebulaApi,
-  port: 52060
+  port: 52170
 });
 
 console.log(`Service running on http://localhost:${server.port}`);

--- a/src/systems/nebula/service/src/endpoints.ts
+++ b/src/systems/nebula/service/src/endpoints.ts
@@ -1,8 +1,9 @@
 import { RedisClient } from 'bun';
 import { nebulaApi } from './controllers';
 import { db } from './db';
-import { keyProviderService } from './services';
+import { consumerService, keyProviderService } from './services';
 
+await consumerService.ensureEnvConsumers();
 await keyProviderService.ensureSystemDefaultProvider();
 
 let server = Bun.serve({

--- a/src/systems/nebula/service/src/endpoints.ts
+++ b/src/systems/nebula/service/src/endpoints.ts
@@ -1,0 +1,33 @@
+import { RedisClient } from 'bun';
+import { nebulaApi } from './controllers';
+import { db } from './db';
+import { keyProviderService } from './services';
+
+await keyProviderService.ensureSystemDefaultProvider();
+
+let server = Bun.serve({
+  fetch: nebulaApi,
+  port: 52060
+});
+
+console.log(`Service running on http://localhost:${server.port}`);
+
+let redis = new RedisClient(process.env.REDIS_URL?.replace('rediss://', 'redis://'), {
+  tls: process.env.REDIS_URL?.startsWith('rediss://')
+});
+
+if (process.env.NODE_ENV === 'production') {
+  Bun.serve({
+    fetch: async _ => {
+      try {
+        await db.tenant.count();
+        await redis.ping();
+
+        return new Response('OK');
+      } catch (e) {
+        return new Response('Service Unavailable', { status: 503 });
+      }
+    },
+    port: 12121
+  });
+}

--- a/src/systems/nebula/service/src/env.ts
+++ b/src/systems/nebula/service/src/env.ts
@@ -21,8 +21,38 @@ export let env = createValidatedEnv({
     KMS_AWS_SECRET_ACCESS_KEY: v.optional(v.string()),
     KMS_DEFAULT_KEY_ID: v.optional(v.string()),
     KMS_CREATE_DEFAULT_KEY: v.optional(v.string())
+  },
+
+  consumerAuth: {
+    CONSUMER_INSTANCE_TOKEN_SECRET: v.string(),
+    CONSUMER_INSTANCE_TOKEN_TTL_SECONDS: v.optional(v.string())
   }
 });
+
+export let consumerRegistrationSecrets = Object.entries(process.env).flatMap(([key, secret]) => {
+  if (!key.startsWith('CONSUMER_REGISTRATION_') || !secret) return [];
+
+  let identifier = key.slice('CONSUMER_REGISTRATION_'.length).toLowerCase();
+  if (!identifier) return [];
+
+  return [{ identifier, secret }];
+});
+
+export let consumerInstanceTokenTtlSeconds = (() => {
+  let value = env.consumerAuth.CONSUMER_INSTANCE_TOKEN_TTL_SECONDS;
+  if (!value) return 60 * 60;
+
+  let parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error('CONSUMER_INSTANCE_TOKEN_TTL_SECONDS must be a positive number');
+  }
+
+  return Math.floor(parsed);
+})();
+
+if (env.consumerAuth.CONSUMER_INSTANCE_TOKEN_SECRET.length < 32) {
+  throw new Error('CONSUMER_INSTANCE_TOKEN_SECRET must be at least 32 characters');
+}
 
 if (
   env.provider.DEFAULT_PROVIDER === 'local' &&

--- a/src/systems/nebula/service/src/env.ts
+++ b/src/systems/nebula/service/src/env.ts
@@ -1,0 +1,40 @@
+import { createValidatedEnv } from '@lowerdeck/env';
+import { v } from '@lowerdeck/validation';
+
+export let env = createValidatedEnv({
+  service: {
+    REDIS_URL: v.string(),
+    DATABASE_URL: v.string()
+  },
+
+  provider: {
+    DEFAULT_PROVIDER: v.enumOf(['aws.kms', 'local'])
+  },
+
+  local: {
+    LOCAL_MASTER_SECRET: v.optional(v.string())
+  },
+
+  kms: {
+    KMS_AWS_REGION: v.optional(v.string()),
+    KMS_AWS_ACCESS_KEY_ID: v.optional(v.string()),
+    KMS_AWS_SECRET_ACCESS_KEY: v.optional(v.string()),
+    KMS_DEFAULT_KEY_ID: v.optional(v.string()),
+    KMS_CREATE_DEFAULT_KEY: v.optional(v.string())
+  }
+});
+
+if (
+  env.provider.DEFAULT_PROVIDER === 'local' &&
+  process.env.NODE_ENV === 'production'
+) {
+  throw new Error('Local provider cannot be used in production');
+}
+
+if (env.provider.DEFAULT_PROVIDER === 'local' && (env.local.LOCAL_MASTER_SECRET?.length ?? 0) < 32) {
+  throw new Error('LOCAL_MASTER_SECRET must be at least 32 characters');
+}
+
+if (env.provider.DEFAULT_PROVIDER === 'aws.kms' && !env.kms.KMS_AWS_REGION) {
+  throw new Error('KMS_AWS_REGION is required when DEFAULT_PROVIDER=aws.kms');
+}

--- a/src/systems/nebula/service/src/env.ts
+++ b/src/systems/nebula/service/src/env.ts
@@ -20,7 +20,8 @@ export let env = createValidatedEnv({
     KMS_AWS_ACCESS_KEY_ID: v.optional(v.string()),
     KMS_AWS_SECRET_ACCESS_KEY: v.optional(v.string()),
     KMS_DEFAULT_KEY_ID: v.optional(v.string()),
-    KMS_CREATE_DEFAULT_KEY: v.optional(v.string())
+    KMS_CREATE_DEFAULT_KEY: v.optional(v.string()),
+    KMS_EXTERNAL_KEY_ROLE_ARN: v.optional(v.string())
   },
 
   consumerAuth: {

--- a/src/systems/nebula/service/src/id.ts
+++ b/src/systems/nebula/service/src/id.ts
@@ -1,0 +1,31 @@
+import { createIdGenerator, idType } from '@lowerdeck/id';
+import { Snowflake } from '@lowerdeck/snowflake';
+
+export let ID = createIdGenerator({
+  tenant: idType.sorted('ntn_'),
+  keyProvider: idType.sorted('nkp_'),
+  key: idType.sorted('nkey_'),
+  keyError: idType.sorted('nker_'),
+  secret: idType.sorted('nsec_'),
+  secretVersion: idType.sorted('nsv_'),
+  secretUse: idType.sorted('nsu_'),
+  consumer: idType.sorted('ncon_')
+});
+
+let workerIdBits = 12;
+let workerIdMask = (1 << workerIdBits) - 1;
+
+let workerId = (() => {
+  let array = new Uint16Array(1);
+  crypto.getRandomValues(array);
+  return array[0]! & workerIdMask;
+})();
+
+export let snowflake = new Snowflake({
+  workerId,
+  datacenterId: 0,
+  workerIdBits,
+  datacenterIdBits: 0,
+  sequenceBits: 9,
+  epoch: new Date('2025-06-01T00:00:00Z')
+});

--- a/src/systems/nebula/service/src/id.ts
+++ b/src/systems/nebula/service/src/id.ts
@@ -9,7 +9,8 @@ export let ID = createIdGenerator({
   secret: idType.sorted('nsec_'),
   secretVersion: idType.sorted('nsv_'),
   secretUse: idType.sorted('nsu_'),
-  consumer: idType.sorted('ncon_')
+  consumer: idType.sorted('ncon_'),
+  consumerInstance: idType.sorted('nci_')
 });
 
 let workerIdBits = 12;

--- a/src/systems/nebula/service/src/init.ts
+++ b/src/systems/nebula/service/src/init.ts
@@ -1,0 +1,39 @@
+if (!process.env.DATABASE_URL) {
+  if (process.env.NEBULA_DATABASE_URL) {
+    process.env.DATABASE_URL = process.env.NEBULA_DATABASE_URL;
+  } else if (
+    process.env.DATABASE_USERNAME &&
+    process.env.DATABASE_PASSWORD &&
+    process.env.DATABASE_HOST &&
+    process.env.DATABASE_PORT &&
+    process.env.DATABASE_NAME
+  ) {
+    process.env.DATABASE_URL = `postgres://${process.env.DATABASE_USERNAME}:${process.env.DATABASE_PASSWORD}@${process.env.DATABASE_HOST}:${process.env.DATABASE_PORT}/${process.env.DATABASE_NAME}?schema=public&sslmode=no-verify&connection_limit=20`;
+
+    if (process.env.DATABASE_READER === 'true') {
+      process.env.DATABASE_URL_READER = `postgres://${process.env.DATABASE_USERNAME}:${process.env.DATABASE_PASSWORD}@${process.env.DATABASE_HOST?.replace('.cluster-', '.cluster-ro-')}:${process.env.DATABASE_PORT}/${process.env.DATABASE_NAME}?schema=public&sslmode=no-verify&connection_limit=20`;
+    }
+  } else {
+    throw new Error('DATABASE_URL is not set and database component env vars are missing');
+  }
+}
+
+if (!process.env.REDIS_URL) {
+  if (!process.env.REDIS_AUTH_TOKEN || !process.env.REDIS_HOST || !process.env.REDIS_PORT) {
+    throw new Error('REDIS_URL is not set and redis component env vars are missing');
+  }
+
+  process.env.REDIS_URL = `${
+    process.env.REDIS_TLS == 'true' ? 'rediss' : 'redis'
+  }://:${process.env.REDIS_AUTH_TOKEN}@${process.env.REDIS_HOST}:${process.env.REDIS_PORT}/0`;
+} else {
+  try {
+    let url = new URL(process.env.REDIS_URL);
+    if (url.pathname === '' || url.pathname === '/') {
+      url.pathname = '/0';
+      process.env.REDIS_URL = url.toString();
+    }
+  } catch {
+    // Leave REDIS_URL as-is if parsing fails.
+  }
+}

--- a/src/systems/nebula/service/src/instrument.ts
+++ b/src/systems/nebula/service/src/instrument.ts
@@ -1,0 +1,31 @@
+import { setSentry } from '@lowerdeck/sentry';
+import * as Sentry from '@sentry/bun';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var sentryInitialized: boolean | undefined;
+}
+
+if (
+  process.env.METORIAL_ENV !== 'development' &&
+  !global.sentryInitialized &&
+  process.env.SENTRY_DSN
+) {
+  global.sentryInitialized = true;
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    sendDefaultPii: true,
+    environment: process.env.METORIAL_ENV,
+    beforeSend(event) {
+      if (!event.tags) event.tags = {};
+      event.tags.allocationId = process.env.NOMAD_ALLOC_ID || 'unknown';
+      return event;
+    },
+    ignoreErrors: ['The client is closed']
+  });
+
+  setSentry(Sentry as any);
+
+  console.log('Sentry initialized for Bun');
+}

--- a/src/systems/nebula/service/src/lib/crypto.ts
+++ b/src/systems/nebula/service/src/lib/crypto.ts
@@ -1,0 +1,57 @@
+import { canonicalize } from '@lowerdeck/canonicalize';
+import { createCipheriv, createDecipheriv, createHash, timingSafeEqual } from 'crypto';
+
+export let sha256Hex = (input: string | Uint8Array) =>
+  createHash('sha256').update(input).digest('hex');
+
+export let sha512Hex = (input: string | Uint8Array) =>
+  createHash('sha512').update(input).digest('hex');
+
+export let deriveSha256Key = (secret: string) =>
+  createHash('sha256').update(secret, 'utf8').digest();
+
+export let canonicalJson = (input: any) => canonicalize(input ?? null);
+
+export let constantTimeEqual = (left: string, right: string) => {
+  let leftBuffer = Buffer.from(left);
+  let rightBuffer = Buffer.from(right);
+  if (leftBuffer.length !== rightBuffer.length) return false;
+  return timingSafeEqual(leftBuffer, rightBuffer);
+};
+
+export let encryptAes256Gcm = (d: {
+  key: Uint8Array;
+  plaintext: Uint8Array;
+  aad?: Uint8Array;
+}) => {
+  let iv = crypto.getRandomValues(new Uint8Array(12));
+  let cipher = createCipheriv('aes-256-gcm', Buffer.from(d.key), Buffer.from(iv));
+  if (d.aad) cipher.setAAD(Buffer.from(d.aad));
+
+  let ciphertext = Buffer.concat([cipher.update(Buffer.from(d.plaintext)), cipher.final()]);
+  let authTag = cipher.getAuthTag();
+
+  return {
+    iv,
+    ciphertext,
+    authTag
+  };
+};
+
+export let decryptAes256Gcm = (d: {
+  key: Uint8Array;
+  iv: Uint8Array;
+  ciphertext: Uint8Array;
+  authTag: Uint8Array;
+  aad?: Uint8Array;
+}) => {
+  let decipher = createDecipheriv('aes-256-gcm', Buffer.from(d.key), Buffer.from(d.iv));
+  if (d.aad) decipher.setAAD(Buffer.from(d.aad));
+  decipher.setAuthTag(Buffer.from(d.authTag));
+
+  return Buffer.concat([decipher.update(Buffer.from(d.ciphertext)), decipher.final()]);
+};
+
+export let zeroBuffer = (buffer: Uint8Array) => {
+  buffer.fill(0);
+};

--- a/src/systems/nebula/service/src/lib/dataKeyCache.ts
+++ b/src/systems/nebula/service/src/lib/dataKeyCache.ts
@@ -1,0 +1,56 @@
+import { sha256Hex, zeroBuffer } from './crypto';
+
+type CacheEntry = {
+  key: Uint8Array;
+  expiresAt: number;
+};
+
+let ttlMs = 10 * 60 * 1000;
+
+class DataKeyCache {
+  private entries = new Map<string, CacheEntry>();
+
+  get(cacheKey: string) {
+    let entry = this.entries.get(cacheKey);
+    if (!entry) return null;
+
+    if (entry.expiresAt <= Date.now()) {
+      zeroBuffer(entry.key);
+      this.entries.delete(cacheKey);
+      return null;
+    }
+
+    return new Uint8Array(entry.key);
+  }
+
+  set(cacheKey: string, key: Uint8Array) {
+    let previous = this.entries.get(cacheKey);
+    if (previous) zeroBuffer(previous.key);
+
+    this.entries.set(cacheKey, {
+      key: new Uint8Array(key),
+      expiresAt: Date.now() + ttlMs
+    });
+  }
+
+  delete(cacheKey: string) {
+    let entry = this.entries.get(cacheKey);
+    if (entry) zeroBuffer(entry.key);
+    this.entries.delete(cacheKey);
+  }
+
+  clear() {
+    for (let entry of this.entries.values()) zeroBuffer(entry.key);
+    this.entries.clear();
+  }
+}
+
+export let dataKeyCache = new DataKeyCache();
+
+export let getDataKeyCacheKey = (d: { keyId: string; encryptedDataKey: Uint8Array; keyInfo: any }) =>
+  `${d.keyId}:${sha256Hex(
+    Buffer.concat([
+      Buffer.from(d.encryptedDataKey),
+      Buffer.from(JSON.stringify(d.keyInfo ?? null), 'utf8')
+    ])
+  )}`;

--- a/src/systems/nebula/service/src/presenters/consumer.ts
+++ b/src/systems/nebula/service/src/presenters/consumer.ts
@@ -1,0 +1,11 @@
+import type { Consumer } from '../../prisma/generated/client';
+
+export let consumerPresenter = (consumer: Consumer) => ({
+  object: 'nebula#consumer',
+  id: consumer.id,
+  identifier: consumer.identifier,
+  name: consumer.name,
+  status: consumer.status,
+  createdAt: consumer.createdAt,
+  updatedAt: consumer.updatedAt
+});

--- a/src/systems/nebula/service/src/presenters/index.ts
+++ b/src/systems/nebula/service/src/presenters/index.ts
@@ -1,0 +1,6 @@
+export * from './consumer';
+export * from './keyProvider';
+export * from './keyProviderError';
+export * from './secret';
+export * from './secretUse';
+export * from './tenant';

--- a/src/systems/nebula/service/src/presenters/keyProvider.ts
+++ b/src/systems/nebula/service/src/presenters/keyProvider.ts
@@ -1,0 +1,33 @@
+import type { KeyProvider } from '../../prisma/generated/client';
+
+let safeKeyInfo = (keyProvider: KeyProvider) => {
+  let info = keyProvider.keyInfo as any;
+
+  if (keyProvider.type === 'aws_kms') {
+    return {
+      region: info.region,
+      keyId: info.keyId,
+      keyArn: info.keyArn,
+      accountId: info.accountId,
+      isCustomerManaged: !info.managedByNebula
+    };
+  }
+
+  return {
+    variant: info.variant,
+    version: info.version
+  };
+};
+
+export let keyProviderPresenter = (keyProvider: KeyProvider) => ({
+  object: 'nebula#key_provider',
+  id: keyProvider.id,
+  name: keyProvider.name,
+  type: keyProvider.type,
+  owner: keyProvider.owner,
+  status: keyProvider.status,
+  keyReuseTimeSeconds: keyProvider.keyReuseTimeSeconds,
+  keyInfo: safeKeyInfo(keyProvider),
+  createdAt: keyProvider.createdAt,
+  updatedAt: keyProvider.updatedAt
+});

--- a/src/systems/nebula/service/src/presenters/keyProviderError.ts
+++ b/src/systems/nebula/service/src/presenters/keyProviderError.ts
@@ -1,0 +1,13 @@
+import type { KeyError } from '../../prisma/generated/client';
+
+export let keyProviderErrorPresenter = (error: KeyError) => ({
+  object: 'nebula#key_provider_error',
+  id: error.id,
+  day: error.day,
+  operation: error.operation,
+  code: error.code,
+  count: error.count,
+  sampleMessage: error.sampleMessage,
+  firstSeenAt: error.firstSeenAt,
+  lastSeenAt: error.lastSeenAt
+});

--- a/src/systems/nebula/service/src/presenters/secret.ts
+++ b/src/systems/nebula/service/src/presenters/secret.ts
@@ -1,0 +1,32 @@
+import type { Consumer, KeyProvider, Secret, SecretVersion } from '../../prisma/generated/client';
+
+type SecretWithVersion = Secret & {
+  consumer?: Consumer | null;
+  currentVersion?: (SecretVersion & { keyProvider?: KeyProvider }) | null;
+};
+
+export let secretPresenter = (secret: SecretWithVersion) => ({
+  object: 'nebula#secret',
+  id: secret.id,
+  purpose: secret.purpose,
+  status: secret.status,
+  consumerId: secret.consumer?.id ?? null,
+  currentVersionId: secret.currentVersion?.id ?? null,
+  keyProviderId: secret.currentVersion?.keyProvider?.id ?? null,
+  createdAt: secret.createdAt,
+  updatedAt: secret.updatedAt
+});
+
+export let secretVersionPresenter = (version: SecretVersion & { keyProvider?: KeyProvider }) => ({
+  object: 'nebula#secret_version',
+  id: version.id,
+  alg: version.alg,
+  keyProviderId: version.keyProvider?.id ?? null,
+  createdAt: version.createdAt
+});
+
+export let secretUsePresenter = (d: { secret: SecretWithVersion; plaintext: string }) => ({
+  object: 'nebula#secret_use',
+  secretId: d.secret.id,
+  plaintext: d.plaintext
+});

--- a/src/systems/nebula/service/src/presenters/secretUse.ts
+++ b/src/systems/nebula/service/src/presenters/secretUse.ts
@@ -1,0 +1,7 @@
+import type { SecretUse } from '../../prisma/generated/client';
+
+export let secretUseRecordPresenter = (use: SecretUse) => ({
+  object: 'nebula#secret_use_record',
+  note: use.note,
+  ts: use.ts
+});

--- a/src/systems/nebula/service/src/presenters/tenant.ts
+++ b/src/systems/nebula/service/src/presenters/tenant.ts
@@ -1,0 +1,12 @@
+import type { KeyProvider, Tenant } from '../../prisma/generated/client';
+
+export let tenantPresenter = (tenant: Tenant & { defaultKeyProvider?: KeyProvider | null }) => ({
+  object: 'nebula#tenant',
+  id: tenant.id,
+  identifier: tenant.identifier,
+  name: tenant.name,
+  keyReuseTimeSeconds: tenant.keyReuseTimeSeconds,
+  defaultKeyProviderId: tenant.defaultKeyProvider?.id ?? null,
+  createdAt: tenant.createdAt,
+  updatedAt: tenant.updatedAt
+});

--- a/src/systems/nebula/service/src/queues/cleanupSecretUse.ts
+++ b/src/systems/nebula/service/src/queues/cleanupSecretUse.ts
@@ -1,0 +1,63 @@
+import { createCron } from '@lowerdeck/cron';
+import { combineQueueProcessors, createQueue } from '@lowerdeck/queue';
+import { subDays } from 'date-fns';
+import { db } from '../db';
+import { env } from '../env';
+
+let cleanupSecretUseCron = createCron(
+  {
+    name: 'neb/suse/cleanup',
+    cron: '0 0 * * *',
+    redisUrl: env.service.REDIS_URL
+  },
+  async () => {
+    await cleanupSecretUseSearchQueue.add({
+      before: subDays(new Date(), 7)
+    });
+  }
+);
+
+let cleanupSecretUseSearchQueue = createQueue<{ before: Date; cursor?: bigint }>({
+  name: 'neb/suse/cleanup/search',
+  redisUrl: env.service.REDIS_URL
+});
+
+let cleanupSecretUseSearchQueueProcessor = cleanupSecretUseSearchQueue.process(async data => {
+  let uses = await db.secretUse.findMany({
+    where: {
+      ts: { lt: data.before },
+      oid: data.cursor ? { lt: data.cursor } : undefined
+    },
+    orderBy: { oid: 'desc' },
+    take: 500
+  });
+  if (!uses.length) return;
+
+  await cleanupSecretUseDeleteQueue.add({
+    oids: uses.map(use => use.oid)
+  });
+
+  await cleanupSecretUseSearchQueue.add({
+    before: data.before,
+    cursor: uses[uses.length - 1]!.oid
+  });
+});
+
+let cleanupSecretUseDeleteQueue = createQueue<{ oids: bigint[] }>({
+  name: 'neb/suse/cleanup/delete',
+  redisUrl: env.service.REDIS_URL
+});
+
+let cleanupSecretUseDeleteQueueProcessor = cleanupSecretUseDeleteQueue.process(async data => {
+  await db.secretUse.deleteMany({
+    where: {
+      oid: { in: data.oids }
+    }
+  });
+});
+
+export let cleanupSecretUseProcessors = combineQueueProcessors([
+  cleanupSecretUseCron,
+  cleanupSecretUseSearchQueueProcessor,
+  cleanupSecretUseDeleteQueueProcessor
+]);

--- a/src/systems/nebula/service/src/server.ts
+++ b/src/systems/nebula/service/src/server.ts
@@ -1,0 +1,24 @@
+import { createRequire } from 'module';
+
+let require = createRequire(import.meta.url);
+(globalThis as any).require = require;
+
+async function main() {
+  await import('./init');
+  await import('./instrument');
+  await import('./endpoints');
+  await import('./worker');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+
+if (process.env.HEARTBEAT_URL) {
+  setInterval(() => {
+    fetch(process.env.HEARTBEAT_URL!, { method: 'POST' }).catch(error => {
+      console.error('Failed to send heartbeat:', error);
+    });
+  }, 45 * 1000);
+}

--- a/src/systems/nebula/service/src/services/consumer.ts
+++ b/src/systems/nebula/service/src/services/consumer.ts
@@ -1,59 +1,385 @@
-import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { JWT } from '@lowerdeck/jwt';
+import { getSentry } from '@lowerdeck/sentry';
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import type { Tenant } from '../../prisma/generated/client';
+import type { Consumer, ConsumerInstance } from '../../prisma/generated/client';
 import { db } from '../db';
+import {
+  consumerInstanceTokenTtlSeconds,
+  consumerRegistrationSecrets,
+  env
+} from '../env';
 import { ID, snowflake } from '../id';
+import { constantTimeEqual } from '../lib/crypto';
 
-class ConsumerServiceImpl {
-  async upsertConsumer(d: {
-    tenant: Tenant;
-    input: {
-      name: string;
-      identifier: string;
-    };
-  }) {
-    return await db.consumer.upsert({
-      where: {
-        tenantOid_identifier: {
-          tenantOid: d.tenant.oid,
-          identifier: d.input.identifier
-        }
-      },
-      update: {
-        name: d.input.name,
-        status: 'active'
-      },
-      create: {
-        oid: snowflake.nextId(),
-        id: await ID.generateId('consumer'),
-        tenantOid: d.tenant.oid,
-        name: d.input.name,
-        identifier: d.input.identifier,
-        status: 'active'
-      }
+let tokenType = 'nebula_consumer_instance';
+let tokenIssuer = 'nebula';
+let tokenAudience = 'nebula_consumer_instance';
+let Sentry = getSentry();
+
+type ConsumerAuthOperation = 'register' | 'refresh' | 'authenticate';
+
+let reportConsumerAuthIssue = (
+  message: string,
+  context: {
+    operation: ConsumerAuthOperation;
+    reason: string;
+    consumerId?: string | null;
+    consumerIdentifier?: string | null;
+    consumerInstanceId?: string | null;
+  },
+  error?: unknown
+) => {
+  let extra = {
+    reason: context.reason,
+    consumerId: context.consumerId ?? null,
+    consumerIdentifier: context.consumerIdentifier ?? null,
+    consumerInstanceId: context.consumerInstanceId ?? null
+  };
+
+  console.warn(`[nebula] Consumer ${context.operation} issue: ${message}`, extra, error);
+  Sentry.captureException(error instanceof Error ? error : new Error(message), {
+    tags: {
+      system: 'nebula',
+      operation: `consumer.${context.operation}`,
+      reason: context.reason
+    },
+    extra
+  });
+};
+
+let consumerAuthError = (
+  message: string,
+  context: Parameters<typeof reportConsumerAuthIssue>[1],
+  error?: unknown
+) => {
+  reportConsumerAuthIssue(message, context, error);
+  return new ServiceError(badRequestError({ message }));
+};
+
+let normalizeIdentifier = (identifier: string) => identifier.trim().toLowerCase();
+
+let randomTokenNonce = () => {
+  let buffer = new Uint8Array(32);
+  crypto.getRandomValues(buffer);
+  return Buffer.from(buffer).toString('hex');
+};
+
+let getTokenExpiresAt = () =>
+  new Date(Date.now() + consumerInstanceTokenTtlSeconds * 1000);
+
+let getConsumerRegistrationSecret = (consumer: Consumer) =>
+  consumerRegistrationSecrets.find(registration => registration.identifier === consumer.identifier)?.secret;
+
+let findConsumerRegistrationBySecret = (secret: string) => {
+  let matches = consumerRegistrationSecrets.filter(registration =>
+    constantTimeEqual(registration.secret, secret)
+  );
+
+  if (matches.length !== 1) {
+    throw consumerAuthError('Registration secret must match exactly one configured consumer', {
+      operation: 'register',
+      reason: matches.length === 0 ? 'registration_secret_not_found' : 'registration_secret_ambiguous'
     });
   }
 
-  async getConsumerById(d: { tenant: Tenant; id: string }) {
+  return matches[0]!;
+};
+
+let signConsumerInstanceToken = async (d: {
+  consumer: Consumer;
+  consumerInstance: ConsumerInstance;
+}) =>
+  await JWT.sign(
+    {
+      type: tokenType,
+      consumerId: d.consumer.id,
+      consumerInstanceId: d.consumerInstance.id,
+      nonce: d.consumerInstance.tokenNonce
+    },
+    {
+      issuer: tokenIssuer,
+      audience: tokenAudience,
+      expiresIn: consumerInstanceTokenTtlSeconds,
+      alg: 'HS256'
+    },
+    env.consumerAuth.CONSUMER_INSTANCE_TOKEN_SECRET
+  );
+
+type ConsumerInstanceTokenPayload = {
+  type: string;
+  consumerId: string;
+  consumerInstanceId: string;
+  nonce: string;
+};
+
+let verifyConsumerInstanceToken = async (token: string) => {
+  if (!token) {
+    throw consumerAuthError('Consumer token is required', {
+      operation: 'authenticate',
+      reason: 'missing_token'
+    });
+  }
+
+  let payload: ConsumerInstanceTokenPayload;
+
+  try {
+    payload = await JWT.verify<ConsumerInstanceTokenPayload>(
+      token,
+      {
+        issuer: tokenIssuer,
+        audience: tokenAudience,
+        alg: 'HS256'
+      },
+      env.consumerAuth.CONSUMER_INSTANCE_TOKEN_SECRET
+    );
+  } catch (error) {
+    throw consumerAuthError(
+      'Consumer token is invalid',
+      {
+        operation: 'authenticate',
+        reason: 'invalid_token'
+      },
+      error
+    );
+  }
+
+  if (
+    payload.type !== tokenType ||
+    !payload.consumerId ||
+    !payload.consumerInstanceId ||
+    !payload.nonce
+  ) {
+    throw consumerAuthError('Consumer token payload is invalid', {
+      operation: 'authenticate',
+      reason: 'invalid_payload',
+      consumerId: payload.consumerId,
+      consumerInstanceId: payload.consumerInstanceId
+    });
+  }
+
+  return payload;
+};
+
+class ConsumerServiceImpl {
+  async ensureEnvConsumers() {
+    for (let registration of consumerRegistrationSecrets) {
+      await db.consumer.upsert({
+        where: { identifier: registration.identifier },
+        update: { status: 'active' },
+        create: {
+          oid: snowflake.nextId(),
+          id: await ID.generateId('consumer'),
+          name: registration.identifier,
+          identifier: registration.identifier,
+          status: 'active'
+        }
+      });
+    }
+  }
+
+  async registerConsumerInstance(d: { secret: string; identifier: string }) {
+    let registration = findConsumerRegistrationBySecret(d.secret);
+    let consumer = await db.consumer.findUnique({
+      where: { identifier: registration.identifier }
+    });
+    if (!consumer) {
+      throw consumerAuthError('Configured consumer has not been seeded yet', {
+        operation: 'register',
+        reason: 'consumer_not_seeded',
+        consumerIdentifier: registration.identifier
+      });
+    }
+    if (consumer.status !== 'active') {
+      throw consumerAuthError('Configured consumer is not active', {
+        operation: 'register',
+        reason: 'consumer_inactive',
+        consumerId: consumer.id,
+        consumerIdentifier: consumer.identifier
+      });
+    }
+
+    let expiresAt = getTokenExpiresAt();
+    try {
+      let consumerInstance = await db.consumerInstance.create({
+        data: {
+          oid: snowflake.nextId(),
+          id: await ID.generateId('consumerInstance'),
+          consumerOid: consumer.oid,
+          identifier: normalizeIdentifier(d.identifier),
+          tokenNonce: randomTokenNonce(),
+          status: 'active',
+          expiresAt
+        }
+      });
+
+      return {
+        token: await signConsumerInstanceToken({ consumer, consumerInstance }),
+        consumerInstanceId: consumerInstance.id,
+        expiresAt
+      };
+    } catch (error) {
+      throw consumerAuthError(
+        'Unable to register consumer instance',
+        {
+          operation: 'register',
+          reason: 'register_failed',
+          consumerId: consumer.id,
+          consumerIdentifier: consumer.identifier
+        },
+        error
+      );
+    }
+  }
+
+  async refreshConsumerInstance(d: { secret: string; token: string }) {
+    let { consumer, consumerInstance } = await this.authenticateConsumerInstanceToken({
+      token: d.token
+    });
+    let registrationSecret = getConsumerRegistrationSecret(consumer);
+
+    if (!registrationSecret || !constantTimeEqual(registrationSecret, d.secret)) {
+      throw consumerAuthError('Registration secret does not match consumer', {
+        operation: 'refresh',
+        reason: 'registration_secret_mismatch',
+        consumerId: consumer.id,
+        consumerIdentifier: consumer.identifier,
+        consumerInstanceId: consumerInstance.id
+      });
+    }
+
+    let expiresAt = getTokenExpiresAt();
+    try {
+      let updated = await db.consumerInstance.update({
+        where: { oid: consumerInstance.oid },
+        data: {
+          tokenNonce: randomTokenNonce(),
+          expiresAt,
+          status: 'active'
+        }
+      });
+
+      return {
+        token: await signConsumerInstanceToken({ consumer, consumerInstance: updated }),
+        consumerInstanceId: updated.id,
+        expiresAt
+      };
+    } catch (error) {
+      throw consumerAuthError(
+        'Unable to refresh consumer instance',
+        {
+          operation: 'refresh',
+          reason: 'refresh_failed',
+          consumerId: consumer.id,
+          consumerIdentifier: consumer.identifier,
+          consumerInstanceId: consumerInstance.id
+        },
+        error
+      );
+    }
+  }
+
+  async authenticateConsumerInstanceToken(d: { token: string }) {
+    let payload = await verifyConsumerInstanceToken(d.token);
+    let consumerInstance = await db.consumerInstance.findUnique({
+      where: { id: payload.consumerInstanceId },
+      include: { consumer: true }
+    });
+
+    if (!consumerInstance) {
+      throw consumerAuthError('Consumer instance was not found', {
+        operation: 'authenticate',
+        reason: 'consumer_instance_not_found',
+        consumerId: payload.consumerId,
+        consumerInstanceId: payload.consumerInstanceId
+      });
+    }
+    if (consumerInstance.status !== 'active' || consumerInstance.revokedAt) {
+      throw consumerAuthError('Consumer instance is not active', {
+        operation: 'authenticate',
+        reason: consumerInstance.revokedAt ? 'consumer_instance_revoked' : 'consumer_instance_inactive',
+        consumerId: payload.consumerId,
+        consumerIdentifier: consumerInstance.consumer.identifier,
+        consumerInstanceId: consumerInstance.id
+      });
+    }
+    if (consumerInstance.consumer.status !== 'active') {
+      throw consumerAuthError('Consumer is not active', {
+        operation: 'authenticate',
+        reason: 'consumer_inactive',
+        consumerId: consumerInstance.consumer.id,
+        consumerIdentifier: consumerInstance.consumer.identifier,
+        consumerInstanceId: consumerInstance.id
+      });
+    }
+    if (consumerInstance.consumer.id !== payload.consumerId) {
+      throw consumerAuthError('Consumer token does not match its instance', {
+        operation: 'authenticate',
+        reason: 'consumer_mismatch',
+        consumerId: payload.consumerId,
+        consumerIdentifier: consumerInstance.consumer.identifier,
+        consumerInstanceId: consumerInstance.id
+      });
+    }
+    if (consumerInstance.tokenNonce !== payload.nonce) {
+      throw consumerAuthError('Consumer token has been rotated or revoked', {
+        operation: 'authenticate',
+        reason: 'nonce_mismatch',
+        consumerId: consumerInstance.consumer.id,
+        consumerIdentifier: consumerInstance.consumer.identifier,
+        consumerInstanceId: consumerInstance.id
+      });
+    }
+    if (consumerInstance.expiresAt.getTime() <= Date.now()) {
+      throw consumerAuthError('Consumer token has expired', {
+        operation: 'authenticate',
+        reason: 'token_expired',
+        consumerId: consumerInstance.consumer.id,
+        consumerIdentifier: consumerInstance.consumer.identifier,
+        consumerInstanceId: consumerInstance.id
+      });
+    }
+
+    try {
+      await db.consumerInstance.update({
+        where: { oid: consumerInstance.oid },
+        data: { lastUsedAt: new Date() }
+      });
+    } catch (error) {
+      throw consumerAuthError(
+        'Unable to update consumer instance usage',
+        {
+          operation: 'authenticate',
+          reason: 'last_used_update_failed',
+          consumerId: consumerInstance.consumer.id,
+          consumerIdentifier: consumerInstance.consumer.identifier,
+          consumerInstanceId: consumerInstance.id
+        },
+        error
+      );
+    }
+
+    return {
+      consumer: consumerInstance.consumer,
+      consumerInstance
+    };
+  }
+
+  async getConsumerById(d: { id: string }) {
+    let identifier = normalizeIdentifier(d.id);
     let consumer = await db.consumer.findFirst({
-      where: {
-        tenantOid: d.tenant.oid,
-        OR: [{ id: d.id }, { identifier: d.id }]
-      }
+      where: { OR: [{ id: d.id }, { identifier }] }
     });
     if (!consumer) throw new ServiceError(notFoundError('consumer'));
     return consumer;
   }
 
-  async listConsumers(d: { tenant: Tenant }) {
+  async listConsumers() {
     return Paginator.create(({ prisma }) =>
       prisma(async opts =>
         db.consumer.findMany({
           ...opts,
-          where: {
-            tenantOid: d.tenant.oid
-          },
           orderBy: { createdAt: 'desc' }
         })
       )

--- a/src/systems/nebula/service/src/services/consumer.ts
+++ b/src/systems/nebula/service/src/services/consumer.ts
@@ -1,0 +1,67 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import type { Tenant } from '../../prisma/generated/client';
+import { db } from '../db';
+import { ID, snowflake } from '../id';
+
+class ConsumerServiceImpl {
+  async upsertConsumer(d: {
+    tenant: Tenant;
+    input: {
+      name: string;
+      identifier: string;
+    };
+  }) {
+    return await db.consumer.upsert({
+      where: {
+        tenantOid_identifier: {
+          tenantOid: d.tenant.oid,
+          identifier: d.input.identifier
+        }
+      },
+      update: {
+        name: d.input.name,
+        status: 'active'
+      },
+      create: {
+        oid: snowflake.nextId(),
+        id: await ID.generateId('consumer'),
+        tenantOid: d.tenant.oid,
+        name: d.input.name,
+        identifier: d.input.identifier,
+        status: 'active'
+      }
+    });
+  }
+
+  async getConsumerById(d: { tenant: Tenant; id: string }) {
+    let consumer = await db.consumer.findFirst({
+      where: {
+        tenantOid: d.tenant.oid,
+        OR: [{ id: d.id }, { identifier: d.id }]
+      }
+    });
+    if (!consumer) throw new ServiceError(notFoundError('consumer'));
+    return consumer;
+  }
+
+  async listConsumers(d: { tenant: Tenant }) {
+    return Paginator.create(({ prisma }) =>
+      prisma(async opts =>
+        db.consumer.findMany({
+          ...opts,
+          where: {
+            tenantOid: d.tenant.oid
+          },
+          orderBy: { createdAt: 'desc' }
+        })
+      )
+    );
+  }
+}
+
+export let consumerService = Service.create(
+  'consumerService',
+  () => new ConsumerServiceImpl()
+).build();

--- a/src/systems/nebula/service/src/services/index.ts
+++ b/src/systems/nebula/service/src/services/index.ts
@@ -1,0 +1,7 @@
+export * from './consumer';
+export * from './key';
+export * from './keyProvider';
+export * from './keyProviderError';
+export * from './secret';
+export * from './secretUse';
+export * from './tenant';

--- a/src/systems/nebula/service/src/services/key.ts
+++ b/src/systems/nebula/service/src/services/key.ts
@@ -1,0 +1,147 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { createLock } from '@lowerdeck/lock';
+import { Service } from '@lowerdeck/service';
+import type { Key, KeyProvider, Tenant } from '../../prisma/generated/client';
+import { getKeyProviderAdapter } from '../adapters';
+import { normalizeAdapterError } from '../adapters/_lib/errors';
+import { db } from '../db';
+import { env } from '../env';
+import { ID, snowflake } from '../id';
+import { dataKeyCache, getDataKeyCacheKey } from '../lib/dataKeyCache';
+import { keyProviderErrorService } from './keyProviderError';
+
+let currentKeyLock = createLock({
+  name: 'neb/key/current/lock',
+  redisUrl: env.service.REDIS_URL
+});
+
+let maxReuseSeconds = 24 * 60 * 60;
+
+let getEffectiveReuseSeconds = (d: { tenant: Tenant; keyProvider: KeyProvider }) =>
+  Math.max(
+    1,
+    Math.min(
+      maxReuseSeconds,
+      d.tenant.keyReuseTimeSeconds ?? maxReuseSeconds,
+      d.keyProvider.keyReuseTimeSeconds ?? maxReuseSeconds
+    )
+  );
+
+class KeyServiceImpl {
+  async getCurrentKeyForEncryption(d: { tenant: Tenant; keyProvider: KeyProvider }) {
+    let existing = await this.findCurrentKey(d);
+    if (existing) return existing;
+
+    return await currentKeyLock.usingLock(`${d.tenant.id}:${d.keyProvider.id}`, async () => {
+      let lockedExisting = await this.findCurrentKey(d);
+      if (lockedExisting) return lockedExisting;
+
+      let adapter = getKeyProviderAdapter(d.keyProvider.type);
+      let currentUntil = new Date(Date.now() + getEffectiveReuseSeconds(d) * 1000);
+      let keyId = await ID.generateId('key');
+
+      try {
+        let dataKey = await adapter.generateDataKey(d.keyProvider, {
+          tenantId: d.tenant.id,
+          tenantOid: d.tenant.oid,
+          keyProviderId: d.keyProvider.id,
+          keyProviderOid: d.keyProvider.oid,
+          keyId
+        });
+
+        let key = await db.key.create({
+          data: {
+            oid: snowflake.nextId(),
+            id: keyId,
+            tenantOid: d.tenant.oid,
+            keyProviderOid: d.keyProvider.oid,
+            encryptedDataKey: new Uint8Array(dataKey.encryptedDataKey),
+            keyInfo: dataKey.keyInfo,
+            currentUntil
+          }
+        });
+
+        dataKeyCache.set(
+          getDataKeyCacheKey({
+            keyId: key.id,
+            encryptedDataKey: dataKey.encryptedDataKey,
+            keyInfo: dataKey.keyInfo
+          }),
+          dataKey.plaintextDataKey
+        );
+
+        return key;
+      } catch (err) {
+        let normalized = normalizeAdapterError(err);
+        await keyProviderErrorService.recordKeyProviderError({
+          keyProvider: d.keyProvider,
+          tenant: d.tenant,
+          operation: 'generate_data_key',
+          code: normalized.code,
+          message: normalized.safeMessage
+        });
+
+        throw new ServiceError(badRequestError({ message: 'Key provider is unavailable' }));
+      }
+    });
+  }
+
+  async getPlaintextDataKey(d: { tenant: Tenant; key: Key & { keyProvider: KeyProvider } }) {
+    if (d.key.tenantOid !== d.tenant.oid) {
+      throw new ServiceError(badRequestError({ message: 'Unable to use secret' }));
+    }
+
+    let cacheKey = getDataKeyCacheKey({
+      keyId: d.key.id,
+      encryptedDataKey: d.key.encryptedDataKey,
+      keyInfo: d.key.keyInfo
+    });
+    let cached = dataKeyCache.get(cacheKey);
+    if (cached) return cached;
+
+    let adapter = getKeyProviderAdapter(d.key.keyProvider.type);
+
+    try {
+      let plaintext = await adapter.decryptDataKey(
+        d.key.keyProvider,
+        d.key.encryptedDataKey,
+        d.key.keyInfo,
+        {
+          tenantId: d.tenant.id,
+          tenantOid: d.tenant.oid,
+          keyProviderId: d.key.keyProvider.id,
+          keyProviderOid: d.key.keyProvider.oid,
+          keyId: d.key.id
+        }
+      );
+
+      dataKeyCache.set(cacheKey, plaintext);
+      return plaintext;
+    } catch (err) {
+      let normalized = normalizeAdapterError(err);
+      await keyProviderErrorService.recordKeyProviderError({
+        keyProvider: d.key.keyProvider,
+        tenant: d.tenant,
+        operation: 'decrypt_data_key',
+        code: normalized.code,
+        message: normalized.safeMessage
+      });
+
+      throw new ServiceError(badRequestError({ message: 'Unable to use secret' }));
+    }
+  }
+
+  private async findCurrentKey(d: { tenant: Tenant; keyProvider: KeyProvider }) {
+    return await db.key.findFirst({
+      where: {
+        tenantOid: d.tenant.oid,
+        keyProviderOid: d.keyProvider.oid,
+        currentUntil: { gt: new Date() },
+        retiredAt: null
+      },
+      orderBy: { currentUntil: 'desc' }
+    });
+  }
+}
+
+export let keyService = Service.create('keyService', () => new KeyServiceImpl()).build();

--- a/src/systems/nebula/service/src/services/keyProvider.ts
+++ b/src/systems/nebula/service/src/services/keyProvider.ts
@@ -1,0 +1,287 @@
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { createLock } from '@lowerdeck/lock';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import type { KeyProvider, Tenant } from '../../prisma/generated/client';
+import { getKeyProviderAdapter } from '../adapters';
+import type { AdapterKeyProviderInput, KeyProviderCreateInput } from '../adapters/_lib/adapter';
+import { normalizeAdapterError } from '../adapters/_lib/errors';
+import { db } from '../db';
+import { env } from '../env';
+import { ID, snowflake } from '../id';
+import { keyProviderErrorService } from './keyProviderError';
+
+let defaultProviderSystemIdentifier = 'system:global:default';
+
+let defaultProviderLock = createLock({
+  name: 'neb/kprov/default/lock',
+  redisUrl: env.service.REDIS_URL
+});
+
+let toProviderType = (type: AdapterKeyProviderInput['type'] | 'aws.kms') =>
+  type === 'aws.kms' ? 'aws_kms' : type;
+
+let getConfiguredProviderType = () => toProviderType(env.provider.DEFAULT_PROVIDER);
+
+let createConfiguredAdapterInput = (input: KeyProviderCreateInput): AdapterKeyProviderInput => {
+  let type = getConfiguredProviderType();
+  if (type === 'aws_kms') {
+    return {
+      type,
+      name: input.name,
+      keyId: input.keyId,
+      region: input.region
+    };
+  }
+
+  return {
+    type,
+    name: input.name
+  };
+};
+
+let getSystemIdentifier = (d: {
+  owner: KeyProvider['owner'];
+  keyProviderId: string;
+  tenant?: Tenant | null;
+}) => {
+  if (d.owner === 'system' && !d.tenant) return `system:global:${d.keyProviderId}`;
+  if (d.owner === 'system' && d.tenant) return `system:tenant:${d.tenant.id}:${d.keyProviderId}`;
+  if (d.owner === 'tenant' && d.tenant) return `tenant:${d.tenant.id}:${d.keyProviderId}`;
+  throw new Error('Tenant is required for tenant-scoped key provider');
+};
+
+class KeyProviderServiceImpl {
+  async ensureSystemDefaultProvider() {
+    return await defaultProviderLock.usingLock(defaultProviderSystemIdentifier, async () => {
+      let existing = await db.keyProvider.findFirst({
+        where: {
+          owner: 'system',
+          systemIdentifier: defaultProviderSystemIdentifier,
+          tenantOid: null,
+          deletedAt: null
+        }
+      });
+      if (existing) return existing;
+
+      let type = getConfiguredProviderType();
+      let adapter = getKeyProviderAdapter(type);
+
+      try {
+        let provider = await adapter.createSystemKeyProvider();
+        let id = await ID.generateId('keyProvider');
+
+        return await db.keyProvider.create({
+          data: {
+            oid: snowflake.nextId(),
+            id,
+            systemIdentifier: defaultProviderSystemIdentifier,
+            name: provider.name,
+            type,
+            owner: 'system',
+            status: 'active',
+            keyInfo: provider.keyInfo
+          }
+        });
+      } catch (err) {
+        throw normalizeAdapterError(err);
+      }
+    });
+  }
+
+  async createKeyProvider(d: {
+    tenant: Tenant;
+    input: KeyProviderCreateInput & {
+      keyReuseTimeSeconds?: number | null;
+    };
+  }) {
+    let type = getConfiguredProviderType();
+    let adapter = getKeyProviderAdapter(type);
+
+    try {
+      let validated = await adapter.validateKeyProvider(createConfiguredAdapterInput(d.input));
+      let id = await ID.generateId('keyProvider');
+
+      return await db.keyProvider.create({
+        data: {
+          oid: snowflake.nextId(),
+          id,
+          tenantOid: d.tenant.oid,
+          systemIdentifier: getSystemIdentifier({
+            owner: 'tenant',
+            tenant: d.tenant,
+            keyProviderId: id
+          }),
+          name: d.input.name,
+          type,
+          owner: 'tenant',
+          status: 'active',
+          keyInfo: validated.keyInfo,
+          keyReuseTimeSeconds: d.input.keyReuseTimeSeconds ?? undefined
+        }
+      });
+    } catch (err) {
+      let normalized = normalizeAdapterError(err);
+      throw new ServiceError(
+        badRequestError({
+          message: normalized.safeMessage
+        })
+      );
+    }
+  }
+
+  async createManagedKeyProvider(d: {
+    tenant: Tenant;
+    input: {
+      name: string;
+      region?: string | null;
+      keyReuseTimeSeconds?: number | null;
+    };
+  }) {
+    let type = getConfiguredProviderType();
+    let adapter = getKeyProviderAdapter(type);
+
+    try {
+      let id = await ID.generateId('keyProvider');
+      let systemIdentifier = getSystemIdentifier({
+        owner: 'system',
+        tenant: d.tenant,
+        keyProviderId: id
+      });
+
+      let provider = await adapter.createTenantManagedKeyProvider({
+        tenantId: d.tenant.id,
+        tenantIdentifier: d.tenant.identifier,
+        name: d.input.name,
+        systemIdentifier,
+        region: d.input.region ?? undefined
+      });
+
+      return await db.keyProvider.create({
+        data: {
+          oid: snowflake.nextId(),
+          id,
+          tenantOid: d.tenant.oid,
+          systemIdentifier,
+          name: provider.name,
+          type,
+          owner: 'system',
+          status: 'active',
+          keyInfo: provider.keyInfo,
+          keyReuseTimeSeconds: d.input.keyReuseTimeSeconds ?? undefined
+        }
+      });
+    } catch (err) {
+      let normalized = normalizeAdapterError(err);
+      throw new ServiceError(
+        badRequestError({
+          message: normalized.safeMessage
+        })
+      );
+    }
+  }
+
+  async createManagedKmsKeyProvider(d: Parameters<KeyProviderServiceImpl['createManagedKeyProvider']>[0]) {
+    return await this.createManagedKeyProvider(d);
+  }
+
+  async getKeyProviderById(d: { tenant?: Tenant | null; id: string }) {
+    let keyProvider = await db.keyProvider.findFirst({
+      where: {
+        OR: [
+          { id: d.id },
+          { systemIdentifier: d.id }
+        ],
+        deletedAt: null
+      }
+    });
+    if (!keyProvider) throw new ServiceError(notFoundError('key.provider'));
+
+    this.guardKeyProviderForTenant({ tenant: d.tenant ?? null, keyProvider });
+
+    return keyProvider;
+  }
+
+  async listKeyProviders(d: { tenant: Tenant }) {
+    return Paginator.create(({ prisma }) =>
+      prisma(async opts =>
+        db.keyProvider.findMany({
+          ...opts,
+          where: {
+            deletedAt: null,
+            OR: [
+              { owner: 'system', tenantOid: null },
+              { owner: 'system', tenantOid: d.tenant.oid },
+              { owner: 'tenant', tenantOid: d.tenant.oid }
+            ]
+          },
+          orderBy: { createdAt: 'desc' }
+        })
+      )
+    );
+  }
+
+  async resolveForTenant(d: { tenant: Tenant; keyProviderId?: string | null }) {
+    if (d.keyProviderId) {
+      return await this.getKeyProviderById({ tenant: d.tenant, id: d.keyProviderId });
+    }
+
+    if (d.tenant.defaultKeyProviderOid) {
+      let tenantDefault = await db.keyProvider.findUnique({
+        where: { oid: d.tenant.defaultKeyProviderOid }
+      });
+
+      if (tenantDefault) {
+        this.guardKeyProviderForTenant({ tenant: d.tenant, keyProvider: tenantDefault });
+        if (tenantDefault.status === 'active') return tenantDefault;
+      }
+    }
+
+    return await this.ensureSystemDefaultProvider();
+  }
+
+  async setDefaultKeyProvider(d: { tenant: Tenant; keyProviderId: string }) {
+    let keyProvider = await this.getKeyProviderById({
+      tenant: d.tenant,
+      id: d.keyProviderId
+    });
+
+    return await db.tenant.update({
+      where: { oid: d.tenant.oid },
+      data: { defaultKeyProviderOid: keyProvider.oid },
+      include: { defaultKeyProvider: true }
+    });
+  }
+
+  async validateKeyProvider(d: { tenant: Tenant; keyProviderId: string }) {
+    let keyProvider = await this.getKeyProviderById({ tenant: d.tenant, id: d.keyProviderId });
+    let adapter = getKeyProviderAdapter(keyProvider.type);
+
+    try {
+      return await adapter.describeKeyProvider(keyProvider);
+    } catch (err) {
+      let normalized = normalizeAdapterError(err);
+      await keyProviderErrorService.recordKeyProviderError({
+        keyProvider,
+        tenant: d.tenant,
+        operation: 'validate_provider',
+        code: normalized.code,
+        message: normalized.safeMessage
+      });
+      throw new ServiceError(badRequestError({ message: 'Key provider is unavailable' }));
+    }
+  }
+
+  guardKeyProviderForTenant(d: { tenant: Tenant | null; keyProvider: KeyProvider }) {
+    if (d.keyProvider.owner === 'system' && d.keyProvider.tenantOid === null) return;
+
+    if (!d.tenant || d.keyProvider.tenantOid !== d.tenant.oid) {
+      throw new ServiceError(notFoundError('key.provider'));
+    }
+  }
+}
+
+export let keyProviderService = Service.create(
+  'keyProviderService',
+  () => new KeyProviderServiceImpl()
+).build();

--- a/src/systems/nebula/service/src/services/keyProvider.ts
+++ b/src/systems/nebula/service/src/services/keyProvider.ts
@@ -4,7 +4,6 @@ import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import type { KeyProvider, Tenant } from '../../prisma/generated/client';
 import { getKeyProviderAdapter } from '../adapters';
-import type { AdapterKeyProviderInput, KeyProviderCreateInput } from '../adapters/_lib/adapter';
 import { normalizeAdapterError } from '../adapters/_lib/errors';
 import { db } from '../db';
 import { env } from '../env';
@@ -18,27 +17,10 @@ let defaultProviderLock = createLock({
   redisUrl: env.service.REDIS_URL
 });
 
-let toProviderType = (type: AdapterKeyProviderInput['type'] | 'aws.kms') =>
+let toProviderType = (type: KeyProvider['type'] | 'aws.kms') =>
   type === 'aws.kms' ? 'aws_kms' : type;
 
 let getConfiguredProviderType = () => toProviderType(env.provider.DEFAULT_PROVIDER);
-
-let createConfiguredAdapterInput = (input: KeyProviderCreateInput): AdapterKeyProviderInput => {
-  let type = getConfiguredProviderType();
-  if (type === 'aws_kms') {
-    return {
-      type,
-      name: input.name,
-      keyId: input.keyId,
-      region: input.region
-    };
-  }
-
-  return {
-    type,
-    name: input.name
-  };
-};
 
 let getSystemIdentifier = (d: {
   owner: KeyProvider['owner'];
@@ -89,17 +71,15 @@ class KeyProviderServiceImpl {
     });
   }
 
-  async createKeyProvider(d: {
+  async importKeyProvider(d: {
     tenant: Tenant;
-    input: KeyProviderCreateInput & {
-      keyReuseTimeSeconds?: number | null;
-    };
+    keyInput: Record<string, any>;
   }) {
     let type = getConfiguredProviderType();
     let adapter = getKeyProviderAdapter(type);
 
     try {
-      let validated = await adapter.validateKeyProvider(createConfiguredAdapterInput(d.input));
+      let validated = await adapter.validateKeyProvider(d.keyInput);
       let id = await ID.generateId('keyProvider');
 
       return await db.keyProvider.create({
@@ -112,12 +92,11 @@ class KeyProviderServiceImpl {
             tenant: d.tenant,
             keyProviderId: id
           }),
-          name: d.input.name,
+          name: validated.name,
           type,
           owner: 'tenant',
           status: 'active',
-          keyInfo: validated.keyInfo,
-          keyReuseTimeSeconds: d.input.keyReuseTimeSeconds ?? undefined
+          keyInfo: validated.keyInfo
         }
       });
     } catch (err) {
@@ -134,8 +113,6 @@ class KeyProviderServiceImpl {
     tenant: Tenant;
     input: {
       name: string;
-      region?: string | null;
-      keyReuseTimeSeconds?: number | null;
     };
   }) {
     let type = getConfiguredProviderType();
@@ -153,8 +130,7 @@ class KeyProviderServiceImpl {
         tenantId: d.tenant.id,
         tenantIdentifier: d.tenant.identifier,
         name: d.input.name,
-        systemIdentifier,
-        region: d.input.region ?? undefined
+        systemIdentifier
       });
 
       return await db.keyProvider.create({
@@ -167,8 +143,7 @@ class KeyProviderServiceImpl {
           type,
           owner: 'system',
           status: 'active',
-          keyInfo: provider.keyInfo,
-          keyReuseTimeSeconds: d.input.keyReuseTimeSeconds ?? undefined
+          keyInfo: provider.keyInfo
         }
       });
     } catch (err) {
@@ -181,7 +156,7 @@ class KeyProviderServiceImpl {
     }
   }
 
-  async createManagedKmsKeyProvider(d: Parameters<KeyProviderServiceImpl['createManagedKeyProvider']>[0]) {
+  async createManaged(d: Parameters<KeyProviderServiceImpl['createManagedKeyProvider']>[0]) {
     return await this.createManagedKeyProvider(d);
   }
 
@@ -270,6 +245,25 @@ class KeyProviderServiceImpl {
       });
       throw new ServiceError(badRequestError({ message: 'Key provider is unavailable' }));
     }
+  }
+
+  async getSetupInfo(d: {
+    tenant: Tenant;
+    input: {
+      region?: string | null;
+      keyId?: string | null;
+    };
+  }) {
+    let type = getConfiguredProviderType();
+    let adapter = getKeyProviderAdapter(type);
+
+    return await adapter.getSetupInfo({
+      tenantId: d.tenant.id,
+      tenantIdentifier: d.tenant.identifier,
+      region: d.input.region ?? undefined,
+      keyId: d.input.keyId ?? undefined,
+      roleArn: env.kms.KMS_EXTERNAL_KEY_ROLE_ARN
+    });
   }
 
   guardKeyProviderForTenant(d: { tenant: Tenant | null; keyProvider: KeyProvider }) {

--- a/src/systems/nebula/service/src/services/keyProviderError.ts
+++ b/src/systems/nebula/service/src/services/keyProviderError.ts
@@ -1,0 +1,76 @@
+import { Hash } from '@lowerdeck/hash';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import type {
+  KeyProvider,
+  KeyProviderErrorOperation,
+  Tenant
+} from '../../prisma/generated/client';
+import { db } from '../db';
+import { ID, snowflake } from '../id';
+
+let startOfUtcDay = (date = new Date()) =>
+  new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+
+let safeSample = (message: string) => message.slice(0, 500);
+
+class KeyProviderErrorServiceImpl {
+  async recordKeyProviderError(d: {
+    keyProvider: KeyProvider;
+    tenant?: Tenant | null;
+    operation: KeyProviderErrorOperation;
+    code: string;
+    message: string;
+  }) {
+    let day = startOfUtcDay();
+    let messageHash = await Hash.sha256(d.message);
+
+    return await db.keyError.upsert({
+      where: {
+        keyProviderOid_day_operation_code_messageHash: {
+          keyProviderOid: d.keyProvider.oid,
+          day,
+          operation: d.operation,
+          code: d.code,
+          messageHash
+        }
+      },
+      update: {
+        count: { increment: 1 },
+        lastSeenAt: new Date(),
+        sampleMessage: safeSample(d.message)
+      },
+      create: {
+        oid: snowflake.nextId(),
+        id: await ID.generateId('keyError'),
+        keyProviderOid: d.keyProvider.oid,
+        tenantOid: d.tenant?.oid,
+        day,
+        operation: d.operation,
+        code: d.code,
+        messageHash,
+        sampleMessage: safeSample(d.message)
+      }
+    });
+  }
+
+  async listKeyProviderErrors(d: { keyProvider: KeyProvider; tenant?: Tenant | null }) {
+    return Paginator.create(({ prisma }) =>
+      prisma(async opts =>
+        db.keyError.findMany({
+          ...opts,
+          where: {
+            keyProviderOid: d.keyProvider.oid,
+            tenantOid: d.keyProvider.owner === 'tenant' ? d.tenant?.oid : undefined
+          },
+          orderBy: { lastSeenAt: 'desc' }
+        })
+      )
+    );
+  }
+}
+
+export let keyProviderErrorService = Service.create(
+  'keyProviderErrorService',
+  () => new KeyProviderErrorServiceImpl()
+).build();

--- a/src/systems/nebula/service/src/services/secret.ts
+++ b/src/systems/nebula/service/src/services/secret.ts
@@ -1,7 +1,8 @@
-import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { getSentry } from '@lowerdeck/sentry';
+import { badRequestError, isServiceError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import type { Consumer, Secret, Tenant } from '../../prisma/generated/client';
+import type { Consumer, ConsumerInstance, Secret, Tenant } from '../../prisma/generated/client';
 import { db } from '../db';
 import { ID, snowflake } from '../id';
 import {
@@ -15,8 +16,65 @@ import { keyProviderService } from './keyProvider';
 import { keyService } from './key';
 import { secretUseService } from './secretUse';
 
+let Sentry = getSentry();
+
 let genericUseError = () =>
   new ServiceError(badRequestError({ message: 'Unable to use secret' }));
+
+type SecretUseFailureStage =
+  | 'validate'
+  | 'load_secret'
+  | 'proof'
+  | 'get_data_key'
+  | 'decrypt_secret'
+  | 'record_secret_use';
+
+let shouldReportSecretUseFailure = (stage: SecretUseFailureStage, error: unknown) => {
+  if (stage === 'get_data_key' || stage === 'decrypt_secret' || stage === 'record_secret_use') {
+    return true;
+  }
+
+  return !isServiceError(error);
+};
+
+let reportSecretUseFailure = (
+  error: unknown,
+  d: {
+    tenant: Tenant;
+    secret: Secret;
+    consumer: Consumer;
+    consumerInstance: ConsumerInstance;
+  },
+  context: {
+    stage: SecretUseFailureStage;
+    secretVersionId: string | null;
+    keyId: string | null;
+    keyProviderId: string | null;
+  }
+) => {
+  if (!shouldReportSecretUseFailure(context.stage, error)) return;
+
+  let extra = {
+    stage: context.stage,
+    tenantId: d.tenant.id,
+    secretId: d.secret.id,
+    consumerId: d.consumer.id,
+    consumerInstanceId: d.consumerInstance.id,
+    secretVersionId: context.secretVersionId,
+    keyId: context.keyId,
+    keyProviderId: context.keyProviderId
+  };
+
+  console.error('[nebula] Secret use failed internally', extra, error);
+  Sentry.captureException(error, {
+    tags: {
+      system: 'nebula',
+      operation: 'secret.use',
+      stage: context.stage
+    },
+    extra
+  });
+};
 
 let assertBoundedJson = (name: string, value: any) => {
   let json = canonicalJson(value);
@@ -238,12 +296,19 @@ class SecretServiceImpl {
     tenant: Tenant;
     secret: Secret;
     consumer: Consumer;
+    consumerInstance: ConsumerInstance;
     proof: any;
     note: string;
   }) {
+    let stage: SecretUseFailureStage = 'validate';
+    let secretVersionId: string | null = null;
+    let keyId: string | null = null;
+    let keyProviderId: string | null = null;
+
     try {
       let note = validateSecretUseNote(d.note);
 
+      stage = 'load_secret';
       let secret = await db.secret.findFirst({
         where: {
           oid: d.secret.oid,
@@ -255,12 +320,17 @@ class SecretServiceImpl {
       });
 
       if (!secret?.currentVersion) throw genericUseError();
+      secretVersionId = secret.currentVersion.id;
+      keyId = secret.currentVersion.key.id;
+      keyProviderId = secret.currentVersion.keyProvider.id;
 
+      stage = 'proof';
       let proofHash = getProofHash(d.tenant, d.proof);
       if (!constantTimeEqual(proofHash, secret.currentVersion.proofHash)) {
         throw genericUseError();
       }
 
+      stage = 'get_data_key';
       let dataKey = await keyService.getPlaintextDataKey({
         tenant: d.tenant,
         key: secret.currentVersion.key
@@ -277,6 +347,7 @@ class SecretServiceImpl {
         encryptionContext: secret.currentVersion.encryptionContext
       });
 
+      stage = 'decrypt_secret';
       let plaintext = decryptAes256Gcm({
         key: dataKey,
         iv: secret.currentVersion.iv,
@@ -285,10 +356,12 @@ class SecretServiceImpl {
         aad
       }).toString('utf8');
 
+      stage = 'record_secret_use';
       await secretUseService.recordSecretUse({
         tenant: d.tenant,
         secret,
         consumer: d.consumer,
+        consumerInstance: d.consumerInstance,
         note
       });
 
@@ -296,7 +369,13 @@ class SecretServiceImpl {
         secret,
         plaintext
       };
-    } catch {
+    } catch (error) {
+      reportSecretUseFailure(error, d, {
+        stage,
+        secretVersionId,
+        keyId,
+        keyProviderId
+      });
       throw genericUseError();
     }
   }

--- a/src/systems/nebula/service/src/services/secret.ts
+++ b/src/systems/nebula/service/src/services/secret.ts
@@ -1,0 +1,364 @@
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import type { Consumer, Secret, Tenant } from '../../prisma/generated/client';
+import { db } from '../db';
+import { ID, snowflake } from '../id';
+import {
+  canonicalJson,
+  constantTimeEqual,
+  decryptAes256Gcm,
+  encryptAes256Gcm,
+  sha512Hex
+} from '../lib/crypto';
+import { keyProviderService } from './keyProvider';
+import { keyService } from './key';
+import { secretUseService } from './secretUse';
+
+let genericUseError = () =>
+  new ServiceError(badRequestError({ message: 'Unable to use secret' }));
+
+let assertBoundedJson = (name: string, value: any) => {
+  let json = canonicalJson(value);
+  if (json.length > 16_384) {
+    throw new ServiceError(badRequestError({ message: `${name} is too large` }));
+  }
+  return json;
+};
+
+let getProofHash = (tenant: Tenant, proof: any) =>
+  sha512Hex(`${tenant.id}::${assertBoundedJson('proof', proof)}`);
+
+let validateSecretUseNote = (note: string) => {
+  if (!note || note.trim().length === 0 || note.length > 1024) {
+    throw genericUseError();
+  }
+
+  return note;
+};
+
+let getAad = (d: {
+  tenant: Tenant;
+  consumerId: string;
+  secretId: string;
+  versionId: string;
+  purpose: string;
+  keyId: string;
+  keyProviderId: string;
+  encryptionContext: any;
+}) =>
+  Buffer.from(
+    canonicalJson({
+      tenantId: d.tenant.id,
+      consumerId: d.consumerId,
+      secretId: d.secretId,
+      versionId: d.versionId,
+      purpose: d.purpose,
+      keyId: d.keyId,
+      keyProviderId: d.keyProviderId,
+      encryptionContext: d.encryptionContext
+    }),
+    'utf8'
+  );
+
+let include = {
+  consumer: true,
+  currentVersion: {
+    include: {
+      key: { include: { keyProvider: true } },
+      keyProvider: true
+    }
+  }
+};
+
+class SecretServiceImpl {
+  async createSecret(d: {
+    tenant: Tenant;
+    consumer: Consumer;
+    input: {
+      purpose: string;
+      secret: string;
+      proof: any;
+      encryptionContext?: any;
+      keyProviderId?: string | null;
+    };
+  }) {
+    this.validateSecretInput(d.input);
+
+    let keyProvider = await keyProviderService.resolveForTenant({
+      tenant: d.tenant,
+      keyProviderId: d.input.keyProviderId
+    });
+    let key = await keyService.getCurrentKeyForEncryption({ tenant: d.tenant, keyProvider });
+    let plaintextDataKey = await keyService.getPlaintextDataKey({
+      tenant: d.tenant,
+      key: { ...key, keyProvider }
+    });
+
+    let secretId = await ID.generateId('secret');
+    let versionId = await ID.generateId('secretVersion');
+    let encryptionContext = d.input.encryptionContext ?? {};
+    assertBoundedJson('encryptionContext', encryptionContext);
+
+    let aad = getAad({
+      tenant: d.tenant,
+      consumerId: d.consumer.id,
+      secretId,
+      versionId,
+      purpose: d.input.purpose,
+      keyId: key.id,
+      keyProviderId: keyProvider.id,
+      encryptionContext
+    });
+
+    let encrypted = encryptAes256Gcm({
+      key: plaintextDataKey,
+      plaintext: Buffer.from(d.input.secret, 'utf8'),
+      aad
+    });
+
+    return await db.$transaction(async tx => {
+      let secret = await tx.secret.create({
+        data: {
+          oid: snowflake.nextId(),
+          id: secretId,
+          tenantOid: d.tenant.oid,
+          consumerOid: d.consumer.oid,
+          purpose: d.input.purpose,
+          status: 'active'
+        }
+      });
+
+      let version = await tx.secretVersion.create({
+        data: {
+          oid: snowflake.nextId(),
+          id: versionId,
+          tenantOid: d.tenant.oid,
+          secretOid: secret.oid,
+          keyOid: key.oid,
+          keyProviderOid: keyProvider.oid,
+          proofHash: getProofHash(d.tenant, d.input.proof),
+          encryptionContext,
+          alg: 'aes_256_gcm',
+          iv: new Uint8Array(encrypted.iv),
+          ciphertext: new Uint8Array(encrypted.ciphertext),
+          authTag: new Uint8Array(encrypted.authTag),
+          aadHash: sha512Hex(aad)
+        }
+      });
+
+      return await tx.secret.update({
+        where: { oid: secret.oid },
+        data: { currentVersionOid: version.oid },
+        include
+      });
+    });
+  }
+
+  async updateSecret(d: {
+    tenant: Tenant;
+    consumer: Consumer;
+    secret: Secret;
+    input: {
+      secret: string;
+      proof: any;
+      encryptionContext?: any;
+      keyProviderId?: string | null;
+    };
+  }) {
+    if (d.secret.consumerOid !== d.consumer.oid) throw genericUseError();
+
+    this.validateSecretInput({
+      purpose: d.secret.purpose,
+      secret: d.input.secret,
+      proof: d.input.proof,
+      encryptionContext: d.input.encryptionContext
+    });
+
+    let keyProvider = await keyProviderService.resolveForTenant({
+      tenant: d.tenant,
+      keyProviderId: d.input.keyProviderId
+    });
+    let key = await keyService.getCurrentKeyForEncryption({ tenant: d.tenant, keyProvider });
+    let plaintextDataKey = await keyService.getPlaintextDataKey({
+      tenant: d.tenant,
+      key: { ...key, keyProvider }
+    });
+
+    let versionId = await ID.generateId('secretVersion');
+    let encryptionContext = d.input.encryptionContext ?? {};
+    let aad = getAad({
+      tenant: d.tenant,
+      consumerId: d.consumer.id,
+      secretId: d.secret.id,
+      versionId,
+      purpose: d.secret.purpose,
+      keyId: key.id,
+      keyProviderId: keyProvider.id,
+      encryptionContext
+    });
+
+    let encrypted = encryptAes256Gcm({
+      key: plaintextDataKey,
+      plaintext: Buffer.from(d.input.secret, 'utf8'),
+      aad
+    });
+
+    return await db.$transaction(async tx => {
+      let version = await tx.secretVersion.create({
+        data: {
+          oid: snowflake.nextId(),
+          id: versionId,
+          tenantOid: d.tenant.oid,
+          secretOid: d.secret.oid,
+          keyOid: key.oid,
+          keyProviderOid: keyProvider.oid,
+          proofHash: getProofHash(d.tenant, d.input.proof),
+          encryptionContext,
+          alg: 'aes_256_gcm',
+          iv: new Uint8Array(encrypted.iv),
+          ciphertext: new Uint8Array(encrypted.ciphertext),
+          authTag: new Uint8Array(encrypted.authTag),
+          aadHash: sha512Hex(aad)
+        }
+      });
+
+      return await tx.secret.update({
+        where: { oid: d.secret.oid },
+        data: {
+          currentVersionOid: version.oid,
+          status: 'active'
+        },
+        include
+      });
+    });
+  }
+
+  async useSecret(d: {
+    tenant: Tenant;
+    secret: Secret;
+    consumer: Consumer;
+    proof: any;
+    note: string;
+  }) {
+    try {
+      let note = validateSecretUseNote(d.note);
+
+      let secret = await db.secret.findFirst({
+        where: {
+          oid: d.secret.oid,
+          tenantOid: d.tenant.oid,
+          consumerOid: d.consumer.oid,
+          status: 'active'
+        },
+        include
+      });
+
+      if (!secret?.currentVersion) throw genericUseError();
+
+      let proofHash = getProofHash(d.tenant, d.proof);
+      if (!constantTimeEqual(proofHash, secret.currentVersion.proofHash)) {
+        throw genericUseError();
+      }
+
+      let dataKey = await keyService.getPlaintextDataKey({
+        tenant: d.tenant,
+        key: secret.currentVersion.key
+      });
+
+      let aad = getAad({
+        tenant: d.tenant,
+        consumerId: d.consumer.id,
+        secretId: secret.id,
+        versionId: secret.currentVersion.id,
+        purpose: secret.purpose,
+        keyId: secret.currentVersion.key.id,
+        keyProviderId: secret.currentVersion.keyProvider.id,
+        encryptionContext: secret.currentVersion.encryptionContext
+      });
+
+      let plaintext = decryptAes256Gcm({
+        key: dataKey,
+        iv: secret.currentVersion.iv,
+        ciphertext: secret.currentVersion.ciphertext,
+        authTag: secret.currentVersion.authTag,
+        aad
+      }).toString('utf8');
+
+      await secretUseService.recordSecretUse({
+        tenant: d.tenant,
+        secret,
+        consumer: d.consumer,
+        note
+      });
+
+      return {
+        secret,
+        plaintext
+      };
+    } catch {
+      throw genericUseError();
+    }
+  }
+
+  async getSecretById(d: { tenant: Tenant; id: string }) {
+    let secret = await db.secret.findFirst({
+      where: {
+        tenantOid: d.tenant.oid,
+        id: d.id
+      },
+      include
+    });
+    if (!secret) throw new ServiceError(notFoundError('secret'));
+    return secret;
+  }
+
+  async listSecrets(d: { tenant: Tenant }) {
+    return Paginator.create(({ prisma }) =>
+      prisma(async opts =>
+        db.secret.findMany({
+          ...opts,
+          where: { tenantOid: d.tenant.oid },
+          orderBy: { createdAt: 'desc' },
+          include
+        })
+      )
+    );
+  }
+
+  async listSecretVersions(d: { tenant: Tenant; secret: Secret }) {
+    return Paginator.create(({ prisma }) =>
+      prisma(async opts =>
+        db.secretVersion.findMany({
+          ...opts,
+          where: {
+            tenantOid: d.tenant.oid,
+            secretOid: d.secret.oid
+          },
+          orderBy: { createdAt: 'desc' },
+          include: {
+            keyProvider: true
+          }
+        })
+      )
+    );
+  }
+
+  private validateSecretInput(input: {
+    purpose: string;
+    secret: string;
+    proof: any;
+    encryptionContext?: any;
+  }) {
+    if (!input.purpose || input.purpose.length > 256) {
+      throw new ServiceError(badRequestError({ message: 'Invalid purpose' }));
+    }
+    if (!input.secret || Buffer.byteLength(input.secret, 'utf8') > 64 * 1024) {
+      throw new ServiceError(badRequestError({ message: 'Invalid secret' }));
+    }
+    assertBoundedJson('proof', input.proof);
+    assertBoundedJson('encryptionContext', input.encryptionContext ?? {});
+  }
+}
+
+export let secretService = Service.create('secretService', () => new SecretServiceImpl()).build();

--- a/src/systems/nebula/service/src/services/secretUse.ts
+++ b/src/systems/nebula/service/src/services/secretUse.ts
@@ -1,11 +1,17 @@
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import type { Consumer, Secret, Tenant } from '../../prisma/generated/client';
+import type { Consumer, ConsumerInstance, Secret, Tenant } from '../../prisma/generated/client';
 import { db } from '../db';
 import { ID, snowflake } from '../id';
 
 class SecretUseServiceImpl {
-  async recordSecretUse(d: { tenant: Tenant; secret: Secret; consumer: Consumer; note: string }) {
+  async recordSecretUse(d: {
+    tenant: Tenant;
+    secret: Secret;
+    consumer: Consumer;
+    consumerInstance: ConsumerInstance;
+    note: string;
+  }) {
     return await db.secretUse.create({
       data: {
         oid: snowflake.nextId(),
@@ -13,6 +19,7 @@ class SecretUseServiceImpl {
         tenantOid: d.tenant.oid,
         secretOid: d.secret.oid,
         consumerOid: d.consumer.oid,
+        consumerInstanceOid: d.consumerInstance.oid,
         note: d.note
       }
     });

--- a/src/systems/nebula/service/src/services/secretUse.ts
+++ b/src/systems/nebula/service/src/services/secretUse.ts
@@ -1,0 +1,40 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import type { Consumer, Secret, Tenant } from '../../prisma/generated/client';
+import { db } from '../db';
+import { ID, snowflake } from '../id';
+
+class SecretUseServiceImpl {
+  async recordSecretUse(d: { tenant: Tenant; secret: Secret; consumer: Consumer; note: string }) {
+    return await db.secretUse.create({
+      data: {
+        oid: snowflake.nextId(),
+        id: await ID.generateId('secretUse'),
+        tenantOid: d.tenant.oid,
+        secretOid: d.secret.oid,
+        consumerOid: d.consumer.oid,
+        note: d.note
+      }
+    });
+  }
+
+  async listSecretUses(d: { tenant: Tenant; secret: Secret }) {
+    return Paginator.create(({ prisma }) =>
+      prisma(async opts =>
+        db.secretUse.findMany({
+          ...opts,
+          where: {
+            tenantOid: d.tenant.oid,
+            secretOid: d.secret.oid
+          },
+          orderBy: { ts: 'desc' }
+        })
+      )
+    );
+  }
+}
+
+export let secretUseService = Service.create(
+  'secretUseService',
+  () => new SecretUseServiceImpl()
+).build();

--- a/src/systems/nebula/service/src/services/tenant.ts
+++ b/src/systems/nebula/service/src/services/tenant.ts
@@ -1,0 +1,48 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { Service } from '@lowerdeck/service';
+import { db } from '../db';
+import { ID, snowflake } from '../id';
+
+let include = {
+  defaultKeyProvider: true
+};
+
+class TenantServiceImpl {
+  async upsertTenant(d: {
+    input: {
+      name: string;
+      identifier: string;
+      keyReuseTimeSeconds?: number | null;
+    };
+  }) {
+    return await db.tenant.upsert({
+      where: { identifier: d.input.identifier },
+      update: {
+        name: d.input.name,
+        keyReuseTimeSeconds: d.input.keyReuseTimeSeconds ?? undefined
+      },
+      create: {
+        oid: snowflake.nextId(),
+        id: await ID.generateId('tenant'),
+        name: d.input.name,
+        identifier: d.input.identifier,
+        keyReuseTimeSeconds: d.input.keyReuseTimeSeconds ?? undefined
+      },
+      include
+    });
+  }
+
+  async getTenantById(d: { id: string }) {
+    let tenant = await db.tenant.findFirst({
+      where: { OR: [{ id: d.id }, { identifier: d.id }] },
+      include
+    });
+    if (!tenant) throw new ServiceError(notFoundError('tenant'));
+    return tenant;
+  }
+}
+
+export let tenantService = Service.create(
+  'tenantService',
+  () => new TenantServiceImpl()
+).build();

--- a/src/systems/nebula/service/src/test/client.ts
+++ b/src/systems/nebula/service/src/test/client.ts
@@ -1,0 +1,26 @@
+import { createClient } from '@lowerdeck/rpc-client';
+import { createFetchRouter } from '@lowerdeck/testing-tools';
+import { nebulaApi, type NebulaClient } from '../controllers';
+
+type ClientOptsLike = Parameters<typeof createClient>[0];
+
+let fetchRouter = createFetchRouter();
+let registerInMemoryRoute = (endpoint: string) => {
+  fetchRouter.registerRoute(endpoint, request => nebulaApi(request, undefined));
+};
+
+let defaultEndpoint = 'http://nebula.test/metorial-nebula';
+
+export let createTestNebulaClient = (opts: Partial<ClientOptsLike> = {}) => {
+  let endpoint = opts.endpoint ?? defaultEndpoint;
+  registerInMemoryRoute(endpoint);
+  fetchRouter.install();
+
+  return createClient<NebulaClient>({
+    ...opts,
+    endpoint
+  } as ClientOptsLike);
+};
+
+export let nebulaClient = createTestNebulaClient();
+export type NebulaTestClient = ReturnType<typeof createTestNebulaClient>;

--- a/src/systems/nebula/service/src/test/setup.ts
+++ b/src/systems/nebula/service/src/test/setup.ts
@@ -1,0 +1,29 @@
+import { PrismaPg } from '@prisma/adapter-pg';
+import { setupPrismaTestDb, setupTestGlobals } from '@lowerdeck/testing-tools';
+import { afterAll, vi } from 'vitest';
+import { PrismaClient } from '../../prisma/generated/client';
+import { dataKeyCache } from '../lib/dataKeyCache';
+
+setupTestGlobals({ nodeEnv: 'test' });
+
+vi.mock('@lowerdeck/lock', () => ({
+  createLock: () => ({
+    usingLock: async (_key: string, fn: () => Promise<any>) => await fn()
+  })
+}));
+
+let db = await setupPrismaTestDb<PrismaClient>({
+  guard: 'nebula-test',
+  prismaClientFactory: url => new PrismaClient({ adapter: new PrismaPg({ connectionString: url }) })
+});
+
+afterAll(async () => {
+  await db.disconnect();
+});
+
+export let testDb: PrismaClient = db.client;
+
+export let cleanDatabase = async () => {
+  dataKeyCache.clear();
+  await db.clean();
+};

--- a/src/systems/nebula/service/src/worker.ts
+++ b/src/systems/nebula/service/src/worker.ts
@@ -1,0 +1,4 @@
+import { runQueueProcessors } from '@lowerdeck/queue';
+import { cleanupSecretUseProcessors } from './queues/cleanupSecretUse';
+
+await runQueueProcessors([cleanupSecretUseProcessors]);

--- a/src/systems/nebula/service/tsconfig.json
+++ b/src/systems/nebula/service/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}

--- a/src/systems/nebula/service/vitest.config.ts
+++ b/src/systems/nebula/service/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+import { createVitestConfig, loadTestEnv } from '@lowerdeck/testing-tools';
+
+export default defineConfig(({ mode }) => {
+  let env = loadTestEnv(mode || 'test', process.cwd(), '');
+
+  return createVitestConfig({
+    test: {
+      pool: 'forks',
+      setupFiles: ['./src/test/setup.ts'],
+      env: {
+        ...env,
+        NODE_ENV: 'test',
+        DATABASE_URL:
+          env.DATABASE_URL ?? 'postgresql://postgres:postgres@localhost:5432/nebula-test',
+        REDIS_URL: env.REDIS_URL ?? 'redis://localhost:6379/0',
+        DEFAULT_PROVIDER: env.DEFAULT_PROVIDER ?? 'local',
+        LOCAL_MASTER_SECRET:
+          env.LOCAL_MASTER_SECRET ?? 'nebula-test-local-master-secret-with-enough-entropy'
+      }
+    }
+  });
+});

--- a/src/systems/nebula/service/vitest.config.ts
+++ b/src/systems/nebula/service/vitest.config.ts
@@ -22,6 +22,9 @@ export default defineConfig(({ mode }) => {
           'nebula-test-consumer-instance-token-secret-with-enough-entropy',
         CONSUMER_INSTANCE_TOKEN_TTL_SECONDS:
           env.CONSUMER_INSTANCE_TOKEN_TTL_SECONDS ?? '3600',
+        KMS_EXTERNAL_KEY_ROLE_ARN:
+          env.KMS_EXTERNAL_KEY_ROLE_ARN ??
+          'arn:aws:iam::123456789012:role/metorial-test-nebula-task-role',
         CONSUMER_REGISTRATION_worker: env.CONSUMER_REGISTRATION_worker ?? 'worker-secret',
         CONSUMER_REGISTRATION_owner: env.CONSUMER_REGISTRATION_owner ?? 'owner-secret',
         CONSUMER_REGISTRATION_other: env.CONSUMER_REGISTRATION_other ?? 'other-secret'

--- a/src/systems/nebula/service/vitest.config.ts
+++ b/src/systems/nebula/service/vitest.config.ts
@@ -16,7 +16,15 @@ export default defineConfig(({ mode }) => {
         REDIS_URL: env.REDIS_URL ?? 'redis://localhost:6379/0',
         DEFAULT_PROVIDER: env.DEFAULT_PROVIDER ?? 'local',
         LOCAL_MASTER_SECRET:
-          env.LOCAL_MASTER_SECRET ?? 'nebula-test-local-master-secret-with-enough-entropy'
+          env.LOCAL_MASTER_SECRET ?? 'nebula-test-local-master-secret-with-enough-entropy',
+        CONSUMER_INSTANCE_TOKEN_SECRET:
+          env.CONSUMER_INSTANCE_TOKEN_SECRET ??
+          'nebula-test-consumer-instance-token-secret-with-enough-entropy',
+        CONSUMER_INSTANCE_TOKEN_TTL_SECONDS:
+          env.CONSUMER_INSTANCE_TOKEN_TTL_SECONDS ?? '3600',
+        CONSUMER_REGISTRATION_worker: env.CONSUMER_REGISTRATION_worker ?? 'worker-secret',
+        CONSUMER_REGISTRATION_owner: env.CONSUMER_REGISTRATION_owner ?? 'owner-secret',
+        CONSUMER_REGISTRATION_other: env.CONSUMER_REGISTRATION_other ?? 'other-secret'
       }
     }
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> New security-critical surface: secret encryption/decryption, consumer auth, KMS policies, and cross-tenant isolation; large greenfield footprint needs careful production config review.
> 
> **Overview**
> Introduces **Nebula**, a new platform service for **tenant-scoped secret storage** with envelope encryption via **local** or **AWS KMS** key providers, plus RPC at `/metorial-nebula`.
> 
> The service adds tenants, key providers (import, managed, default, setup docs), versioned secrets bound to a **consumer** and **proof**, and **consumer instance** auth (registration secrets from env, JWT tokens with refresh/rotation). Slates and Shuttle are wired via `CONSUMER_REGISTRATION_*` in dev/CI. A **`@metorial-platform-systems/nebula-client`** package wraps the RPC client and auto-injects/refreshes consumer tokens for secret create/update/use.
> 
> **Ops and monorepo integration:** GitHub Actions build + reusable compose e2e tests, Dockerfiles and `docker-compose.dev.yml`, `NEBULA_DATABASE_URL` / `nebulaServiceEnv` in dev-tools, and workspace entries in `bun.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36223bc76f90690af2583bafce4ed367efdce80f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->