### PR TITLE
Add ingress protection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3039,6 +3039,7 @@
         "@metorial-subspace/generator": "^1.0.0",
         "@metorial-subspace/list-utils": "^1.0.0",
         "@metorial-subspace/module-agent": "^1.0.0",
+        "@metorial-subspace/module-enclave": "^1.0.0",
         "@metorial-subspace/module-provider-internal": "^1.0.0",
         "@metorial-subspace/provider": "^1.0.0",
         "@metorial-subspace/redis-url": "^1.0.0",

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_networks.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_networks.ts
@@ -102,7 +102,7 @@ export class MetorialDashboardInstanceNetworksEndpoint {
 
   /**
    * @name List network logs
-   * @description Returns egress network logs for enclaves in the instance environment.
+   * @description Returns ingress or egress network logs for enclaves in the instance environment.
    *
    * @param `instanceId` - string
    * @param `query` - DashboardInstanceNetworksListNetworkLogsQuery

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/management_instance_networks.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/management_instance_networks.ts
@@ -102,7 +102,7 @@ export class MetorialManagementInstanceNetworksEndpoint {
 
   /**
    * @name List network logs
-   * @description Returns egress network logs for enclaves in the instance environment.
+   * @description Returns ingress or egress network logs for enclaves in the instance environment.
    *
    * @param `instanceId` - string
    * @param `query` - DashboardInstanceNetworksListNetworkLogsQuery

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/networks.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/networks.ts
@@ -98,7 +98,7 @@ export class MetorialNetworksEndpoint {
 
   /**
    * @name List network logs
-   * @description Returns egress network logs for enclaves in the instance environment.
+   * @description Returns ingress or egress network logs for enclaves in the instance environment.
    *
    * @param `query` - DashboardInstanceNetworksListNetworkLogsQuery
    * @param `opts` - { headers?: Record<string, string> }

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/networks/list-network-logs.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/networks/list-network-logs.ts
@@ -2,15 +2,18 @@ import { mtMap } from '@metorial/util-resource-mapper';
 
 export type DashboardInstanceNetworksListNetworkLogsOutput = {
   object: 'network.logs';
+  direction: 'ingress' | 'egress';
   enclaveIds: string[];
   records: {
     object: 'network.log';
+    direction: 'ingress' | 'egress';
     enclaveId: string;
     bucketStart: string;
     hostname: string;
     ip: string;
     port: number;
     count: number;
+    result?: 'allowed' | 'denied' | undefined;
     firstSeenAt: string;
     lastSeenAt: string;
   }[];
@@ -19,6 +22,7 @@ export type DashboardInstanceNetworksListNetworkLogsOutput = {
 export let mapDashboardInstanceNetworksListNetworkLogsOutput =
   mtMap.object<DashboardInstanceNetworksListNetworkLogsOutput>({
     object: mtMap.objectField('object', mtMap.passthrough()),
+    direction: mtMap.objectField('direction', mtMap.passthrough()),
     enclaveIds: mtMap.objectField(
       'enclave_ids',
       mtMap.array(mtMap.passthrough())
@@ -28,12 +32,14 @@ export let mapDashboardInstanceNetworksListNetworkLogsOutput =
       mtMap.array(
         mtMap.object({
           object: mtMap.objectField('object', mtMap.passthrough()),
+          direction: mtMap.objectField('direction', mtMap.passthrough()),
           enclaveId: mtMap.objectField('enclave_id', mtMap.passthrough()),
           bucketStart: mtMap.objectField('bucket_start', mtMap.passthrough()),
           hostname: mtMap.objectField('hostname', mtMap.passthrough()),
           ip: mtMap.objectField('ip', mtMap.passthrough()),
           port: mtMap.objectField('port', mtMap.passthrough()),
           count: mtMap.objectField('count', mtMap.passthrough()),
+          result: mtMap.objectField('result', mtMap.passthrough()),
           firstSeenAt: mtMap.objectField('first_seen_at', mtMap.passthrough()),
           lastSeenAt: mtMap.objectField('last_seen_at', mtMap.passthrough())
         })
@@ -42,6 +48,7 @@ export let mapDashboardInstanceNetworksListNetworkLogsOutput =
   });
 
 export type DashboardInstanceNetworksListNetworkLogsQuery = {
+  direction: 'ingress' | 'egress';
   enclaveId?: string | string[] | undefined;
   hostname?: string | string[] | undefined;
   ip?: string | string[] | undefined;
@@ -52,6 +59,7 @@ export type DashboardInstanceNetworksListNetworkLogsQuery = {
 
 export let mapDashboardInstanceNetworksListNetworkLogsQuery =
   mtMap.object<DashboardInstanceNetworksListNetworkLogsQuery>({
+    direction: mtMap.objectField('direction', mtMap.passthrough()),
     enclaveId: mtMap.objectField(
       'enclave_id',
       mtMap.union([

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/networks/list-network-logs.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/networks/list-network-logs.ts
@@ -2,15 +2,18 @@ import { mtMap } from '@metorial/util-resource-mapper';
 
 export type ManagementInstanceNetworksListNetworkLogsOutput = {
   object: 'network.logs';
+  direction: 'ingress' | 'egress';
   enclaveIds: string[];
   records: {
     object: 'network.log';
+    direction: 'ingress' | 'egress';
     enclaveId: string;
     bucketStart: string;
     hostname: string;
     ip: string;
     port: number;
     count: number;
+    result?: 'allowed' | 'denied' | undefined;
     firstSeenAt: string;
     lastSeenAt: string;
   }[];
@@ -19,6 +22,7 @@ export type ManagementInstanceNetworksListNetworkLogsOutput = {
 export let mapManagementInstanceNetworksListNetworkLogsOutput =
   mtMap.object<ManagementInstanceNetworksListNetworkLogsOutput>({
     object: mtMap.objectField('object', mtMap.passthrough()),
+    direction: mtMap.objectField('direction', mtMap.passthrough()),
     enclaveIds: mtMap.objectField(
       'enclave_ids',
       mtMap.array(mtMap.passthrough())
@@ -28,12 +32,14 @@ export let mapManagementInstanceNetworksListNetworkLogsOutput =
       mtMap.array(
         mtMap.object({
           object: mtMap.objectField('object', mtMap.passthrough()),
+          direction: mtMap.objectField('direction', mtMap.passthrough()),
           enclaveId: mtMap.objectField('enclave_id', mtMap.passthrough()),
           bucketStart: mtMap.objectField('bucket_start', mtMap.passthrough()),
           hostname: mtMap.objectField('hostname', mtMap.passthrough()),
           ip: mtMap.objectField('ip', mtMap.passthrough()),
           port: mtMap.objectField('port', mtMap.passthrough()),
           count: mtMap.objectField('count', mtMap.passthrough()),
+          result: mtMap.objectField('result', mtMap.passthrough()),
           firstSeenAt: mtMap.objectField('first_seen_at', mtMap.passthrough()),
           lastSeenAt: mtMap.objectField('last_seen_at', mtMap.passthrough())
         })
@@ -42,6 +48,7 @@ export let mapManagementInstanceNetworksListNetworkLogsOutput =
   });
 
 export type ManagementInstanceNetworksListNetworkLogsQuery = {
+  direction: 'ingress' | 'egress';
   enclaveId?: string | string[] | undefined;
   hostname?: string | string[] | undefined;
   ip?: string | string[] | undefined;
@@ -52,6 +59,7 @@ export type ManagementInstanceNetworksListNetworkLogsQuery = {
 
 export let mapManagementInstanceNetworksListNetworkLogsQuery =
   mtMap.object<ManagementInstanceNetworksListNetworkLogsQuery>({
+    direction: mtMap.objectField('direction', mtMap.passthrough()),
     enclaveId: mtMap.objectField(
       'enclave_id',
       mtMap.union([

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/networks/list-network-logs.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/networks/list-network-logs.ts
@@ -2,15 +2,18 @@ import { mtMap } from '@metorial/util-resource-mapper';
 
 export type NetworksListNetworkLogsOutput = {
   object: 'network.logs';
+  direction: 'ingress' | 'egress';
   enclaveIds: string[];
   records: {
     object: 'network.log';
+    direction: 'ingress' | 'egress';
     enclaveId: string;
     bucketStart: string;
     hostname: string;
     ip: string;
     port: number;
     count: number;
+    result?: 'allowed' | 'denied' | undefined;
     firstSeenAt: string;
     lastSeenAt: string;
   }[];
@@ -19,6 +22,7 @@ export type NetworksListNetworkLogsOutput = {
 export let mapNetworksListNetworkLogsOutput =
   mtMap.object<NetworksListNetworkLogsOutput>({
     object: mtMap.objectField('object', mtMap.passthrough()),
+    direction: mtMap.objectField('direction', mtMap.passthrough()),
     enclaveIds: mtMap.objectField(
       'enclave_ids',
       mtMap.array(mtMap.passthrough())
@@ -28,12 +32,14 @@ export let mapNetworksListNetworkLogsOutput =
       mtMap.array(
         mtMap.object({
           object: mtMap.objectField('object', mtMap.passthrough()),
+          direction: mtMap.objectField('direction', mtMap.passthrough()),
           enclaveId: mtMap.objectField('enclave_id', mtMap.passthrough()),
           bucketStart: mtMap.objectField('bucket_start', mtMap.passthrough()),
           hostname: mtMap.objectField('hostname', mtMap.passthrough()),
           ip: mtMap.objectField('ip', mtMap.passthrough()),
           port: mtMap.objectField('port', mtMap.passthrough()),
           count: mtMap.objectField('count', mtMap.passthrough()),
+          result: mtMap.objectField('result', mtMap.passthrough()),
           firstSeenAt: mtMap.objectField('first_seen_at', mtMap.passthrough()),
           lastSeenAt: mtMap.objectField('last_seen_at', mtMap.passthrough())
         })
@@ -42,6 +48,7 @@ export let mapNetworksListNetworkLogsOutput =
   });
 
 export type NetworksListNetworkLogsQuery = {
+  direction: 'ingress' | 'egress';
   enclaveId?: string | string[] | undefined;
   hostname?: string | string[] | undefined;
   ip?: string | string[] | undefined;
@@ -52,6 +59,7 @@ export type NetworksListNetworkLogsQuery = {
 
 export let mapNetworksListNetworkLogsQuery =
   mtMap.object<NetworksListNetworkLogsQuery>({
+    direction: mtMap.objectField('direction', mtMap.passthrough()),
     enclaveId: mtMap.objectField(
       'enclave_id',
       mtMap.union([

--- a/src/backend/apis/connection/src/index.ts
+++ b/src/backend/apis/connection/src/index.ts
@@ -48,7 +48,10 @@ export let startMcpServer = (d: { port: number; authenticate: Authenticator<Auth
         }),
         async () => {
           let { instance } = await authenticateAndResolveInstance(req, url, d.authenticate);
-          return proxyMcpRequestToSubspace(c, instance, sessionId);
+          return proxyMcpRequestToSubspace(c, instance, sessionId, {
+            enforceIngressNetworkPolicy: true,
+            ingressIp: context.ip
+          });
         }
       );
     })

--- a/src/backend/apis/connection/src/magic.ts
+++ b/src/backend/apis/connection/src/magic.ts
@@ -308,6 +308,8 @@ export let handleMagicMcpRequest = async (d: {
         sessionInfo.subspaceSessionId,
         {
           agentClient: sessionInfo.agentClient,
+          enforceIngressNetworkPolicy: true,
+          ingressIp: context.ip,
           onSubspaceSessionResolved: async ({ subspaceSessionId }) => {
             let magicMcpSession = await syncMagicMcpSubspaceSession(
               sessionInfo.magicMcpTarget,

--- a/src/backend/apis/core/src/controllers/instance/network/network.ts
+++ b/src/backend/apis/core/src/controllers/instance/network/network.ts
@@ -85,13 +85,14 @@ export let networkController = Controller.create(
     listNetworkLogs: instanceGroup
       .get(instancePath('network-logs', 'networks.listNetworkLogs'), {
         name: 'List network logs',
-        description: 'Returns egress network logs for enclaves in the instance environment.'
+        description: 'Returns ingress or egress network logs for enclaves in the instance environment.'
       })
       .use(checkAccess({ possibleScopes: [...networkReadScopes] }))
       .output(networkLogsPresenter)
       .query(
         'default',
         v.object({
+          direction: v.enumOf(['ingress', 'egress']),
           enclave_id: v.optional(v.union([v.string(), v.array(v.string())])),
           hostname: v.optional(v.union([v.string(), v.array(v.string())])),
           ip: v.optional(v.union([v.string(), v.array(v.string())])),
@@ -103,6 +104,7 @@ export let networkController = Controller.create(
       .do(async ctx => {
         let logs = await subspaceEnclaveService.listNetworkLogs({
           instance: ctx.instance,
+          direction: ctx.query.direction,
           enclaveIds: normalizeArrayParam(ctx.query.enclave_id),
           hostnames: normalizeArrayParam(ctx.query.hostname),
           ips: normalizeArrayParam(ctx.query.ip),

--- a/src/backend/apis/core/src/middleware/checkFineGrainedSessionAccess.ts
+++ b/src/backend/apis/core/src/middleware/checkFineGrainedSessionAccess.ts
@@ -1,5 +1,6 @@
 import { forbiddenError, ServiceError } from '@lowerdeck/error';
 import { AuthInfo, Scope } from '@metorial/module-access';
+import { subspaceEnclaveService } from '@metorial/module-subspace';
 import { apiGroup } from './apiGroup';
 
 type FineGrainedSessionCtx = {
@@ -7,6 +8,8 @@ type FineGrainedSessionCtx = {
   params: Record<string, any>;
   query: Record<string, any>;
   body: Record<string, any>;
+  context: { ip: string };
+  url: string;
 } & Record<string, any>;
 
 let getAllowedSessionIds = (
@@ -30,7 +33,59 @@ export let getFineGrainedAllowedSessionIds = (
   requiredRoles?: Scope[]
 ) => getAllowedSessionIds(ctx, requiredRoles);
 
-let ensureSessionAllowed = (d: {
+let getFineGrainedInstance = (ctx: FineGrainedSessionCtx) => {
+  if (ctx.auth.type != 'fine_grained' || ctx.auth.restrictions.type != 'instance') {
+    return undefined;
+  }
+
+  return {
+    ...ctx.auth.restrictions.instance,
+    organization: ctx.auth.restrictions.organization
+  } as any;
+};
+
+let getRequestHost = (ctx: FineGrainedSessionCtx) => {
+  try {
+    let url = new URL(ctx.url);
+    return {
+      hostname: url.hostname,
+      port: url.port
+        ? Number(url.port)
+        : url.protocol === 'https:'
+          ? 443
+          : url.protocol === 'http:'
+            ? 80
+            : 0
+    };
+  } catch {
+    return { hostname: 'api', port: 0 };
+  }
+};
+
+let filterIngressAllowedSessionIds = async (d: {
+  ctx: FineGrainedSessionCtx;
+  sessionIds: string[];
+  recordLog?: boolean;
+}) => {
+  let instance = getFineGrainedInstance(d.ctx);
+  if (!instance || d.sessionIds.length === 0) return d.sessionIds;
+
+  let host = getRequestHost(d.ctx);
+  let check = await subspaceEnclaveService.checkIngressAccess({
+    instance,
+    sessionIds: d.sessionIds,
+    sourceIp: d.ctx.context.ip,
+    hostname: host.hostname,
+    port: host.port,
+    recordLog: d.recordLog
+  });
+
+  return check.results
+    .filter((result: any) => result.allowed)
+    .map((result: any) => result.sessionId);
+};
+
+let ensureSessionAllowed = async (d: {
   ctx: FineGrainedSessionCtx;
   sessionId: string | undefined;
   requiredRoles?: Scope[];
@@ -46,6 +101,20 @@ let ensureSessionAllowed = (d: {
       })
     );
   }
+
+  let ingressAllowedSessionIds = await filterIngressAllowedSessionIds({
+    ctx: d.ctx,
+    sessionIds: [d.sessionId],
+    recordLog: true
+  });
+
+  if (!ingressAllowedSessionIds.includes(d.sessionId)) {
+    throw new ServiceError(
+      forbiddenError({
+        message: 'Ingress network policy blocked access to this session'
+      })
+    );
+  }
 };
 
 export let requireFineGrainedSessionAccess = (d: {
@@ -54,7 +123,7 @@ export let requireFineGrainedSessionAccess = (d: {
   message?: string;
 }) =>
   apiGroup.createMiddleware(async ctx => {
-    ensureSessionAllowed({
+    await ensureSessionAllowed({
       ctx,
       sessionId: d.resolveSessionId(ctx),
       requiredRoles: d.requiredRoles,
@@ -111,12 +180,19 @@ export let constrainFineGrainedSessionQuery = (
     }
 
     if (currentValue === undefined || currentValue === null || currentValue === '') {
-      query[queryKey] = allowedSessionIds;
+      query[queryKey] = await filterIngressAllowedSessionIds({
+        ctx,
+        sessionIds: allowedSessionIds
+      });
       return;
     }
 
     let current = Array.isArray(currentValue) ? currentValue : [currentValue];
     let intersection = current.filter(v => allowedSessionIds.includes(v));
+    intersection = await filterIngressAllowedSessionIds({
+      ctx,
+      sessionIds: intersection
+    });
     if (intersection.length == 0) {
       throw new ServiceError(
         forbiddenError({

--- a/src/backend/apis/core/src/presenters/implementation/network/networkLogs.ts
+++ b/src/backend/apis/core/src/presenters/implementation/network/networkLogs.ts
@@ -4,12 +4,14 @@ import { networkLogsType } from '../../types';
 
 let networkLogRecordSchema = v.object({
   object: v.literal('network.log'),
+  direction: v.enumOf(['ingress', 'egress']),
   enclave_id: v.string(),
   bucket_start: v.string(),
   hostname: v.string(),
   ip: v.string(),
   port: v.number(),
   count: v.number(),
+  result: v.optional(v.enumOf(['allowed', 'denied'])),
   first_seen_at: v.string(),
   last_seen_at: v.string()
 });
@@ -17,15 +19,18 @@ let networkLogRecordSchema = v.object({
 export let v1NetworkLogsPresenter = Presenter.create(networkLogsType)
   .presenter(async ({ logs }) => ({
     object: 'network.logs' as const,
+    direction: logs.direction,
     enclave_ids: logs.enclaveIds,
     records: logs.records.map(record => ({
       object: 'network.log' as const,
+      direction: record.direction,
       enclave_id: record.enclaveId,
       bucket_start: record.bucketStart,
       hostname: record.hostname,
       ip: record.ip,
       port: record.port,
       count: record.count,
+      ...(record.result ? { result: record.result } : {}),
       first_seen_at: record.firstSeenAt,
       last_seen_at: record.lastSeenAt
     }))
@@ -33,6 +38,7 @@ export let v1NetworkLogsPresenter = Presenter.create(networkLogsType)
   .schema(
     v.object({
       object: v.literal('network.logs'),
+      direction: v.enumOf(['ingress', 'egress']),
       enclave_ids: v.array(v.string()),
       records: v.array(networkLogRecordSchema)
     })

--- a/src/backend/modules/subspace/src/proxy/index.ts
+++ b/src/backend/modules/subspace/src/proxy/index.ts
@@ -30,6 +30,8 @@ export let proxyMcpRequestToSubspace = async (
   sessionId: string,
   d?: {
     agentClient?: SubspaceProxyAgentClient | null;
+    enforceIngressNetworkPolicy?: boolean;
+    ingressIp?: string | null;
     onSubspaceSessionResolved?: (d: {
       subspaceSessionId: string;
       response: Response;
@@ -66,6 +68,11 @@ export let proxyMcpRequestToSubspace = async (
 
   if (d?.agentClient) {
     headers.set('Metorial-Agent-Client', JSON.stringify(d.agentClient));
+  }
+
+  if (d?.enforceIngressNetworkPolicy) {
+    headers.set('Metorial-Ingress-Policy-Check', 'true');
+    if (d.ingressIp) headers.set('Metorial-Ingress-IP', d.ingressIp);
   }
 
   await Fabric.fire('provider.session_message.created:before', { instance });

--- a/src/backend/modules/subspace/src/services/enclave.ts
+++ b/src/backend/modules/subspace/src/services/enclave.ts
@@ -3,7 +3,7 @@ import { subspace } from '../subspace';
 
 export let subspaceEnclaveService = createSubspaceService(
   subspace.enclave,
-  ['get', 'list', 'listNetworkLogs', 'getLastUsedEnclaves'],
+  ['get', 'list', 'listNetworkLogs', 'getLastUsedEnclaves', 'checkIngressAccess'],
   () => ({})
 );
 

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-deployment/network.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-deployment/network.tsx
@@ -25,7 +25,10 @@ export let ProviderDeploymentNetworkPage = () => {
     order: 'desc'
   });
   let firewallBindings = useFirewallBindings(instance.data?.id, { limit: 100, order: 'desc' });
-  let networkLogs = useNetworkLogs(instance.data?.id, { intervalMinutes: 60 });
+  let networkLogs = useNetworkLogs(instance.data?.id, {
+    direction: 'egress',
+    intervalMinutes: 60
+  });
   let deleteBinding = useDeleteFirewallBinding();
 
   return renderWithLoader({ deployment, enclaves, firewallBindings, networkLogs })(

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(network)/(list)/network.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(network)/(list)/network.tsx
@@ -9,7 +9,7 @@ import {
   useNetworkLogs,
   useNetworks
 } from '@metorial/state';
-import { Badge, RenderDate, Spacer, Text } from '@metorial/ui';
+import { Badge, Callout, RenderDate, Spacer, Text } from '@metorial/ui';
 import { Box, ID, Table } from '@metorial/ui-product';
 import { useMemo } from 'react';
 import { EmptyText } from '../_common';
@@ -37,9 +37,9 @@ let getHourlyBuckets = (from: Date, to: Date) => {
 let getNetworkLogSeries = (
   records: {
     bucketStart: string;
-    hostname: string;
     ip: string;
     count: number;
+    result?: 'allowed' | 'denied';
   }[],
   from: Date,
   to: Date
@@ -55,7 +55,9 @@ let getNetworkLogSeries = (
     let bucketKey = bucket.toISOString();
     if (!bucketKeys.has(bucketKey)) continue;
 
-    let groupKey = record.hostname || record.ip || 'Unknown';
+    let result = record.result === 'denied' ? 'Denied' : 'Accepted';
+    let ip = record.ip || 'Unknown IP';
+    let groupKey = `${ip} (${result})`;
     let group = grouped.get(groupKey) ?? new Map<string, number>();
     group.set(bucketKey, (group.get(bucketKey) ?? 0) + record.count);
     grouped.set(groupKey, group);
@@ -75,6 +77,16 @@ let getNetworkLogSeries = (
     .slice(0, 7);
 };
 
+let getDeniedNetworkLogCount = (
+  records: {
+    count: number;
+    result?: 'allowed' | 'denied';
+  }[]
+) =>
+  records
+    .filter(record => record.result === 'denied')
+    .reduce((sum, record) => sum + record.count, 0);
+
 export let NetworkOverviewPage = () => {
   let organization = useCurrentOrganization();
   let project = useCurrentProject();
@@ -86,7 +98,8 @@ export let NetworkOverviewPage = () => {
     () => ({
       from: range.from.toISOString(),
       to: range.to.toISOString(),
-      intervalMinutes: 60
+      intervalMinutes: 60,
+      direction: 'ingress' as const
     }),
     [range]
   );
@@ -95,18 +108,29 @@ export let NetworkOverviewPage = () => {
   return renderWithLoader({ networks, firewalls, networkLogs })(
     ({ firewalls, networkLogs }) => {
       let series = getNetworkLogSeries(networkLogs.data.records, range.from, range.to);
+      let deniedCount = getDeniedNetworkLogCount(networkLogs.data.records);
 
       return (
         <>
           <Box
             title="Recent Connections"
-            description="Connections grouped by hostname or IP in 60-minute intervals over the last 24 hours."
+            description="Ingress connections grouped by IP and result in 60-minute intervals over the last 24 hours."
           >
             {series.length > 0 ? (
               <Chart height={300} type="line" series={series} />
             ) : (
               <EmptyText>No network connections found in the last 24 hours.</EmptyText>
             )}
+
+            {deniedCount > 0 ? (
+              <>
+                <Spacer size={12} />
+                <Callout color="red">
+                  {deniedCount} ingress {deniedCount === 1 ? 'request was' : 'requests were'}{' '}
+                  denied by Metorial Magic Network policies.
+                </Callout>
+              </>
+            ) : null}
           </Box>
 
           <Spacer size={20} />

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/components/inspectorFrame.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTracing/components/inspectorFrame.tsx
@@ -189,12 +189,7 @@ export let InspectorFrame = (p: {
           >
             <BreathingIndicator />
             <span>
-              Connected via{' '}
-              {location.host.endsWith('.metorial.com') ? (
-                <i>api.metorial.com</i>
-              ) : (
-                <i>Metorial API</i>
-              )}
+              Connected via <i>Metorial Magic Network</i>
             </span>
           </Status>
         </ConnectionNavSection>

--- a/src/frontend/state/src/network/loaders/network.ts
+++ b/src/frontend/state/src/network/loaders/network.ts
@@ -70,7 +70,16 @@ export let networkLogsLoader = createLoader({
 export let useNetworkLogs = (
   instanceId: string | null | undefined,
   query?: DashboardInstanceNetworksListNetworkLogsQuery | null
-) => networkLogsLoader.use(instanceId && query !== null ? { instanceId, ...(query ?? {}) } : null);
+) => {
+  let queryWithDirection = {
+    direction: 'egress',
+    ...(query ?? {})
+  } as DashboardInstanceNetworksListNetworkLogsQuery;
+
+  return networkLogsLoader.use(
+    instanceId && query !== null ? { instanceId, ...queryWithDirection } : null
+  );
+};
 
 export let enclavesLoader = createLoader({
   name: 'enclaves',
@@ -296,15 +305,15 @@ export let networkPolicyLoader = createLoader({
                   description: rule.description ?? undefined,
                   enabled: rule.enabled,
                   priority: rule.priority,
-                  ports: rule.direction === 'egress' ? rule.ports ?? undefined : undefined
+                  ports: rule.direction === 'egress' ? (rule.ports ?? undefined) : undefined
                 }
           )
         })
       ),
-    deleteRule: (
-      body: { ruleId: string },
-      { input: { instanceId, networkPolicyId } }
-    ) => withAuth(sdk => sdk.networkPolicies.rules.delete(instanceId, networkPolicyId, body.ruleId))
+    deleteRule: (body: { ruleId: string }, { input: { instanceId, networkPolicyId } }) =>
+      withAuth(sdk =>
+        sdk.networkPolicies.rules.delete(instanceId, networkPolicyId, body.ruleId)
+      )
   }
 });
 

--- a/src/systems/subspace/apps/controller/src/connection/api/mcp.ts
+++ b/src/systems/subspace/apps/controller/src/connection/api/mcp.ts
@@ -46,7 +46,7 @@ export let mcpRouter = createHono().all(`/:key?`, async c => {
     c.res.headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, DELETE');
     c.res.headers.set(
       'Access-Control-Allow-Headers',
-      'Content-Type, Metorial-Proxy-URL, Metorial-Agent-Client, Metorial-Connection-Private-Metadata, MCP-Protocol-Version, MCP-Session-ID, Authorization'
+      'Content-Type, Metorial-Proxy-URL, Metorial-Agent-Client, Metorial-Connection-Private-Metadata, Metorial-Ingress-Policy-Check, Metorial-Ingress-IP, MCP-Protocol-Version, MCP-Session-ID, Authorization'
     );
     c.res.headers.set('Access-Control-Allow-Credentials', 'true');
     c.res.headers.set(
@@ -75,6 +75,14 @@ export let mcpRouter = createHono().all(`/:key?`, async c => {
     agentClient: undefined as z.infer<typeof agentClientHeaderSchema> | undefined,
     connectionPrivateMetadata: undefined as
       | z.infer<typeof privateMetadataHeaderSchema>
+      | undefined,
+    ingressPolicyCheck: undefined as
+      | {
+          sourceIp: string;
+          hostname?: string;
+          port?: number;
+          recordLog?: boolean;
+        }
       | undefined
   };
 
@@ -82,6 +90,28 @@ export let mcpRouter = createHono().all(`/:key?`, async c => {
   if (!metorialProxyUrl) {
     if (!isDev) return c.text('Missing Metorial-Proxy-URL header', 400);
     metorialProxyUrl = c.req.url;
+  }
+
+  let enforceIngressPolicy = c.req.header('metorial-ingress-policy-check') === 'true';
+  if (enforceIngressPolicy) {
+    let sourceIp = c.req.header('metorial-ingress-ip');
+    if (!sourceIp) return c.text('Missing Metorial-Ingress-IP header', 400);
+
+    let proxyUrl = new URL(metorialProxyUrl);
+    let port = proxyUrl.port
+      ? Number(proxyUrl.port)
+      : proxyUrl.protocol === 'https:'
+        ? 443
+        : proxyUrl.protocol === 'http:'
+          ? 80
+          : 0;
+
+    baseParams.ingressPolicyCheck = {
+      sourceIp,
+      hostname: proxyUrl.hostname,
+      port,
+      recordLog: true
+    };
   }
 
   let agentClientHeader = parseOptionalJsonHeader(

--- a/src/systems/subspace/apps/controller/src/controllers/enclave.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/enclave.ts
@@ -1,6 +1,10 @@
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
-import { enclaveNetworkLogService, enclaveService } from '@metorial-subspace/module-enclave';
+import {
+  enclaveIngressPolicyService,
+  enclaveNetworkLogService,
+  enclaveService
+} from '@metorial-subspace/module-enclave';
 import { enclavePresenter } from '@metorial-subspace/presenters';
 import { app } from './_app';
 import { createdAtValidator } from './_dateFilter';
@@ -105,6 +109,7 @@ export let enclaveController = app.controller({
       v.object({
         tenantId: v.string(),
         environmentId: v.string(),
+        direction: v.enumOf(['ingress', 'egress']),
         enclaveIds: v.optional(v.array(v.string())),
         hostnames: v.optional(v.array(v.string())),
         ips: v.optional(v.array(v.string())),
@@ -118,6 +123,7 @@ export let enclaveController = app.controller({
         tenant: ctx.tenant,
         environment: ctx.environment,
         solution: ctx.solution,
+        direction: ctx.input.direction,
         enclaveIds: ctx.input.enclaveIds,
         filters: {
           hostnames: ctx.input.hostnames,
@@ -126,6 +132,32 @@ export let enclaveController = app.controller({
           to: ctx.input.to,
           intervalMinutes: ctx.input.intervalMinutes
         }
+      })
+    ),
+
+  checkIngressAccess: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        sessionIds: v.array(v.string()),
+        sourceIp: v.string(),
+        hostname: v.optional(v.string()),
+        port: v.optional(v.number()),
+        recordLog: v.optional(v.boolean())
+      })
+    )
+    .do(async ctx =>
+      enclaveIngressPolicyService.checkSessionIngressAccess({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        solution: ctx.solution,
+        sessionIds: ctx.input.sessionIds,
+        sourceIp: ctx.input.sourceIp,
+        hostname: ctx.input.hostname,
+        port: ctx.input.port,
+        recordLog: ctx.input.recordLog
       })
     ),
 

--- a/src/systems/subspace/db/prisma/schema/enclave/network.prisma
+++ b/src/systems/subspace/db/prisma/schema/enclave/network.prisma
@@ -165,3 +165,38 @@ model FirewallNetworkPolicy {
 
   @@unique([firewallOid, networkPolicyOid])
 }
+
+enum EnclaveIngressNetworkLogResult {
+  allowed
+  denied
+}
+
+model EnclaveIngressNetworkLog {
+  oid BigInt @id
+  id  String @unique
+
+  enclaveOid BigInt
+  sessionId  String?
+
+  bucketStart DateTime
+
+  sourceIp String
+  hostname String
+  port     Int
+
+  result EnclaveIngressNetworkLogResult
+  count  Int @default(1)
+
+  tenantOid      BigInt
+  environmentOid BigInt
+  solutionOid    Int
+
+  firstSeenAt DateTime
+  lastSeenAt  DateTime
+  createdAt   DateTime @default(now())
+
+  @@index([tenantOid, environmentOid, bucketStart])
+  @@index([enclaveOid, bucketStart])
+  @@index([sourceIp])
+  @@index([result])
+}

--- a/src/systems/subspace/db/src/id.ts
+++ b/src/systems/subspace/db/src/id.ts
@@ -41,6 +41,7 @@ export let ID = createIdGenerator({
   networkPolicyRule: idType.sorted('npr'),
   networkPolicyVersion: idType.sorted('npv'),
   firewallNetworkPolicy: idType.sorted('fwn'),
+  enclaveIngressNetworkLog: idType.sorted('einl'),
 
   providerConfig: idType.sorted('pcf'),
   providerConfigVersion: idType.sorted('pcv'),

--- a/src/systems/subspace/modules/connection/package.json
+++ b/src/systems/subspace/modules/connection/package.json
@@ -27,6 +27,7 @@
     "@metorial-subspace/db": "^1.0.0",
     "@metorial-subspace/generator": "^1.0.0",
     "@metorial-subspace/list-utils": "^1.0.0",
+    "@metorial-subspace/module-enclave": "^1.0.0",
     "@metorial-subspace/module-agent": "^1.0.0",
     "@metorial-subspace/module-provider-internal": "^1.0.0",
     "@metorial-subspace/provider": "^1.0.0",

--- a/src/systems/subspace/modules/connection/src/sender/manager.ts
+++ b/src/systems/subspace/modules/connection/src/sender/manager.ts
@@ -34,6 +34,7 @@ import {
   agentInstanceService,
   agentService
 } from '@metorial-subspace/module-agent';
+import { enclaveIngressPolicyService } from '@metorial-subspace/module-enclave';
 import {
   checkToolAccess,
   checkToolScopesSatisfied,
@@ -109,6 +110,12 @@ export interface SenderMangerProps {
     oauthRegistrationId: string;
   };
   connectionPrivateMetadata?: Record<string, any>;
+  ingressPolicyCheck?: {
+    sourceIp: string;
+    hostname?: string;
+    port?: number;
+    recordLog?: boolean;
+  };
 }
 
 export class SenderManager {
@@ -199,6 +206,23 @@ export class SenderManager {
       throw new ServiceError(
         goneError({ message: 'Connection has been archived or deleted' })
       );
+    }
+
+    if (d.ingressPolicyCheck) {
+      let environment = await db.environment.findUniqueOrThrow({
+        where: { oid: session.environmentOid }
+      });
+
+      await enclaveIngressPolicyService.assertSessionIngressAccess({
+        tenant: session.tenant,
+        solution: session.solution,
+        environment,
+        sessionId: session.id,
+        sourceIp: d.ingressPolicyCheck.sourceIp,
+        hostname: d.ingressPolicyCheck.hostname,
+        port: d.ingressPolicyCheck.port,
+        recordLog: d.ingressPolicyCheck.recordLog
+      });
     }
 
     if (connection) {

--- a/src/systems/subspace/modules/enclave/src/lib/ingressAllowList.ts
+++ b/src/systems/subspace/modules/enclave/src/lib/ingressAllowList.ts
@@ -1,0 +1,28 @@
+import ipaddr from 'ipaddr.js';
+import type { CompiledNetworkAllowList } from './compileNetworkAllowList';
+
+export let isIpAllowedByIngressAllowList = (d: {
+  sourceIp: string;
+  ingressPolicy: CompiledNetworkAllowList | PrismaJson.CompiledNetworkAllowList;
+}) => {
+  if (d.ingressPolicy.direction !== 'ingress') return false;
+
+  let source;
+  try {
+    source = ipaddr.process(d.sourceIp);
+  } catch {
+    return false;
+  }
+
+  for (let entry of d.ingressPolicy.entries) {
+    try {
+      let [range, prefix] = ipaddr.parseCIDR(entry.cidr);
+      if (source.kind() !== range.kind()) continue;
+      if (source.match(range, prefix)) return true;
+    } catch {
+      continue;
+    }
+  }
+
+  return false;
+};

--- a/src/systems/subspace/modules/enclave/src/lib/ingressNetworkLogBuffer.ts
+++ b/src/systems/subspace/modules/enclave/src/lib/ingressNetworkLogBuffer.ts
@@ -1,0 +1,272 @@
+import { RedisClient } from 'bun';
+import { Buffer } from 'node:buffer';
+
+export type BufferedIngressNetworkLogResult = 'allowed' | 'denied';
+
+export type BufferedIngressNetworkLogDimensions = {
+  tenantOid: bigint;
+  environmentOid: bigint;
+  solutionOid: number;
+  enclaveOid: bigint;
+  sessionId: string | null;
+  sourceIp: string;
+  hostname: string;
+  port: number;
+  result: BufferedIngressNetworkLogResult;
+  bucketStart: string;
+};
+
+export type BufferedIngressNetworkLogEntry = BufferedIngressNetworkLogDimensions & {
+  count: number;
+  firstSeenAt: string;
+  lastSeenAt: string;
+};
+
+type SerializedIngressNetworkLogDimensions = Omit<
+  BufferedIngressNetworkLogDimensions,
+  'tenantOid' | 'environmentOid' | 'enclaveOid'
+> & {
+  tenantOid: string;
+  environmentOid: string;
+  enclaveOid: string;
+};
+
+let PENDING_COUNTS_KEY = 'sub:enc:ingressNetworkLog:pending:counts';
+let PENDING_META_KEY = 'sub:enc:ingressNetworkLog:pending:meta';
+let PENDING_FIRST_SEEN_KEY = 'sub:enc:ingressNetworkLog:pending:firstSeen';
+let PENDING_LAST_SEEN_KEY = 'sub:enc:ingressNetworkLog:pending:lastSeen';
+let SNAPSHOT_TTL_SECONDS = 60 * 60;
+let THIRTY_MINUTES_MS = 30 * 60 * 1000;
+
+let buffer = new Map<string, BufferedIngressNetworkLogEntry>();
+let redis: RedisClient | null = null;
+let flushTimer: ReturnType<typeof setInterval> | null = null;
+
+let getBucketStart = (date: Date) =>
+  new Date(Math.floor(date.getTime() / THIRTY_MINUTES_MS) * THIRTY_MINUTES_MS);
+
+let getRedisUrl = () => process.env.REDIS_URL;
+
+let getRedis = () => {
+  if (redis) return redis;
+
+  let redisUrl = getRedisUrl();
+  if (!redisUrl) return null;
+
+  redis = new RedisClient(redisUrl.replace('rediss://', 'redis://'), {
+    tls: redisUrl.startsWith('rediss://')
+  });
+
+  return redis;
+};
+
+let serializeDimensions = (
+  dimensions: BufferedIngressNetworkLogDimensions
+): SerializedIngressNetworkLogDimensions => ({
+  tenantOid: dimensions.tenantOid.toString(),
+  environmentOid: dimensions.environmentOid.toString(),
+  solutionOid: dimensions.solutionOid,
+  enclaveOid: dimensions.enclaveOid.toString(),
+  sessionId: dimensions.sessionId,
+  sourceIp: dimensions.sourceIp,
+  hostname: dimensions.hostname,
+  port: dimensions.port,
+  result: dimensions.result,
+  bucketStart: dimensions.bucketStart
+});
+
+let deserializeDimensions = (
+  dimensions: SerializedIngressNetworkLogDimensions
+): BufferedIngressNetworkLogDimensions => ({
+  ...dimensions,
+  tenantOid: BigInt(dimensions.tenantOid),
+  environmentOid: BigInt(dimensions.environmentOid),
+  enclaveOid: BigInt(dimensions.enclaveOid)
+});
+
+let encodeDimensions = (dimensions: BufferedIngressNetworkLogDimensions) =>
+  Buffer.from(JSON.stringify(serializeDimensions(dimensions))).toString('base64url');
+
+let decodeDimensions = (key: string) =>
+  deserializeDimensions(JSON.parse(Buffer.from(key, 'base64url').toString('utf8')));
+
+let mergeIntoBuffer = (entry: BufferedIngressNetworkLogEntry) => {
+  let key = encodeDimensions(entry);
+  let existing = buffer.get(key);
+
+  if (!existing) {
+    buffer.set(key, entry);
+    return;
+  }
+
+  existing.count += entry.count;
+  if (entry.firstSeenAt < existing.firstSeenAt) existing.firstSeenAt = entry.firstSeenAt;
+  if (entry.lastSeenAt > existing.lastSeenAt) existing.lastSeenAt = entry.lastSeenAt;
+};
+
+export let recordIngressNetworkLog = (d: {
+  tenantOid: bigint;
+  environmentOid: bigint;
+  solutionOid: number;
+  enclaveOid: bigint;
+  sessionId?: string | null;
+  sourceIp: string;
+  hostname: string;
+  port: number;
+  result: BufferedIngressNetworkLogResult;
+  at?: Date;
+}) => {
+  let seenAt = d.at ?? new Date();
+  let dimensions: BufferedIngressNetworkLogDimensions = {
+    tenantOid: d.tenantOid,
+    environmentOid: d.environmentOid,
+    solutionOid: d.solutionOid,
+    enclaveOid: d.enclaveOid,
+    sessionId: d.sessionId ?? null,
+    sourceIp: d.sourceIp,
+    hostname: d.hostname,
+    port: d.port,
+    result: d.result,
+    bucketStart: getBucketStart(seenAt).toISOString()
+  };
+
+  mergeIntoBuffer({
+    ...dimensions,
+    count: 1,
+    firstSeenAt: seenAt.toISOString(),
+    lastSeenAt: seenAt.toISOString()
+  });
+};
+
+let setEarlierDate = async (redis: RedisClient, key: string, field: string, value: string) => {
+  let existing = await redis.hget(key, field);
+  if (!existing || value < existing) await redis.hset(key, field, value);
+};
+
+let setLaterDate = async (redis: RedisClient, key: string, field: string, value: string) => {
+  let existing = await redis.hget(key, field);
+  if (!existing || value > existing) await redis.hset(key, field, value);
+};
+
+export let flushBufferedIngressNetworkLogsToRedis = async () => {
+  if (buffer.size === 0) return;
+
+  let redis = getRedis();
+  if (!redis) return;
+
+  let entries = [...buffer.entries()];
+  buffer.clear();
+
+  try {
+    for (let [key, entry] of entries) {
+      await redis.hincrby(PENDING_COUNTS_KEY, key, entry.count);
+      await redis.hset(PENDING_META_KEY, key, JSON.stringify(serializeDimensions(entry)));
+      await setEarlierDate(redis, PENDING_FIRST_SEEN_KEY, key, entry.firstSeenAt);
+      await setLaterDate(redis, PENDING_LAST_SEEN_KEY, key, entry.lastSeenAt);
+    }
+
+    await Promise.all([
+      redis.expire(PENDING_COUNTS_KEY, SNAPSHOT_TTL_SECONDS),
+      redis.expire(PENDING_META_KEY, SNAPSHOT_TTL_SECONDS),
+      redis.expire(PENDING_FIRST_SEEN_KEY, SNAPSHOT_TTL_SECONDS),
+      redis.expire(PENDING_LAST_SEEN_KEY, SNAPSHOT_TTL_SECONDS)
+    ]);
+  } catch (error) {
+    for (let [, entry] of entries) mergeIntoBuffer(entry);
+    throw error;
+  }
+};
+
+let getSnapshotKey = (baseKey: string, snapshotId: string) =>
+  `${baseKey}:snapshot:${snapshotId}`;
+
+let renameIfExists = async (redis: RedisClient, from: string, to: string) => {
+  if (!(await redis.exists(from))) return false;
+  await redis.rename(from, to);
+  await redis.expire(to, SNAPSHOT_TTL_SECONDS);
+  return true;
+};
+
+export let snapshotPendingIngressNetworkLogs = async () => {
+  let redis = getRedis();
+  if (!redis) return null;
+
+  let snapshotId = `${Date.now()}`;
+  let countsKey = getSnapshotKey(PENDING_COUNTS_KEY, snapshotId);
+
+  let hasCounts = await renameIfExists(redis, PENDING_COUNTS_KEY, countsKey);
+  if (!hasCounts) return null;
+
+  await renameIfExists(redis, PENDING_META_KEY, getSnapshotKey(PENDING_META_KEY, snapshotId));
+  await renameIfExists(
+    redis,
+    PENDING_FIRST_SEEN_KEY,
+    getSnapshotKey(PENDING_FIRST_SEEN_KEY, snapshotId)
+  );
+  await renameIfExists(
+    redis,
+    PENDING_LAST_SEEN_KEY,
+    getSnapshotKey(PENDING_LAST_SEEN_KEY, snapshotId)
+  );
+
+  return {
+    snapshotId,
+    fields: await redis.hkeys(countsKey)
+  };
+};
+
+export let getIngressNetworkLogSnapshotEntry = async (d: {
+  snapshotId: string;
+  field: string;
+}): Promise<BufferedIngressNetworkLogEntry | null> => {
+  let redis = getRedis();
+  if (!redis) return null;
+
+  let [count, meta, firstSeenAt, lastSeenAt] = await Promise.all([
+    redis.hget(getSnapshotKey(PENDING_COUNTS_KEY, d.snapshotId), d.field),
+    redis.hget(getSnapshotKey(PENDING_META_KEY, d.snapshotId), d.field),
+    redis.hget(getSnapshotKey(PENDING_FIRST_SEEN_KEY, d.snapshotId), d.field),
+    redis.hget(getSnapshotKey(PENDING_LAST_SEEN_KEY, d.snapshotId), d.field)
+  ]);
+
+  if (!count) return null;
+
+  let dimensions = meta
+    ? deserializeDimensions(JSON.parse(meta))
+    : decodeDimensions(d.field);
+
+  return {
+    ...dimensions,
+    count: Number(count),
+    firstSeenAt: firstSeenAt ?? dimensions.bucketStart,
+    lastSeenAt: lastSeenAt ?? dimensions.bucketStart
+  };
+};
+
+export let deleteIngressNetworkLogSnapshotEntry = async (d: {
+  snapshotId: string;
+  field: string;
+}) => {
+  let redis = getRedis();
+  if (!redis) return;
+
+  await Promise.all([
+    redis.hdel(getSnapshotKey(PENDING_COUNTS_KEY, d.snapshotId), d.field),
+    redis.hdel(getSnapshotKey(PENDING_META_KEY, d.snapshotId), d.field),
+    redis.hdel(getSnapshotKey(PENDING_FIRST_SEEN_KEY, d.snapshotId), d.field),
+    redis.hdel(getSnapshotKey(PENDING_LAST_SEEN_KEY, d.snapshotId), d.field)
+  ]);
+};
+
+let startFlushTimer = () => {
+  if (flushTimer) return;
+
+  flushTimer = setInterval(() => {
+    flushBufferedIngressNetworkLogsToRedis().catch(error => {
+      console.error('Failed to flush ingress network logs to Redis', error);
+    });
+  }, 60 * 1000);
+  flushTimer.unref?.();
+};
+
+startFlushTimer();

--- a/src/systems/subspace/modules/enclave/src/queues.ts
+++ b/src/systems/subspace/modules/enclave/src/queues.ts
@@ -1,8 +1,10 @@
 import { combineQueueProcessors } from '@lowerdeck/queue';
 import { lifecycleQueues } from './queues/lifecycle';
+import { ingressNetworkLogProcessors } from './queues/networkLog/ingress';
 import { reconcileProviderDeploymentEnclaveProcessors } from './queues/reconcile/providerDeploymentEnclave';
 
 export let enclaveQueueProcessor = combineQueueProcessors([
   lifecycleQueues,
+  ingressNetworkLogProcessors,
   reconcileProviderDeploymentEnclaveProcessors
 ]);

--- a/src/systems/subspace/modules/enclave/src/queues/networkLog/ingress.ts
+++ b/src/systems/subspace/modules/enclave/src/queues/networkLog/ingress.ts
@@ -1,0 +1,130 @@
+import { createCron } from '@lowerdeck/cron';
+import { combineQueueProcessors, createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { db, getId } from '@metorial-subspace/db';
+import { env } from '../../env';
+import {
+  type BufferedIngressNetworkLogEntry,
+  deleteIngressNetworkLogSnapshotEntry,
+  flushBufferedIngressNetworkLogsToRedis,
+  getIngressNetworkLogSnapshotEntry,
+  snapshotPendingIngressNetworkLogs
+} from '../../lib/ingressNetworkLogBuffer';
+
+let persistIngressNetworkLog = async (entry: BufferedIngressNetworkLogEntry) => {
+  let bucketStart = new Date(entry.bucketStart);
+  let firstSeenAt = new Date(entry.firstSeenAt);
+  let lastSeenAt = new Date(entry.lastSeenAt);
+
+  let existing = await db.enclaveIngressNetworkLog.findFirst({
+    where: {
+      tenantOid: entry.tenantOid,
+      environmentOid: entry.environmentOid,
+      solutionOid: entry.solutionOid,
+      enclaveOid: entry.enclaveOid,
+      sessionId: entry.sessionId,
+      sourceIp: entry.sourceIp,
+      hostname: entry.hostname,
+      port: entry.port,
+      result: entry.result,
+      bucketStart
+    },
+    select: {
+      oid: true,
+      firstSeenAt: true,
+      lastSeenAt: true
+    }
+  });
+
+  if (existing) {
+    await db.enclaveIngressNetworkLog.update({
+      where: { oid: existing.oid },
+      data: {
+        count: { increment: entry.count },
+        firstSeenAt: firstSeenAt < existing.firstSeenAt ? firstSeenAt : existing.firstSeenAt,
+        lastSeenAt: lastSeenAt > existing.lastSeenAt ? lastSeenAt : existing.lastSeenAt
+      }
+    });
+    return;
+  }
+
+  await db.enclaveIngressNetworkLog.create({
+    data: {
+      ...getId('enclaveIngressNetworkLog'),
+      tenantOid: entry.tenantOid,
+      environmentOid: entry.environmentOid,
+      solutionOid: entry.solutionOid,
+      enclaveOid: entry.enclaveOid,
+      sessionId: entry.sessionId,
+      sourceIp: entry.sourceIp,
+      hostname: entry.hostname,
+      port: entry.port,
+      result: entry.result,
+      bucketStart,
+      count: entry.count,
+      firstSeenAt,
+      lastSeenAt
+    }
+  });
+};
+
+let ingressNetworkLogPersistCron = createCron(
+  {
+    name: 'sub/enc/netLog/ingress/cron',
+    cron: '*/5 * * * *',
+    redisUrl: env.service.REDIS_URL
+  },
+  async () => {
+    await ingressNetworkLogPersistManyQueue.add(
+      {},
+      { id: `ingress-network-log-persist:${Math.floor(Date.now() / (5 * 60 * 1000))}` }
+    );
+  }
+);
+
+export let ingressNetworkLogPersistManyQueue = createQueue<{}>({
+  name: 'sub/enc/netLog/ingress/many',
+  redisUrl: env.service.REDIS_URL
+});
+
+let ingressNetworkLogPersistManyQueueProcessor =
+  ingressNetworkLogPersistManyQueue.process(async () => {
+    await flushBufferedIngressNetworkLogsToRedis();
+
+    let snapshot = await snapshotPendingIngressNetworkLogs();
+    if (!snapshot || snapshot.fields.length === 0) return;
+
+    await ingressNetworkLogPersistSingleQueue.addMany(
+      snapshot.fields.map(field => ({
+        snapshotId: snapshot.snapshotId,
+        field
+      }))
+    );
+  });
+
+let ingressNetworkLogPersistSingleQueue = createQueue<{
+  snapshotId: string;
+  field: string;
+}>({
+  name: 'sub/enc/netLog/ingress/single',
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: { concurrency: 5 }
+});
+
+let ingressNetworkLogPersistSingleQueueProcessor =
+  ingressNetworkLogPersistSingleQueue.process(async data => {
+    let entry = await getIngressNetworkLogSnapshotEntry(data);
+    if (!entry) return;
+
+    try {
+      await persistIngressNetworkLog(entry);
+      await deleteIngressNetworkLogSnapshotEntry(data);
+    } catch {
+      throw new QueueRetryError();
+    }
+  });
+
+export let ingressNetworkLogProcessors = combineQueueProcessors([
+  ingressNetworkLogPersistCron,
+  ingressNetworkLogPersistManyQueueProcessor,
+  ingressNetworkLogPersistSingleQueueProcessor
+]);

