### PR TITLE
Add ip access flag

### DIFF
--- a/src/backend/apis/core/src/controllers/instance/network/network.ts
+++ b/src/backend/apis/core/src/controllers/instance/network/network.ts
@@ -1,16 +1,23 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
+import type { Organization } from '@metorial/db';
+import { flagService } from '@metorial/module-flags';
 import { subspaceEnclaveService, subspaceNetworkService } from '@metorial/module-subspace';
 import { Controller } from '@metorial/rest';
 import { dateFilterValidator } from '../../../lib/dateFilter';
 import { normalizeArrayParam } from '../../../lib/normalizeArrayParam';
 import { checkAccess } from '../../../middleware/checkAccess';
 import { instancePath } from '../../../middleware/instanceGroup';
-import { networkInstanceGroup } from './_middleware';
 import { networkLogsPresenter, networkPresenter } from '../../../presenters';
+import { networkInstanceGroup } from './_middleware';
 
 let networkReadScopes = ['instance.network:read'] as const;
+
+let getMaskPublicIp = async (organization: Organization) => {
+  let flags = await flagService.getFlags({ organization });
+  return !flags['paid-network-ip-access'];
+};
 
 export let networkGroup = networkInstanceGroup.use(async ctx => {
   if (!ctx.params.networkId) {
@@ -66,10 +73,12 @@ export let networkController = Controller.create(
         });
 
         let list = await paginator.run(ctx.query);
+        let maskPublicIp = await getMaskPublicIp(ctx.instance.organization);
 
         return Paginator.present(list, network =>
           networkPresenter.present({
-            network
+            network,
+            maskPublicIp
           })
         );
       }),
@@ -81,12 +90,17 @@ export let networkController = Controller.create(
       })
       .use(checkAccess({ possibleScopes: [...networkReadScopes] }))
       .output(networkPresenter)
-      .do(async ctx => networkPresenter.present({ network: ctx.network })),
+      .do(async ctx => {
+        let maskPublicIp = await getMaskPublicIp(ctx.instance.organization);
+
+        return networkPresenter.present({ network: ctx.network, maskPublicIp });
+      }),
 
     listNetworkLogs: networkInstanceGroup
       .get(instancePath('network-logs', 'networks.listNetworkLogs'), {
         name: 'List network logs',
-        description: 'Returns ingress or egress network logs for enclaves in the instance environment.'
+        description:
+          'Returns ingress or egress network logs for enclaves in the instance environment.'
       })
       .use(checkAccess({ possibleScopes: [...networkReadScopes] }))
       .output(networkLogsPresenter)

--- a/src/backend/apis/core/src/presenters/implementation/network/network.ts
+++ b/src/backend/apis/core/src/presenters/implementation/network/network.ts
@@ -5,26 +5,31 @@ import { networkType } from '../../types';
 
 let ip = process.env.METORIAL_DEFLECTOR_PUBLIC_IP ?? '1.1.1.1';
 let region = process.env.METORIAL_REGION ?? 'LO1';
+let maskedPublicIp = 'x.x.x.x';
 
 export let v1NetworkPresenter = Presenter.create(networkType)
