### PR TITLE
Fix key onboarding

### DIFF
--- a/src/systems/nebula/service/src/adapters/aws-kms/index.ts
+++ b/src/systems/nebula/service/src/adapters/aws-kms/index.ts
@@ -13,7 +13,7 @@ import type {
   DataKeyResult,
   KeyProviderSetupInfoInput
 } from '../_lib/adapter';
-import { detag, KeyProviderAdapter } from '../_lib/adapter';
+import { KeyProviderAdapter } from '../_lib/adapter';
 import { KeyProviderAdapterError, normalizeAdapterError } from '../_lib/errors';
 
 let importKeyInputSchema = v.object({
@@ -115,17 +115,6 @@ export class AwsKmsKeyProviderAdapter extends KeyProviderAdapter {
       Resource: '*'
     };
     let policyJson = JSON.stringify(policyStatement, null, 2);
-    let importKeyProviderPayload = {
-      tenantId: input.tenantId,
-      keyInput: {
-        keyId,
-        region
-      }
-    };
-    let optionalTags = {
-      'metorial-system': 'metorial',
-      'metorial-tenant-id': input.tenantId
-    };
 
     let steps = [
       {
@@ -134,26 +123,19 @@ export class AwsKmsKeyProviderAdapter extends KeyProviderAdapter {
       },
       {
         title: 'Grant the Metorial role access to the key',
-        description: `Allow Metorial's AWS role to describe the key, generate data keys, and decrypt wrapped data keys.`,
-        markdown: detag`
-          Add this statement to the KMS key policy, or create an equivalent KMS grant:
+        description: `Grant Metorial access to the key by adding the following statement to the key policy.`,
+        markdown: `
+Add this statement to the KMS key policy, or create an equivalent KMS grant:
 
-          \`\`\`json
-          ${policyJson}
-          \`\`\`
+\`\`\`json
+${policyJson}
+\`\`\`
         `
       },
       {
         title: 'Create the key provider',
         description:
           'Create the key provider after the key policy is updated. Metorial validates KMS access before storing it.',
-        markdown: detag`
-          Call \`keyProvider.import\` with this payload:
-
-          \`\`\`json
-          ${JSON.stringify(importKeyProviderPayload, null, 2)}
-          \`\`\`
-        `,
         inputs: [
           {
             type: 'text' as const,
@@ -168,18 +150,6 @@ export class AwsKmsKeyProviderAdapter extends KeyProviderAdapter {
             description: 'The AWS region where the KMS key exists.'
           }
         ]
-      },
-      {
-        title: 'Optional: tag the customer key',
-        description:
-          'Tags are optional for customer-managed keys, but they help with inventory and cost allocation.',
-        markdown: detag`
-          Suggested optional tags:
-
-          \`\`\`json
-          ${JSON.stringify(optionalTags, null, 2)}
-          \`\`\`
-        `
       }
     ];
 

--- a/src/systems/nebula/service/src/controllers/keyProvider.ts
+++ b/src/systems/nebula/service/src/controllers/keyProvider.ts
@@ -31,7 +31,7 @@ export let keyProviderController = app.controller({
         tenant: ctx.tenant,
         keyInput: ctx.input.keyInput
       });
-      return keyProviderPresenter(keyProvider);
+      return await keyProviderPresenter(keyProvider);
     }),
 
   createManaged: tenantApp
@@ -49,7 +49,7 @@ export let keyProviderController = app.controller({
           name: ctx.input.name
         }
       });
-      return keyProviderPresenter(keyProvider);
+      return await keyProviderPresenter(keyProvider);
     }),
 
   list: tenantApp
