### PR TITLE
Harden proxy auth

### DIFF
--- a/src/systems/function-bay/deflector/internal/auth/jwt.go
+++ b/src/systems/function-bay/deflector/internal/auth/jwt.go
@@ -3,10 +3,13 @@ package auth
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/metorial/function-bay-deflector/internal/policy"
 )
+
+const verifierClockSkewLeeway = 30 * time.Second
 
 type Verifier struct {
 	secret   []byte
@@ -26,6 +29,7 @@ func (v *Verifier) Verify(ctx context.Context, token string) (policy.Claims, err
 	parserOptions := []jwt.ParserOption{
 		jwt.WithExpirationRequired(),
 		jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}),
+		jwt.WithLeeway(verifierClockSkewLeeway),
 	}
 	if v.audience != "" {
 		parserOptions = append(parserOptions, jwt.WithAudience(v.audience))

--- a/src/systems/function-bay/deflector/internal/auth/jwt_test.go
+++ b/src/systems/function-bay/deflector/internal/auth/jwt_test.go
@@ -67,3 +67,18 @@ func TestVerifierRejectsExpiredToken(t *testing.T) {
 		t.Fatal("expected expired token to be rejected")
 	}
 }
+
+func TestVerifierAcceptsTokenWithinClockSkewLeeway(t *testing.T) {
+	verifier := NewVerifier("secret", "deflector")
+
+	claims, err := verifier.Verify(
+		context.Background(),
+		signedToken(t, "secret", "deflector", time.Now().Add(-10*time.Second)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claims.FunctionVersionID != "functionVersion_123" {
+		t.Fatalf("unexpected function version id %q", claims.FunctionVersionID)
+	}
+}

--- a/src/systems/function-bay/deflector/internal/proxy/server.go
+++ b/src/systems/function-bay/deflector/internal/proxy/server.go
@@ -3,7 +3,10 @@ package proxy
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -51,6 +54,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Metorial Magic Network: proxy authentication failed", http.StatusProxyAuthRequired)
 		return
 	}
+	s.logAuthorizedRequest(r, requestPolicy)
 
 	if r.Method == http.MethodConnect {
 		s.handleConnect(w, r, requestPolicy)
@@ -152,6 +156,60 @@ func authFailureReason(err error) string {
 		return "jwt_missing_invocation_claims"
 	default:
 		return "jwt_invalid"
+	}
+}
+
+func (s *Server) logAuthorizedRequest(r *http.Request, requestPolicy *requestPolicy) {
+	if s.Logger == nil {
+		return
+	}
+
+	summary := policyLogSummary(requestPolicy.Claims.EgressPolicy)
+	s.Logger.Info(
+		"proxy request authorized",
+		"jti", requestPolicy.Claims.ID,
+		"tenantId", requestPolicy.Claims.TenantID,
+		"functionId", requestPolicy.Claims.FunctionID,
+		"effectiveFunctionId", requestPolicy.Claims.EffectiveFunctionID,
+		"functionVersionId", requestPolicy.Claims.FunctionVersionID,
+		"enclaveId", requestPolicy.Claims.EnclaveID,
+		"method", r.Method,
+		"host", r.Host,
+		"path", r.URL.Path,
+		"policyMode", summary.Mode,
+		"policyDirection", summary.Direction,
+		"policyEntries", summary.Entries,
+		"policyFingerprint", summary.Fingerprint,
+	)
+}
+
+type policySummary struct {
+	Mode        string
+	Direction   string
+	Entries     int
+	Fingerprint string
+}
+
+func policyLogSummary(egressPolicy *policy.CompiledNetworkAllowList) policySummary {
+	if egressPolicy == nil {
+		return policySummary{Mode: "default"}
+	}
+
+	serialized, err := json.Marshal(egressPolicy)
+	if err != nil {
+		return policySummary{
+			Mode:      "explicit",
+			Direction: egressPolicy.Direction,
+			Entries:   len(egressPolicy.Entries),
+		}
+	}
+
+	hash := sha256.Sum256(serialized)
+	return policySummary{
+		Mode:        "explicit",
+		Direction:   egressPolicy.Direction,
+		Entries:     len(egressPolicy.Entries),
+		Fingerprint: hex.EncodeToString(hash[:]),
 	}
 }
 

--- a/src/systems/function-bay/deflector/internal/proxy/server.go
+++ b/src/systems/function-bay/deflector/internal/proxy/server.go
@@ -17,6 +17,15 @@ import (
 	"github.com/metorial/function-bay-deflector/internal/policy"
 )
 
+var (
+	errMissingProxyAuthorization            = errors.New("missing proxy authorization")
+	errInvalidProxyAuthorization            = errors.New("invalid proxy authorization")
+	errUnsupportedProxyAuthorizationScheme  = errors.New("unsupported proxy authorization scheme")
+	errInvalidProxyAuthorizationCredentials = errors.New("invalid proxy authorization credentials")
+	errVerifierRequired                     = errors.New("jwt verifier is required")
+	errInvalidEgressPolicy                  = errors.New("invalid egress policy")
+)
+
 type Server struct {
 	Logger   *slog.Logger
 	Dialer   *net.Dialer
@@ -38,7 +47,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	requestPolicy, err := s.policyFromRequest(r)
 	if err != nil {
-		http.Error(w, "proxy authentication failed", http.StatusProxyAuthRequired)
+		s.logAuthFailure(r, err)
+		http.Error(w, "Metorial Magic Network: proxy authentication failed", http.StatusProxyAuthRequired)
 		return
 	}
 
@@ -52,7 +62,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) policyFromRequest(r *http.Request) (*requestPolicy, error) {
 	if s.Verifier == nil {
-		return nil, errors.New("jwt verifier is required")
+		return nil, errVerifierRequired
 	}
 
 	token, err := tokenFromProxyAuthorization(r.Header.Get("Proxy-Authorization"))
@@ -66,57 +76,103 @@ func (s *Server) policyFromRequest(r *http.Request) (*requestPolicy, error) {
 	}
 	compiled, err := policy.Compile(claims)
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(errInvalidEgressPolicy, err)
 	}
 	return &requestPolicy{Claims: claims, Compiled: compiled}, nil
 }
 
 func tokenFromProxyAuthorization(header string) (string, error) {
 	if header == "" {
-		return "", errors.New("missing proxy authorization")
+		return "", errMissingProxyAuthorization
 	}
 
 	scheme, value, ok := strings.Cut(header, " ")
 	if !ok || value == "" {
-		return "", errors.New("invalid proxy authorization")
+		return "", errInvalidProxyAuthorization
 	}
 
 	if strings.EqualFold(scheme, "Bearer") {
 		return value, nil
 	}
 	if !strings.EqualFold(scheme, "Basic") {
-		return "", errors.New("unsupported proxy authorization scheme")
+		return "", errUnsupportedProxyAuthorizationScheme
 	}
 
 	decoded, err := base64.StdEncoding.DecodeString(value)
 	if err != nil {
-		return "", err
+		return "", errors.Join(errInvalidProxyAuthorizationCredentials, err)
 	}
 	username, _, ok := strings.Cut(string(decoded), ":")
 	if !ok || username == "" {
-		return "", errors.New("invalid proxy authorization credentials")
+		return "", errInvalidProxyAuthorizationCredentials
 	}
 	return username, nil
+}
+
+func (s *Server) logAuthFailure(r *http.Request, err error) {
+	if s.Logger == nil {
+		return
+	}
+	s.Logger.Warn(
+		"proxy authentication failed",
+		"reason", authFailureReason(err),
+		"method", r.Method,
+		"host", r.Host,
+		"path", r.URL.Path,
+	)
+}
+
+func authFailureReason(err error) string {
+	switch {
+	case errors.Is(err, errVerifierRequired):
+		return "verifier_unconfigured"
+	case errors.Is(err, errMissingProxyAuthorization):
+		return "missing_proxy_authorization"
+	case errors.Is(err, errInvalidProxyAuthorization):
+		return "invalid_proxy_authorization"
+	case errors.Is(err, errUnsupportedProxyAuthorizationScheme):
+		return "unsupported_proxy_authorization_scheme"
+	case errors.Is(err, errInvalidProxyAuthorizationCredentials):
+		return "invalid_proxy_authorization_credentials"
+	case errors.Is(err, errInvalidEgressPolicy):
+		return "invalid_egress_policy"
+	}
+
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "expired"):
+		return "jwt_expired"
+	case strings.Contains(message, "audience"):
+		return "jwt_audience_mismatch"
+	case strings.Contains(message, "not valid yet"):
+		return "jwt_not_before"
+	case strings.Contains(message, "signature"):
+		return "jwt_signature_invalid"
+	case strings.Contains(message, "missing required invocation claims"):
+		return "jwt_missing_invocation_claims"
+	default:
+		return "jwt_invalid"
+	}
 }
 
 func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request, requestPolicy *requestPolicy) {
 	host, port, err := net.SplitHostPort(r.Host)
 	if err != nil {
-		http.Error(w, "invalid CONNECT target", http.StatusBadRequest)
+		http.Error(w, "Metorial Magic Network: invalid CONNECT target", http.StatusBadRequest)
 		return
 	}
 
 	upstream, err := s.dialAllowed(r.Context(), host, port, requestPolicy)
 	if err != nil {
 		s.Logger.Warn("proxy denied connect", "host", host, "error", err)
-		http.Error(w, "destination not allowed", http.StatusForbidden)
+		http.Error(w, "Metorial Magic Network: policy denied outgoing request", http.StatusForbidden)
 		return
 	}
 	defer upstream.Close()
 
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
-		http.Error(w, "hijacking unsupported", http.StatusInternalServerError)
+		http.Error(w, "Metorial Magic Network: hijacking unsupported", http.StatusInternalServerError)
 		return
 	}
 	client, _, err := hijacker.Hijack()