-  .presenter(async ({ network }) => ({
-    object: 'network' as const,
-    id: network.id,
-    name: network.name,
-    description: network.description,
-    created_at: network.createdAt,
-    updated_at: network.updatedAt,
-    public_ips: [
-      {
-        object: 'network.public_ip' as const,
-        id: shadowId('ntip_', [network.id, ip]),
-        ip,
-        region,
-        created_at: network.createdAt,
-        updated_at: network.createdAt
-      }
-    ]
-  }))
+  .presenter(async ({ network, maskPublicIp }) => {
+    let displayedIp = maskPublicIp ? maskedPublicIp : ip;
+
+    return {
+      object: 'network' as const,
+      id: network.id,
+      name: network.name,
+      description: network.description,
+      created_at: network.createdAt,
+      updated_at: network.updatedAt,
+      public_ips: [
+        {
+          object: 'network.public_ip' as const,
+          id: shadowId('ntip_', [network.id, displayedIp]),
+          ip: displayedIp,
+          region,
+          created_at: network.createdAt,
+          updated_at: network.createdAt
+        }
+      ]
+    };
+  })
   .schema(
     v.object({
       object: v.literal('network'),

--- a/src/backend/apis/core/src/presenters/types.ts
+++ b/src/backend/apis/core/src/presenters/types.ts
@@ -1222,6 +1222,7 @@ export let skillTemplateItemType = PresentableType.create<{
 
 export let networkType = PresentableType.create<{
   network: SubspaceNetwork;
+  maskPublicIp?: boolean;
 }>()('network');
 
 export let networkLogsType = PresentableType.create<{

--- a/src/backend/modules/flags/src/definitions.ts
+++ b/src/backend/modules/flags/src/definitions.ts
@@ -27,6 +27,7 @@ export type Flags = {
   'paid-portals': boolean;
   'paid-key-providers': boolean;
   'paid-networking': boolean;
+  'paid-network-ip-access': boolean;
 };
 
 export let defaultFlags: Flags = {
@@ -55,7 +56,8 @@ export let defaultFlags: Flags = {
   'paid-sso-tenants': true,
   'paid-portals': true,
   'paid-key-providers': true,
-  'paid-networking': false
+  'paid-networking': false,
+  'paid-network-ip-access': false
 };
 
 export type FlagProviderParams = {

--- a/src/frontend/apps/dashboard/src/slices/product/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/index.tsx
@@ -7,8 +7,8 @@ import { Error } from '@metorial/ui';
 import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Upgrade } from '../../components/emptyState';
-import { NetworkManagedPage } from './pages/(network)/_gate';
 import { ProjectHomePage } from './pages';
+import { NetworkManagedPage } from './pages/(network)/_gate';
 import { InstanceLayout } from './pages/_instanceLayout';
 
 // Provider API pages
@@ -1377,19 +1377,11 @@ export let productHomeSlice = createSlice([
 
           {
             path: 'security',
-            element: (
-              <NetworkManagedPage>
-                <SecurityOverviewPage />
-              </NetworkManagedPage>
-            )
+            element: <SecurityOverviewPage />
           },
           {
             path: 'network',
-            element: (
-              <NetworkManagedPage>
-                <NetworkListLayout />
-              </NetworkManagedPage>
-            ),
+            element: <NetworkListLayout />,
             children: [
               {
                 path: '',
@@ -1411,11 +1403,7 @@ export let productHomeSlice = createSlice([
           },
           {
             path: 'network/firewall/:firewallId',
-            element: (
-              <NetworkManagedPage>
-                <NetworkFirewallPageLayout />
-              </NetworkManagedPage>
-            ),
+            element: <NetworkFirewallPageLayout />,
             children: [
               {
                 path: '',

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(network)/(list)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(network)/(list)/_layout.tsx
@@ -8,6 +8,7 @@ import {
 } from '@metorial/state';
 import { LinkTabs } from '@metorial/ui';
 import { Outlet, useLocation } from 'react-router-dom';
+import { NetworkManagedPage } from '../_gate';
 
 export let NetworkListLayout = () => {
   let organization = useCurrentOrganization();
@@ -22,31 +23,45 @@ export let NetworkListLayout = () => {
         description="Monitor network activity and manage firewalls for this instance."
       />
 
-      <LinkTabs
-        current={location.pathname}
-        links={[
-          {
-            label: 'Overview',
-            to: Paths.instance.network(organization.data, project.data, instance.data)
-          },
-          {
-            label: 'Firewalls',
-            to: Paths.instance.networkFirewalls(organization.data, project.data, instance.data)
-          },
-          {
-            label: 'Enclaves',
-            to: Paths.instance.networkEnclaves(organization.data, project.data, instance.data)
-          },
-          {
-            label: 'Settings',
-            to: Paths.instance.networkSettings(organization.data, project.data, instance.data)
-          }
-        ]}
-      />
+      <NetworkManagedPage>
+        <LinkTabs
+          current={location.pathname}
+          links={[
+            {
+              label: 'Overview',
+              to: Paths.instance.network(organization.data, project.data, instance.data)
+            },
+            {
+              label: 'Firewalls',
+              to: Paths.instance.networkFirewalls(
+                organization.data,
+                project.data,
+                instance.data
+              )
+            },
+            {
+              label: 'Enclaves',
+              to: Paths.instance.networkEnclaves(
+                organization.data,
+                project.data,
+                instance.data
+              )
+            },
+            {
+              label: 'Settings',
+              to: Paths.instance.networkSettings(
+                organization.data,
+                project.data,
+                instance.data
+              )
+            }
+          ]}
+        />
 
-      <PaginationSearchParamsProvider enabled={true}>
-        <Outlet />
-      </PaginationSearchParamsProvider>
+        <PaginationSearchParamsProvider enabled={true}>
+          <Outlet />
+        </PaginationSearchParamsProvider>
+      </NetworkManagedPage>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(network)/_gate.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(network)/_gate.tsx
@@ -9,10 +9,16 @@ export let useNetworkManagementAccess = () => {
     flags,
     isEnabled: !!flags.data?.flags['networking-enabled'],
     isPaid: !!flags.data?.flags['paid-networking'],
+    hasPublicIpAccess: !!flags.data?.flags['paid-network-ip-access'],
     canWrite:
       !!flags.data?.flags['networking-enabled'] && !!flags.data?.flags['paid-networking']
   };
 };
+
+export let getDisplayedNetworkPublicIp = (
+  ip: string | undefined,
+  hasPublicIpAccess: boolean
+) => (hasPublicIpAccess ? ip ?? '-' : 'shared');
 
 export let NetworkManagedPage = ({ children }: { children: React.ReactNode }) => {
   let flags = useDashboardFlags();

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(network)/firewall/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(network)/firewall/index.tsx
@@ -12,7 +12,18 @@ import {
   useNetwork,
   useNetworkPolicy
 } from '@metorial/state';
-import { Attributes, Badge, Button, Dialog, Input, Menu, Select, Spacer, Text, showModal } from '@metorial/ui';
+import {
+  Attributes,
+  Badge,
+  Button,
+  Dialog,
+  Input,
+  Menu,
+  Select,
+  Spacer,
+  Text,
+  showModal
+} from '@metorial/ui';
 import { Box, ID, Table } from '@metorial/ui-product';
 import { RiArrowDownLine, RiArrowUpLine, RiMore2Line } from '@remixicon/react';
 import { Link, useParams } from 'react-router-dom';
@@ -38,11 +49,10 @@ type PolicyRule = {
   description: string | null;
   enabled: boolean;
   priority: number;
-  ports: ({ object: 'network.policy.port_range'; from: number; to: number }[] | null);
+  ports: { object: 'network.policy.port_range'; from: number; to: number }[] | null;
 };
 
-let ipv4AddressRegex =
-  /^(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)$/;
+let ipv4AddressRegex = /^(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)$/;
 
 let ipv6SegmentRegex = /^[0-9a-fA-F]{1,4}$/;
 
@@ -80,7 +90,9 @@ let isValidCidr = (cidr: string) => {
 };
 
 let parsePorts = (portFrom: string, portTo: string) =>
-  portFrom !== '' && portTo !== '' ? [{ from: Number(portFrom), to: Number(portTo) }] : undefined;
+  portFrom !== '' && portTo !== ''
+    ? [{ from: Number(portFrom), to: Number(portTo) }]
+    : undefined;
 
 let getRuleInput = (values: {
   effect: 'allow' | 'deny';
@@ -306,7 +318,11 @@ let showRuleModal = (p: {
             .max(65535, 'Port must be 65535 or lower')
             .transform((value, originalValue) => (originalValue === '' ? undefined : value))
             .test('port-pair', 'Port From is required when Port To is set', function (value) {
-              return this.parent.direction === 'ingress' || this.parent.portTo === undefined || value !== undefined;
+              return (
+                this.parent.direction === 'ingress' ||
+                this.parent.portTo === undefined ||
+                value !== undefined
+              );
             })
             .optional(),
           portTo: yup
@@ -316,11 +332,24 @@ let showRuleModal = (p: {
             .max(65535, 'Port must be 65535 or lower')
             .transform((value, originalValue) => (originalValue === '' ? undefined : value))
             .test('port-pair', 'Port To is required when Port From is set', function (value) {
-              return this.parent.direction === 'ingress' || this.parent.portFrom === undefined || value !== undefined;
+              return (
+                this.parent.direction === 'ingress' ||
+                this.parent.portFrom === undefined ||
+                value !== undefined
+              );
             })
-            .test('port-range', 'Port To must be greater than or equal to Port From', function (value) {
-              return this.parent.direction === 'ingress' || this.parent.portFrom === undefined || value === undefined || value >= this.parent.portFrom;
-            })
+            .test(
+              'port-range',
+              'Port To must be greater than or equal to Port From',
+              function (value) {
+                return (
+                  this.parent.direction === 'ingress' ||
+                  this.parent.portFrom === undefined ||
+                  value === undefined ||
+                  value >= this.parent.portFrom
+                );
+              }
+            )
             .optional(),
           description: yup.string()
         }) as any
@@ -357,15 +386,35 @@ let showRuleModal = (p: {
           <Input label="CIDRs" {...form.getFieldProps('cidrs')} />
           <form.RenderError field="cidrs" />
           <Spacer size={12} />
-          <Input label="Priority" type="number" min={0} step={1} {...form.getFieldProps('priority')} />
+          <Input
+            label="Priority"
+            type="number"
+            min={0}
+            step={1}
+            {...form.getFieldProps('priority')}
+          />
           <form.RenderError field="priority" />
           {form.values.direction === 'egress' && (
             <>
               <Spacer size={12} />
-              <Input label="Port From" type="number" min={1} max={65535} step={1} {...form.getFieldProps('portFrom')} />
+              <Input
+                label="Port From"
+                type="number"
+                min={1}
+                max={65535}
+                step={1}
+                {...form.getFieldProps('portFrom')}
+              />
               <form.RenderError field="portFrom" />
               <Spacer size={12} />
-              <Input label="Port To" type="number" min={1} max={65535} step={1} {...form.getFieldProps('portTo')} />
+              <Input
+                label="Port To"
+                type="number"
+                min={1}
+                max={65535}
+                step={1}
+                {...form.getFieldProps('portTo')}
+              />
               <form.RenderError field="portTo" />
             </>
           )}
@@ -404,7 +453,7 @@ let PolicyBox = (p: {
       title={policy.data.name}
       description={`Version ${policy.data.version}`}
       rightActions={
-        p.canWrite ?
+        p.canWrite ? (
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <Button
               size="2"
@@ -432,44 +481,44 @@ let PolicyBox = (p: {
             </Button>
 
             <Menu
-            items={[
-              { id: 'edit', label: 'Edit' },
-              { id: 'detach', label: 'Detach' }
-            ]}
-            onItemClick={async item => {
-              if (item === 'edit') {
-                showEditPolicyModal({
-                  name: policy.data.name,
-                  description: policy.data.description,
-                  onSubmit: async values => {
-                    await updatePolicy.mutate({
-                      name: values.name,
-                      description: values.description || undefined
-                    });
-                    p.onComplete();
-                  }
-                });
-              }
+              items={[
+                { id: 'edit', label: 'Edit' },
+                { id: 'detach', label: 'Detach' }
+              ]}
+              onItemClick={async item => {
+                if (item === 'edit') {
+                  showEditPolicyModal({
+                    name: policy.data.name,
+                    description: policy.data.description,
+                    onSubmit: async values => {
+                      await updatePolicy.mutate({
+                        name: values.name,
+                        description: values.description || undefined
+                      });
+                      p.onComplete();
+                    }
+                  });
+                }
 
-              if (item === 'detach') {
-                await detachPolicy.mutate({
-                  instanceId: p.instanceId,
-                  firewallId: p.firewallId,
-                  networkPolicyId: p.policyId
-                });
-                p.onComplete();
-              }
-            }}
-          >
-            <Button
-              size="2"
-              variant="outline"
-              iconLeft={<RiMore2Line />}
-              title="Policy actions"
-            />
+                if (item === 'detach') {
+                  await detachPolicy.mutate({
+                    instanceId: p.instanceId,
+                    firewallId: p.firewallId,
+                    networkPolicyId: p.policyId
+                  });
+                  p.onComplete();
+                }
+              }}
+            >
+              <Button
+                size="2"
+                variant="outline"
+                iconLeft={<RiMore2Line />}
+                title="Policy actions"
+              />
             </Menu>
           </div>
-        : undefined
+        ) : undefined
       }
     >
       {policy.data.rules.length > 0 ? (
@@ -486,7 +535,7 @@ let PolicyBox = (p: {
                 {rule.ports?.map(port => `${port.from}-${port.to}`).join(', ') ?? 'All'}
               </Text>,
               <Text size="2">{rule.priority}</Text>,
-              p.canWrite ?
+              p.canWrite ? (
                 <div style={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
                   <Menu
                     items={[
@@ -494,58 +543,60 @@ let PolicyBox = (p: {
                       { id: 'remove', label: 'Remove' }
                     ]}
                     onItemClick={async item => {
-                    if (item === 'edit') {
-                      showRuleModal({
-                        title: 'Edit Network Rule',
-                        description: 'Update this network policy rule.',
-                        initialValues: {
-                          effect: rule.effect,
-                          direction: rule.direction,
-                          cidrs: rule.cidrs.join(', '),
-                          priority: String(rule.priority),
-                          portFrom: rule.ports?.[0] ? String(rule.ports[0].from) : '',
-                          portTo: rule.ports?.[0] ? String(rule.ports[0].to) : '',
-                          description: rule.description ?? ''
-                        },
-                        onSubmit: async nextRule => {
-                          await updateRule.mutate({
-                            ruleId: rule.id,
-                            rule: nextRule,
-                            currentRules: policy.data.rules.map((currentRule: PolicyRule) => ({
-                              id: currentRule.id,
-                              effect: currentRule.effect,
-                              direction: currentRule.direction,
-                              cidrs: currentRule.cidrs,
-                              description: currentRule.description,
-                              enabled: currentRule.enabled,
-                              priority: currentRule.priority,
-                              ports:
-                                currentRule.ports?.map(port => ({
-                                  from: port.from,
-                                  to: port.to
-                                })) ?? null
-                            }))
-                          });
-                          p.onComplete();
-                        }
-                      });
-                    }
+                      if (item === 'edit') {
+                        showRuleModal({
+                          title: 'Edit Network Rule',
+                          description: 'Update this network policy rule.',
+                          initialValues: {
+                            effect: rule.effect,
+                            direction: rule.direction,
+                            cidrs: rule.cidrs.join(', '),
+                            priority: String(rule.priority),
+                            portFrom: rule.ports?.[0] ? String(rule.ports[0].from) : '',
+                            portTo: rule.ports?.[0] ? String(rule.ports[0].to) : '',
+                            description: rule.description ?? ''
+                          },
+                          onSubmit: async nextRule => {
+                            await updateRule.mutate({
+                              ruleId: rule.id,
+                              rule: nextRule,
+                              currentRules: policy.data.rules.map(
+                                (currentRule: PolicyRule) => ({
+                                  id: currentRule.id,
+                                  effect: currentRule.effect,
+                                  direction: currentRule.direction,
+                                  cidrs: currentRule.cidrs,
+                                  description: currentRule.description,
+                                  enabled: currentRule.enabled,
+                                  priority: currentRule.priority,
+                                  ports:
+                                    currentRule.ports?.map(port => ({
+                                      from: port.from,
+                                      to: port.to
+                                    })) ?? null
+                                })
+                              )
+                            });
+                            p.onComplete();
+                          }
+                        });
+                      }
 
-                    if (item === 'remove') {
-                      await deleteRule.mutate({ ruleId: rule.id });
-                      p.onComplete();
-                    }
-                  }}
-                >
-                  <Button
-                    size="1"
-                    variant="outline"
-                    iconLeft={<RiMore2Line />}
-                    title="Rule actions"
-                  />
+                      if (item === 'remove') {
+                        await deleteRule.mutate({ ruleId: rule.id });
+                        p.onComplete();
+                      }
+                    }}
+                  >
+                    <Button
+                      size="1"
+                      variant="outline"
+                      iconLeft={<RiMore2Line />}
+                      title="Rule actions"
+                    />
                   </Menu>
                 </div>
-              : null
+              ) : null
             ]
           }))}
         />
@@ -577,7 +628,9 @@ export let NetworkFirewallPage = () => {
           {
             label: 'Network',
             content: (
-              <Link to={Paths.instance.network(organization.data, project.data, instance.data)}>
+              <Link
+                to={Paths.instance.network(organization.data, project.data, instance.data)}
+              >
                 {network.data?.name ?? 'Loading...'}
               </Link>
             )
@@ -596,7 +649,7 @@ export let NetworkFirewallPage = () => {
         title="Network Policies"
         description="Network policies define which connections this firewall allows or blocks."
         actions={
-          canWrite ?
+          canWrite ? (
             <Button
               size="2"
               onClick={() =>
@@ -609,7 +662,7 @@ export let NetworkFirewallPage = () => {
             >
               Create Policy
             </Button>
-          : undefined
+          ) : undefined
         }
       />
 

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(network)/security.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(network)/security.tsx
@@ -13,6 +13,7 @@ import { Attributes, Spacer } from '@metorial/ui';
 import { Box } from '@metorial/ui-product';
 import { RiArrowRightSLine } from '@remixicon/react';
 import { EmptyText, EnclavesTable } from './_common';
+import { getDisplayedNetworkPublicIp, NetworkManagedPage, useNetworkManagementAccess } from './_gate';
 
 type NetworkDiagramProps = {
   ipAddress: string;
@@ -31,6 +32,7 @@ export let SecurityOverviewPage = () => {
   let networks = useNetworks(instance.data?.id, { limit: 1 });
   let lastUsedEnclaves = useLastUsedEnclaves(instance.data?.id, { limit: 8 });
   let apiHost = new URL(getConfig().publicApiUrl).host;
+  let { hasPublicIpAccess } = useNetworkManagementAccess();
 
   return (
     <ContentLayout>
@@ -39,62 +41,68 @@ export let SecurityOverviewPage = () => {
         description="Review your Metorial Magic Network, firewall options, and recent network activity."
       />
 
-      {renderWithLoader({ networks, lastUsedEnclaves })(({ networks, lastUsedEnclaves }) => {
-        let networkPublicIp = networks.data.items[0]?.publicIps[0];
+      <NetworkManagedPage>
+        {renderWithLoader({ networks, lastUsedEnclaves })(({ networks, lastUsedEnclaves }) => {
+          let networkPublicIp = networks.data.items[0]?.publicIps[0];
+          let displayedPublicIp = getDisplayedNetworkPublicIp(
+            networkPublicIp?.ip,
+            hasPublicIpAccess
+          );
 
-        return (
-          <>
-            <Attributes
-              itemWidth="300px"
-              attributes={[
-                {
-                  label: 'Project',
-                  content: (
-                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-                      {organization.data?.name ?? 'Organization'}
-                      <RiArrowRightSLine size={14} />
-                      {project.data?.name ?? 'Project'}
-                    </span>
-                  )
-                },
-                {
-                  label: 'Public IP',
-                  content: networkPublicIp?.ip ?? '-'
-                },
-                {
-                  label: 'Region',
-                  content: networkPublicIp?.region ?? '-'
-                }
-              ]}
-            />
+          return (
+            <>
+              <Attributes
+                itemWidth="300px"
+                attributes={[
+                  {
+                    label: 'Project',
+                    content: (
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                        {organization.data?.name ?? 'Organization'}
+                        <RiArrowRightSLine size={14} />
+                        {project.data?.name ?? 'Project'}
+                      </span>
+                    )
+                  },
+                  {
+                    label: 'Public IP',
+                    content: displayedPublicIp
+                  },
+                  {
+                    label: 'Region',
+                    content: networkPublicIp?.region ?? '-'
+                  }
+                ]}
+              />
 
-            <Spacer size={20} />
+              <Spacer size={20} />
 
-            {networkPublicIp && (
-              <>
-                <NetworkDiagram
-                  ipAddress={networkPublicIp.ip}
-                  region={networkPublicIp.region}
-                  apiHost={apiHost}
-                />
+              {networkPublicIp && (
+                <>
+                  <NetworkDiagram
+                    ipAddress={displayedPublicIp}
+                    region={networkPublicIp.region}
+                    apiHost={apiHost}
+                  />
 
-                <Spacer size={20} />
-              </>
-            )}
-
-            <Box
-              title="Recently Used Enclaves"
-              description="Enclaves that were recently used to run providers."
-            >
-              {lastUsedEnclaves.data.items.length > 0 ? (
-                <EnclavesTable enclaves={lastUsedEnclaves.data.items} />
-              ) : (
-                <EmptyText>No recently used enclaves.</EmptyText>
+                  <Spacer size={20} />
+                </>
               )}
-            </Box>
-          </>
-        );
-      })}
+
+              <Box
+                title="Recently Used Enclaves"
+                description="Enclaves that were recently used to run providers."
+              >
+                {lastUsedEnclaves.data.items.length > 0 ? (
+                  <EnclavesTable enclaves={lastUsedEnclaves.data.items} />
+                ) : (
+                  <EmptyText>No recently used enclaves.</EmptyText>
+                )}
+              </Box>
+            </>
+          );
+        })}
+      </NetworkManagedPage>
     </ContentLayout>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> API responses intentionally hide real public IPs for orgs without the flag, but clients that relied on always seeing the true IP will see masked values; flag misconfiguration could block legitimate paid customers from seeing IPs.
> 
> **Overview**
> Introduces a **`paid-network-ip-access`** feature flag (default off) and wires it through the network API and dashboard so public egress IPs are a paid capability.
> 
> On the **API**, list/get network responses now resolve organization flags and pass **`maskPublicIp`** into the network presenter. When the flag is absent, **`public_ips`** show a placeholder (`x.x.x.x`) instead of the real deflector IP.
> 
> On the **dashboard**, **`useNetworkManagementAccess`** exposes **`hasPublicIpAccess`**, and **`getDisplayedNetworkPublicIp`** shows **`shared`** when access is not paid (Security overview and diagram use this). **`NetworkManagedPage`** gating moves from top-level routes into **`NetworkListLayout`** and Security, so Security is reachable without the full network product gate while network tabs stay behind the existing networking / paid-networking checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d17450d7370acaed39187b83a39b75b08bec1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->