### PR TITLE
Fix integration provider search

### DIFF
--- a/src/frontend/apps/dashboard/src/hooks/useSearchFilter.ts
+++ b/src/frontend/apps/dashboard/src/hooks/useSearchFilter.ts
@@ -1,13 +1,26 @@
+import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useDebounced } from './useDebounced';
 
-export let useSearchFilter = (delay = 500) => {
+export let useSearchFilter = (
+  delay = 500,
+  opts: {
+    updateSearchParams?: boolean;
+  } = {}
+) => {
+  let updateSearchParams = opts.updateSearchParams ?? true;
+  let [localSearch, setLocalSearch] = useState('');
   let [searchParams, setSearchParams] = useSearchParams();
-  let search = searchParams.get('search') ?? '';
+  let search = updateSearchParams ? (searchParams.get('search') ?? '') : localSearch;
   let searchDebounced = useDebounced(search, delay);
   let searchQuery = searchDebounced.trim() || undefined;
 
   let setSearch = (value: string) => {
+    if (!updateSearchParams) {
+      setLocalSearch(value);
+      return;
+    }
+
     setSearchParams(
       current => {
         let next = new URLSearchParams(current);

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
@@ -502,8 +502,7 @@ let IntegrationProviderSetupStep = (p: {
   // empty-state copy still renders for transparency.
   let effectiveShowAuth =
     visibility.showAuth &&
-    (!isUpdate ||
-      (!authMethods.isLoading && (authMethods.data?.items.length ?? 0) > 0));
+    (!isUpdate || (!authMethods.isLoading && (authMethods.data?.items.length ?? 0) > 0));
 
   let submitProviderSetup = async (values: IntegrationProviderFormValues) => {
     if (!instance.data) return false;
@@ -928,7 +927,7 @@ let AddIntegrationProviderPanel = (p: {
         p.description ??
         (p.integrationProvider
           ? 'Update optional provider settings for this integration.'
-          : 'Select a provider. Deployment and empty configuration setup are handled automatically.')
+          : 'Choose a provider to add to this integration.')
       }
       steps={p.integrationProvider ? [steps[1]!] : steps}
       currentStep={p.integrationProvider ? 0 : step}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerCreationPanel/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerCreationPanel/index.tsx
@@ -1,8 +1,9 @@
-import { Panel, showModal } from '@metorial/ui';
-import { type ReactNode, useState } from 'react';
+import { Input, Panel, showModal } from '@metorial/ui';
+import { type ReactNode, useMemo, useState } from 'react';
 import type { DashboardInstanceProviderListingsListQuery } from '@metorial/dashboard-sdk';
 import { ProvidersWithDeploymentsSearch } from '../providers/search';
 import { PillStepper } from '../../../../components/stepper';
+import { useSearchFilter } from '../../../../hooks/useSearchFilter';
 
 type ProviderCreationPanelStep = {
   title: string;
@@ -57,25 +58,50 @@ export let ProviderSelectionStep = (p: {
   providerListingsFilter?: DashboardInstanceProviderListingsListQuery;
   excludeProviderIds?: string[];
 }) => {
+  let { search, setSearch, searchQuery } = useSearchFilter(500, {
+    updateSearchParams: false
+  });
+  let providerListingsFilter = useMemo(
+    (): DashboardInstanceProviderListingsListQuery => ({
+      ...p.providerListingsFilter,
+      ...(searchQuery ? { search: searchQuery } : {})
+    }),
+    [p.providerListingsFilter, searchQuery]
+  );
+
   return (
-    <ProvidersWithDeploymentsSearch
-      instanceId={p.instanceId}
-      columns={3}
-      limit={p.limit ?? 30}
-      variant="providerCard"
-      cardSize="compact"
-      includeAllProviders
-      prioritizeProvidersWithDeployments
-      internalScroll
-      internalScrollHeight={p.internalScrollHeight ?? 'calc(100vh - 260px)'}
-      selectionMode={p.selectionMode}
-      providerListingsFilter={p.providerListingsFilter}
-      excludeProviderIds={p.excludeProviderIds}
-      emptyText={p.emptyText ?? 'No providers found.'}
-      onSelect={provider => {
-        p.onSelect(provider.id);
-      }}
-    />
+    <>
+      <div style={{ marginBottom: 12 }}>
+        <Input
+          label="Search"
+          hideLabel
+          size="2"
+          placeholder="Search providers..."
+          value={search}
+          onInput={setSearch}
+        />
+      </div>
+
+      <ProvidersWithDeploymentsSearch
+        instanceId={p.instanceId}
+        columns={3}
+        limit={p.limit ?? 30}
+        variant="providerCard"
+        cardSize="compact"
+        includeAllProviders
+        prioritizeProvidersWithDeployments
+        internalScroll
+        internalScrollHeight={p.internalScrollHeight ?? 'calc(100vh - 260px)'}
+        selectionMode={p.selectionMode}
+        providerListingsFilter={providerListingsFilter}
+        excludeProviderIds={p.excludeProviderIds}
+        hideSearch
+        emptyText={p.emptyText ?? 'No providers found.'}
+        onSelect={provider => {
+          p.onSelect(provider.id);
+        }}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only search and hook behavior in the provider creation flow; default URL sync for other `useSearchFilter` callers is unchanged.
> 
> **Overview**
> Provider picking in the **Add Provider** modal now uses a **dedicated search field** whose debounced query is sent to the listings API via `providerListingsFilter`, while the embedded list hides its own search UI (`hideSearch`).
> 
> `useSearchFilter` gains an **`updateSearchParams` option** (default still syncs to the URL). The provider selection step sets **`updateSearchParams: false`** so typing in the modal does not change the page’s query string.
> 
> Copy on the integration add-provider step is shortened to *“Choose a provider to add to this integration.”*
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a8e8ab70da709847d6a8f79105400c07039cc85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->