@@ -143,7 +199,7 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request, requestPolic
 	upstream, err := s.dialAllowed(r.Context(), host, port, requestPolicy)
 	if err != nil {
 		s.Logger.Warn("proxy denied http request", "host", host, "error", err)
-		http.Error(w, "destination not allowed", http.StatusForbidden)
+		http.Error(w, "Metorial Magic Network: policy denied outgoing request", http.StatusForbidden)
 		return
 	}
 	defer upstream.Close()
@@ -161,13 +217,13 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request, requestPolic
 	out.Header.Del("Proxy-Connection")
 
 	if err := out.Write(upstream); err != nil {
-		http.Error(w, "upstream write failed", http.StatusBadGateway)
+		http.Error(w, "Metorial Magic Network: upstream write failed", http.StatusBadGateway)
 		return
 	}
 
 	resp, err := http.ReadResponse(bufio.NewReader(upstream), r)
 	if err != nil {
-		http.Error(w, "upstream read failed", http.StatusBadGateway)
+		http.Error(w, "Metorial Magic Network: upstream read failed", http.StatusBadGateway)
 		return
 	}
 	defer resp.Body.Close()
@@ -195,7 +251,7 @@ func isUpgradeRequest(r *http.Request) bool {
 func (s *Server) handleUpgrade(w http.ResponseWriter, r *http.Request, upstream net.Conn) {
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
-		http.Error(w, "hijacking unsupported", http.StatusInternalServerError)
+		http.Error(w, "Metorial Magic Network: hijacking unsupported", http.StatusInternalServerError)
 		return
 	}
 

--- a/src/systems/function-bay/deflector/internal/proxy/server_test.go
+++ b/src/systems/function-bay/deflector/internal/proxy/server_test.go
@@ -1,7 +1,10 @@
 package proxy
 
 import (
+	"bytes"
 	"encoding/base64"
+	"encoding/json"
+	"log/slog"
 	"net"
 	"net/http/httptest"
 	"testing"
@@ -92,5 +95,50 @@ func TestExplicitPrivateIPAllowlistOverridesDefaultBlock(t *testing.T) {
 	}
 	if !compiled.AllowsDestination(net.ParseIP("10.0.0.1"), 443) {
 		t.Fatal("expected explicit private IP allowlist to allow matching IP")
+	}
+}
+
+func TestLogAuthorizedRequestIncludesJTIAndPolicySummary(t *testing.T) {
+	var buf bytes.Buffer
+	server := &Server{
+		Logger: slog.New(slog.NewJSONHandler(&buf, nil)),
+	}
+
+	request := httptest.NewRequest("GET", "http://example.com/resource", nil)
+	server.logAuthorizedRequest(request, &requestPolicy{
+		Claims: policy.Claims{
+			TenantID:          "tenant_123",
+			FunctionID:        "function_123",
+			FunctionVersionID: "functionVersion_123",
+			EgressPolicy: &policy.CompiledNetworkAllowList{
+				Direction: "egress",
+				Entries: []policy.CompiledNetworkAllowEntry{
+					{CIDR: "93.184.216.34/32", PortRange: &policy.PortRange{From: 443, To: 443}},
+				},
+			},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ID: "jti_123",
+			},
+		},
+	})
+
+	var logged map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &logged); err != nil {
+		t.Fatal(err)
+	}
+	if logged["msg"] != "proxy request authorized" {
+		t.Fatalf("unexpected log message %q", logged["msg"])
+	}
+	if logged["jti"] != "jti_123" {
+		t.Fatalf("unexpected jti %q", logged["jti"])
+	}
+	if logged["policyMode"] != "explicit" || logged["policyDirection"] != "egress" {
+		t.Fatalf("unexpected policy summary %#v", logged)
+	}
+	if logged["policyEntries"] != float64(1) {
+		t.Fatalf("unexpected policy entries %#v", logged["policyEntries"])
+	}
+	if logged["policyFingerprint"] == "" {
+		t.Fatal("expected policy fingerprint")
 	}
 }

