### PR TITLE
Add proper secret deletion to nebula

### DIFF
--- a/src/systems/_clients/nebula/src/index.ts
+++ b/src/systems/_clients/nebula/src/index.ts
@@ -7,11 +7,12 @@ type SecretClient = NebulaClient['secret'];
 type SecretCreateInput = Parameters<SecretClient['create']>[0];
 type SecretUpdateInput = Parameters<SecretClient['update']>[0];
 type SecretUseInput = Parameters<SecretClient['use']>[0];
+type SecretDisableInput = Parameters<SecretClient['disable']>[0];
 
 type WithInjectedConsumerToken<T> = Omit<T, 'consumerToken'>;
 
 export type AuthenticatedNebulaClient = Omit<NebulaClient, 'secret'> & {
-  secret: Omit<SecretClient, 'create' | 'update' | 'use'> & {
+  secret: Omit<SecretClient, 'create' | 'update' | 'use' | 'disable'> & {
     create: (
       input: WithInjectedConsumerToken<SecretCreateInput>
     ) => ReturnType<SecretClient['create']>;
@@ -19,6 +20,9 @@ export type AuthenticatedNebulaClient = Omit<NebulaClient, 'secret'> & {
       input: WithInjectedConsumerToken<SecretUpdateInput>
     ) => ReturnType<SecretClient['update']>;
     use: (input: WithInjectedConsumerToken<SecretUseInput>) => ReturnType<SecretClient['use']>;
+    disable: (
+      input: WithInjectedConsumerToken<SecretDisableInput>
+    ) => ReturnType<SecretClient['disable']>;
   };
 };
 
@@ -104,6 +108,11 @@ export let createNebulaClient = (o: NebulaClientOpts): AuthenticatedNebulaClient
         }),
       use: async input =>
         await client.secret.use({
+          ...input,
+          consumerToken: await getToken()
+        }),
+      disable: async input =>
+        await client.secret.disable({
           ...input,
           consumerToken: await getToken()
         })

--- a/src/systems/nebula/service/prisma/schema/secret.prisma
+++ b/src/systems/nebula/service/prisma/schema/secret.prisma
@@ -1,6 +1,6 @@
 enum SecretStatus {
   active
-  inactive
+  disabled
   deleted
 }
 
