### PR TITLE
Fail custom deployments after timeout

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/pages/(network)/(list)/firewalls.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(network)/(list)/firewalls.tsx
@@ -2,7 +2,7 @@ import {
   DashboardInstanceFirewallsListOutput,
   DashboardInstanceFirewallsListQuery
 } from '@metorial/dashboard-sdk';
-import { renderWithLoader, useForm } from '@metorial/data-hooks';
+import { useForm } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import {
   useCreateFirewall,
@@ -12,7 +12,6 @@ import {
   useFirewalls,
   useNetworks
 } from '@metorial/state';
-import { useNetworkManagementAccess } from '../_gate';
 import { Button, Dialog, Input, RenderDate, Spacer, Text, showModal } from '@metorial/ui';
 import { ID } from '@metorial/ui-product';
 import { useNavigate } from 'react-router-dom';
@@ -22,6 +21,7 @@ import {
   TableStateProviderResult
 } from '../../../../../components/table/type';
 import { statusBadge } from '../_common';
+import { useNetworkManagementAccess } from '../_gate';
 
 type Firewall = DashboardInstanceFirewallsListOutput['items'][number];
 
@@ -120,32 +120,32 @@ let FirewallsTable = () => {
     instance,
     emptyState: 'No firewalls configured.',
     headerActions: () =>
-      canWrite ?
+      canWrite ? (
         <Button
-        size="2"
-        disabled={!instance.data || !networks.data?.items[0]}
-        onClick={() => {
-          let network = networks.data?.items[0];
-          if (!instance.data || !network) return;
+          size="2"
+          disabled={!instance.data || !networks.data?.items[0]}
+          onClick={() => {
+            let network = networks.data?.items[0];
+            if (!instance.data || !network) return;
 
-          showCreateFirewallModal({
-            instanceId: instance.data.id,
-            networkId: network.id,
-            onCreate: firewallId =>
-              navigate(
-                Paths.instance.networkFirewall(
-                  organization.data,
-                  project.data,
-                  instance.data,
-                  firewallId
+            showCreateFirewallModal({
+              instanceId: instance.data.id,
+              networkId: network.id,
+              onCreate: firewallId =>
+                navigate(
+                  Paths.instance.networkFirewall(
+                    organization.data,
+                    project.data,
+                    instance.data,
+                    firewallId
+                  )
                 )
-              )
-          });
-        }}
+            });
+          }}
         >
           Create Firewall
         </Button>
-      : null
+      ) : null
   });
 };
 