--- a/src/systems/subspace/modules/enclave/src/services/enclaveNetworkLog.test.ts
+++ b/src/systems/subspace/modules/enclave/src/services/enclaveNetworkLog.test.ts
@@ -4,6 +4,9 @@ let { mockDb, mockFunctionBay, mockGetTenantForFunctionBay } = vi.hoisted(() => 
   mockDb: {
     enclave: {
       findMany: vi.fn()
+    },
+    enclaveIngressNetworkLog: {
+      findMany: vi.fn()
     }
   },
   mockFunctionBay: {
@@ -56,19 +59,21 @@ describe('enclaveNetworkLogService.listNetworkLogs', () => {
 
   it('returns empty records when no enclaves have Function Bay backing', async () => {
     mockDb.enclave.findMany.mockResolvedValueOnce([
-      { id: 'enc_a', hasFunctionBayBacking: false },
-      { id: 'enc_b', hasFunctionBayBacking: false }
+      { oid: BigInt(1), id: 'enc_a', hasFunctionBayBacking: false },
+      { oid: BigInt(2), id: 'enc_b', hasFunctionBayBacking: false }
     ]);
 
     let result = await enclaveNetworkLogService.listNetworkLogs({
       tenant,
       environment,
       solution,
+      direction: 'egress',
       filters: {}
     });
 
     expect(result).toEqual({
       object: 'enclave.network_logs',
+      direction: 'egress',
       enclaveIds: [],
       records: []
     });
@@ -77,8 +82,8 @@ describe('enclaveNetworkLogService.listNetworkLogs', () => {
 
   it('queries only backed enclaves when explicit enclaveIds are provided', async () => {
     mockDb.enclave.findMany.mockResolvedValueOnce([
-      { id: 'enc_backed', hasFunctionBayBacking: true },
-      { id: 'enc_unbacked', hasFunctionBayBacking: false }
+      { oid: BigInt(1), id: 'enc_backed', hasFunctionBayBacking: true },
+      { oid: BigInt(2), id: 'enc_unbacked', hasFunctionBayBacking: false }
     ]);
     mockFunctionBay.networkLog.list.mockResolvedValueOnce([fbLogRecord]);
 
@@ -86,6 +91,7 @@ describe('enclaveNetworkLogService.listNetworkLogs', () => {
       tenant,
       environment,
       solution,
+      direction: 'egress',
       enclaveIds: ['enc_backed', 'enc_unbacked'],
       filters: { hostnames: ['example.com'] }
     });
@@ -105,8 +111,8 @@ describe('enclaveNetworkLogService.listNetworkLogs', () => {
 
   it('loads all environment enclaves when enclaveIds are omitted', async () => {
     mockDb.enclave.findMany.mockResolvedValueOnce([
-      { id: 'enc_backed', hasFunctionBayBacking: true },
-      { id: 'enc_other', hasFunctionBayBacking: true }
+      { oid: BigInt(1), id: 'enc_backed', hasFunctionBayBacking: true },
+      { oid: BigInt(2), id: 'enc_other', hasFunctionBayBacking: true }
     ]);
     mockFunctionBay.networkLog.list.mockResolvedValueOnce([]);
 
@@ -114,6 +120,7 @@ describe('enclaveNetworkLogService.listNetworkLogs', () => {
       tenant,
       environment,
       solution,
+      direction: 'egress',
       filters: {}
     });
 
@@ -122,7 +129,8 @@ describe('enclaveNetworkLogService.listNetworkLogs', () => {
         tenantOid: tenant.oid,
         environmentOid: environment.oid
       },
-      select: { id: true, hasFunctionBayBacking: true }
+      select: { oid: true, id: true, hasFunctionBayBacking: true },
+      take: 500
     });
     expect(mockFunctionBay.networkLog.list).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -132,13 +140,16 @@ describe('enclaveNetworkLogService.listNetworkLogs', () => {
   });
 
   it('throws not found when an explicit enclave id is missing', async () => {
-    mockDb.enclave.findMany.mockResolvedValueOnce([{ id: 'enc_backed', hasFunctionBayBacking: true }]);
+    mockDb.enclave.findMany.mockResolvedValueOnce([
+      { oid: BigInt(1), id: 'enc_backed', hasFunctionBayBacking: true }
+    ]);
 
     await expect(
       enclaveNetworkLogService.listNetworkLogs({
         tenant,
         environment,
         solution,
+        direction: 'egress',
         enclaveIds: ['enc_backed', 'enc_missing'],
         filters: {}
       })
@@ -147,7 +158,7 @@ describe('enclaveNetworkLogService.listNetworkLogs', () => {
 
   it('strips Function Bay-only fields from records', async () => {
     mockDb.enclave.findMany.mockResolvedValueOnce([
-      { id: 'enc_backed', hasFunctionBayBacking: true }
+      { oid: BigInt(1), id: 'enc_backed', hasFunctionBayBacking: true }
     ]);
     mockFunctionBay.networkLog.list.mockResolvedValueOnce([fbLogRecord]);
 
@@ -155,12 +166,14 @@ describe('enclaveNetworkLogService.listNetworkLogs', () => {
       tenant,
       environment,
       solution,
+      direction: 'egress',
       enclaveIds: ['enc_backed'],
       filters: {}
     });
 
     expect(result.records[0]).toEqual({
       object: 'enclave.network_log',
+      direction: 'egress',
       enclaveId: 'enc_backed',
       bucketStart: fbLogRecord.bucketStart,
       hostname: fbLogRecord.hostname,
@@ -173,5 +186,66 @@ describe('enclaveNetworkLogService.listNetworkLogs', () => {
     expect(result.records[0]).not.toHaveProperty('functionId');
     expect(result.records[0]).not.toHaveProperty('effectiveFunctionId');
     expect(result.records[0]).not.toHaveProperty('tenantId');
+  });
+
+  it('returns ingress logs from subspace-owned records', async () => {
+    mockDb.enclave.findMany.mockResolvedValueOnce([
+      { oid: BigInt(1), id: 'enc_backed', hasFunctionBayBacking: true }
+    ]);
+    mockDb.enclaveIngressNetworkLog.findMany.mockResolvedValueOnce([
+      {
+        enclaveOid: BigInt(1),
+        sourceIp: '203.0.113.10',
+        hostname: 'mcp.example.com',
+        port: 443,
+        result: 'denied',
+        bucketStart: new Date('2026-05-29T10:00:00.000Z'),
+        count: 2,
+        firstSeenAt: new Date('2026-05-29T10:01:00.000Z'),
+        lastSeenAt: new Date('2026-05-29T10:03:00.000Z')
+      },
+      {
+        enclaveOid: BigInt(1),
+        sourceIp: '203.0.113.10',
+        hostname: 'mcp.example.com',
+        port: 443,
+        result: 'denied',
+        bucketStart: new Date('2026-05-29T10:30:00.000Z'),
+        count: 3,
+        firstSeenAt: new Date('2026-05-29T10:31:00.000Z'),
+        lastSeenAt: new Date('2026-05-29T10:35:00.000Z')
+      }
+    ]);
+
+    let result = await enclaveNetworkLogService.listNetworkLogs({
+      tenant,
+      environment,
+      solution,
+      direction: 'ingress',
+      enclaveIds: ['enc_backed'],
+      filters: { intervalMinutes: 60 }
+    });
+
+    expect(mockFunctionBay.networkLog.list).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      object: 'enclave.network_logs',
+      direction: 'ingress',
+      enclaveIds: ['enc_backed'],
+      records: [
+        {
+          object: 'enclave.network_log',
+          direction: 'ingress',
+          enclaveId: 'enc_backed',
+          bucketStart: '2026-05-29T10:00:00.000Z',
+          hostname: 'mcp.example.com',
+          ip: '203.0.113.10',
+          port: 443,
+          count: 5,
+          result: 'denied',
+          firstSeenAt: '2026-05-29T10:01:00.000Z',
+          lastSeenAt: '2026-05-29T10:35:00.000Z'
+        }
+      ]
+    });
   });
 });

--- a/src/systems/subspace/modules/enclave/src/services/enclaveNetworkLog.ts
+++ b/src/systems/subspace/modules/enclave/src/services/enclaveNetworkLog.ts
@@ -3,47 +3,82 @@ import { Service } from '@lowerdeck/service';
 import { db, type Environment, type Solution, type Tenant } from '@metorial-subspace/db';
 import { functionBay, getTenantForFunctionBay } from '../functionBay';
 
+export type EnclaveNetworkLogDirection = 'ingress' | 'egress';
+
 export type EnclaveNetworkLogRecord = {
   object: 'enclave.network_log';
+  direction: EnclaveNetworkLogDirection;
   enclaveId?: string;
   bucketStart: string;
   hostname: string;
   ip: string;
   port: number;
   count: number;
+  result?: 'allowed' | 'denied';
   firstSeenAt: string;
   lastSeenAt: string;
 };
 
 export type EnclaveNetworkLogsResponse = {
   object: 'enclave.network_logs';
+  direction: EnclaveNetworkLogDirection;
   enclaveIds: string[];
   records: EnclaveNetworkLogRecord[];
 };
 
 let presentNetworkLogRecord = (r: {
+  direction: EnclaveNetworkLogDirection;
   enclaveId?: string;
   bucketStart: string;
   hostname: string;
   ip: string;
   port: number;
   count: number;
+  result?: 'allowed' | 'denied';
   firstSeenAt: string;
   lastSeenAt: string;
 }): EnclaveNetworkLogRecord => ({
   object: 'enclave.network_log',
+  direction: r.direction,
   enclaveId: r.enclaveId,
   bucketStart: r.bucketStart,
   hostname: r.hostname,
   ip: r.ip,
   port: r.port,
   count: r.count,
+  result: r.result,
   firstSeenAt: r.firstSeenAt,
   lastSeenAt: r.lastSeenAt
 });
 
+let getBucketStart = (date: Date, intervalMinutes: number) => {
+  let intervalMs = intervalMinutes * 60 * 1000;
+  return new Date(Math.floor(date.getTime() / intervalMs) * intervalMs).toISOString();
+};
+
 class enclaveNetworkLogServiceImpl {
   async listNetworkLogs(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    direction: EnclaveNetworkLogDirection;
+    enclaveIds?: string[];
+    filters: {
+      hostnames?: string[];
+      ips?: string[];
+      from?: string;
+      to?: string;
+      intervalMinutes?: number;
+    };
+  }): Promise<EnclaveNetworkLogsResponse> {
+    if (d.direction === 'ingress') {
+      return await this.listIngressNetworkLogs(d);
+    }
+
+    return await this.listEgressNetworkLogs(d);
+  }
+
+  private async listEgressNetworkLogs(d: {
     tenant: Tenant;
     solution: Solution;
     environment: Environment;
@@ -60,7 +95,12 @@ class enclaveNetworkLogServiceImpl {
 
     let backedEnclaves = enclaves.filter(e => e.hasFunctionBayBacking);
     if (backedEnclaves.length === 0) {
-      return { object: 'enclave.network_logs', enclaveIds: [], records: [] };
+      return {
+        object: 'enclave.network_logs',
+        direction: 'egress',
+        enclaveIds: [],
+        records: []
+      };
     }
 
     let fbTenant = await getTenantForFunctionBay(d.tenant);
@@ -77,9 +117,11 @@ class enclaveNetworkLogServiceImpl {
 
     return {
       object: 'enclave.network_logs',
+      direction: 'egress',
       enclaveIds: backedEnclaves.map(e => e.id),
       records: logs.map(r =>
         presentNetworkLogRecord({
+          direction: 'egress',
           enclaveId: r.enclaveId,
           bucketStart: r.bucketStart,
           hostname: r.hostname,
@@ -88,6 +130,123 @@ class enclaveNetworkLogServiceImpl {
           count: r.count,
           firstSeenAt: r.firstSeenAt,
           lastSeenAt: r.lastSeenAt
+        })
+      )
+    };
+  }
+
+  private async listIngressNetworkLogs(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    enclaveIds?: string[];
+    filters: {
+      hostnames?: string[];
+      ips?: string[];
+      from?: string;
+      to?: string;
+      intervalMinutes?: number;
+    };
+  }): Promise<EnclaveNetworkLogsResponse> {
+    let enclaves = await this.resolveEnclaves(d);
+    if (enclaves.length === 0) {
+      return {
+        object: 'enclave.network_logs',
+        direction: 'ingress',
+        enclaveIds: [],
+        records: []
+      };
+    }
+
+    let enclaveIdsByOid = new Map(enclaves.map(e => [e.oid, e.id]));
+    let from = d.filters.from ? new Date(d.filters.from) : undefined;
+    let to = d.filters.to ? new Date(d.filters.to) : undefined;
+
+    let logs = await db.enclaveIngressNetworkLog.findMany({
+      where: {
+        tenantOid: d.tenant.oid,
+        environmentOid: d.environment.oid,
+        solutionOid: d.solution.oid,
+        enclaveOid: { in: enclaves.map(e => e.oid) },
+        hostname: d.filters.hostnames?.length ? { in: d.filters.hostnames } : undefined,
+        sourceIp: d.filters.ips?.length ? { in: d.filters.ips } : undefined,
+        bucketStart:
+          from || to
+            ? {
+                gte: from,
+                lte: to
+              }
+            : undefined
+      },
+      orderBy: { bucketStart: 'desc' },
+      take: 5000
+    });
+
+    let intervalMinutes = d.filters.intervalMinutes ?? 5;
+    let grouped = new Map<
+      string,
+      {
+        enclaveId?: string;
+        bucketStart: string;
+        hostname: string;
+        ip: string;
+        port: number;
+        result: 'allowed' | 'denied';
+        count: number;
+        firstSeenAt: Date;
+        lastSeenAt: Date;
+      }
+    >();
+
+    for (let log of logs) {
+      let bucketStart = getBucketStart(log.bucketStart, intervalMinutes);
+      let enclaveId = enclaveIdsByOid.get(log.enclaveOid);
+      let key = [
+        enclaveId,
+        bucketStart,
+        log.hostname,
+        log.sourceIp,
+        log.port,
+        log.result
+      ].join('\0');
+
+      let existing = grouped.get(key);
+      if (!existing) {
+        grouped.set(key, {
+          enclaveId,
+          bucketStart,
+          hostname: log.hostname,
+          ip: log.sourceIp,
+          port: log.port,
+          result: log.result,
+          count: log.count,
+          firstSeenAt: log.firstSeenAt,
+          lastSeenAt: log.lastSeenAt
+        });
+        continue;
+      }
+
+      existing.count += log.count;
+      if (log.firstSeenAt < existing.firstSeenAt) existing.firstSeenAt = log.firstSeenAt;
+      if (log.lastSeenAt > existing.lastSeenAt) existing.lastSeenAt = log.lastSeenAt;
+    }
+
+    return {
+      object: 'enclave.network_logs',
+      direction: 'ingress',
+      enclaveIds: enclaves.map(e => e.id),
+      records: [...grouped.values()].map(record =>
+        presentNetworkLogRecord({
+          direction: 'ingress',
+          enclaveId: record.enclaveId,
+          bucketStart: record.bucketStart,
+          hostname: record.hostname,
+          ip: record.ip,
+          port: record.port,
+          count: record.count,
+          result: record.result,
+          firstSeenAt: record.firstSeenAt.toISOString(),
+          lastSeenAt: record.lastSeenAt.toISOString()
         })
       )
     };
@@ -105,7 +264,7 @@ class enclaveNetworkLogServiceImpl {
           tenantOid: d.tenant.oid,
           environmentOid: d.environment.oid
         },
-        select: { id: true, hasFunctionBayBacking: true },
+        select: { oid: true, id: true, hasFunctionBayBacking: true },
         take: 500
       });
 
@@ -123,7 +282,7 @@ class enclaveNetworkLogServiceImpl {
         tenantOid: d.tenant.oid,
         environmentOid: d.environment.oid
       },
-      select: { id: true, hasFunctionBayBacking: true },
+      select: { oid: true, id: true, hasFunctionBayBacking: true },
       take: 500
     });
   }

--- a/src/systems/subspace/modules/enclave/src/services/index.ts
+++ b/src/systems/subspace/modules/enclave/src/services/index.ts
@@ -3,6 +3,7 @@ export * from './enclaveInternal';
 export * from './enclaveNetworkLog';
 export * from './firewall';
 export * from './firewallBinding';
+export * from './ingressPolicy';
 export * from './network';
 export * from './networkInternal';
 export * from './networkPolicy';

--- a/src/systems/subspace/modules/enclave/src/services/ingressPolicy.test.ts
+++ b/src/systems/subspace/modules/enclave/src/services/ingressPolicy.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { mockDb, mockEnclaveService, mockRecordIngressNetworkLog } = vi.hoisted(() => ({
+  mockDb: {
+    session: {
+      findMany: vi.fn()
+    },
+    ephemeralManagedSession: {
+      findMany: vi.fn()
+    }
+  },
+  mockEnclaveService: {
+    getCompiledNetworkRules: vi.fn()
+  },
+  mockRecordIngressNetworkLog: vi.fn()
+}));
+
+vi.mock('@metorial-subspace/db', async () => ({
+  db: mockDb
+}));
+
+vi.mock('./enclave', () => ({
+  enclaveService: mockEnclaveService
+}));
+
+vi.mock('../lib/ingressNetworkLogBuffer', () => ({
+  recordIngressNetworkLog: mockRecordIngressNetworkLog
+}));
+
+import { enclaveIngressPolicyService } from './ingressPolicy';
+
+let tenant = { oid: BigInt(10), id: 'ktn_test' } as any;
+let environment = { oid: BigInt(20), id: 'ken_test' } as any;
+let solution = { oid: 30, id: 'ksn_test' } as any;
+let enclave = {
+  oid: BigInt(40),
+  id: 'enc_test',
+  compiledNetworkRules: null
+} as any;
+
+describe('enclaveIngressPolicyService.checkSessionIngressAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.ephemeralManagedSession.findMany.mockResolvedValue([]);
+  });
+
+  it('allows sessions when all linked enclave ingress policies allow the source IP', async () => {
+    mockDb.session.findMany.mockResolvedValueOnce([
+      {
+        id: 'ses_test',
+        providers: [{ deployment: { enclave } }]
+      }
+    ]);
+    mockEnclaveService.getCompiledNetworkRules.mockResolvedValueOnce({
+      ingress: { direction: 'ingress', entries: [{ cidr: '203.0.113.0/24' }] },
+      egress: { direction: 'egress', entries: [] }
+    });
+
+    let result = await enclaveIngressPolicyService.checkSessionIngressAccess({
+      tenant,
+      environment,
+      solution,
+      sessionIds: ['ses_test'],
+      sourceIp: '203.0.113.10'
+    });
+
+    expect(result.results).toEqual([
+      {
+        sessionId: 'ses_test',
+        resolvedSessionId: 'ses_test',
+        allowed: true,
+        enclaveIds: ['enc_test'],
+        deniedEnclaveIds: []
+      }
+    ]);
+  });
+
+  it('denies sessions when any linked enclave ingress policy denies the source IP', async () => {
+    mockDb.session.findMany.mockResolvedValueOnce([
+      {
+        id: 'ses_test',
+        providers: [{ deployment: { enclave } }]
+      }
+    ]);
+    mockEnclaveService.getCompiledNetworkRules.mockResolvedValueOnce({
+      ingress: { direction: 'ingress', entries: [{ cidr: '198.51.100.0/24' }] },
+      egress: { direction: 'egress', entries: [] }
+    });
+
+    let result = await enclaveIngressPolicyService.checkSessionIngressAccess({
+      tenant,
+      environment,
+      solution,
+      sessionIds: ['ses_test'],
+      sourceIp: '203.0.113.10',
+      hostname: 'mcp.example.com',
+      port: 443,
+      recordLog: true
+    });
+
+    expect(result.results[0]).toMatchObject({
+      sessionId: 'ses_test',
+      allowed: false,
+      enclaveIds: ['enc_test'],
+      deniedEnclaveIds: ['enc_test']
+    });
+    expect(mockRecordIngressNetworkLog).toHaveBeenCalledWith({
+      tenantOid: tenant.oid,
+      environmentOid: environment.oid,
+      solutionOid: solution.oid,
+      enclaveOid: enclave.oid,
+      sessionId: 'ses_test',
+      sourceIp: '203.0.113.10',
+      hostname: 'mcp.example.com',
+      port: 443,
+      result: 'denied'
+    });
+  });
+
+  it('allows sessions without linked enclaves', async () => {
+    mockDb.session.findMany.mockResolvedValueOnce([
+      {
+        id: 'ses_plain',
+        providers: [{ deployment: { enclave: null } }]
+      }
+    ]);
+
+    let result = await enclaveIngressPolicyService.checkSessionIngressAccess({
+      tenant,
+      environment,
+      solution,
+      sessionIds: ['ses_plain'],
+      sourceIp: '203.0.113.10',
+      recordLog: true
+    });
+
+    expect(result.results[0]).toMatchObject({
+      sessionId: 'ses_plain',
+      allowed: true,
+      enclaveIds: [],
+      deniedEnclaveIds: []
+    });
+    expect(mockRecordIngressNetworkLog).not.toHaveBeenCalled();
+  });
+});

--- a/src/systems/subspace/modules/enclave/src/services/ingressPolicy.ts
+++ b/src/systems/subspace/modules/enclave/src/services/ingressPolicy.ts
@@ -1,0 +1,237 @@
+import { forbiddenError, ServiceError } from '@lowerdeck/error';
+import { Service } from '@lowerdeck/service';
+import {
+  type Enclave,
+  type Environment,
+  db,
+  type Session,
+  type Solution,
+  type Tenant
+} from '@metorial-subspace/db';
+import { isIpAllowedByIngressAllowList } from '../lib/ingressAllowList';
+import { recordIngressNetworkLog } from '../lib/ingressNetworkLogBuffer';
+import { enclaveService } from './enclave';
+
+type SessionWithProviders = Session & {
+  providers: {
+    deployment: {
+      enclave: Enclave | null;
+    };
+  }[];
+};
+
+export type EnclaveIngressCheckResult = {
+  sessionId: string;
+  resolvedSessionId?: string;
+  allowed: boolean;
+  enclaveIds: string[];
+  deniedEnclaveIds: string[];
+};
+
+let dedupeEnclaves = (enclaves: (Enclave | null)[]) => {
+  let seen = new Set<bigint>();
+  let result: Enclave[] = [];
+
+  for (let enclave of enclaves) {
+    if (!enclave) continue;
+    if (seen.has(enclave.oid)) continue;
+    seen.add(enclave.oid);
+    result.push(enclave);
+  }
+
+  return result;
+};
+
+let sessionInclude = {
+  providers: {
+    where: { status: 'active' as const },
+    include: {
+      deployment: {
+        include: {
+          enclave: true
+        }
+      }
+    }
+  }
+};
+
+class enclaveIngressPolicyServiceImpl {
+  private async resolveSessions(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    sessionIds: string[];
+  }) {
+    let sessions = await db.session.findMany({
+      where: {
+        id: { in: d.sessionIds },
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid,
+        status: 'active'
+      },
+      include: sessionInclude
+    });
+
+    let sessionsByRequestedId = new Map<string, SessionWithProviders>();
+    for (let session of sessions) {
+      sessionsByRequestedId.set(session.id, session as SessionWithProviders);
+    }
+
+    let missingSessionIds = d.sessionIds.filter(id => !sessionsByRequestedId.has(id));
+    if (missingSessionIds.length === 0) return sessionsByRequestedId;
+
+    let ephemeralManagedSessions = await db.ephemeralManagedSession.findMany({
+      where: {
+        id: { in: missingSessionIds },
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid,
+        status: 'active'
+      },
+      include: {
+        currentSession: {
+          include: sessionInclude
+        }
+      }
+    });
+
+    for (let ephemeralManagedSession of ephemeralManagedSessions) {
+      if (!ephemeralManagedSession.currentSession) continue;
+      sessionsByRequestedId.set(
+        ephemeralManagedSession.id,
+        ephemeralManagedSession.currentSession as SessionWithProviders
+      );
+    }
+
+    return sessionsByRequestedId;
+  }
+
+  async checkSessionIngressAccess(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    sessionIds: string[];
+    sourceIp: string;
+    hostname?: string | null;
+    port?: number | null;
+    recordLog?: boolean;
+  }): Promise<{
+    object: 'enclave.ingress_check';
+    results: EnclaveIngressCheckResult[];
+  }> {
+    let sessionIds = Array.from(new Set(d.sessionIds));
+    let sessionsByRequestedId = await this.resolveSessions({ ...d, sessionIds });
+
+    let results: EnclaveIngressCheckResult[] = [];
+    let logRecords: {
+      enclave: Enclave;
+      sessionId: string;
+      result: 'allowed' | 'denied';
+    }[] = [];
+
+    for (let sessionId of sessionIds) {
+      let session = sessionsByRequestedId.get(sessionId);
+      if (!session) {
+        results.push({
+          sessionId,
+          allowed: false,
+          enclaveIds: [],
+          deniedEnclaveIds: []
+        });
+        continue;
+      }
+
+      let enclaves = dedupeEnclaves(
+        session.providers.map(provider => provider.deployment.enclave)
+      );
+      let deniedEnclaves: Enclave[] = [];
+
+      for (let enclave of enclaves) {
+        let compiledNetworkRules = await enclaveService.getCompiledNetworkRules({
+          tenant: d.tenant,
+          environment: d.environment,
+          enclave
+        });
+
+        let allowed = isIpAllowedByIngressAllowList({
+          sourceIp: d.sourceIp,
+          ingressPolicy: compiledNetworkRules.ingress
+        });
+
+        if (!allowed) deniedEnclaves.push(enclave);
+      }
+
+      let allowed = deniedEnclaves.length === 0;
+      results.push({
+        sessionId,
+        resolvedSessionId: session.id,
+        allowed,
+        enclaveIds: enclaves.map(enclave => enclave.id),
+        deniedEnclaveIds: deniedEnclaves.map(enclave => enclave.id)
+      });
+
+      for (let enclave of enclaves) {
+        logRecords.push({
+          enclave,
+          sessionId: session.id,
+          result: deniedEnclaves.some(e => e.oid === enclave.oid) ? 'denied' : 'allowed'
+        });
+      }
+    }
+
+    if (d.recordLog && logRecords.length > 0) {
+      for (let record of logRecords) {
+        recordIngressNetworkLog({
+          tenantOid: d.tenant.oid,
+          environmentOid: d.environment.oid,
+          solutionOid: d.solution.oid,
+          enclaveOid: record.enclave.oid,
+          sessionId: record.sessionId,
+          sourceIp: d.sourceIp,
+          hostname: d.hostname ?? 'unknown',
+          port: d.port ?? 0,
+          result: record.result
+        });
+      }
+    }
+
+    return {
+      object: 'enclave.ingress_check',
+      results
+    };
+  }
+
+  async assertSessionIngressAccess(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    sessionId: string;
+    sourceIp: string;
+    hostname?: string | null;
+    port?: number | null;
+    recordLog?: boolean;
+  }) {
+    let check = await this.checkSessionIngressAccess({
+      ...d,
+      sessionIds: [d.sessionId]
+    });
+
+    let result = check.results[0];
+    if (!result?.allowed) {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Ingress network policy blocked this connection',
+          code: 'ingress_network_policy_blocked'
+        })
+      );
+    }
+
+    return result;
+  }
+}
+
+export let enclaveIngressPolicyService = Service.create(
+  'enclaveIngressPolicyService',
+  () => new enclaveIngressPolicyServiceImpl()
+).build();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes connection-time authorization and fine-grained session filtering against ingress CIDR policies; misconfiguration could block legitimate MCP access or leak policy gaps.
> 
> **Overview**
> Adds **ingress network protection** for MCP traffic: connection and magic MCP proxies now require subspace to evaluate compiled enclave ingress allow-lists using the client IP (and optional host/port), blocking disallowed connections.
> 
> **Enforcement path:** `proxyMcpRequestToSubspace` sets `Metorial-Ingress-Policy-Check` / `Metorial-Ingress-IP`; the subspace MCP router forwards an `ingressPolicyCheck` into `SenderManager`, which calls `enclaveIngressPolicyService.assertSessionIngressAccess`. Fine-grained API tokens additionally filter session access and query constraints through `checkIngressAccess`.
> 
> **Observability & API:** Ingress attempts are buffered (Redis) and persisted (`EnclaveIngressNetworkLog`) with **allowed/denied** results. `listNetworkLogs` now requires a **`direction`** (`ingress` | `egress`); ingress reads subspace DB, egress unchanged (Function Bay). Generated dashboard SDK types and presenters include `direction` and optional `result`.
> 
> **UI:** Network overview charts **ingress** connections by IP and result with a denied-policy callout; provider deployment logs stay **egress**. Session tracing copy references Metorial Magic Network.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d93c736bdde2a983c6869f6de3d6b4070dc1908b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->