### PR TITLE
Add slates enclave support

### DIFF
--- a/src/systems/function-bay/deflector/internal/policy/policy.go
+++ b/src/systems/function-bay/deflector/internal/policy/policy.go
@@ -4,127 +4,107 @@ import (
 	"errors"
 	"net"
 	"net/netip"
-	"strings"
 
 	"github.com/golang-jwt/jwt/v5"
 )
 
+type PortRange struct {
+	From int `json:"from"`
+	To   int `json:"to"`
+}
+
+type CompiledNetworkAllowEntry struct {
+	CIDR      string     `json:"cidr"`
+	PortRange *PortRange `json:"portRange,omitempty"`
+}
+
+type CompiledNetworkAllowList struct {
+	Direction string                      `json:"direction"`
+	Entries   []CompiledNetworkAllowEntry `json:"entries"`
+}
+
 type Claims struct {
-	TenantID            string    `json:"tenantId"`
-	FunctionID          string    `json:"functionId"`
-	EffectiveFunctionID string    `json:"effectiveFunctionId,omitempty"`
-	FunctionVersionID   string    `json:"functionVersionId"`
-	EnclaveID           string    `json:"enclaveId,omitempty"`
-	EnclaveIdentifier   string    `json:"enclaveIdentifier,omitempty"`
-	AllowedIPs          *[]string `json:"allowedIps,omitempty"`
-	AllowedHosts        *[]string `json:"allowedHosts,omitempty"`
+	TenantID            string                    `json:"tenantId"`
+	FunctionID          string                    `json:"functionId"`
+	EffectiveFunctionID string                    `json:"effectiveFunctionId,omitempty"`
+	FunctionVersionID   string                    `json:"functionVersionId"`
+	EnclaveID           string                    `json:"enclaveId,omitempty"`
+	EnclaveIdentifier   string                    `json:"enclaveIdentifier,omitempty"`
+	EgressPolicy        *CompiledNetworkAllowList `json:"egressPolicy,omitempty"`
 	jwt.RegisteredClaims
 }
 
 type Compiled struct {
-	ipPrefixes   *[]netip.Prefix
-	hostPatterns *[]string
+	entries *[]compiledEntry
+}
+
+type compiledEntry struct {
+	prefix    netip.Prefix
+	portRange *PortRange
 }
 
 func Compile(claims Claims) (*Compiled, error) {
 	c := &Compiled{}
 
-	if claims.AllowedIPs != nil {
-		prefixes := make([]netip.Prefix, 0, len(*claims.AllowedIPs))
-		for _, raw := range *claims.AllowedIPs {
-			prefix, err := parseIPRule(raw)
+	if claims.EgressPolicy != nil {
+		if claims.EgressPolicy.Direction != "egress" {
+			return nil, errors.New("egress policy must have egress direction")
+		}
+
+		entries := make([]compiledEntry, 0, len(claims.EgressPolicy.Entries))
+		for _, raw := range claims.EgressPolicy.Entries {
+			prefix, err := parseCIDRRule(raw.CIDR)
 			if err != nil {
 				return nil, err
 			}
-			prefixes = append(prefixes, prefix.Masked())
-		}
-		c.ipPrefixes = &prefixes
-	}
 
-	if claims.AllowedHosts != nil {
-		patterns := make([]string, 0, len(*claims.AllowedHosts))
-		for _, raw := range *claims.AllowedHosts {
-			host := normalizeHost(raw)
-			if host == "" {
-				return nil, errors.New("empty host allow rule")
+			if raw.PortRange != nil {
+				if raw.PortRange.From < 1 || raw.PortRange.To < raw.PortRange.From || raw.PortRange.To > 65535 {
+					return nil, errors.New("invalid port range")
+				}
 			}
-			patterns = append(patterns, host)
+
+			entries = append(entries, compiledEntry{
+				prefix:    prefix.Masked(),
+				portRange: raw.PortRange,
+			})
 		}
-		c.hostPatterns = &patterns
+
+		c.entries = &entries
 	}
 
 	return c, nil
 }
 
-func parseIPRule(raw string) (netip.Prefix, error) {
-	rule := strings.TrimSpace(raw)
-	if strings.Contains(rule, "/") {
-		return netip.ParsePrefix(rule)
-	}
-
-	addr, err := netip.ParseAddr(rule)
-	if err != nil {
-		return netip.Prefix{}, err
-	}
-	addr = addr.Unmap()
-	if addr.Is4() {
-		return netip.PrefixFrom(addr, 32), nil
-	}
-	return netip.PrefixFrom(addr, 128), nil
+func parseCIDRRule(raw string) (netip.Prefix, error) {
+	return netip.ParsePrefix(raw)
 }
 
-func (c *Compiled) AllowsHost(host string) bool {
-	if c.hostPatterns == nil {
-		return true
-	}
-	host = normalizeHost(host)
-	if host == "" {
-		return false
-	}
-
-	for _, pattern := range *c.hostPatterns {
-		if strings.HasPrefix(pattern, "*.") {
-			suffix := strings.TrimPrefix(pattern, "*.")
-			if host != suffix && strings.HasSuffix(host, "."+suffix) {
-				return true
-			}
-			continue
-		}
-
-		if host == pattern {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (c *Compiled) AllowsIP(ip net.IP) bool {
+func (c *Compiled) AllowsDestination(ip net.IP, port int) bool {
 	addr, ok := netip.AddrFromSlice(ip)
 	if !ok {
 		return false
 	}
 	addr = addr.Unmap()
 
-	if c.ipPrefixes == nil {
+	if c.entries == nil {
 		return !isAlwaysBlocked(addr)
 	}
 
-	for _, prefix := range *c.ipPrefixes {
-		if prefix.Contains(addr) {
-			return true
+	for _, entry := range *c.entries {
+		if !entry.prefix.Contains(addr) {
+			continue
 		}
+		if entry.portRange != nil && (port < entry.portRange.From || port > entry.portRange.To) {
+			continue
+		}
+		if entry.portRange == nil && (port < 1 || port > 65535) {
+			continue
+		}
+
+		return true
 	}
 	return false
-}
-
-func normalizeHost(host string) string {
-	host = strings.TrimSpace(strings.ToLower(host))
-	host = strings.TrimSuffix(host, ".")
-	if h, _, err := net.SplitHostPort(host); err == nil {
-		host = h
-	}
-	return host
 }
 
 func isAlwaysBlocked(addr netip.Addr) bool {

--- a/src/systems/function-bay/deflector/internal/policy/policy_test.go
+++ b/src/systems/function-bay/deflector/internal/policy/policy_test.go
@@ -5,20 +5,30 @@ import (
 	"testing"
 )
 
-func TestCompileSupportsPlainIPRules(t *testing.T) {
-	allowedIPs := []string{"203.0.113.10", "2001:db8::1"}
-	compiled, err := Compile(Claims{AllowedIPs: &allowedIPs})
+func TestCompileSupportsCIDRRulesWithPorts(t *testing.T) {
+	compiled, err := Compile(Claims{
+		EgressPolicy: &CompiledNetworkAllowList{
+			Direction: "egress",
+			Entries: []CompiledNetworkAllowEntry{
+				{CIDR: "203.0.113.10/32", PortRange: &PortRange{From: 443, To: 443}},
+				{CIDR: "2001:db8::1/128"},
+			},
+		},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !compiled.AllowsIP(net.ParseIP("203.0.113.10")) {
+	if !compiled.AllowsDestination(net.ParseIP("203.0.113.10"), 443) {
 		t.Fatal("expected IPv4 address to be allowed")
 	}
-	if !compiled.AllowsIP(net.ParseIP("2001:db8::1")) {
+	if !compiled.AllowsDestination(net.ParseIP("2001:db8::1"), 8443) {
 		t.Fatal("expected IPv6 address to be allowed")
 	}
-	if compiled.AllowsIP(net.ParseIP("203.0.113.11")) {
+	if compiled.AllowsDestination(net.ParseIP("203.0.113.10"), 80) {
+		t.Fatal("expected unmatched port to be denied")
+	}
+	if compiled.AllowsDestination(net.ParseIP("203.0.113.11"), 443) {
 		t.Fatal("expected unmatched IP address to be denied")
 	}
 }
@@ -29,50 +39,11 @@ func TestDefaultIPPolicyBlocksPrivateAndAllowsPublic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if compiled.AllowsIP(net.ParseIP("10.0.0.1")) {
+	if compiled.AllowsDestination(net.ParseIP("10.0.0.1"), 443) {
 		t.Fatal("expected private IP address to be blocked by default")
 	}
-	if !compiled.AllowsIP(net.ParseIP("8.8.8.8")) {
+	if !compiled.AllowsDestination(net.ParseIP("8.8.8.8"), 443) {
 		t.Fatal("expected public IP address to be allowed by default")
-	}
-}
-
-func TestHostAllowlistSupportsWildcardSuffix(t *testing.T) {
-	allowedHosts := []string{"api.example.com", "*.trusted.example"}
-	compiled, err := Compile(Claims{AllowedHosts: &allowedHosts})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !compiled.AllowsHost("api.example.com") {
-		t.Fatal("expected exact host to be allowed")
-	}
-	if !compiled.AllowsHost("sub.trusted.example") {
-		t.Fatal("expected wildcard suffix host to be allowed")
-	}
-	if compiled.AllowsHost("trusted.example") {
-		t.Fatal("expected wildcard suffix not to match apex host")
-	}
-}
-
-func TestHostRules(t *testing.T) {
-	hosts := []string{"api.example.com", "*.allowed.test"}
-	compiled, err := Compile(Claims{AllowedHosts: &hosts})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !compiled.AllowsHost("api.example.com") {
-		t.Fatal("expected exact host to be allowed")
-	}
-	if !compiled.AllowsHost("a.b.allowed.test") {
-		t.Fatal("expected wildcard subdomain to be allowed")
-	}
-	if compiled.AllowsHost("allowed.test") {
-		t.Fatal("wildcard must not allow the root domain")
-	}
-	if compiled.AllowsHost("blocked.test") {
-		t.Fatal("unexpected blocked host allowed")
 	}
 }
 
@@ -82,44 +53,47 @@ func TestMissingRulesAllowPublicDestinations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !compiled.AllowsHost("anything.example") {
-		t.Fatal("missing host rules should allow all hosts")
-	}
-	if !compiled.AllowsIP(net.ParseIP("93.184.216.34")) {
+	if !compiled.AllowsDestination(net.ParseIP("93.184.216.34"), 443) {
 		t.Fatal("missing IP rules should allow public IPs")
 	}
-	if compiled.AllowsIP(net.ParseIP("169.254.169.254")) {
+	if compiled.AllowsDestination(net.ParseIP("169.254.169.254"), 443) {
 		t.Fatal("metadata IP must remain blocked by default")
 	}
 }
 
 func TestEmptyRulesDenyAllForDimension(t *testing.T) {
-	hosts := []string{}
-	ips := []string{}
-	compiled, err := Compile(Claims{AllowedHosts: &hosts, AllowedIPs: &ips})
+	compiled, err := Compile(Claims{
+		EgressPolicy: &CompiledNetworkAllowList{
+			Direction: "egress",
+			Entries:   []CompiledNetworkAllowEntry{},
+		},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if compiled.AllowsHost("example.com") {
-		t.Fatal("empty host rules should deny all hosts")
-	}
-	if compiled.AllowsIP(net.ParseIP("93.184.216.34")) {
+	if compiled.AllowsDestination(net.ParseIP("93.184.216.34"), 443) {
 		t.Fatal("empty IP rules should deny all IPs")
 	}
 }
 
 func TestCIDRRules(t *testing.T) {
-	ips := []string{"93.184.216.0/24"}
-	compiled, err := Compile(Claims{AllowedIPs: &ips})
+	compiled, err := Compile(Claims{
+		EgressPolicy: &CompiledNetworkAllowList{
+			Direction: "egress",
+			Entries: []CompiledNetworkAllowEntry{
+				{CIDR: "93.184.216.0/24", PortRange: &PortRange{From: 443, To: 443}},
+			},
+		},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !compiled.AllowsIP(net.ParseIP("93.184.216.34")) {
+	if !compiled.AllowsDestination(net.ParseIP("93.184.216.34"), 443) {
 		t.Fatal("expected IP inside CIDR to be allowed")
 	}
-	if compiled.AllowsIP(net.ParseIP("1.1.1.1")) {
+	if compiled.AllowsDestination(net.ParseIP("1.1.1.1"), 443) {
 		t.Fatal("unexpected IP outside CIDR allowed")
 	}
 }

--- a/src/systems/function-bay/deflector/internal/proxy/server.go
+++ b/src/systems/function-bay/deflector/internal/proxy/server.go
@@ -243,18 +243,19 @@ func copyStreaming(w http.ResponseWriter, r io.Reader) {
 }
 
 func (s *Server) dialAllowed(ctx context.Context, host string, port string, requestPolicy *requestPolicy) (net.Conn, error) {
-	if !requestPolicy.Compiled.AllowsHost(host) {
-		return nil, errors.New("host denied")
-	}
-
 	resolver := net.DefaultResolver
 	ips, err := resolver.LookupIP(ctx, "ip", host)
 	if err != nil {
 		return nil, err
 	}
 
+	portNum, err := net.LookupPort("tcp", port)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, ip := range ips {
-		if !requestPolicy.Compiled.AllowsIP(ip) {
+		if !requestPolicy.Compiled.AllowsDestination(ip, portNum) {
 			continue
 		}
 		dialer := s.Dialer

--- a/src/systems/function-bay/deflector/internal/proxy/server_test.go
+++ b/src/systems/function-bay/deflector/internal/proxy/server_test.go
@@ -42,12 +42,16 @@ func TestPolicyFromRequestRequiresValidToken(t *testing.T) {
 		t.Fatal("expected missing token to be rejected")
 	}
 
-	allowedHosts := []string{"example.com"}
 	token := proxyToken(t, "secret", policy.Claims{
 		TenantID:          "tenant_123",
 		FunctionID:        "function_123",
 		FunctionVersionID: "functionVersion_123",
-		AllowedHosts:      &allowedHosts,
+		EgressPolicy: &policy.CompiledNetworkAllowList{
+			Direction: "egress",
+			Entries: []policy.CompiledNetworkAllowEntry{
+				{CIDR: "93.184.216.34/32", PortRange: &policy.PortRange{From: 443, To: 443}},
+			},
+		},
 		RegisteredClaims: jwt.RegisteredClaims{
 			Audience:  jwt.ClaimStrings{"deflector"},
 			Subject:   "functionVersion_123",
@@ -66,21 +70,27 @@ func TestPolicyFromRequestRequiresValidToken(t *testing.T) {
 	if requestPolicy.Claims.TenantID != "tenant_123" {
 		t.Fatalf("unexpected tenant id %q", requestPolicy.Claims.TenantID)
 	}
-	if !requestPolicy.Compiled.AllowsHost("example.com") {
-		t.Fatal("expected verified claims to allow configured host")
+	if !requestPolicy.Compiled.AllowsDestination(net.ParseIP("93.184.216.34"), 443) {
+		t.Fatal("expected verified claims to allow configured destination")
 	}
-	if requestPolicy.Compiled.AllowsHost("other.example") {
-		t.Fatal("expected verified claims to deny unconfigured host")
+	if requestPolicy.Compiled.AllowsDestination(net.ParseIP("93.184.216.34"), 80) {
+		t.Fatal("expected verified claims to deny unconfigured port")
 	}
 }
 
 func TestExplicitPrivateIPAllowlistOverridesDefaultBlock(t *testing.T) {
-	allowedIPs := []string{"10.0.0.1"}
-	compiled, err := policy.Compile(policy.Claims{AllowedIPs: &allowedIPs})
+	compiled, err := policy.Compile(policy.Claims{
+		EgressPolicy: &policy.CompiledNetworkAllowList{
+			Direction: "egress",
+			Entries: []policy.CompiledNetworkAllowEntry{
+				{CIDR: "10.0.0.1/32"},
+			},
+		},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !compiled.AllowsIP(net.ParseIP("10.0.0.1")) {
+	if !compiled.AllowsDestination(net.ParseIP("10.0.0.1"), 443) {
 		t.Fatal("expected explicit private IP allowlist to allow matching IP")
 	}
 }

--- a/src/systems/function-bay/service/src/controllers/function.ts
+++ b/src/systems/function-bay/service/src/controllers/function.ts
@@ -95,19 +95,29 @@ export let functionController = app.controller({
     .input(
       v.object({
         tenantId: v.string(),
+        functionTenantId: v.optional(v.string()),
         functionId: v.string(),
 
         payload: v.record(v.any()),
         egressPolicy: v.optional(
           v.object({
-            allowedIps: v.optional(v.array(v.string())),
-            allowedHosts: v.optional(v.array(v.string()))
+            direction: v.literal('egress'),
+            entries: v.array(
+              v.object({
+                cidr: v.string(),
+                portRange: v.optional(
+                  v.object({
+                    from: v.number(),
+                    to: v.number()
+                  })
+                )
+              })
+            )
           })
         ),
 
         enclave: v.optional(
           v.object({
-            tenantId: v.string(),
             identifier: v.string()
           })
         )
@@ -118,6 +128,7 @@ export let functionController = app.controller({
         await functionInvocationService.invokeFunction({
           functionId: ctx.input.functionId,
           tenantId: ctx.input.tenantId,
+          functionTenantId: ctx.input.functionTenantId,
           payload: ctx.input.payload,
           egressPolicy: ctx.input.egressPolicy,
           enclave: ctx.input.enclave

--- a/src/systems/function-bay/service/src/controllers/tests/function.e2e.test.ts
+++ b/src/systems/function-bay/service/src/controllers/tests/function.e2e.test.ts
@@ -215,7 +215,8 @@ describe('function:invoke E2E', () => {
     });
 
     const result = await functionBayClient.function.invoke({
-      tenantId: sourceVersion.function.tenant.id,
+      tenantId: enclaveTenant.id,
+      functionTenantId: sourceVersion.function.tenant.id,
       functionId: sourceVersion.function.id,
       payload: { input: 'test' },
       enclave: {
@@ -260,7 +261,8 @@ describe('function:invoke E2E', () => {
     });
 
     const result = await functionBayClient.function.invoke({
-      tenantId: sourceVersion.function.tenant.id,
+      tenantId: enclaveTenant.id,
+      functionTenantId: sourceVersion.function.tenant.id,
       functionId: sourceVersion.function.id,
       payload: { input: 'test' },
       enclave: {
@@ -340,7 +342,8 @@ describe('function:invoke E2E', () => {
     });
 
     const result = await functionBayClient.function.invoke({
-      tenantId: sourceVersion.function.tenant.id,
+      tenantId: enclaveTenant.id,
+      functionTenantId: sourceVersion.function.tenant.id,
       functionId: sourceVersion.function.id,
       payload: { input: 'test' },
       enclave: {

--- a/src/systems/function-bay/service/src/controllers/tests/function.e2e.test.ts
+++ b/src/systems/function-bay/service/src/controllers/tests/function.e2e.test.ts
@@ -219,7 +219,6 @@ describe('function:invoke E2E', () => {
       functionId: sourceVersion.function.id,
       payload: { input: 'test' },
       enclave: {
-        tenantId: enclaveTenant.id,
         identifier: 'customer-a'
       }
     });
@@ -265,7 +264,6 @@ describe('function:invoke E2E', () => {
       functionId: sourceVersion.function.id,
       payload: { input: 'test' },
       enclave: {
-        tenantId: enclaveTenant.id,
         identifier: 'customer-a'
       }
     });
@@ -346,7 +344,6 @@ describe('function:invoke E2E', () => {
       functionId: sourceVersion.function.id,
       payload: { input: 'test' },
       enclave: {
-        tenantId: enclaveTenant.id,
         identifier: 'customer-a'
       }
     });
@@ -358,6 +355,45 @@ describe('function:invoke E2E', () => {
         function: expect.objectContaining({ id: cloneFunction.id }),
         functionVersion: expect.objectContaining({ id: cloneVersion.id }),
         providerData: expect.objectContaining({ functionName: 'override-function' })
+      })
+    );
+  });
+
+  it('supports invoking a shared function through a tenant-scoped runtime context', async () => {
+    const version = await f.functionVersion.complete();
+    const runtimeTenant = await f.tenant.withIdentifier('runtime-tenant');
+    const egressPolicy = {
+      direction: 'egress' as const,
+      entries: [
+        {
+          cidr: '203.0.113.10/32',
+          portRange: { from: 443, to: 443 }
+        }
+      ]
+    };
+
+    providerMocks.invokeFunction.mockResolvedValue({
+      type: 'success',
+      result: { ok: true },
+      logs: [],
+      computeTimeMs: 10,
+      billedTimeMs: 10
+    });
+
+    await functionBayClient.function.invoke({
+      tenantId: runtimeTenant.id,
+      functionTenantId: version.function.tenant.id,
+      functionId: version.function.id,
+      payload: { input: 'test' },
+      egressPolicy
+    });
+
+    expect(providerMocks.invokeFunction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: runtimeTenant.id,
+        function: expect.objectContaining({ id: version.function.id }),
+        functionVersion: expect.objectContaining({ id: version.id }),
+        egressPolicy
       })
     );
   });

--- a/src/systems/function-bay/service/src/db.ts
+++ b/src/systems/function-bay/service/src/db.ts
@@ -33,6 +33,26 @@ export let db = baseClient;
 
 declare global {
   namespace PrismaJson {
+    type PortRange = {
+      from: number;
+      to: number;
+    };
+
+    type CompiledNetworkAllowEntry = {
+      cidr: string;
+      portRange?: PortRange;
+    };
+
+    type CompiledNetworkAllowList = {
+      direction: 'ingress' | 'egress';
+      entries: CompiledNetworkAllowEntry[];
+    };
+
+    type CompiledEgressNetworkAllowList = {
+      direction: 'egress';
+      entries: CompiledNetworkAllowEntry[];
+    };
+
     interface FunctionConfiguration {
       memorySizeMb: number;
       timeoutSeconds: number;

--- a/src/systems/function-bay/service/src/providers/_lib.ts
+++ b/src/systems/function-bay/service/src/providers/_lib.ts
@@ -58,10 +58,7 @@ export interface FunctionInvocationParams {
   payload: Record<string, any>;
   providerData: any;
   functionBundle?: FunctionBundle | null;
-  egressPolicy?: {
-    allowedIps?: string[];
-    allowedHosts?: string[];
-  };
+  egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
 }
 
 export abstract class ProviderAdapter {

--- a/src/systems/function-bay/service/src/providers/aws-lambda/deflector.test.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/deflector.test.ts
@@ -28,8 +28,13 @@ describe('deflector token', () => {
         identifier: 'preview'
       },
       egressPolicy: {
-        allowedHosts: ['api.example.com'],
-        allowedIps: ['203.0.113.10']
+        direction: 'egress',
+        entries: [
+          {
+            cidr: '203.0.113.10/32',
+            portRange: { from: 443, to: 443 }
+          }
+        ]
       }
     });
 
@@ -49,8 +54,15 @@ describe('deflector token', () => {
       functionVersionId: 'functionVersion_123',
       enclaveId: 'enclave_123',
       enclaveIdentifier: 'preview',
-      allowedHosts: ['api.example.com'],
-      allowedIps: ['203.0.113.10']
+      egressPolicy: {
+        direction: 'egress',
+        entries: [
+          {
+            cidr: '203.0.113.10/32',
+            portRange: { from: 443, to: 443 }
+          }
+        ]
+      }
     });
   });
 

--- a/src/systems/function-bay/service/src/providers/aws-lambda/deflector.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/deflector.ts
@@ -15,10 +15,7 @@ export let createDeflectorToken = async (d: {
     id: string;
     identifier: string;
   };
-  egressPolicy?: {
-    allowedIps?: string[];
-    allowedHosts?: string[];
-  };
+  egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
 }) => {
   if (!jwtSecret) return undefined;
 
@@ -30,8 +27,7 @@ export let createDeflectorToken = async (d: {
     functionVersionId: string;
     enclaveId?: string;
     enclaveIdentifier?: string;
-    allowedIps?: string[];
-    allowedHosts?: string[];
+    egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
   } = {
     aud: env.deflector.DEFLECTOR_JWT_AUDIENCE ?? 'deflector',
     sub: d.functionVersionId,
@@ -46,11 +42,8 @@ export let createDeflectorToken = async (d: {
     exp: now + 5 * 60
   };
 
-  if (d.egressPolicy?.allowedIps !== undefined) {
-    payload.allowedIps = d.egressPolicy.allowedIps;
-  }
-  if (d.egressPolicy?.allowedHosts !== undefined) {
-    payload.allowedHosts = d.egressPolicy.allowedHosts;
+  if (d.egressPolicy !== undefined) {
+    payload.egressPolicy = d.egressPolicy;
   }
 
   return await new SignJWT(payload)

--- a/src/systems/function-bay/service/src/providers/aws-lambda/invoke.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/invoke.ts
@@ -47,10 +47,7 @@ export let invokeFunction = async (d: {
     identifier: string;
   };
   payload: Record<string, any>;
-  egressPolicy?: {
-    allowedIps?: string[];
-    allowedHosts?: string[];
-  };
+  egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
   providerData: {
     functionArn: string;
     functionName: string;

--- a/src/systems/function-bay/service/src/services/enclave.ts
+++ b/src/systems/function-bay/service/src/services/enclave.ts
@@ -112,14 +112,14 @@ class enclaveServiceImpl {
   }
 
   async resolveInvocationOverride(d: {
+    tenantId: string;
     enclave: {
-      tenantId: string;
       identifier: string;
     };
     function: Function;
     sourceVersion: FunctionVersion;
   }) {
-    let tenant = await tenantService.getTenantById({ id: d.enclave.tenantId });
+    let tenant = await tenantService.getTenantById({ id: d.tenantId });
 
     let enclave = await this.getOrCreateEnclave({
       tenantOid: tenant.oid,

--- a/src/systems/function-bay/service/src/services/functionInvocation.ts
+++ b/src/systems/function-bay/service/src/services/functionInvocation.ts
@@ -39,20 +39,17 @@ let getFunctionData = createLocallyCachedFunction({
 class functionInvocationServiceImpl {
   async invokeFunction(d: {
     tenantId: string;
+    functionTenantId?: string;
     functionId: string;
     versionId?: string;
     payload: Record<string, any>;
-    egressPolicy?: {
-      allowedIps?: string[];
-      allowedHosts?: string[];
-    };
+    egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
     enclave?: {
-      tenantId: string;
       identifier: string;
     };
   }): Promise<FunctionInvokeResponse> {
     let func = await getFunctionData({
-      tenantId: d.tenantId,
+      tenantId: d.functionTenantId ?? d.tenantId,
       functionId: d.functionId,
       versionId: d.versionId
     });
@@ -75,6 +72,7 @@ class functionInvocationServiceImpl {
 
     let invocationTarget = d.enclave
       ? await enclaveService.resolveInvocationOverride({
+          tenantId: d.tenantId,
           enclave: d.enclave,
           function: func,
           sourceVersion: version

--- a/src/systems/slates/apps/hub/prisma/schema/tenant.prisma
+++ b/src/systems/slates/apps/hub/prisma/schema/tenant.prisma
@@ -7,6 +7,8 @@ model Tenant {
 
   signalTenantId String? @unique
   nebulaTenantId String?
+  functionBayTenantId String?
+  functionBayTenantIdentifier String?
 
   logRetentionInDays Int @default(30)
 

--- a/src/systems/slates/apps/hub/src/apis/internal/slateSessionToolCall.ts
+++ b/src/systems/slates/apps/hub/src/apis/internal/slateSessionToolCall.ts
@@ -51,6 +51,23 @@ export let slateSessionToolCallController = app.controller({
           sessionId: v.string(),
           toolId: v.string(),
           authConfigId: v.optional(v.string()),
+          enclaveId: v.optional(v.string()),
+          egressPolicy: v.optional(
+            v.object({
+              direction: v.literal('egress'),
+              entries: v.array(
+                v.object({
+                  cidr: v.string(),
+                  portRange: v.optional(
+                    v.object({
+                      from: v.number(),
+                      to: v.number()
+                    })
+                  )
+                })
+              )
+            })
+          ),
           input: v.record(v.any()),
           participants: v.array(
             v.object({
@@ -71,6 +88,8 @@ export let slateSessionToolCallController = app.controller({
           sessionId: ctx.input.sessionId,
           toolId: ctx.input.toolId,
           authConfigId: ctx.input.authConfigId,
+          enclaveId: ctx.input.enclaveId,
+          egressPolicy: ctx.input.egressPolicy,
           input: ctx.input.input,
           participants: ctx.input.participants
         }

--- a/src/systems/slates/apps/hub/src/db.ts
+++ b/src/systems/slates/apps/hub/src/db.ts
@@ -37,6 +37,26 @@ export let db = baseClient;
 
 declare global {
   namespace PrismaJson {
+    type PortRange = {
+      from: number;
+      to: number;
+    };
+
+    type CompiledNetworkAllowEntry = {
+      cidr: string;
+      portRange?: PortRange;
+    };
+
+    type CompiledNetworkAllowList = {
+      direction: 'ingress' | 'egress';
+      entries: CompiledNetworkAllowEntry[];
+    };
+
+    type CompiledEgressNetworkAllowList = {
+      direction: 'egress';
+      entries: CompiledNetworkAllowEntry[];
+    };
+
     interface SlateJson {
       name: string;
       version: string;

--- a/src/systems/slates/apps/hub/src/functionBay.ts
+++ b/src/systems/slates/apps/hub/src/functionBay.ts
@@ -1,6 +1,7 @@
 import { delay } from '@lowerdeck/delay';
 import { ProgrammablePromise } from '@lowerdeck/programmable-promise';
 import { createFunctionBayClient } from '@metorial-platform-systems/function-bay-client';
+import type { Tenant } from '../prisma/generated/client';
 import { db } from './db';
 import { env } from './env';
 import { getId } from './id';
@@ -50,3 +51,30 @@ export let functionBayProvider = await db.deploymentProvider.upsert({
     await delay(5000);
   }
 })();
+
+export let getFunctionBayTenantForTenant = async (
+  tenant: Pick<
+    Tenant,
+    'oid' | 'identifier' | 'name' | 'functionBayTenantId' | 'functionBayTenantIdentifier'
+  >
+) => {
+  if (!tenant.functionBayTenantId) {
+    let functionBayTenant = await functionBay.tenant.upsert({
+      identifier: tenant.identifier,
+      name: tenant.name
+    });
+
+    tenant = await db.tenant.update({
+      where: { oid: tenant.oid },
+      data: {
+        functionBayTenantId: functionBayTenant.id,
+        functionBayTenantIdentifier: functionBayTenant.identifier
+      }
+    });
+  }
+
+  return {
+    id: tenant.functionBayTenantId!,
+    identifier: tenant.functionBayTenantIdentifier!
+  };
+};

--- a/src/systems/slates/apps/hub/src/lib/invocation/stack.ts
+++ b/src/systems/slates/apps/hub/src/lib/invocation/stack.ts
@@ -11,7 +11,11 @@ import type {
 import z from 'zod';
 import type { SlateInvocation, SlateVersion } from '../../../prisma/generated/client';
 import { db } from '../../db';
-import { functionBay, functionBayTenant } from '../../functionBay';
+import {
+  functionBay,
+  functionBayTenant,
+  getFunctionBayTenantForTenant
+} from '../../functionBay';
 import { hub } from '../../hub';
 import { ID, snowflake } from '../../id';
 import { invocationsBucketRecord } from '../../storage';
@@ -36,6 +40,9 @@ export class SlateInvocationStack {
   #initialMessages: SlatesRequest[];
   #slateVersion: SlateVersion;
   #participants: SlatesParticipant[];
+  #tenant?: SlateInvocationBaseParams['tenant'];
+  #enclaveId?: string;
+  #egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
   #productiveMessages: SlatesRequest[] = [];
   #alreadyInvoked = false;
   #runPromise: ReturnType<typeof this.run>;
@@ -44,6 +51,9 @@ export class SlateInvocationStack {
     this.#initialMessages = d.initialMessages ?? [];
     this.#slateVersion = d.slateVersion;
     this.#participants = d.participants;
+    this.#tenant = d.tenant;
+    this.#enclaveId = d.enclaveId;
+    this.#egressPolicy = d.egressPolicy;
 
     this.#runPromise = this.run();
   }
@@ -78,11 +88,19 @@ export class SlateInvocationStack {
     ];
 
     let invocationId = await ID.generateId('slateInvocation');
+    let [runtimeTenant, deploymentTenant] = await Promise.all([
+      this.#tenant ? getFunctionBayTenantForTenant(this.#tenant) : functionBayTenant,
+      functionBayTenant
+    ]);
     let [providerInvocation, invocationRecord] = await Promise.all([
       functionBay.function.invoke({
-        tenantId: (await functionBayTenant).id,
+        tenantId: runtimeTenant.id,
+        functionTenantId: deploymentTenant.id,
         functionId: this.#slateVersion.providerDeploymentInfo.functionId,
-        payload: { messages, invocationId }
+        payload: { messages, invocationId },
+        enclave:
+          this.#enclaveId && runtimeTenant ? { identifier: this.#enclaveId } : undefined,
+        egressPolicy: this.#egressPolicy
       }),
       db.slateInvocation.create({
         data: {

--- a/src/systems/slates/apps/hub/src/lib/invocation/stack.ts
+++ b/src/systems/slates/apps/hub/src/lib/invocation/stack.ts
@@ -297,8 +297,11 @@ export class SlateInvocationStack {
       );
 
       return new SlateInvocationStack({
+        tenant: this.#tenant,
         slateVersion: this.#slateVersion,
         participants: this.#participants,
+        enclaveId: this.#enclaveId,
+        egressPolicy: this.#egressPolicy,
         initialMessages: this.#initialMessages
       }).invoke(method, params);
     }

--- a/src/systems/slates/apps/hub/src/lib/invocation/types.ts
+++ b/src/systems/slates/apps/hub/src/lib/invocation/types.ts
@@ -7,12 +7,18 @@ import type {
   slatesResponsesByMethod
 } from '@slates/proto';
 import type z from 'zod';
-import type { SlateInvocation, SlateVersion } from '../../../prisma/generated/client';
+import type { SlateInvocation, SlateVersion, Tenant } from '../../../prisma/generated/client';
 import type { SlateInvocationProviderMetadata } from './store';
 
 export interface SlateInvocationBaseParams {
+  tenant?: Pick<
+    Tenant,
+    'oid' | 'identifier' | 'name' | 'functionBayTenantId' | 'functionBayTenantIdentifier'
+  >;
   slateVersion: SlateVersion;
   participants: SlatesParticipant[];
+  enclaveId?: string;
+  egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
 }
 
 export type SlatesRequest = SlatesNotifications | SlatesRequests;

--- a/src/systems/slates/apps/hub/src/services/slateSessionToolCall.ts
+++ b/src/systems/slates/apps/hub/src/services/slateSessionToolCall.ts
@@ -53,6 +53,8 @@ class slateSessionToolCallServiceImpl {
 
       toolId: string;
       authConfigId?: string;
+      enclaveId?: string;
+      egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
       input: Record<string, any>;
       participants: SlatesParticipant[];
     };
@@ -160,8 +162,11 @@ class slateSessionToolCallServiceImpl {
     let startTime = Date.now();
 
     let stack = await slateInvocationService.createInvocationWithState({
+      tenant: session.tenant,
       participants: d.input.participants,
       slateVersion: session.slateVersion,
+      enclaveId: d.input.enclaveId,
+      egressPolicy: d.input.egressPolicy,
 
       config: session.slateInstance.currentConfig.value ?? {},
       session: { id: session.id, state: {} },

--- a/src/systems/subspace/db/src/db.ts
+++ b/src/systems/subspace/db/src/db.ts
@@ -264,6 +264,11 @@ declare global {
       entries: CompiledNetworkAllowEntry[];
     };
 
+    type CompiledEgressNetworkAllowList = {
+      direction: 'egress';
+      entries: CompiledNetworkAllowEntry[];
+    };
+
     type CompiledNetworkRules = {
       ingress: CompiledNetworkAllowList;
       egress: CompiledNetworkAllowList;

--- a/src/systems/subspace/modules/custom-provider/src/origin.ts
+++ b/src/systems/subspace/modules/custom-provider/src/origin.ts
@@ -21,7 +21,7 @@ export let origin: ReturnType<typeof createOriginClient> = createOriginClient({
       console.error('Failed to connect to Origin, retrying in 5 seconds...', error);
     }
 
-    delay(5000);
+    await delay(5000);
   }
 })();
 

--- a/src/systems/subspace/modules/enclave/src/functionBay.ts
+++ b/src/systems/subspace/modules/enclave/src/functionBay.ts
@@ -21,7 +21,7 @@ export let functionBay: ReturnType<typeof createFunctionBayClient> = createFunct
       console.error('Failed to connect to FunctionBay, retrying in 5 seconds...', error);
     }
 
-    delay(5000);
+    await delay(5000);
   }
 })();
 

--- a/src/systems/subspace/modules/search/src/index.ts
+++ b/src/systems/subspace/modules/search/src/index.ts
@@ -30,7 +30,7 @@ export let voyagerSource = voyagerSourceProm.promise;
       console.error('Failed to create source in Voyager, retrying in 5 seconds...', error);
     }
 
-    delay(5000);
+    await delay(5000);
   }
 })();
 

--- a/src/systems/subspace/provider-backends/provider-shuttle/src/client.ts
+++ b/src/systems/subspace/provider-backends/provider-shuttle/src/client.ts
@@ -29,7 +29,7 @@ export let shuttleLiveClient = await createLiveConnectionClient({
       console.error('Failed to connect to Shuttle, retrying in 5 seconds...', error);
     }
 
-    delay(5000);
+    await delay(5000);
   }
 })();
 

--- a/src/systems/subspace/provider-backends/provider-slates/package.json
+++ b/src/systems/subspace/provider-backends/provider-slates/package.json
@@ -28,6 +28,7 @@
     "@metorial-platform-systems/slates-client": "^1.0.0",
     "@metorial-subspace/db": "^1.0.0",
     "@metorial-subspace/module-catalog": "^1.0.0",
+    "@metorial-subspace/module-enclave": "^1.0.0",
     "@metorial-subspace/module-provider-internal": "^1.0.0",
     "@metorial-subspace/provider-utils": "^1.0.0",
     "p-queue": "^9.1.0"

--- a/src/systems/subspace/provider-backends/provider-slates/src/client.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/client.ts
@@ -21,7 +21,7 @@ export let slates = createSlatesHubInternalClient({
       console.error('Failed to connect to Slates, retrying in 5 seconds...', error);
     }
 
-    delay(5000);
+    await delay(5000);
   }
 })();
 

--- a/src/systems/subspace/provider-backends/provider-slates/src/impl/run.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/impl/run.ts
@@ -4,6 +4,7 @@ import {
   snowflake,
   type SlateSession
 } from '@metorial-subspace/db';
+import { enclaveService } from '@metorial-subspace/module-enclave';
 import type {
   HandleMcpNotificationOrRequestParam,
   HandleMcpNotificationOrRequestRes,
@@ -104,6 +105,13 @@ export class ProviderRun extends IProviderRun {
 }
 
 export class ProviderRunConnection extends IProviderRunConnection {
+  private enclaveInvocationContextPromise:
+    | Promise<{
+        enclaveId?: string;
+        egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
+      }>
+    | null = null;
+
   constructor(
     private readonly params: ProviderRunCreateParam,
     private readonly slateSession: SlateSession
@@ -117,6 +125,37 @@ export class ProviderRunConnection extends IProviderRunConnection {
 
   private get tenant() {
     return this.params.tenant;
+  }
+
+  private async getEnclaveInvocationContext() {
+    if (!this.enclaveInvocationContextPromise) {
+      this.enclaveInvocationContextPromise = (async () => {
+        let providerDeployment = await db.providerDeployment.findUnique({
+          where: { oid: this.params.providerDeployment.oid },
+          include: {
+            environment: true,
+            enclave: true
+          }
+        });
+
+        if (!providerDeployment?.enclave) {
+          return {};
+        }
+
+        let compiledNetworkRules = await enclaveService.getCompiledNetworkRules({
+          tenant: this.params.tenant,
+          environment: providerDeployment.environment,
+          enclave: providerDeployment.enclave
+        });
+
+        return {
+          enclaveId: providerDeployment.enclave.id,
+          egressPolicy: compiledNetworkRules.egress as PrismaJson.CompiledEgressNetworkAllowList
+        };
+      })();
+    }
+
+    return this.enclaveInvocationContextPromise;
   }
 
   override async handleMcpResponseOrNotification(
@@ -139,6 +178,7 @@ export class ProviderRunConnection extends IProviderRunConnection {
           where: { oid: this.providerAuthConfigVersion.slateAuthConfigOid }
         })
       : null;
+    let enclaveInvocationContext = await this.getEnclaveInvocationContext();
 
     let input = await messageInputToToolCall(data.input, data.message);
 
@@ -147,6 +187,8 @@ export class ProviderRunConnection extends IProviderRunConnection {
       toolId: data.tool.callableId,
       sessionId: this.slateSession.id,
       authConfigId: slateAuthConfig?.id,
+      enclaveId: enclaveInvocationContext.enclaveId,
+      egressPolicy: enclaveInvocationContext.egressPolicy,
 
       input,
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes egress authorization (JWT, proxy, and API contract) and cross-tenant invoke semantics; misconfiguration could block legitimate traffic or widen egress if policies are wrong.
> 
> **Overview**
> This PR wires **enclave-scoped Slates tool runs** through to Function Bay with **compiled egress network policy**, and aligns **deflector** enforcement with that model.
> 
> **Egress policy shape and enforcement:** JWT claims and invoke APIs drop `allowedIps` / `allowedHosts` in favor of an **`egressPolicy`** list (direction `egress`, CIDR entries, optional port ranges). Deflector compiles that into prefix/port checks via **`AllowsDestination(ip, port)`** after DNS resolution; host-only allowlists are removed. Deflector JWTs and Lambda invoke pass the new structure unchanged.
> 
> **Invocation tenancy:** `function.invoke` gains optional **`functionTenantId`** so the **runtime tenant** (`tenantId`) can differ from the tenant that owns the deployed function—used for enclave overrides and shared deployments. Enclave resolution uses **`tenantId`** only (no `enclave.tenantId` on the request).
> 
> **Slates hub:** Tool-call and invocation stacks accept **`enclaveId`** and **`egressPolicy`**, persist per-hub **Function Bay tenant** mappings on `Tenant`, and invoke with runtime vs deployment tenants. **Subspace** Slates provider loads enclave + compiled rules from the deployment and forwards them on `slateSessionToolCall.call`.
> 
> **Other:** Shared `CompiledEgressNetworkAllowList` Prisma JSON types; several startup retry loops **`await delay(5000)`** correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 160ececb00451f505d641f49e61c36be15b0d4db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->