### PR TITLE
Fix nebula auto registration

### DIFF
--- a/src/systems/_clients/nebula/src/index.ts
+++ b/src/systems/_clients/nebula/src/index.ts
@@ -40,7 +40,8 @@ type ConsumerInstanceToken = {
 
 let toDate = (value: Date | string) => (value instanceof Date ? value : new Date(value));
 
-export let createRawNebulaClient = (o: ClientOpts): NebulaClient => createClient<NebulaClient>(o);
+export let createRawNebulaClient = (o: ClientOpts): NebulaClient =>
+  createClient<NebulaClient>(o);
 
 export let createNebulaClient = (o: NebulaClientOpts): AuthenticatedNebulaClient => {
   let { consumerToken, identifier, refreshSkewMs = 60_000, ...clientOpts } = o;
@@ -48,17 +49,17 @@ export let createNebulaClient = (o: NebulaClientOpts): AuthenticatedNebulaClient
   let current: ConsumerInstanceToken | null = null;
   let inFlight: Promise<ConsumerInstanceToken> | null = null;
 
-  let register = async () => {
+  let registration = (async () => {
     let next = await client.consumer.register({
       secret: consumerToken,
       identifier
     });
     current = next;
     return next;
-  };
+  })();
 
   let refresh = async () => {
-    if (!current) return await register();
+    if (!current) return await registration;
 
     try {
       let next = await client.consumer.refresh({
@@ -68,15 +69,12 @@ export let createNebulaClient = (o: NebulaClientOpts): AuthenticatedNebulaClient
       current = next;
       return next;
     } catch {
-      return await register();
+      return await registration;
     }
   };
 
   let getToken = async () => {
-    if (
-      current &&
-      toDate(current.expiresAt).getTime() - refreshSkewMs > Date.now()
-    ) {
+    if (current && toDate(current.expiresAt).getTime() - refreshSkewMs > Date.now()) {
       return current.token;
     }
 

--- a/src/systems/slates/apps/hub/src/nebula.ts
+++ b/src/systems/slates/apps/hub/src/nebula.ts
@@ -1,4 +1,5 @@
 import { createNebulaClient } from '@metorial-platform-systems/nebula-client';
+import os from 'os';
 import type { Tenant } from '../prisma/generated/client';
 import { db } from './db';
 import { env } from './env';
@@ -6,7 +7,7 @@ import { env } from './env';
 export let nebula = createNebulaClient({
   endpoint: env.nebula.NEBULA_API_URL,
   consumerToken: env.nebula.NEBULA_CONSUMER_TOKEN,
-  identifier: env.nebula.NEBULA_CONSUMER_IDENTIFIER
+  identifier: os.hostname()
 });
 
 export let getNebulaTenantForSlatesTenant = async (tenant: Tenant) => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Nebula consumer token lifecycle and how hub instances identify themselves to Nebula, which can affect instance registration and secret API auth behavior across deploys.
> 
> **Overview**
> Fixes Nebula consumer **auto-registration** so registration runs as soon as `createNebulaClient` is called, instead of only on the first token request.
> 
> In `createNebulaClient`, consumer registration is now a single **eager** `registration` promise started at client construction. `refresh` and failed-refresh paths await that same promise rather than invoking a separate `register()` again, which avoids duplicate registrations and races when refresh fails or runs before the first register completes.
> 
> The Slates hub passes **`os.hostname()`** as the Nebula consumer `identifier` instead of the static `NEBULA_CONSUMER_IDENTIFIER` env value, so each hub process/instance registers under a host-specific identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 781c660912294c06a624f3d1a6a2589ab4b50560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->