@@ -24,15 +24,17 @@ model Secret {
   currentVersionOid BigInt?
   currentVersion    SecretVersion? @relation("CurrentSecretVersion", fields: [currentVersionOid], references: [oid])
 
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @default(now()) @updatedAt
-  deletedAt DateTime?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @default(now()) @updatedAt
+  disabledAt DateTime?
+  deletedAt  DateTime?
 
   versions   SecretVersion[]
   secretUses SecretUse[]
 
   @@index([tenantOid, status])
   @@index([consumerOid, status])
+  @@index([status, disabledAt])
 }
 
 model SecretVersion {

--- a/src/systems/nebula/service/src/adapters/aws-kms/index.ts
+++ b/src/systems/nebula/service/src/adapters/aws-kms/index.ts
@@ -13,8 +13,7 @@ import type {
   DataKeyResult,
   KeyProviderSetupInfoInput
 } from '../_lib/adapter';
-import { detag } from '../_lib/adapter';
-import { NebulaKeyProviderAdapter } from '../_lib/adapter';
+import { detag, NebulaKeyProviderAdapter } from '../_lib/adapter';
 import { NebulaAdapterError, normalizeAdapterError } from '../_lib/errors';
 
 let importKeyInputSchema = v.object({
@@ -78,7 +77,8 @@ export class AwsKmsKeyProviderAdapter extends NebulaKeyProviderAdapter {
 
   async validateKeyProvider(rawInput: Record<string, any>) {
     let parsed = importKeyInputSchema.validate(rawInput);
-    if (!parsed.success) throw new NebulaAdapterError('invalid_key_input', 'Invalid AWS KMS key input');
+    if (!parsed.success)
+      throw new NebulaAdapterError('invalid_key_input', 'Invalid AWS KMS key input');
 
     let input = parsed.value;
     let region = input.region ?? env.kms.KMS_AWS_REGION;
@@ -87,7 +87,7 @@ export class AwsKmsKeyProviderAdapter extends NebulaKeyProviderAdapter {
 
     try {
       return {
-        name: 'AWS KMS KeyProvider',
+        name: `AWS KMS KeyProvider (${input.keyId})`,
         keyInfo: await this.describeKeyId({ keyId: input.keyId, region })
       };
     } catch (err) {
@@ -139,7 +139,8 @@ export class AwsKmsKeyProviderAdapter extends NebulaKeyProviderAdapter {
       },
       {
         title: 'Create the Nebula KeyProvider',
-        description: 'Create the KeyProvider after the key policy is updated. Nebula validates KMS access before storing it.',
+        description:
+          'Create the KeyProvider after the key policy is updated. Nebula validates KMS access before storing it.',
         markdown: detag`
           Call \`keyProvider.import\` with this payload:
 
@@ -164,7 +165,8 @@ export class AwsKmsKeyProviderAdapter extends NebulaKeyProviderAdapter {
       },
       {
         title: 'Optional: tag the customer key',
-        description: 'Tags are optional for customer-managed keys, but they help with inventory. Nebula-managed keys always use metorial-system=nebula.',
+        description:
+          'Tags are optional for customer-managed keys, but they help with inventory. Nebula-managed keys always use metorial-system=nebula.',
         markdown: detag`
           Suggested optional tags:
 
@@ -227,7 +229,10 @@ export class AwsKmsKeyProviderAdapter extends NebulaKeyProviderAdapter {
     }
   }
 
-  async generateDataKey(keyProvider: KeyProvider, context: DataKeyContext): Promise<DataKeyResult> {
+  async generateDataKey(
+    keyProvider: KeyProvider,
+    context: DataKeyContext
+  ): Promise<DataKeyResult> {
     let keyInfo = keyProvider.keyInfo as any;
 
     try {

--- a/src/systems/nebula/service/src/controllers/secret.ts
+++ b/src/systems/nebula/service/src/controllers/secret.ts
@@ -80,6 +80,29 @@ export let secretController = app.controller({
       return secretPresenter(secret);
     }),
 
+  disable: consumerInstanceApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        secretId: v.string(),
+        consumerToken: v.string()
+      })
+    )
+    .do(async ctx => {
+      let currentSecret = await secretService.getSecretById({
+        tenant: ctx.tenant,
+        id: ctx.input.secretId
+      });
+
+      let secret = await secretService.disableSecret({
+        tenant: ctx.tenant,
+        consumer: ctx.consumer,
+        secret: currentSecret
+      });
+      return secretPresenter(secret);
+    }),
+
   list: tenantApp
     .handler()
     .input(Paginator.validate(v.object({ tenantId: v.string() })))

--- a/src/systems/nebula/service/src/controllers/tests/secret.e2e.test.ts
+++ b/src/systems/nebula/service/src/controllers/tests/secret.e2e.test.ts
@@ -232,4 +232,128 @@ describe('secret E2E', () => {
       })
     ).rejects.toThrow('Consumer instance is not active');
   });
+
+  it('disables an active secret and blocks use and update', async () => {
+    let tenant = await createTenant('tenant-disable');
+    let registration = await registerWorker();
+
+    let secret = await nebulaClient.secret.create({
+      tenantId: tenant.id,
+      consumerToken: registration.token,
+      purpose: 'disable_me',
+      secret: 'high-entropy-secret-value-disable',
+      proof: { binding: 'disable' }
+    });
+
+    let disabled = await nebulaClient.secret.disable({
+      tenantId: tenant.id,
+      consumerToken: registration.token,
+      secretId: secret.id
+    });
+
+    expect(disabled).toMatchObject({
+      id: secret.id,
+      status: 'disabled',
+      disabledAt: expect.any(Date)
+    });
+
+    await expect(
+      nebulaClient.secret.use({
+        tenantId: tenant.id,
+        consumerToken: registration.token,
+        secretId: secret.id,
+        proof: { binding: 'disable' },
+        note: 'Attempt use after disable'
+      })
+    ).rejects.toThrow('Unable to use secret');
+
+    await expect(
+      nebulaClient.secret.update({
+        tenantId: tenant.id,
+        consumerToken: registration.token,
+        secretId: secret.id,
+        secret: 'new-value',
+        proof: { binding: 'disable' }
+      })
+    ).rejects.toThrow('Unable to modify secret');
+  });
+
+  it('only allows the creating consumer to disable a secret', async () => {
+    let tenant = await createTenant('tenant-disable-lock');
+    let ownerRegistration = await registerWorker('owner-secret', 'OWNER-DISABLE');
+    let otherRegistration = await registerWorker('other-secret', 'OTHER-DISABLE');
+
+    let secret = await nebulaClient.secret.create({
+      tenantId: tenant.id,
+      consumerToken: ownerRegistration.token,
+      purpose: 'disable_lock',
+      secret: 'high-entropy-secret-value-disable-lock',
+      proof: { binding: 'owner' }
+    });
+
+    await expect(
+      nebulaClient.secret.disable({
+        tenantId: tenant.id,
+        consumerToken: otherRegistration.token,
+        secretId: secret.id
+      })
+    ).rejects.toThrow('Only the creating consumer can disable this secret');
+  });
+
+  it('rejects disabling an already deleted secret', async () => {
+    let tenant = await createTenant('tenant-disable-deleted');
+    let registration = await registerWorker();
+
+    let secret = await nebulaClient.secret.create({
+      tenantId: tenant.id,
+      consumerToken: registration.token,
+      purpose: 'disable_deleted',
+      secret: 'high-entropy-secret-value-disable-deleted',
+      proof: { binding: 'deleted' }
+    });
+
+    await testDb.secret.update({
+      where: { id: secret.id },
+      data: { status: 'deleted', deletedAt: new Date() }
+    });
+
+    await expect(
+      nebulaClient.secret.disable({
+        tenantId: tenant.id,
+        consumerToken: registration.token,
+        secretId: secret.id
+      })
+    ).rejects.toThrow('Secret has already been deleted');
+  });
+
+  it('is idempotent when disabling an already disabled secret', async () => {
+    let tenant = await createTenant('tenant-disable-idempotent');
+    let registration = await registerWorker();
+
+    let secret = await nebulaClient.secret.create({
+      tenantId: tenant.id,
+      consumerToken: registration.token,
+      purpose: 'disable_idempotent',
+      secret: 'high-entropy-secret-value-disable-idempotent',
+      proof: { binding: 'idempotent' }
+    });
+
+    let first = await nebulaClient.secret.disable({
+      tenantId: tenant.id,
+      consumerToken: registration.token,
+      secretId: secret.id
+    });
+
+    let second = await nebulaClient.secret.disable({
+      tenantId: tenant.id,
+      consumerToken: registration.token,
+      secretId: secret.id
+    });
+
+    expect(second).toMatchObject({
+      id: secret.id,
+      status: 'disabled',
+      disabledAt: first.disabledAt
+    });
+  });
 });

--- a/src/systems/nebula/service/src/presenters/secret.ts
+++ b/src/systems/nebula/service/src/presenters/secret.ts
@@ -14,7 +14,9 @@ export let secretPresenter = (secret: SecretWithVersion) => ({
   currentVersionId: secret.currentVersion?.id ?? null,
   keyProviderId: secret.currentVersion?.keyProvider?.id ?? null,
   createdAt: secret.createdAt,
-  updatedAt: secret.updatedAt
+  updatedAt: secret.updatedAt,
+  disabledAt: secret.disabledAt,
+  deletedAt: secret.deletedAt
 });
 
 export let secretVersionPresenter = (version: SecretVersion & { keyProvider?: KeyProvider }) => ({

--- a/src/systems/nebula/service/src/queues/purgeDisabledSecrets.ts
+++ b/src/systems/nebula/service/src/queues/purgeDisabledSecrets.ts
@@ -1,0 +1,85 @@
+import { createCron } from '@lowerdeck/cron';
+import { combineQueueProcessors, createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { subDays } from 'date-fns';
+import { db } from '../db';
+import { env } from '../env';
+
+let disabledSecretRetentionDays = 14;
+
+export let purgeDisabledSecret = async (secretOid: bigint) => {
+  let secret = await db.secret.findUnique({
+    where: { oid: secretOid }
+  });
+  if (!secret) throw new QueueRetryError();
+  if (secret.status !== 'disabled') return;
+
+  await db.secret.update({
+    where: { oid: secret.oid },
+    data: {
+      status: 'deleted',
+      deletedAt: new Date()
+    }
+  });
+};
+
+let purgeDisabledSecretsCron = createCron(
+  {
+    name: 'neb/sec/disabled/purge',
+    cron: '0 0 * * *',
+    redisUrl: env.service.REDIS_URL
+  },
+  async () => {
+    await purgeDisabledSecretsSearchQueue.add({
+      before: subDays(new Date(), disabledSecretRetentionDays)
+    });
+  }
+);
+
+let purgeDisabledSecretsSearchQueue = createQueue<{ before: Date; cursor?: bigint }>({
+  name: 'neb/sec/disabled/purge/search',
+  redisUrl: env.service.REDIS_URL
+});
+
+let purgeDisabledSecretsSearchQueueProcessor = purgeDisabledSecretsSearchQueue.process(
+  async data => {
+    let secrets = await db.secret.findMany({
+      where: {
+        status: 'disabled',
+        disabledAt: { lte: data.before },
+        oid: data.cursor ? { lt: data.cursor } : undefined
+      },
+      orderBy: { oid: 'desc' },
+      take: 500
+    });
+    if (!secrets.length) return;
+
+    await purgeDisabledSecretSingleQueue.addMany(
+      secrets.map(secret => ({
+        secretOid: secret.oid
+      }))
+    );
+
+    await purgeDisabledSecretsSearchQueue.add({
+      before: data.before,
+      cursor: secrets[secrets.length - 1]!.oid
+    });
+  }
+);
+
+let purgeDisabledSecretSingleQueue = createQueue<{ secretOid: bigint }>({
+  name: 'neb/sec/disabled/purge/single',
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: {
+    concurrency: 5
+  }
+});
+
+let purgeDisabledSecretSingleQueueProcessor = purgeDisabledSecretSingleQueue.process(async data => {
+  await purgeDisabledSecret(data.secretOid);
+});
+
+export let purgeDisabledSecretsProcessors = combineQueueProcessors([
+  purgeDisabledSecretsCron,
+  purgeDisabledSecretsSearchQueueProcessor,
+  purgeDisabledSecretSingleQueueProcessor
+]);

--- a/src/systems/nebula/service/src/queues/tests/purgeDisabledSecrets.test.ts
+++ b/src/systems/nebula/service/src/queues/tests/purgeDisabledSecrets.test.ts
@@ -1,0 +1,83 @@
+import { subDays } from 'date-fns';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { cleanDatabase, testDb } from '../../test/setup';
+import { purgeDisabledSecret } from '../purgeDisabledSecrets';
+
+describe('purgeDisabledSecret', () => {
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  it('marks disabled secrets as deleted', async () => {
+    let tenant = await testDb.tenant.create({
+      data: {
+        oid: 1n,
+        id: 'tenant-1',
+        identifier: 'tenant-1',
+        name: 'Tenant 1'
+      }
+    });
+    let consumer = await testDb.consumer.create({
+      data: {
+        oid: 2n,
+        id: 'consumer-1',
+        identifier: 'consumer-1',
+        name: 'Consumer 1',
+        status: 'active'
+      }
+    });
+    let secret = await testDb.secret.create({
+      data: {
+        oid: 3n,
+        id: 'secret-1',
+        tenantOid: tenant.oid,
+        consumerOid: consumer.oid,
+        purpose: 'test',
+        status: 'disabled',
+        disabledAt: subDays(new Date(), 15)
+      }
+    });
+
+    await purgeDisabledSecret(secret.oid);
+
+    let updated = await testDb.secret.findUniqueOrThrow({ where: { oid: secret.oid } });
+    expect(updated.status).toBe('deleted');
+    expect(updated.deletedAt).toBeInstanceOf(Date);
+  });
+
+  it('ignores secrets that are not disabled', async () => {
+    let tenant = await testDb.tenant.create({
+      data: {
+        oid: 4n,
+        id: 'tenant-2',
+        identifier: 'tenant-2',
+        name: 'Tenant 2'
+      }
+    });
+    let consumer = await testDb.consumer.create({
+      data: {
+        oid: 5n,
+        id: 'consumer-2',
+        identifier: 'consumer-2',
+        name: 'Consumer 2',
+        status: 'active'
+      }
+    });
+    let secret = await testDb.secret.create({
+      data: {
+        oid: 6n,
+        id: 'secret-2',
+        tenantOid: tenant.oid,
+        consumerOid: consumer.oid,
+        purpose: 'test',
+        status: 'active'
+      }
+    });
+
+    await purgeDisabledSecret(secret.oid);
+
+    let updated = await testDb.secret.findUniqueOrThrow({ where: { oid: secret.oid } });
+    expect(updated.status).toBe('active');
+    expect(updated.deletedAt).toBeNull();
+  });
+});

--- a/src/systems/nebula/service/src/services/secret.ts
+++ b/src/systems/nebula/service/src/services/secret.ts
@@ -1,5 +1,5 @@
 import { getSentry } from '@lowerdeck/sentry';
-import { badRequestError, isServiceError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, forbiddenError, isServiceError, notFoundError, preconditionFailedError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import type { Consumer, ConsumerInstance, Secret, Tenant } from '../../prisma/generated/client';
@@ -20,6 +20,9 @@ let Sentry = getSentry();
 
 let genericUseError = () =>
   new ServiceError(badRequestError({ message: 'Unable to use secret' }));
+
+let genericSecretMutationError = () =>
+  new ServiceError(badRequestError({ message: 'Unable to modify secret' }));
 
 type SecretUseFailureStage =
   | 'validate'
@@ -225,6 +228,7 @@ class SecretServiceImpl {
     };
   }) {
     if (d.secret.consumerOid !== d.consumer.oid) throw genericUseError();
+    if (d.secret.status !== 'active') throw genericSecretMutationError();
 
     this.validateSecretInput({
       purpose: d.secret.purpose,
@@ -378,6 +382,48 @@ class SecretServiceImpl {
       });
       throw genericUseError();
     }
+  }
+
+  async disableSecret(d: { tenant: Tenant; consumer: Consumer; secret: Secret }) {
+    if (d.secret.consumerOid !== d.consumer.oid) {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Only the creating consumer can disable this secret'
+        })
+      );
+    }
+
+    if (d.secret.status === 'disabled') {
+      return await db.secret.findUniqueOrThrow({
+        where: { oid: d.secret.oid },
+        include
+      });
+    }
+
+    if (d.secret.status === 'deleted') {
+      throw new ServiceError(
+        preconditionFailedError({
+          message: 'Secret has already been deleted'
+        })
+      );
+    }
+
+    if (d.secret.status !== 'active') {
+      throw new ServiceError(
+        preconditionFailedError({
+          message: 'Secret is not active and cannot be disabled'
+        })
+      );
+    }
+
+    return await db.secret.update({
+      where: { oid: d.secret.oid },
+      data: {
+        status: 'disabled',
+        disabledAt: new Date()
+      },
+      include
+    });
   }
 
   async getSecretById(d: { tenant: Tenant; id: string }) {

--- a/src/systems/nebula/service/src/worker.ts
+++ b/src/systems/nebula/service/src/worker.ts
@@ -1,4 +1,5 @@
 import { runQueueProcessors } from '@lowerdeck/queue';
 import { cleanupSecretUseProcessors } from './queues/cleanupSecretUse';
+import { purgeDisabledSecretsProcessors } from './queues/purgeDisabledSecrets';
 
-await runQueueProcessors([cleanupSecretUseProcessors]);
+await runQueueProcessors([cleanupSecretUseProcessors, purgeDisabledSecretsProcessors]);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes secret lifecycle, authorization on disable, and background deletion of disabled secrets—security-sensitive but guarded by consumer ownership, status checks, and tests.
> 
> **Overview**
> Adds a **disable → retain → delete** lifecycle for Nebula secrets instead of relying on an ambiguous `inactive` status.
> 
> Consumers can call **`secret.disable`** (wired through the RPC controller and authenticated client with injected `consumerToken`). Only the **creating consumer** may disable; the operation is **idempotent** when already disabled and rejects **deleted** secrets. Disabled secrets set **`disabledAt`** and **`status: disabled`**; **`use`** and **`update`** are blocked for non-`active` secrets (updates use a dedicated “Unable to modify secret” error).
> 
> The data model replaces **`inactive`** with **`disabled`**, adds **`disabledAt`**, and indexes **`(status, disabledAt)`** for retention scans. API responses expose **`disabledAt`** and **`deletedAt`**.
> 
> A **daily cron + queue pipeline** finds secrets disabled for **14+ days** and marks them **`deleted`** with **`deletedAt`**; the worker registers the new processors. E2E and unit tests cover disable rules and purge behavior.
> 
> Minor unrelated tweaks: AWS KMS KeyProvider display name includes the key id; small formatting in the KMS adapter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d51a7965b9bc53811678a98789fc0fff2584912d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->