### PR TITLE
Fix config reuse for integrations

### DIFF
--- a/src/systems/subspace/modules/integration/src/services/integrationInstanceProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstanceProvider.ts
@@ -524,8 +524,15 @@ class integrationInstanceProviderServiceImpl {
         if (inheritSharedConfigs[idx] && sharedConfigId) return sharedConfigId;
 
         if (input.providerConfigId === undefined) {
-          return existingByIntegrationProviderOid.get(integrationProviders[idx]!.oid)
-            ?.currentVersion?.config?.id;
+          let existingConfigId = existingByIntegrationProviderOid.get(
+            integrationProviders[idx]!.oid
+          )?.currentVersion?.config?.id;
+          if (existingConfigId) return existingConfigId;
+
+          // On create, inherit the integration provider's shared config by default.
+          if (sharedConfigId) return sharedConfigId;
+
+          return undefined;
         }
 
         if (input.providerConfigId === null) return undefined;
@@ -592,7 +599,6 @@ class integrationInstanceProviderServiceImpl {
         let existing = existingByIntegrationProviderOid.get(integrationProvider.oid);
         let deploymentOid = materialProvider.currentVersion!.deploymentOid;
         let isInheritedSharedConfig =
-          inheritSharedConfigs[idx] &&
           materialProvider.currentVersion!.config?.oid === combination.config.oid;
 
         if (!isInheritedSharedConfig) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes provider config resolution and when ownership checks apply for integration instance providers, which can affect which configs attach and whether configs get locked.
> 
> **Overview**
> Fixes how **integration instance providers** pick a provider config when callers omit `providerConfigId`, and aligns “shared config” handling with that resolved config.
> 
> When `providerConfigId` is **undefined**, resolution now prefers an existing instance-provider config, then on **create** defaults to the integration provider’s **shared** config, instead of stopping after “no existing row” and leaving config unset.
> 
> **Inherited shared config** is now detected by comparing the integration provider’s current shared config to the resolved combination config, not by also requiring the explicit inherit flag from input. That keeps ownership checks and resource locking skipped when the instance is actually using the shared config, including the new default-on-create path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18336f885ac2dcd99a889cc8ed5e59053da04c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->