### PR TITLE
Add fallback tokens for deflector

### DIFF
--- a/src/systems/function-bay/deflector/internal/auth/jwt.go
+++ b/src/systems/function-bay/deflector/internal/auth/jwt.go
@@ -47,6 +47,9 @@ func (v *Verifier) Verify(ctx context.Context, token string) (policy.Claims, err
 	if !parsed.Valid {
 		return policy.Claims{}, errors.New("invalid jwt")
 	}
+	if claims.LegacyFallback {
+		return claims, nil
+	}
 	if claims.TenantID == "" || claims.FunctionID == "" || claims.FunctionVersionID == "" {
 		return policy.Claims{}, errors.New("jwt is missing required invocation claims")
 	}

--- a/src/systems/function-bay/deflector/internal/auth/jwt_test.go
+++ b/src/systems/function-bay/deflector/internal/auth/jwt_test.go
@@ -29,6 +29,23 @@ func signedToken(t *testing.T, secret string, audience string, expiresAt time.Ti
 	return token
 }
 
+func signedLegacyToken(t *testing.T, secret string, audience string, expiresAt time.Time) string {
+	t.Helper()
+
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, policy.Claims{
+		LegacyFallback: true,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Audience:  jwt.ClaimStrings{audience},
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}).SignedString([]byte(secret))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return token
+}
+
 func TestVerifierAcceptsValidToken(t *testing.T) {
 	verifier := NewVerifier("secret", "deflector")
 
@@ -80,5 +97,23 @@ func TestVerifierAcceptsTokenWithinClockSkewLeeway(t *testing.T) {
 	}
 	if claims.FunctionVersionID != "functionVersion_123" {
 		t.Fatalf("unexpected function version id %q", claims.FunctionVersionID)
+	}
+}
+
+func TestVerifierAcceptsLegacyFallbackWithoutInvocationClaims(t *testing.T) {
+	verifier := NewVerifier("secret", "deflector")
+
+	claims, err := verifier.Verify(
+		context.Background(),
+		signedLegacyToken(t, "secret", "deflector", time.Now().Add(time.Minute)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !claims.LegacyFallback {
+		t.Fatal("expected legacy fallback claim")
+	}
+	if claims.TenantID != "" || claims.FunctionID != "" || claims.FunctionVersionID != "" {
+		t.Fatalf("expected no invocation identifiers: %#v", claims)
 	}
 }

--- a/src/systems/function-bay/deflector/internal/policy/policy.go
+++ b/src/systems/function-bay/deflector/internal/policy/policy.go
@@ -31,11 +31,13 @@ type Claims struct {
 	EnclaveID           string                    `json:"enclaveId,omitempty"`
 	EnclaveIdentifier   string                    `json:"enclaveIdentifier,omitempty"`
 	EgressPolicy        *CompiledNetworkAllowList `json:"egressPolicy,omitempty"`
+	LegacyFallback      bool                      `json:"legacyFallback,omitempty"`
 	jwt.RegisteredClaims
 }
 
 type Compiled struct {
-	entries *[]compiledEntry
+	entries  *[]compiledEntry
+	allowAll bool
 }
 
 type compiledEntry struct {
@@ -45,6 +47,10 @@ type compiledEntry struct {
 
 func Compile(claims Claims) (*Compiled, error) {
 	c := &Compiled{}
+	if claims.LegacyFallback {
+		c.allowAll = true
+		return c, nil
+	}
 
 	if claims.EgressPolicy != nil {
 		if claims.EgressPolicy.Direction != "egress" {
@@ -86,6 +92,10 @@ func (c *Compiled) AllowsDestination(ip net.IP, port int) bool {
 		return false
 	}
 	addr = addr.Unmap()
+
+	if c.allowAll {
+		return port >= 1 && port <= 65535
+	}
 
 	if c.entries == nil {
 		return !isAlwaysBlocked(addr)

--- a/src/systems/function-bay/deflector/internal/policy/policy_test.go
+++ b/src/systems/function-bay/deflector/internal/policy/policy_test.go
@@ -61,6 +61,23 @@ func TestMissingRulesAllowPublicDestinations(t *testing.T) {
 	}
 }
 
+func TestLegacyFallbackAllowsAllDestinations(t *testing.T) {
+	compiled, err := Compile(Claims{LegacyFallback: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !compiled.AllowsDestination(net.ParseIP("10.0.0.1"), 443) {
+		t.Fatal("legacy fallback should allow private IPs")
+	}
+	if !compiled.AllowsDestination(net.ParseIP("169.254.169.254"), 80) {
+		t.Fatal("legacy fallback should allow metadata IPs")
+	}
+	if !compiled.AllowsDestination(net.ParseIP("93.184.216.34"), 443) {
+		t.Fatal("legacy fallback should allow public IPs")
+	}
+}
+
 func TestEmptyRulesDenyAllForDimension(t *testing.T) {
 	compiled, err := Compile(Claims{
 		EgressPolicy: &CompiledNetworkAllowList{

--- a/src/systems/function-bay/deflector/internal/proxy/server.go
+++ b/src/systems/function-bay/deflector/internal/proxy/server.go
@@ -54,7 +54,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Metorial Magic Network: proxy authentication failed", http.StatusProxyAuthRequired)
 		return
 	}
-	s.logAuthorizedRequest(r, requestPolicy)
+	if !requestPolicy.Claims.LegacyFallback {
+		s.logAuthorizedRequest(r, requestPolicy)
+	}
 
 	if r.Method == http.MethodConnect {
 		s.handleConnect(w, r, requestPolicy)
@@ -378,7 +380,7 @@ func (s *Server) dialAllowed(ctx context.Context, host string, port string, requ
 		}
 		conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(ip.String(), port))
 		if err == nil {
-			if s.Recorder != nil {
+			if s.Recorder != nil && !requestPolicy.Claims.LegacyFallback {
 				s.Recorder.Record(requestPolicy.Claims, host, ip.String(), port)
 			}
 			return conn, nil

--- a/src/systems/function-bay/deflector/internal/proxy/server_test.go
+++ b/src/systems/function-bay/deflector/internal/proxy/server_test.go
@@ -142,3 +142,29 @@ func TestLogAuthorizedRequestIncludesJTIAndPolicySummary(t *testing.T) {
 		t.Fatal("expected policy fingerprint")
 	}
 }
+
+func TestLegacyFallbackSkipsAuthorizedRequestLog(t *testing.T) {
+	var buf bytes.Buffer
+	server := &Server{
+		Logger:   slog.New(slog.NewJSONHandler(&buf, nil)),
+		Verifier: auth.NewVerifier("secret", "deflector"),
+	}
+	token := proxyToken(t, "secret", policy.Claims{
+		LegacyFallback: true,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Audience:  jwt.ClaimStrings{"deflector"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute)),
+		},
+	})
+	request := httptest.NewRequest("GET", "http://127.0.0.1:1/resource", nil)
+	request.Header.Set(
+		"Proxy-Authorization",
+		"Basic "+base64.StdEncoding.EncodeToString([]byte(token+":x")),
+	)
+
+	server.ServeHTTP(httptest.NewRecorder(), request)
+
+	if bytes.Contains(buf.Bytes(), []byte("proxy request authorized")) {
+		t.Fatal("legacy fallback should not emit authorized request logs")
+	}
+}

--- a/src/systems/function-bay/service/prisma/schema/function.prisma
+++ b/src/systems/function-bay/service/prisma/schema/function.prisma
@@ -16,8 +16,8 @@ model Function {
   currentVersion    FunctionVersion? @relation(fields: [currentVersionOid], references: [oid], name: "CurrentVersion")
 
   cloneOfFunctionOid BigInt?
-  cloneOfFunction    Function? @relation("FunctionClones", fields: [cloneOfFunctionOid], references: [oid])
-  clones              Function[] @relation("FunctionClones")
+  cloneOfFunction    Function?  @relation("FunctionClones", fields: [cloneOfFunctionOid], references: [oid])
+  clones             Function[] @relation("FunctionClones")
 
   tenantOid BigInt
   tenant    Tenant @relation(fields: [tenantOid], references: [oid])
@@ -25,14 +25,14 @@ model Function {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  functionVersions                 FunctionVersion[]
-  functionDeployments              FunctionDeployment[]
-  runtime                          Runtime?                  @relation(fields: [runtimeOid], references: [oid])
-  runtimeOid                       BigInt?
-  functionBundles                  FunctionBundle[]
-  enclaveFunctions                 EnclaveFunction[]
-  enclaveFunctionOverrides         EnclaveFunctionOverride[]
-  enclaveFunctionOverrideBackings  EnclaveFunctionOverride[] @relation("EnclaveFunctionOverrideFunction")
+  functionVersions                FunctionVersion[]
+  functionDeployments             FunctionDeployment[]
+  runtime                         Runtime?                  @relation(fields: [runtimeOid], references: [oid])
+  runtimeOid                      BigInt?
+  functionBundles                 FunctionBundle[]
+  enclaveFunctions                EnclaveFunction[]
+  enclaveFunctionOverrides        EnclaveFunctionOverride[]
+  enclaveFunctionOverrideBackings EnclaveFunctionOverride[] @relation("EnclaveFunctionOverrideFunction")
 
   @@unique([identifier, tenantOid])
 }
@@ -128,6 +128,8 @@ model FunctionVersion {
   identifier String
   name       String
 
+  supportsV2Proxy Boolean @default(false)
+
   functionOid BigInt
   function    Function @relation(fields: [functionOid], references: [oid])
 
@@ -138,7 +140,7 @@ model FunctionVersion {
   functionBundle    FunctionBundle @relation(fields: [functionBundleOid], references: [oid])
 
   cloneOfFunctionVersionOid BigInt?
-  cloneOfFunctionVersion    FunctionVersion? @relation("FunctionVersionClones", fields: [cloneOfFunctionVersionOid], references: [oid])
+  cloneOfFunctionVersion    FunctionVersion?  @relation("FunctionVersionClones", fields: [cloneOfFunctionVersionOid], references: [oid])
   clones                    FunctionVersion[] @relation("FunctionVersionClones")
 
   /// [FunctionConfiguration]

--- a/src/systems/function-bay/service/src/providers/aws-lambda/deflector.test.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/deflector.test.ts
@@ -14,7 +14,11 @@ vi.mock('../../env', () => ({
   }
 }));
 
-import { createDeflectorToken, getDeflectorProxyUrl } from './deflector';
+import {
+  createDeflectorToken,
+  createLegacyDeflectorToken,
+  getDeflectorProxyUrl
+} from './deflector';
 
 describe('deflector token', () => {
   it('signs invocation claims with the shared secret', async () => {
@@ -81,5 +85,25 @@ describe('deflector token', () => {
 
   it('returns the configured proxy url', () => {
     expect(getDeflectorProxyUrl()).toBe('http://deflector.local:8080');
+  });
+
+  it('signs legacy fallback claims for long-lived compatibility tokens', async () => {
+    let before = Math.floor(Date.now() / 1000);
+    let token = await createLegacyDeflectorToken();
+    let verified = await jwtVerify(token!, new TextEncoder().encode('test-secret'), {
+      audience: 'deflector',
+      algorithms: ['HS256']
+    });
+
+    expect(verified.payload).toMatchObject({
+      aud: 'deflector',
+      legacyFallback: true
+    });
+    expect(verified.payload.tenantId).toBeUndefined();
+    expect(verified.payload.functionId).toBeUndefined();
+    expect(verified.payload.functionVersionId).toBeUndefined();
+    expect(verified.payload.jti).toBeUndefined();
+    expect(verified.payload.exp).toBeGreaterThanOrEqual(before + 7 * 24 * 60 * 60 - 1);
+    expect(verified.payload.exp).toBeLessThanOrEqual(before + 7 * 24 * 60 * 60 + 5);
   });
 });

--- a/src/systems/function-bay/service/src/providers/aws-lambda/deflector.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/deflector.ts
@@ -7,6 +7,15 @@ let jwtSecret =
     ? new TextEncoder().encode(env.deflector.DEFLECTOR_JWT_SECRET)
     : undefined;
 
+let getBaseClaims = () => {
+  let now = Math.floor(Date.now() / 1000);
+  return {
+    aud: env.deflector.DEFLECTOR_JWT_AUDIENCE ?? 'deflector',
+    iat: now,
+    nbf: now - 30
+  };
+};
+
 export let createDeflectorToken = async (d: {
   tenantId: string;
   functionId: string;
@@ -20,7 +29,7 @@ export let createDeflectorToken = async (d: {
 }) => {
   if (!jwtSecret) return undefined;
 
-  let now = Math.floor(Date.now() / 1000);
+  let baseClaims = getBaseClaims();
   let payload: JWTPayload & {
     tenantId: string;
     functionId: string;
@@ -30,7 +39,7 @@ export let createDeflectorToken = async (d: {
     enclaveIdentifier?: string;
     egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
   } = {
-    aud: env.deflector.DEFLECTOR_JWT_AUDIENCE ?? 'deflector',
+    ...baseClaims,
     sub: d.functionVersionId,
     tenantId: d.tenantId,
     functionId: d.functionId,
@@ -39,14 +48,29 @@ export let createDeflectorToken = async (d: {
     enclaveId: d.enclave?.id,
     enclaveIdentifier: d.enclave?.identifier,
     jti: randomUUID(),
-    iat: now,
-    nbf: now - 30,
-    exp: now + 5 * 60
+    exp: baseClaims.iat + 5 * 60
   };
 
   if (d.egressPolicy !== undefined) {
     payload.egressPolicy = d.egressPolicy;
   }
+
+  return await new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .sign(jwtSecret);
+};
+
+export let createLegacyDeflectorToken = async () => {
+  if (!jwtSecret) return undefined;
+
+  let baseClaims = getBaseClaims();
+  let payload: JWTPayload & {
+    legacyFallback: true;
+  } = {
+    ...baseClaims,
+    legacyFallback: true,
+    exp: baseClaims.iat + 7 * 24 * 60 * 60
+  };
 
   return await new SignJWT(payload)
     .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })

--- a/src/systems/function-bay/service/src/providers/aws-lambda/invoke.deflector.test.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/invoke.deflector.test.ts
@@ -1,0 +1,83 @@
+import { InvokeCommand } from '@aws-sdk/client-lambda';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+let mocks = vi.hoisted(() => ({
+  lambdaClient: {
+    send: vi.fn()
+  },
+  createDeflectorToken: vi.fn(),
+  createLegacyDeflectorToken: vi.fn(),
+  getDeflectorProxyUrl: vi.fn()
+}));
+
+vi.mock('./lambda', () => ({
+  lambdaClient: mocks.lambdaClient
+}));
+
+vi.mock('./deflector', () => ({
+  createDeflectorToken: mocks.createDeflectorToken,
+  createLegacyDeflectorToken: mocks.createLegacyDeflectorToken,
+  getDeflectorProxyUrl: mocks.getDeflectorProxyUrl
+}));
+
+import { invokeFunction } from './invoke';
+
+describe('aws lambda deflector invocation token selection', () => {
+  beforeEach(() => {
+    mocks.lambdaClient.send.mockReset();
+    mocks.createDeflectorToken.mockReset();
+    mocks.createLegacyDeflectorToken.mockReset();
+    mocks.getDeflectorProxyUrl.mockReset();
+
+    mocks.getDeflectorProxyUrl.mockReturnValue('http://deflector.local:8080');
+    mocks.createDeflectorToken.mockResolvedValue('v2-token');
+    mocks.createLegacyDeflectorToken.mockResolvedValue('legacy-token');
+    mocks.lambdaClient.send.mockResolvedValue({
+      Payload: new TextEncoder().encode(
+        JSON.stringify({ statusCode: 200, body: { result: { ok: true } } })
+      )
+    });
+  });
+
+  let invoke = async (supportsV2Proxy: boolean) =>
+    await invokeFunction({
+      tenantId: 'tenant_123',
+      function: { id: 'function_123' } as any,
+      sourceFunction: { id: 'function_123' } as any,
+      functionVersion: {
+        id: 'functionVersion_123',
+        supportsV2Proxy
+      } as any,
+      payload: { value: 'hello' },
+      providerData: {
+        functionName: 'lambda-name'
+      }
+    });
+
+  let invocationPayload = () => {
+    let command = mocks.lambdaClient.send.mock.calls[0]?.[0] as InvokeCommand;
+    return JSON.parse(new TextDecoder().decode((command as any).input.Payload));
+  };
+
+  it('uses a V2 token for V2-capable function versions', async () => {
+    await invoke(true);
+
+    expect(mocks.createDeflectorToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant_123',
+        functionId: 'function_123',
+        functionVersionId: 'functionVersion_123'
+      })
+    );
+    expect(mocks.createLegacyDeflectorToken).not.toHaveBeenCalled();
+    expect(invocationPayload().__functionBay.deflector.token).toBe('v2-token');
+  });
+
+  it('uses a legacy fallback token for old function versions', async () => {
+    await invoke(false);
+
+    expect(mocks.createDeflectorToken).not.toHaveBeenCalled();
+    expect(mocks.createLegacyDeflectorToken).toHaveBeenCalledOnce();
+    expect(invocationPayload().__functionBay.deflector.token).toBe('legacy-token');
+  });
+});

--- a/src/systems/function-bay/service/src/providers/aws-lambda/invoke.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/invoke.ts
@@ -2,7 +2,11 @@ import { InvokeCommand, type InvokeCommandOutput } from '@aws-sdk/client-lambda'
 import { getSentry } from '@lowerdeck/sentry';
 import type { Function, FunctionVersion } from '../../../prisma/generated/client';
 import { parseInvocationPayload } from '../_lib';
-import { createDeflectorToken, getDeflectorProxyUrl } from './deflector';
+import {
+  createDeflectorToken,
+  createLegacyDeflectorToken,
+  getDeflectorProxyUrl
+} from './deflector';
 import { lambdaClient } from './lambda';
 
 let Sentry = getSentry();
@@ -66,14 +70,17 @@ export let invokeFunction = async (d: {
   let startTs = Date.now();
 
   try {
-    let deflectorToken = await createDeflectorToken({
-      tenantId: d.tenantId,
-      functionId: d.sourceFunction.id,
-      effectiveFunctionId: d.function.id !== d.sourceFunction.id ? d.function.id : undefined,
-      functionVersionId: d.functionVersion.id,
-      enclave: d.enclave,
-      egressPolicy: d.egressPolicy
-    });
+    let deflectorToken = d.functionVersion.supportsV2Proxy
+      ? await createDeflectorToken({
+          tenantId: d.tenantId,
+          functionId: d.sourceFunction.id,
+          effectiveFunctionId:
+            d.function.id !== d.sourceFunction.id ? d.function.id : undefined,
+          functionVersionId: d.functionVersion.id,
+          enclave: d.enclave,
+          egressPolicy: d.egressPolicy
+        })
+      : await createLegacyDeflectorToken();
 
     res = await lambdaClient.send(
       new InvokeCommand({

--- a/src/systems/function-bay/service/src/queues/build.ts
+++ b/src/systems/function-bay/service/src/queues/build.ts
@@ -295,6 +295,7 @@ let deployToFunctionBayQueueProcessor = deployToFunctionBayQueue.process(async d
 
       name: deployment.name,
       status: 'active',
+      supportsV2Proxy: true,
 
       functionOid: deployment.functionOid,
       runtimeOid: deployment.runtimeOid,

--- a/src/systems/function-bay/service/src/queues/enclaveOverride.test.ts
+++ b/src/systems/function-bay/service/src/queues/enclaveOverride.test.ts
@@ -76,6 +76,7 @@ describe('enclave override clone queue', () => {
     expect(override.overrideFunctionVersion.providerData).toMatchObject({
       functionName: 'cloned-function'
     });
+    expect(override.overrideFunctionVersion.supportsV2Proxy).toBe(true);
     await expect(testDb.functionDeployment.count()).resolves.toBe(0);
   });
 

--- a/src/systems/function-bay/service/src/queues/enclaveOverride.ts
+++ b/src/systems/function-bay/service/src/queues/enclaveOverride.ts
@@ -31,161 +31,162 @@ export let processEnclaveOverrideClone = async (data: {
   functionId: string;
   sourceFunctionVersionId: string;
 }) => {
-    let existingOverride = await db.enclaveFunctionOverride.findFirst({
-      where: {
-        enclave: { id: data.enclaveId },
-        sourceFunction: { id: data.functionId },
-        sourceFunctionVersion: { id: data.sourceFunctionVersionId }
-      }
-    });
-    if (existingOverride) return;
-
-    let enclave = await db.enclave.findFirst({
-      where: { id: data.enclaveId },
-      include: { tenant: true }
-    });
-    if (!enclave) throw new QueueRetryError();
-
-    let func = await db.function.findFirst({
-      where: { id: data.functionId },
-      include: { tenant: true }
-    });
-    if (!func) throw new QueueRetryError();
-
-    let sourceVersion = await db.functionVersion.findFirst({
-      where: {
-        id: data.sourceFunctionVersionId,
-        functionOid: func.oid
-      },
-      include: {
-        runtime: true,
-        functionBundle: true
-      }
-    });
-    if (!sourceVersion) throw new QueueRetryError();
-
-    if (
-      sourceVersion.functionBundle.status !== 'available' ||
-      !sourceVersion.functionBundle.bucket ||
-      !sourceVersion.functionBundle.storageKey
-    ) {
-      throw new QueueRetryError();
+  let existingOverride = await db.enclaveFunctionOverride.findFirst({
+    where: {
+      enclave: { id: data.enclaveId },
+      sourceFunction: { id: data.functionId },
+      sourceFunctionVersion: { id: data.sourceFunctionVersionId }
     }
+  });
+  if (existingOverride) return;
 
-    let previousOverride = await db.enclaveFunctionOverride.findFirst({
+  let enclave = await db.enclave.findFirst({
+    where: { id: data.enclaveId },
+    include: { tenant: true }
+  });
+  if (!enclave) throw new QueueRetryError();
+
+  let func = await db.function.findFirst({
+    where: { id: data.functionId },
+    include: { tenant: true }
+  });
+  if (!func) throw new QueueRetryError();
+
+  let sourceVersion = await db.functionVersion.findFirst({
+    where: {
+      id: data.sourceFunctionVersionId,
+      functionOid: func.oid
+    },
+    include: {
+      runtime: true,
+      functionBundle: true
+    }
+  });
+  if (!sourceVersion) throw new QueueRetryError();
+
+  if (
+    sourceVersion.functionBundle.status !== 'available' ||
+    !sourceVersion.functionBundle.bucket ||
+    !sourceVersion.functionBundle.storageKey
+  ) {
+    throw new QueueRetryError();
+  }
+
+  let previousOverride = await db.enclaveFunctionOverride.findFirst({
+    where: {
+      enclaveOid: enclave.oid,
+      sourceFunctionOid: func.oid
+    },
+    include: {
+      overrideFunction: true
+    },
+    orderBy: { oid: 'desc' }
+  });
+
+  let cloneFunction =
+    previousOverride?.overrideFunction ??
+    (await db.function.upsert({
       where: {
-        enclaveOid: enclave.oid,
-        sourceFunctionOid: func.oid
-      },
-      include: {
-        overrideFunction: true
-      },
-      orderBy: { oid: 'desc' }
-    });
-
-    let cloneFunction =
-      previousOverride?.overrideFunction ??
-      (await db.function.upsert({
-        where: {
-          identifier_tenantOid: {
-            identifier: `${func.identifier}--enclave-${enclave.id}`,
-            tenantOid: enclave.tenantOid
-          }
-        },
-        update: {
-          name: func.name,
-          status: 'active',
-          runtimeOid: sourceVersion.runtimeOid,
-          cloneOfFunctionOid: func.oid
-        },
-        create: {
-          oid: snowflake.nextId(),
-          id: await ID.generateId('function'),
-          status: 'active',
+        identifier_tenantOid: {
           identifier: `${func.identifier}--enclave-${enclave.id}`,
-          name: func.name,
-          tenantOid: enclave.tenantOid,
-          runtimeOid: sourceVersion.runtimeOid,
-          cloneOfFunctionOid: func.oid
-        }
-      }));
-
-    let cloneVersionId = await ID.generateId('functionVersion');
-    let envVars = JSON.parse(
-      await encryption.decrypt({
-        entityId: sourceVersion.id,
-        encrypted: sourceVersion.encryptedEnvironmentVariables
-      })
-    );
-    let bundle = await storage.getObject(
-      sourceVersion.functionBundle.bucket,
-      sourceVersion.functionBundle.storageKey
-    );
-
-    let provider = getProvider(sourceVersion.runtime.providerOid);
-    let manifest = sourceVersion.manifest;
-    let runtimeConfig = manifest.runtime ?? {
-      ...sourceVersion.runtime.configuration,
-      handler: manifest.entrypoint ?? 'index.handler'
-    };
-
-    let res = await provider.cloneFunctionVersion({
-      functionVersion: { id: cloneVersionId },
-      sourceFunctionVersion: sourceVersion,
-      function: cloneFunction,
-      runtimeConfig,
-      runtime: sourceVersion.runtime,
-      env: envVars,
-      zipFile: bundle.data
-    });
-
-    let encryptedEnvironmentVariables = await encryption.encrypt({
-      entityId: cloneVersionId,
-      secret: JSON.stringify(envVars)
-    });
-
-    let cloneVersion = await db.functionVersion.create({
-      data: {
-        oid: snowflake.nextId(),
-        id: cloneVersionId,
-        identifier: generatePlainId(12),
-        name: sourceVersion.name,
-        status: 'active',
-        functionOid: cloneFunction.oid,
-        runtimeOid: sourceVersion.runtimeOid,
-        functionBundleOid: sourceVersion.functionBundleOid,
-        cloneOfFunctionVersionOid: sourceVersion.oid,
-        encryptedEnvironmentVariables,
-        configuration: sourceVersion.configuration,
-        providerData: res.providerData,
-        manifest: sourceVersion.manifest
-      }
-    });
-
-    await db.function.update({
-      where: { oid: cloneFunction.oid },
-      data: { currentVersionOid: cloneVersion.oid }
-    });
-
-    await db.enclaveFunctionOverride.upsert({
-      where: {
-        enclaveOid_sourceFunctionOid_sourceFunctionVersionOid: {
-          enclaveOid: enclave.oid,
-          sourceFunctionOid: func.oid,
-          sourceFunctionVersionOid: sourceVersion.oid
+          tenantOid: enclave.tenantOid
         }
       },
-      update: {},
+      update: {
+        name: func.name,
+        status: 'active',
+        runtimeOid: sourceVersion.runtimeOid,
+        cloneOfFunctionOid: func.oid
+      },
       create: {
         oid: snowflake.nextId(),
+        id: await ID.generateId('function'),
+        status: 'active',
+        identifier: `${func.identifier}--enclave-${enclave.id}`,
+        name: func.name,
+        tenantOid: enclave.tenantOid,
+        runtimeOid: sourceVersion.runtimeOid,
+        cloneOfFunctionOid: func.oid
+      }
+    }));
+
+  let cloneVersionId = await ID.generateId('functionVersion');
+  let envVars = JSON.parse(
+    await encryption.decrypt({
+      entityId: sourceVersion.id,
+      encrypted: sourceVersion.encryptedEnvironmentVariables
+    })
+  );
+  let bundle = await storage.getObject(
+    sourceVersion.functionBundle.bucket,
+    sourceVersion.functionBundle.storageKey
+  );
+
+  let provider = getProvider(sourceVersion.runtime.providerOid);
+  let manifest = sourceVersion.manifest;
+  let runtimeConfig = manifest.runtime ?? {
+    ...sourceVersion.runtime.configuration,
+    handler: manifest.entrypoint ?? 'index.handler'
+  };
+
+  let res = await provider.cloneFunctionVersion({
+    functionVersion: { id: cloneVersionId },
+    sourceFunctionVersion: sourceVersion,
+    function: cloneFunction,
+    runtimeConfig,
+    runtime: sourceVersion.runtime,
+    env: envVars,
+    zipFile: bundle.data
+  });
+
+  let encryptedEnvironmentVariables = await encryption.encrypt({
+    entityId: cloneVersionId,
+    secret: JSON.stringify(envVars)
+  });
+
+  let cloneVersion = await db.functionVersion.create({
+    data: {
+      oid: snowflake.nextId(),
+      id: cloneVersionId,
+      identifier: generatePlainId(12),
+      name: sourceVersion.name,
+      status: 'active',
+      supportsV2Proxy: sourceVersion.supportsV2Proxy,
+      functionOid: cloneFunction.oid,
+      runtimeOid: sourceVersion.runtimeOid,
+      functionBundleOid: sourceVersion.functionBundleOid,
+      cloneOfFunctionVersionOid: sourceVersion.oid,
+      encryptedEnvironmentVariables,
+      configuration: sourceVersion.configuration,
+      providerData: res.providerData,
+      manifest: sourceVersion.manifest
+    }
+  });
+
+  await db.function.update({
+    where: { oid: cloneFunction.oid },
+    data: { currentVersionOid: cloneVersion.oid }
+  });
+
+  await db.enclaveFunctionOverride.upsert({
+    where: {
+      enclaveOid_sourceFunctionOid_sourceFunctionVersionOid: {
         enclaveOid: enclave.oid,
         sourceFunctionOid: func.oid,
-        sourceFunctionVersionOid: sourceVersion.oid,
-        overrideFunctionOid: cloneFunction.oid,
-        overrideFunctionVersionOid: cloneVersion.oid
+        sourceFunctionVersionOid: sourceVersion.oid
       }
-    });
-  };
+    },
+    update: {},
+    create: {
+      oid: snowflake.nextId(),
+      enclaveOid: enclave.oid,
+      sourceFunctionOid: func.oid,
+      sourceFunctionVersionOid: sourceVersion.oid,
+      overrideFunctionOid: cloneFunction.oid,
+      overrideFunctionVersionOid: cloneVersion.oid
+    }
+  });
+};
 
 export let enclaveOverrideCloneQueueProcessor = enclaveOverrideCloneQueue.process(
   processEnclaveOverrideClone

--- a/src/systems/function-bay/service/src/test/fixtures/functionVersionFixtures.ts
+++ b/src/systems/function-bay/service/src/test/fixtures/functionVersionFixtures.ts
@@ -46,6 +46,7 @@ export const FunctionVersionFixtures = (db: PrismaClient) => {
         status: data.overrides?.status ?? FunctionVersionStatus.active,
         identifier,
         name: data.overrides?.name ?? `Version ${identifier}`,
+        supportsV2Proxy: data.overrides?.supportsV2Proxy ?? true,
         functionOid: data.functionOid,
         runtimeOid: data.runtimeOid,
         functionBundleOid: data.functionBundleOid,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Legacy tokens bypass per-invocation identity and default egress restrictions (allow-all including metadata IPs), which is a deliberate compatibility tradeoff in the egress proxy security path.
> 
> **Overview**
> Adds a **legacy deflector JWT** path so older function versions can keep using the proxy without per-invocation tenant/function/version claims or V2 egress rules.
> 
> **Deflector** accepts tokens with `legacyFallback`, compiles them to **allow-all egress** (including private and metadata IPs), and skips **authorized-request logging** and **connection recording** for those tokens. **V2 tokens** still require invocation claims and normal policy.
> 
> **Function-bay service** stores `supportsV2Proxy` on `FunctionVersion` (new deploys set `true`; enclave clones copy the source flag). **Lambda invoke** issues the existing short-lived scoped JWT when `supportsV2Proxy` is true, otherwise a **7-day** `createLegacyDeflectorToken()` with only `legacyFallback` and audience.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21f76d04ac2ca0c62b714feb7b1a67f203d24bee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->