--- a/src/systems/function-bay/service/src/providers/aws-lambda/deflector.test.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/deflector.test.ts
@@ -64,6 +64,19 @@ describe('deflector token', () => {
         ]
       }
     });
+    expect(verified.payload.jti).toEqual(expect.any(String));
+
+    let nextToken = await createDeflectorToken({
+      tenantId: 'tenant_123',
+      functionId: 'function_123',
+      functionVersionId: 'functionVersion_123'
+    });
+    let nextVerified = await jwtVerify(nextToken!, new TextEncoder().encode('test-secret'), {
+      audience: 'deflector',
+      algorithms: ['HS256']
+    });
+    expect(nextVerified.payload.jti).toEqual(expect.any(String));
+    expect(nextVerified.payload.jti).not.toBe(verified.payload.jti);
   });
 
   it('returns the configured proxy url', () => {

--- a/src/systems/function-bay/service/src/providers/aws-lambda/deflector.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/deflector.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { SignJWT, type JWTPayload } from 'jose';
 import { env } from '../../env';
 
@@ -37,6 +38,7 @@ export let createDeflectorToken = async (d: {
     functionVersionId: d.functionVersionId,
     enclaveId: d.enclave?.id,
     enclaveIdentifier: d.enclave?.identifier,
+    jti: randomUUID(),
     iat: now,
     nbf: now - 30,
     exp: now + 5 * 60

--- a/src/systems/function-bay/service/src/providers/aws-lambda/deploy.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/deploy.ts
@@ -64,10 +64,25 @@ let originalHttpRequest;
 let originalHttpGet;
 let originalHttpsRequest;
 let originalHttpsGet;
+let currentHttpAgent;
+let currentHttpsAgent;
+let currentProxyDispatcher;
+
+function destroyAgent(agent) {
+  if (agent && typeof agent.destroy === 'function') {
+    agent.destroy();
+  }
+}
 
 function patchNodeHttpAgents(proxyUrl) {
   const httpAgent = new HttpProxyAgent(proxyUrl);
   const httpsAgent = new HttpsProxyAgent(proxyUrl);
+
+  const previousHttpAgent = currentHttpAgent;
+  const previousHttpsAgent = currentHttpsAgent;
+
+  currentHttpAgent = httpAgent;
+  currentHttpsAgent = httpsAgent;
 
   http.globalAgent = httpAgent;
   https.globalAgent = httpsAgent;
@@ -79,26 +94,29 @@ function patchNodeHttpAgents(proxyUrl) {
     originalHttpsGet = https.get;
 
     http.request = function patchedHttpRequest(...args) {
-      args = withAgent(args, httpAgent);
+      args = withAgent(args, currentHttpAgent);
       return originalHttpRequest.apply(this, args);
     };
     http.get = function patchedHttpGet(...args) {
-      args = withAgent(args, httpAgent);
+      args = withAgent(args, currentHttpAgent);
       const req = originalHttpRequest.apply(this, args);
       req.end();
       return req;
     };
     https.request = function patchedHttpsRequest(...args) {
-      args = withAgent(args, httpsAgent);
+      args = withAgent(args, currentHttpsAgent);
       return originalHttpsRequest.apply(this, args);
     };
     https.get = function patchedHttpsGet(...args) {
-      args = withAgent(args, httpsAgent);
+      args = withAgent(args, currentHttpsAgent);
       const req = originalHttpsRequest.apply(this, args);
       req.end();
       return req;
     };
   }
+
+  if (previousHttpAgent && previousHttpAgent !== httpAgent) destroyAgent(previousHttpAgent);
+  if (previousHttpsAgent && previousHttpsAgent !== httpsAgent) destroyAgent(previousHttpsAgent);
 
   syncBuiltinESMExports();
 }
@@ -144,10 +162,15 @@ exports.applyDeflector = function applyDeflector(event) {
   process.env.no_proxy = noProxy;
 
   patchNodeHttpAgents(proxyUrlWithAuth);
-  setGlobalDispatcher(new ProxyAgent({
+  const previousProxyDispatcher = currentProxyDispatcher;
+  currentProxyDispatcher = new ProxyAgent({
     uri: deflector.proxyUrl,
     token: proxyAuthorization
-  }));
+  });
+  setGlobalDispatcher(currentProxyDispatcher);
+  if (previousProxyDispatcher && previousProxyDispatcher !== currentProxyDispatcher) {
+    destroyAgent(previousProxyDispatcher);
+  }
 };
 `;
 
@@ -244,7 +267,7 @@ let getNodeProxyWrapperBootstrapCachePath = () =>
   join(
     tmpdir(),
     'function-bay-wrapper-build',
-    `metorial-deflector-bootstrap-v2-${process.version.replace(/[^a-zA-Z0-9.-]/g, '-')}.js`
+    `metorial-deflector-bootstrap-v3-${process.version.replace(/[^a-zA-Z0-9.-]/g, '-')}.js`
   );
 
 let bundleNodeProxyWrapperBootstrap = async () => {
@@ -306,6 +329,9 @@ let buildNodeProxyWrapper = async (originalHandler: string) =>
 
 export let buildNodeProxyWrapperScript = (originalHandler: string) =>
   nodeProxyWrapper(originalHandler, 'exports.applyDeflector = function applyDeflector() {};');
+
+export let buildNodeProxyWrapperScriptWithDeflector = (originalHandler: string) =>
+  nodeProxyWrapper(originalHandler, nodeProxyWrapperBootstrap);
 
 let prepareZip = async (d: {
   zipFile: Buffer;

--- a/src/systems/function-bay/service/src/providers/aws-lambda/deploy.wrapper.test.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/deploy.wrapper.test.ts
@@ -2,7 +2,10 @@ import { mkdir, mkdtemp, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { buildNodeProxyWrapperScript } from './deploy';
+import {
+  buildNodeProxyWrapperScript,
+  buildNodeProxyWrapperScriptWithDeflector
+} from './deploy';
 
 let tempDirs: string[] = [];
 
@@ -21,6 +24,65 @@ let createWrapperDir = async (files: Record<string, string>) => {
   );
 
   return dir;
+};
+
+let writeDeflectorAgentStubs = async (dir: string) => {
+  await mkdir(join(dir, 'node_modules', 'http-proxy-agent'), { recursive: true });
+  await mkdir(join(dir, 'node_modules', 'https-proxy-agent'), { recursive: true });
+  await mkdir(join(dir, 'node_modules', 'undici'), { recursive: true });
+
+  await writeFile(
+    join(dir, 'node_modules', 'http-proxy-agent', 'index.js'),
+    `
+      class HttpProxyAgent {
+        constructor(proxyUrl) {
+          this.proxyUrl = proxyUrl;
+          this.destroyed = false;
+        }
+        destroy() {
+          this.destroyed = true;
+        }
+      }
+      module.exports = { HttpProxyAgent };
+    `,
+    'utf-8'
+  );
+  await writeFile(
+    join(dir, 'node_modules', 'https-proxy-agent', 'index.js'),
+    `
+      class HttpsProxyAgent {
+        constructor(proxyUrl) {
+          this.proxyUrl = proxyUrl;
+          this.destroyed = false;
+        }
+        destroy() {
+          this.destroyed = true;
+        }
+      }
+      module.exports = { HttpsProxyAgent };
+    `,
+    'utf-8'
+  );
+  await writeFile(
+    join(dir, 'node_modules', 'undici', 'index.js'),
+    `
+      let dispatcher;
+      class ProxyAgent {
+        constructor(options) {
+          this.options = options;
+          this.destroyed = false;
+        }
+        destroy() {
+          this.destroyed = true;
+        }
+      }
+      function setGlobalDispatcher(next) {
+        dispatcher = next;
+      }
+      module.exports = { ProxyAgent, setGlobalDispatcher, getGlobalDispatcher: () => dispatcher };
+    `,
+    'utf-8'
+  );
 };
 
 afterEach(async () => {
@@ -123,5 +185,88 @@ describe('node proxy wrapper handler loading', () => {
     await expect(wrapper.handler({ payload: {} })).rejects.toThrow(
       /Original handler module not found.*tried=index, index\.js, index\.cjs, index\.mjs/
     );
+  });
+
+  it('refreshes proxy agents across warm invocations', async () => {
+    let dir = await mkdtemp(join(tmpdir(), 'fbay-wrapper-test-'));
+    tempDirs.push(dir);
+    await mkdir(dir, { recursive: true });
+    await writeDeflectorAgentStubs(dir);
+
+    await writeFile(
+      join(dir, 'index.js'),
+      `
+        const http = require('http');
+        const https = require('https');
+
+        exports.handler = async () => {
+          let httpAgent;
+          let httpsAgent;
+          let httpRequest = http.request('http://example.com', () => {});
+          httpAgent = httpRequest.agent;
+          let httpsRequest = https.request('https://example.com', () => {});
+          httpsAgent = httpsRequest.agent;
+
+          return {
+            statusCode: 200,
+            body: {
+              httpProxyUrl: httpAgent && httpAgent.proxyUrl,
+              httpsProxyUrl: httpsAgent && httpsAgent.proxyUrl
+            }
+          };
+        };
+      `,
+      'utf-8'
+    );
+    await writeFile(
+      join(dir, 'metorial_deflector_wrapper.cjs'),
+      buildNodeProxyWrapperScriptWithDeflector('index.handler'),
+      'utf-8'
+    );
+
+    let http = require('http');
+    let https = require('https');
+    let originalHttpRequest = http.request;
+    let originalHttpsRequest = https.request;
+    http.request = (...args: any[]) => ({
+      agent: args[1]?.agent ?? args[0]?.agent,
+      end() {}
+    });
+    https.request = (...args: any[]) => ({
+      agent: args[1]?.agent ?? args[0]?.agent,
+      end() {}
+    });
+
+    try {
+      let wrapperPath = join(dir, 'metorial_deflector_wrapper.cjs');
+      delete require.cache[require.resolve(wrapperPath)];
+      let wrapper = require(wrapperPath);
+
+      await wrapper.handler({
+        __functionBay: {
+          deflector: {
+            proxyUrl: 'http://deflector.local:8080',
+            token: 'first-token'
+          }
+        },
+        payload: {}
+      });
+
+      let secondResult = await wrapper.handler({
+        __functionBay: {
+          deflector: {
+            proxyUrl: 'http://deflector.local:8080',
+            token: 'second-token'
+          }
+        },
+        payload: {}
+      });
+
+      expect(secondResult.body.httpProxyUrl).toContain('second-token');
+      expect(secondResult.body.httpsProxyUrl).toContain('second-token');
+    } finally {
+      http.request = originalHttpRequest;
+      https.request = originalHttpsRequest;
+    }
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches JWT validation, proxy auth logging, and global HTTP agent patching in Lambda; behavior changes are scoped but security- and egress-path sensitive.
> 
> **Overview**
> Hardens **Function Bay deflector** proxy authentication and observability, and fixes **warm Lambda** reuse of stale proxy credentials.
> 
> Deflector JWT verification now allows **30s clock skew** so slightly-late tokens still validate. Each issued deflector token gets a unique **`jti`** (`randomUUID`), and successful proxy auth logs **`jti`**, invocation IDs, and an egress-policy summary (mode, direction, entry count, SHA-256 fingerprint). Auth failures log structured **`reason`** codes instead of only generic HTTP errors; client-facing proxy errors are prefixed with **Metorial Magic Network**.
> 
> The Node Lambda wrapper **re-applies** HTTP/HTTPS/`undici` proxy agents on every invocation (destroying prior agents), so a new per-invocation token is not stuck behind the first warm-start credentials. Bootstrap cache bumps to **v3**; tests cover leeway, logging, unique `jti`, and agent refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6beb5bc6573fed9de216cc68d14866f8870864a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->