@@ -58,7 +58,10 @@ export let keyProviderController = app.controller({
     .do(async ctx => {
       let paginator = await keyProviderService.listKeyProviders({ tenant: ctx.tenant });
       let list = await paginator.run(ctx.input);
-      return Paginator.presentLight(list, keyProviderPresenter);
+      return {
+        ...list,
+        items: await Promise.all(list.items.map(keyProviderPresenter))
+      };
     }),
 
   get: keyProviderApp
@@ -69,7 +72,7 @@ export let keyProviderController = app.controller({
         keyProviderId: v.string()
       })
     )
-    .do(async ctx => keyProviderPresenter(ctx.keyProvider)),
+    .do(async ctx => await keyProviderPresenter(ctx.keyProvider)),
 
   getSetupInfo: tenantApp
     .handler()

--- a/src/systems/nebula/service/src/presenters/keyProvider.test.ts
+++ b/src/systems/nebula/service/src/presenters/keyProvider.test.ts
@@ -1,0 +1,72 @@
+import { Hash } from '@lowerdeck/hash';
+import { describe, expect, it } from 'vitest';
+import type { KeyProvider } from '../../prisma/generated/client';
+import { keyProviderPresenter } from './keyProvider';
+
+let baseKeyProvider = {
+  oid: 1n,
+  id: 'keyProvider_test',
+  systemIdentifier: 'system:tenant:tenant_test:keyProvider_test',
+  name: 'Test provider',
+  type: 'aws_kms',
+  owner: 'system',
+  status: 'active',
+  keyReuseTimeSeconds: null,
+  tenantOid: 1n,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  deletedAt: null
+} satisfies Omit<KeyProvider, 'keyInfo' | 'isMetorialManaged'>;
+
+describe('keyProviderPresenter', () => {
+  it('redacts AWS key IDs and ARNs for Metorial-managed providers', async () => {
+    let keyId = '1234abcd-12ab-34cd-56ef-1234567890ab';
+    let keyProvider = {
+      ...baseKeyProvider,
+      isMetorialManaged: true,
+      keyInfo: {
+        variant: 'aws_kms',
+        region: 'us-east-1',
+        keyId,
+        keyArn: `arn:aws:kms:us-east-1:123456789012:key/${keyId}`,
+        accountId: '123456789012'
+      }
+    } as KeyProvider;
+
+    let presented = await keyProviderPresenter(keyProvider);
+    let hash = (await Hash.sha256(keyId)).slice(0, 20);
+    let safeKeyId = `AWS KMS (via Metorial, ref: ${hash})`;
+
+    expect(presented.keyInfo).toMatchObject({
+      region: 'us-east-1',
+      keyId: safeKeyId,
+      keyArn: safeKeyId,
+      accountId: null
+    });
+  });
+
+  it('keeps AWS key IDs and ARNs for tenant-owned providers', async () => {
+    let keyId = 'customer-key-id';
+    let keyArn = `arn:aws:kms:us-east-1:123456789012:key/${keyId}`;
+    let keyProvider = {
+      ...baseKeyProvider,
+      owner: 'tenant',
+      isMetorialManaged: false,
+      keyInfo: {
+        variant: 'aws_kms',
+        region: 'us-east-1',
+        keyId,
+        keyArn,
+        accountId: '123456789012'
+      }
+    } as KeyProvider;
+
+    let presented = await keyProviderPresenter(keyProvider);
+
+    expect(presented.keyInfo).toMatchObject({
+      keyId,
+      keyArn,
+      accountId: '123456789012'
+    });
+  });
+});

--- a/src/systems/nebula/service/src/presenters/keyProvider.ts
+++ b/src/systems/nebula/service/src/presenters/keyProvider.ts
@@ -1,14 +1,27 @@
+import { Hash } from '@lowerdeck/hash';
 import type { KeyProvider } from '../../prisma/generated/client';
 
-let safeKeyInfo = (keyProvider: KeyProvider) => {
+let isMetorialManaged = (keyProvider: KeyProvider) =>
+  keyProvider.isMetorialManaged || (keyProvider.keyInfo as any)?.managedByNebula === true;
+
+let metorialManagedKeyId = async (keyProvider: KeyProvider, info: any) => {
+  let hash = (await Hash.sha256(info.keyId ?? keyProvider.id)).slice(0, 20);
+  return `AWS KMS (via Metorial, ref: ${hash})`;
+};
+
+let safeKeyInfo = async (keyProvider: KeyProvider) => {
   let info = keyProvider.keyInfo as any;
 
   if (keyProvider.type === 'aws_kms') {
+    let safeKeyId = isMetorialManaged(keyProvider)
+      ? await metorialManagedKeyId(keyProvider, info)
+      : null;
+
     return {
       region: info.region,
-      keyId: info.keyId,
-      keyArn: info.keyArn,
-      accountId: info.accountId
+      keyId: safeKeyId ?? info.keyId,
+      keyArn: safeKeyId ?? info.keyArn,
+      accountId: safeKeyId ? null : info.accountId
     };
   }
 
@@ -18,10 +31,7 @@ let safeKeyInfo = (keyProvider: KeyProvider) => {
   };
 };
 
-let isMetorialManaged = (keyProvider: KeyProvider) =>
-  keyProvider.isMetorialManaged || (keyProvider.keyInfo as any)?.managedByNebula === true;
-
-export let keyProviderPresenter = (keyProvider: KeyProvider) => ({
+export let keyProviderPresenter = async (keyProvider: KeyProvider) => ({
   object: 'nebula#key_provider',
   id: keyProvider.id,
   name: keyProvider.name,
@@ -30,7 +40,7 @@ export let keyProviderPresenter = (keyProvider: KeyProvider) => ({
   status: keyProvider.status,
   isMetorialManaged: isMetorialManaged(keyProvider),
   keyReuseTimeSeconds: keyProvider.keyReuseTimeSeconds,
-  keyInfo: safeKeyInfo(keyProvider),
+  keyInfo: await safeKeyInfo(keyProvider),
   createdAt: keyProvider.createdAt,
   updatedAt: keyProvider.updatedAt
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes external key-provider API shape and onboarding content; redaction reduces credential leakage but clients may have depended on raw managed key ARNs.
> 
> **Overview**
> **AWS KMS onboarding** is streamlined: setup steps drop the embedded `keyProvider.import` JSON example and the optional customer-key tagging step, and the final step relies on **form `inputs`** (key ID and region) instead of copy-paste payloads. Key-policy guidance stays, with simpler markdown formatting (no `detag`).
> 
> **Key provider API responses** now **hide real AWS key IDs, ARNs, and account IDs** for Metorial-managed providers, replacing them with a stable **hashed reference label**; tenant-owned providers still get full `keyInfo`. Controllers **await** the async presenter, and **list** maps items with `Promise.all` instead of `Paginator.presentLight`.
> 
> Tests cover managed vs tenant-owned presentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cb1856cbadb27f163bec30bea05a2b177794846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->