@@ -207,21 +207,9 @@ let showCreateFirewallModal = (p: {
 
 export let NetworkFirewallsPage = () => {
   let instance = useCurrentInstance();
-  let networks = useNetworks(instance.data?.id, { limit: 1 });
 
   return (
     <>
-      {renderWithLoader({ networks })(({ networks }) =>
-        !networks.data.items[0] ? (
-          <>
-            <Text size="2" color="gray600">
-              Firewalls need a default network before they can be created.
-            </Text>
-            <Spacer size={20} />
-          </>
-        ) : null
-      )}
-
       <FirewallsTable />
     </>
   );

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/version.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/version.tsx
@@ -23,6 +23,7 @@ import {
 } from '@metorial/ui';
 import { ID } from '@metorial/ui-product';
 import { RiArrowDownSLine } from '@remixicon/react';
+import Ansi from 'ansi-to-react';
 import { AnimatePresence, motion } from 'framer-motion';
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
@@ -331,6 +332,8 @@ let StepLogLineContent = styled.span`
   font-family: 'JetBrains Mono', monospace;
 `;
 
+let AnsiText = ({ children }: { children: string }) => <Ansi>{children}</Ansi>;
+
 let StepDetails = ({ step }: { step: Step }) => {
   let [isExpanded, setIsExpanded] = useState(false);
   let logsRef = useRef<HTMLDivElement>(null);
@@ -391,7 +394,7 @@ let StepDetails = ({ step }: { step: Step }) => {
                       transition={{ duration: 0.3 }}
                       key={currentLine}
                     >
-                      {currentLine}
+                      <AnsiText>{currentLine}</AnsiText>
                     </StepHeaderExcerptLine>
                   </AnimatePresence>
                 </StepHeaderExcerptWrapper>
@@ -447,7 +450,9 @@ let StepDetails = ({ step }: { step: Step }) => {
             {step.logs.map((log, index) => (
               <StepLogLine key={index} data-log-type={log.type}>
                 <StepLogTs>{log.timestamp?.toLocaleTimeString() ?? '--:--:--'}</StepLogTs>
-                <StepLogLineContent>{log.line}</StepLogLineContent>
+                <StepLogLineContent>
+                  <AnsiText>{log.line}</AnsiText>
+                </StepLogLineContent>
               </StepLogLine>
             ))}
             <Spacer height={5} />

--- a/src/systems/shuttle/service/prisma/schema/deployment.prisma
+++ b/src/systems/shuttle/service/prisma/schema/deployment.prisma
@@ -29,6 +29,8 @@ model ServerDeployment {
   serverVersion ServerVersion?
 
   @@index([tenantOid, createdAt])
+  @@index([status, startedAt])
+  @@index([status, createdAt])
 }
 
 enum ServerDeploymentStepType {

--- a/src/systems/shuttle/service/src/endpoints.ts
+++ b/src/systems/shuttle/service/src/endpoints.ts
@@ -74,9 +74,6 @@ if (process.env.NODE_ENV === 'production') {
           step = 'checking redis';
           await checkRedis();
 
-          // step = 'checking holopod';
-          // await checkHolopodHealth();
-
           return new Response('OK');
         } catch (e) {
           console.error(`Health check failed at step: ${step}`, e);

--- a/src/systems/shuttle/service/src/mcp/holopod/client.ts
+++ b/src/systems/shuttle/service/src/mcp/holopod/client.ts
@@ -1,4 +1,3 @@
-import { delay } from '@lowerdeck/delay';
 import axios from 'axios';
 import { EventEmitter } from 'events';
 import * as https from 'https';
@@ -243,21 +242,21 @@ export let checkHolopodHealth = async (opts?: { timeoutMs?: number }) => {
   return response.data;
 };
 
-(async () => {
-  if (process.env.NODE_ENV !== 'production') return;
+// (async () => {
+//   if (process.env.NODE_ENV !== 'production') return;
 
-  let interval = 1000 * 30;
+//   let interval = 1000 * 30;
 
-  while (true) {
-    try {
-      let health = await checkHolopodHealth({ timeoutMs: 5000 });
-      console.log(`[${new Date().toISOString()}] Holopod health:`, JSON.stringify(health));
+//   while (true) {
+//     try {
+//       let health = await checkHolopodHealth({ timeoutMs: 5000 });
+//       console.log(`[${new Date().toISOString()}] Holopod health:`, JSON.stringify(health));
 
-      interval = 1000 * 60 * 5;
-    } catch (err) {
-      console.error(`[${new Date().toISOString()}] Holopod health check failed:`, err);
-    }
+//       interval = 1000 * 60 * 5;
+//     } catch (err) {
+//       console.error(`[${new Date().toISOString()}] Holopod health check failed:`, err);
+//     }
 
-    await delay(interval);
-  }
-})();
+//     await delay(interval);
+//   }
+// })();

--- a/src/systems/shuttle/service/src/queues/deployment/failed.ts
+++ b/src/systems/shuttle/service/src/queues/deployment/failed.ts
@@ -10,13 +10,24 @@ export let deployServerFailedQueue = createQueue<{
 });
 
 export let deployServerFailedQueueProcessor = deployServerFailedQueue.process(async data => {
-  let deployment = await db.serverDeployment.update({
+  let deployment = await db.serverDeployment.findFirst({
     where: { id: data.serverDeploymentId },
+    select: { oid: true }
+  });
+  if (!deployment) return;
+
+  let endedAt = new Date();
+  let update = await db.serverDeployment.updateMany({
+    where: {
+      id: data.serverDeploymentId,
+      status: { in: ['queued', 'deploying'] }
+    },
     data: {
       status: 'failed',
-      endedAt: new Date()
+      endedAt
     }
   });
+  if (update.count === 0) return;
 
   await db.serverDeploymentStep.updateMany({
     where: {
@@ -25,7 +36,7 @@ export let deployServerFailedQueueProcessor = deployServerFailedQueue.process(as
     },
     data: {
       status: 'failed',
-      endedAt: deployment.endedAt
+      endedAt
     }
   });
 });

--- a/src/systems/shuttle/service/src/queues/deployment/succeeded.ts
+++ b/src/systems/shuttle/service/src/queues/deployment/succeeded.ts
@@ -11,13 +11,24 @@ export let deployServerSucceededQueue = createQueue<{
 
 export let deployServerSucceededQueueProcessor = deployServerSucceededQueue.process(
   async data => {
-    let deployment = await db.serverDeployment.update({
+    let deployment = await db.serverDeployment.findFirst({
       where: { id: data.serverDeploymentId },
+      select: { oid: true }
+    });
+    if (!deployment) return;
+
+    let endedAt = new Date();
+    let update = await db.serverDeployment.updateMany({
+      where: {
+        id: data.serverDeploymentId,
+        status: { in: ['queued', 'deploying'] }
+      },
       data: {
         status: 'succeeded',
-        endedAt: new Date()
+        endedAt
       }
     });
+    if (update.count === 0) return;
 
     await db.serverDeploymentStep.updateMany({
       where: {
@@ -26,7 +37,7 @@ export let deployServerSucceededQueueProcessor = deployServerSucceededQueue.proc
       },
       data: {
         status: 'succeeded',
-        endedAt: deployment.endedAt
+        endedAt
       }
     });
   }

--- a/src/systems/shuttle/service/src/queues/deployment/timeout.ts
+++ b/src/systems/shuttle/service/src/queues/deployment/timeout.ts
@@ -1,0 +1,134 @@
+import { createCron } from '@lowerdeck/cron';
+import { createQueue } from '@lowerdeck/queue';
+import { db } from '../../db';
+import { env } from '../../env';
+
+let DEPLOYING_TIMEOUT_MS = 1000 * 60 * 15;
+let QUEUED_TIMEOUT_MS = 1000 * 60 * 60 * 24;
+
+let getTimeoutThresholds = () => {
+  let now = Date.now();
+
+  return {
+    deploying: new Date(now - DEPLOYING_TIMEOUT_MS),
+    queued: new Date(now - QUEUED_TIMEOUT_MS)
+  };
+};
+
+export let deployServerTimeoutCron = createCron(
+  {
+    name: 'shut/deploy/timeout/cron',
+    redisUrl: env.service.REDIS_URL,
+    cron: '* * * * *'
+  },
+  async () => {
+    await deployServerTimeoutManyQueue.add({});
+  }
+);
+
+export let deployServerTimeoutManyQueue = createQueue<{ cursor?: string }>({
+  name: 'shut/deploy/timeout/many',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let deployServerTimeoutManyQueueProcessor =
+  deployServerTimeoutManyQueue.process(async data => {
+    let thresholds = getTimeoutThresholds();
+
+    let deployments = await db.serverDeployment.findMany({
+      where: {
+        id: data.cursor ? { gt: data.cursor } : undefined,
+        OR: [
+          {
+            status: 'deploying',
+            startedAt: { lte: thresholds.deploying }
+          },
+          {
+            status: 'queued',
+            createdAt: { lte: thresholds.queued }
+          }
+        ]
+      },
+      take: 100,
+      orderBy: { id: 'asc' },
+      select: { id: true }
+    });
+    if (deployments.length === 0) return;
+
+    await deployServerTimeoutSingleQueue.addManyWithOps(
+      deployments.map(deployment => ({
+        data: { serverDeploymentId: deployment.id },
+        opts: { id: deployment.id }
+      }))
+    );
+
+    await deployServerTimeoutManyQueue.add({
+      cursor: deployments[deployments.length - 1]!.id
+    });
+  });
+
+export let deployServerTimeoutSingleQueue = createQueue<{
+  serverDeploymentId: string;
+}>({
+  name: 'shut/deploy/timeout',
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: {
+    concurrency: 10
+  }
+});
+
+export let deployServerTimeoutSingleQueueProcessor =
+  deployServerTimeoutSingleQueue.process(async data => {
+    let thresholds = getTimeoutThresholds();
+
+    let deployment = await db.serverDeployment.findFirst({
+      where: {
+        id: data.serverDeploymentId,
+        OR: [
+          {
+            status: 'deploying',
+            startedAt: { lte: thresholds.deploying }
+          },
+          {
+            status: 'queued',
+            createdAt: { lte: thresholds.queued }
+          }
+        ]
+      },
+      select: { oid: true }
+    });
+    if (!deployment) return;
+
+    let endedAt = new Date();
+    let update = await db.serverDeployment.updateMany({
+      where: {
+        id: data.serverDeploymentId,
+        OR: [
+          {
+            status: 'deploying',
+            startedAt: { lte: thresholds.deploying }
+          },
+          {
+            status: 'queued',
+            createdAt: { lte: thresholds.queued }
+          }
+        ]
+      },
+      data: {
+        status: 'failed',
+        endedAt
+      }
+    });
+    if (update.count === 0) return;
+
+    await db.serverDeploymentStep.updateMany({
+      where: {
+        deploymentOid: deployment.oid,
+        status: { in: ['running'] }
+      },
+      data: {
+        status: 'failed',
+        endedAt
+      }
+    });
+  });

--- a/src/systems/shuttle/service/src/worker.ts
+++ b/src/systems/shuttle/service/src/worker.ts
@@ -10,6 +10,11 @@ import { deployContainerServerWatchQueueProcessor } from './queues/container/mon
 import { deployContainerServerStartQueueProcessor } from './queues/container/startDeployment';
 import { deployServerFailedQueueProcessor } from './queues/deployment/failed';
 import { deployServerSucceededQueueProcessor } from './queues/deployment/succeeded';
+import {
+  deployServerTimeoutCron,
+  deployServerTimeoutManyQueueProcessor,
+  deployServerTimeoutSingleQueueProcessor
+} from './queues/deployment/timeout';
 import { discoverRemoteOAuthConfigQueueProcessor } from './queues/discovery/remoteOAuthConfig';
 import { discoverRemoteOAuthConnectionQueueProcessor } from './queues/discovery/remoteOAuthConnection';
 import { discoverServerQueueProcessor } from './queues/discovery/server';
@@ -81,5 +86,9 @@ await runQueueProcessors([
   deployRemoteServerStartQueueProcessor,
 
   deployServerFailedQueueProcessor,
-  deployServerSucceededQueueProcessor
+  deployServerSucceededQueueProcessor,
+
+  deployServerTimeoutCron,
+  deployServerTimeoutManyQueueProcessor,
+  deployServerTimeoutSingleQueueProcessor
 ]);

--- a/src/systems/subspace/modules/connection/src/mcp/sender.ts
+++ b/src/systems/subspace/modules/connection/src/mcp/sender.ts
@@ -271,11 +271,6 @@ export class McpSender {
         return this.handleInitializedMessage(initNotification.data);
       }
 
-      console.warn(
-        'Received MCP message without id or with notification method, ignoring:',
-        msg
-      );
-
       // TODO: handle notification for mcp-compatible backends
       // -> send to all backends that support it
       return;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes deployment lifecycle and DB status updates for custom deployments; incorrect timeouts or race handling could mark active deploys failed, though conditional updates reduce that risk.
> 
> **Overview**
> Adds **automatic failure for stuck custom/server deployments**: a minute cron scans deployments still **deploying** past ~15 minutes or **queued** past ~24 hours, enqueues per-deployment work, and marks them **failed** while failing any **running** steps. **Succeeded/failed** queue handlers now only transition deployments still in **queued/deploying**, avoiding races with timeouts or duplicate jobs. **Prisma** adds indexes on deployment **status** + **startedAt/createdAt** to support those scans.
> 
> **Shuttle** production readiness no longer depends on Holopod; the periodic Holopod health log loop is disabled. **Dashboard** custom-provider deployment logs render **ANSI** colors in excerpts and log lines. Minor UI cleanup on the network **firewalls** list (drops the “default network required” banner) and less noisy MCP handling for ignored notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96a2a12809d765671686984474e73b14ed0c3df2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->