### PR TITLE
Add ansii rendering for builds

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/version.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/version.tsx
@@ -23,6 +23,7 @@ import {
 } from '@metorial/ui';
 import { ID } from '@metorial/ui-product';
 import { RiArrowDownSLine } from '@remixicon/react';
+import Ansi from 'ansi-to-react';
 import { AnimatePresence, motion } from 'framer-motion';
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
@@ -331,6 +332,8 @@ let StepLogLineContent = styled.span`
   font-family: 'JetBrains Mono', monospace;
 `;
 
+let AnsiText = ({ children }: { children: string }) => <Ansi>{children}</Ansi>;
+
 let StepDetails = ({ step }: { step: Step }) => {
   let [isExpanded, setIsExpanded] = useState(false);
   let logsRef = useRef<HTMLDivElement>(null);
@@ -391,7 +394,7 @@ let StepDetails = ({ step }: { step: Step }) => {
                       transition={{ duration: 0.3 }}
                       key={currentLine}
                     >
-                      {currentLine}
+                      <AnsiText>{currentLine}</AnsiText>
                     </StepHeaderExcerptLine>
                   </AnimatePresence>
                 </StepHeaderExcerptWrapper>
@@ -447,7 +450,9 @@ let StepDetails = ({ step }: { step: Step }) => {
             {step.logs.map((log, index) => (
               <StepLogLine key={index} data-log-type={log.type}>
                 <StepLogTs>{log.timestamp?.toLocaleTimeString() ?? '--:--:--'}</StepLogTs>
-                <StepLogLineContent>{log.line}</StepLogLineContent>
+                <StepLogLineContent>
+                  <AnsiText>{log.line}</AnsiText>
+                </StepLogLineContent>
               </StepLogLine>
             ))}
             <Spacer height={5} />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only change to deployment log display in the dashboard; no auth, API, or deployment logic touched.
> 
> **Overview**
> Custom provider **deployment log** lines in `version.tsx` now render through **`ansi-to-react`** instead of plain text, so build/deploy output shows terminal colors and styles instead of raw escape sequences.
> 
> A small **`AnsiText`** wrapper is used for the collapsed step excerpt (latest log line) and for each line in the expanded log list; behavior and layout are unchanged aside from ANSI parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 391c53b8bf7bba843221255dc743973472911ad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->