### PR TITLE
Fix nebula session name

### DIFF
--- a/src/systems/nebula/service/src/adapters/aws-kms/index.ts
+++ b/src/systems/nebula/service/src/adapters/aws-kms/index.ts
@@ -85,7 +85,7 @@ let getKmsClient = (region?: string, opts?: { assumeExternalRole?: boolean }) =>
         ? fromTemporaryCredentials({
             params: {
               RoleArn: env.kms.KMS_EXTERNAL_KEY_ROLE_ARN,
-              RoleSessionName: 'nebula-kms'
+              RoleSessionName: 'metorial-secret-store-kms'
             }
           })
         : env.kms.KMS_AWS_ACCESS_KEY_ID && env.kms.KMS_AWS_SECRET_ACCESS_KEY

--- a/src/systems/subspace/modules/integration/src/services/integrationInstanceProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstanceProvider.ts
@@ -524,8 +524,15 @@ class integrationInstanceProviderServiceImpl {
         if (inheritSharedConfigs[idx] && sharedConfigId) return sharedConfigId;
 
         if (input.providerConfigId === undefined) {
-          return existingByIntegrationProviderOid.get(integrationProviders[idx]!.oid)
-            ?.currentVersion?.config?.id;
+          let existingConfigId = existingByIntegrationProviderOid.get(
+            integrationProviders[idx]!.oid
+          )?.currentVersion?.config?.id;
+          if (existingConfigId) return existingConfigId;
+
+          // On create, inherit the integration provider's shared config by default.
+          if (sharedConfigId) return sharedConfigId;
+
+          return undefined;
         }
 
         if (input.providerConfigId === null) return undefined;
@@ -592,7 +599,6 @@ class integrationInstanceProviderServiceImpl {
         let existing = existingByIntegrationProviderOid.get(integrationProvider.oid);
         let deploymentOid = materialProvider.currentVersion!.deploymentOid;
         let isInheritedSharedConfig =
-          inheritSharedConfigs[idx] &&
           materialProvider.currentVersion!.config?.oid === combination.config.oid;
 
         if (!isInheritedSharedConfig) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Defaulting omitted providerConfigId to the integration provider’s shared config and broadening inherited-config detection changes which configs attach and when ownership checks run; KMS change is naming-only.
> 
> **Overview**
> Renames the AWS STS **RoleSessionName** used when Nebula assumes the external KMS role from `nebula-kms` to `metorial-secret-store-kms`, so CloudTrail/session logs match the secret-store naming.
> 
> **Integration instance providers:** When `providerConfigId` is omitted, new bindings now default to the integration provider’s shared config if the instance provider has no existing config (previously only an existing instance config was reused). **Inherited shared config** is detected solely by whether the resolved combination config matches the integration provider’s current shared config OID—the prior `inheritSharedConfigs` flag is no longer part of that check, which can treat more combinations as inherited and skip config ownership assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d155123f5276078fdbe4749563c00478af3a12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->