### PR TITLE
Harden function cloning

### DIFF
--- a/src/systems/function-bay/service/prisma/schema/enclave.prisma
+++ b/src/systems/function-bay/service/prisma/schema/enclave.prisma
@@ -3,7 +3,7 @@ model Enclave {
   id  String @unique
 
   name       String
-  identifier String 
+  identifier String
 
   tenantOid BigInt
   tenant    Tenant @relation(fields: [tenantOid], references: [oid])
@@ -11,8 +11,9 @@ model Enclave {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  enclaveFunctions         EnclaveFunction[]
-  enclaveFunctionOverrides EnclaveFunctionOverride[]
+  enclaveFunctions                   EnclaveFunction[]
+  enclaveFunctionOverrides           EnclaveFunctionOverride[]
+  enclaveFunctionOverrideDeployments EnclaveFunctionOverrideDeployment[]
 
   @@unique([identifier, tenantOid])
 }
@@ -47,8 +48,43 @@ model EnclaveFunctionOverride {
   overrideFunctionVersionOid BigInt
   overrideFunctionVersion    FunctionVersion @relation("EnclaveFunctionOverrideVersion", fields: [overrideFunctionVersionOid], references: [oid])
 
+  deployments EnclaveFunctionOverrideDeployment[]
+
   @@unique([enclaveOid, sourceFunctionOid, sourceFunctionVersionOid])
   @@index([enclaveOid, sourceFunctionOid])
-  @@index([overrideFunctionOid])
-  @@index([overrideFunctionVersionOid])
+}
+
+enum EnclaveFunctionOverrideDeploymentStatus {
+  pending
+  succeeded
+  failed
+}
+
+model EnclaveFunctionOverrideDeployment {
+  oid    BigInt                                  @id
+  id     String                                  @unique
+  status EnclaveFunctionOverrideDeploymentStatus
+
+  enclaveOid BigInt
+  enclave    Enclave @relation(fields: [enclaveOid], references: [oid])
+
+  sourceFunctionOid BigInt
+  sourceFunction    Function @relation("EnclaveFunctionOverrideDeploymentSourceFunction", fields: [sourceFunctionOid], references: [oid])
+
+  sourceFunctionVersionOid BigInt
+  sourceFunctionVersion    FunctionVersion @relation("EnclaveFunctionOverrideDeploymentSourceVersion", fields: [sourceFunctionVersionOid], references: [oid])
+
+  overrideFunctionOid BigInt?
+  overrideFunction    Function? @relation("EnclaveFunctionOverrideDeploymentFunction", fields: [overrideFunctionOid], references: [oid])
+
+  overrideFunctionVersionOid BigInt?
+  overrideFunctionVersion    FunctionVersion? @relation("EnclaveFunctionOverrideDeploymentVersion", fields: [overrideFunctionVersionOid], references: [oid])
+
+  enclaveFunctionOverrideOid BigInt?
+  enclaveFunctionOverride    EnclaveFunctionOverride? @relation(fields: [enclaveFunctionOverrideOid], references: [oid])
+
+  errorMessage String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
 }

--- a/src/systems/function-bay/service/prisma/schema/function.prisma
+++ b/src/systems/function-bay/service/prisma/schema/function.prisma
@@ -16,8 +16,8 @@ model Function {
   currentVersion    FunctionVersion? @relation(fields: [currentVersionOid], references: [oid], name: "CurrentVersion")
 
   cloneOfFunctionOid BigInt?
-  cloneOfFunction    Function? @relation("FunctionClones", fields: [cloneOfFunctionOid], references: [oid])
-  clones              Function[] @relation("FunctionClones")
+  cloneOfFunction    Function?  @relation("FunctionClones", fields: [cloneOfFunctionOid], references: [oid])
+  clones             Function[] @relation("FunctionClones")
 
   tenantOid BigInt
   tenant    Tenant @relation(fields: [tenantOid], references: [oid])
@@ -25,14 +25,16 @@ model Function {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  functionVersions                 FunctionVersion[]
-  functionDeployments              FunctionDeployment[]
-  runtime                          Runtime?                  @relation(fields: [runtimeOid], references: [oid])
-  runtimeOid                       BigInt?
-  functionBundles                  FunctionBundle[]
-  enclaveFunctions                 EnclaveFunction[]
-  enclaveFunctionOverrides         EnclaveFunctionOverride[]
-  enclaveFunctionOverrideBackings  EnclaveFunctionOverride[] @relation("EnclaveFunctionOverrideFunction")
+  functionVersions                          FunctionVersion[]
+  functionDeployments                       FunctionDeployment[]
+  runtime                                   Runtime?                            @relation(fields: [runtimeOid], references: [oid])
+  runtimeOid                                BigInt?
+  functionBundles                           FunctionBundle[]
+  enclaveFunctions                          EnclaveFunction[]
+  enclaveFunctionOverrides                  EnclaveFunctionOverride[]
+  enclaveFunctionOverrideBackings           EnclaveFunctionOverride[]           @relation("EnclaveFunctionOverrideFunction")
+  enclaveFunctionOverrideDeploymentSources  EnclaveFunctionOverrideDeployment[] @relation("EnclaveFunctionOverrideDeploymentSourceFunction")
+  enclaveFunctionOverrideDeploymentBackings EnclaveFunctionOverrideDeployment[] @relation("EnclaveFunctionOverrideDeploymentFunction")
 
   @@unique([identifier, tenantOid])
 }
@@ -138,7 +140,7 @@ model FunctionVersion {
   functionBundle    FunctionBundle @relation(fields: [functionBundleOid], references: [oid])
 
   cloneOfFunctionVersionOid BigInt?
-  cloneOfFunctionVersion    FunctionVersion? @relation("FunctionVersionClones", fields: [cloneOfFunctionVersionOid], references: [oid])
+  cloneOfFunctionVersion    FunctionVersion?  @relation("FunctionVersionClones", fields: [cloneOfFunctionVersionOid], references: [oid])
   clones                    FunctionVersion[] @relation("FunctionVersionClones")
 
   /// [FunctionConfiguration]
@@ -153,10 +155,12 @@ model FunctionVersion {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  functions                              Function[]                @relation(name: "CurrentVersion")
-  functionDeployments                    FunctionDeployment[]
-  enclaveFunctionOverrideSourceVersions  EnclaveFunctionOverride[] @relation("EnclaveFunctionOverrideSourceVersion")
-  enclaveFunctionOverrideVersionBackings EnclaveFunctionOverride[] @relation("EnclaveFunctionOverrideVersion")
+  functions                                       Function[]                          @relation(name: "CurrentVersion")
+  functionDeployments                             FunctionDeployment[]
+  enclaveFunctionOverrideSourceVersions           EnclaveFunctionOverride[]           @relation("EnclaveFunctionOverrideSourceVersion")
+  enclaveFunctionOverrideVersionBackings          EnclaveFunctionOverride[]           @relation("EnclaveFunctionOverrideVersion")
+  enclaveFunctionOverrideDeploymentSourceVersions EnclaveFunctionOverrideDeployment[] @relation("EnclaveFunctionOverrideDeploymentSourceVersion")
+  enclaveFunctionOverrideDeploymentBackings       EnclaveFunctionOverrideDeployment[] @relation("EnclaveFunctionOverrideDeploymentVersion")
 
   @@unique([identifier, functionOid])
 }

--- a/src/systems/function-bay/service/src/id.ts
+++ b/src/systems/function-bay/service/src/id.ts
@@ -5,6 +5,7 @@ export let ID = createIdGenerator({
   tenant: idType.sorted('bten_'),
   enclave: idType.sorted('benc_'),
   enclaveFunctionOverride: idType.sorted('befo_'),
+  enclaveFunctionOverrideDeployment: idType.sorted('befod_'),
 
   provider: idType.sorted('bpro_'),
   runtime: idType.sorted('brtm_'),

--- a/src/systems/function-bay/service/src/lib/decryptFunctionVersionEnvironmentVariables.ts
+++ b/src/systems/function-bay/service/src/lib/decryptFunctionVersionEnvironmentVariables.ts
@@ -1,0 +1,46 @@
+import type { FunctionVersion } from '../../prisma/generated/client';
+import { db } from '../db';
+import { encryption } from '../encryption';
+
+let isCryptoOperationError = (err: unknown) =>
+  err instanceof Error && err.name === 'OperationError';
+
+export let decryptFunctionVersionEnvironmentVariables = async (d: {
+  functionVersion: FunctionVersion;
+  encryptedEnvironmentVariables?: string;
+}) => {
+  let encryptedEnvironmentVariables =
+    d.encryptedEnvironmentVariables ?? d.functionVersion.encryptedEnvironmentVariables;
+  if (!encryptedEnvironmentVariables) {
+    throw new Error('Function version environment variables are missing');
+  }
+
+  let decryptError: unknown;
+
+  try {
+    return JSON.parse(
+      await encryption.decrypt({
+        entityId: d.functionVersion.id,
+        encrypted: encryptedEnvironmentVariables
+      })
+    ) as Record<string, string>;
+  } catch (err) {
+    if (!isCryptoOperationError(err)) throw err;
+    decryptError = err;
+  }
+
+  if (!d.functionVersion.oid) throw decryptError;
+
+  let deployment = await db.functionDeployment.findFirst({
+    where: { functionVersionOid: d.functionVersion.oid },
+    orderBy: { oid: 'desc' }
+  });
+  if (!deployment) throw decryptError;
+
+  return JSON.parse(
+    await encryption.decrypt({
+      entityId: deployment.id,
+      encrypted: encryptedEnvironmentVariables
+    })
+  ) as Record<string, string>;
+};

--- a/src/systems/function-bay/service/src/providers/local/invoke.ts
+++ b/src/systems/function-bay/service/src/providers/local/invoke.ts
@@ -3,8 +3,8 @@ import { promises as fs } from 'fs';
 import JSZip from 'jszip';
 import { tmpdir } from 'os';
 import { dirname, join, resolve, sep } from 'path';
-import { encryption } from '../../encryption';
 import { env } from '../../env';
+import { decryptFunctionVersionEnvironmentVariables } from '../../lib/decryptFunctionVersionEnvironmentVariables';
 import { storage } from '../../storage';
 import type { FunctionInvocationParams } from '../_lib';
 import { parseInvocationPayload } from '../_lib';
@@ -217,12 +217,10 @@ export let invokeFunction = async (d: FunctionInvocationParams) => {
     await fs.writeFile(runnerPath, LOCAL_RUNNER_SCRIPT, 'utf-8');
     await fs.writeFile(eventPath, JSON.stringify({ payload: d.payload }), 'utf-8');
 
-    let envVars = JSON.parse(
-      await encryption.decrypt({
-        entityId: d.functionVersion.id,
-        encrypted: d.providerData.encryptedEnvironmentVariables
-      })
-    );
+    let envVars = await decryptFunctionVersionEnvironmentVariables({
+      functionVersion: d.functionVersion,
+      encryptedEnvironmentVariables: d.providerData.encryptedEnvironmentVariables
+    });
 
     let exitCode = await captureProcessLogs({
       command: process.execPath,

--- a/src/systems/function-bay/service/src/queues/enclaveOverride.test.ts
+++ b/src/systems/function-bay/service/src/queues/enclaveOverride.test.ts
@@ -76,7 +76,61 @@ describe('enclave override clone queue', () => {
     expect(override.overrideFunctionVersion.providerData).toMatchObject({
       functionName: 'cloned-function'
     });
+    await expect(
+      testDb.enclaveFunctionOverrideDeployment.findFirstOrThrow({
+        where: {
+          enclaveOid: enclave.oid,
+          sourceFunctionOid: sourceVersion.function.oid,
+          sourceFunctionVersionOid: sourceVersion.oid
+        }
+      })
+    ).resolves.toMatchObject({
+      status: 'succeeded',
+      overrideFunctionOid: override.overrideFunctionOid,
+      overrideFunctionVersionOid: override.overrideFunctionVersionOid,
+      enclaveFunctionOverrideOid: override.oid,
+      errorMessage: null
+    });
     await expect(testDb.functionDeployment.count()).resolves.toBe(0);
+  });
+
+  it('decrypts source env vars from the deployment for versions with legacy ciphertext', async () => {
+    let sourceVersion = await f.functionVersion.complete();
+    let deployment = await f.functionDeployment.default({
+      functionOid: sourceVersion.function.oid,
+      runtimeOid: sourceVersion.runtimeOid,
+      functionBundleOid: sourceVersion.functionBundleOid,
+      overrides: {
+        functionVersionOid: sourceVersion.oid
+      }
+    });
+    await testDb.functionVersion.update({
+      where: { oid: sourceVersion.oid },
+      data: { encryptedEnvironmentVariables: deployment.encryptedEnvironmentVariables }
+    });
+
+    let enclaveTenant = await f.tenant.default({ hasAutomaticEnclaveOverride: true });
+    let enclave = await testDb.enclave.create({
+      data: {
+        ...getId('enclave'),
+        identifier: 'customer-a',
+        name: 'customer-a',
+        tenantOid: enclaveTenant.oid
+      }
+    });
+
+    let { processEnclaveOverrideClone } = await import('./enclaveOverride');
+    await processEnclaveOverrideClone({
+      enclaveId: enclave.id,
+      functionId: sourceVersion.function.id,
+      sourceFunctionVersionId: sourceVersion.id
+    });
+
+    expect(providerMocks.cloneFunctionVersion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: {}
+      })
+    );
   });
 
   it('reuses the backing function from an existing override', async () => {
@@ -150,5 +204,43 @@ describe('enclave override clone queue', () => {
 
     expect(override.overrideFunctionOid).toBe(backingFunction.oid);
     expect(override.overrideFunctionOid).not.toBe(unrelatedClone.oid);
+  });
+
+  it('marks the override deployment as failed when cloning fails', async () => {
+    providerMocks.cloneFunctionVersion.mockRejectedValueOnce(new Error('provider failed'));
+    let sourceVersion = await f.functionVersion.complete();
+    let enclaveTenant = await f.tenant.default({ hasAutomaticEnclaveOverride: true });
+    let enclave = await testDb.enclave.create({
+      data: {
+        ...getId('enclave'),
+        identifier: 'customer-a',
+        name: 'customer-a',
+        tenantOid: enclaveTenant.oid
+      }
+    });
+
+    let { processEnclaveOverrideClone } = await import('./enclaveOverride');
+    await expect(
+      processEnclaveOverrideClone({
+        enclaveId: enclave.id,
+        functionId: sourceVersion.function.id,
+        sourceFunctionVersionId: sourceVersion.id
+      })
+    ).rejects.toThrow('provider failed');
+
+    await expect(
+      testDb.enclaveFunctionOverrideDeployment.findFirstOrThrow({
+        where: {
+          enclaveOid: enclave.oid,
+          sourceFunctionOid: sourceVersion.function.oid,
+          sourceFunctionVersionOid: sourceVersion.oid
+        }
+      })
+    ).resolves.toMatchObject({
+      status: 'failed',
+      errorMessage: 'provider failed',
+      overrideFunctionVersionOid: null,
+      enclaveFunctionOverrideOid: null
+    });
   });
 });

--- a/src/systems/function-bay/service/src/queues/enclaveOverride.ts
+++ b/src/systems/function-bay/service/src/queues/enclaveOverride.ts
@@ -4,8 +4,12 @@ import { db } from '../db';
 import { encryption } from '../encryption';
 import { env } from '../env';
 import { ID, snowflake } from '../id';
+import { decryptFunctionVersionEnvironmentVariables } from '../lib/decryptFunctionVersionEnvironmentVariables';
 import { getProvider } from '../providers';
 import { storage } from '../storage';
+
+let getErrorMessage = (err: unknown) =>
+  err instanceof Error ? err.message : String(err);
 
 export let enclaveOverrideCloneQueue = createQueue<{
   enclaveId: string;
@@ -31,39 +35,51 @@ export let processEnclaveOverrideClone = async (data: {
   functionId: string;
   sourceFunctionVersionId: string;
 }) => {
-    let existingOverride = await db.enclaveFunctionOverride.findFirst({
-      where: {
-        enclave: { id: data.enclaveId },
-        sourceFunction: { id: data.functionId },
-        sourceFunctionVersion: { id: data.sourceFunctionVersionId }
-      }
-    });
-    if (existingOverride) return;
+  let existingOverride = await db.enclaveFunctionOverride.findFirst({
+    where: {
+      enclave: { id: data.enclaveId },
+      sourceFunction: { id: data.functionId },
+      sourceFunctionVersion: { id: data.sourceFunctionVersionId }
+    }
+  });
+  if (existingOverride) return;
 
-    let enclave = await db.enclave.findFirst({
-      where: { id: data.enclaveId },
-      include: { tenant: true }
-    });
-    if (!enclave) throw new QueueRetryError();
+  let enclave = await db.enclave.findFirst({
+    where: { id: data.enclaveId },
+    include: { tenant: true }
+  });
+  if (!enclave) throw new QueueRetryError();
 
-    let func = await db.function.findFirst({
-      where: { id: data.functionId },
-      include: { tenant: true }
-    });
-    if (!func) throw new QueueRetryError();
+  let func = await db.function.findFirst({
+    where: { id: data.functionId },
+    include: { tenant: true }
+  });
+  if (!func) throw new QueueRetryError();
 
-    let sourceVersion = await db.functionVersion.findFirst({
-      where: {
-        id: data.sourceFunctionVersionId,
-        functionOid: func.oid
-      },
-      include: {
-        runtime: true,
-        functionBundle: true
-      }
-    });
-    if (!sourceVersion) throw new QueueRetryError();
+  let sourceVersion = await db.functionVersion.findFirst({
+    where: {
+      id: data.sourceFunctionVersionId,
+      functionOid: func.oid
+    },
+    include: {
+      runtime: true,
+      functionBundle: true
+    }
+  });
+  if (!sourceVersion) throw new QueueRetryError();
 
+  let overrideDeployment = await db.enclaveFunctionOverrideDeployment.create({
+    data: {
+      oid: snowflake.nextId(),
+      id: await ID.generateId('enclaveFunctionOverrideDeployment'),
+      status: 'pending',
+      enclaveOid: enclave.oid,
+      sourceFunctionOid: func.oid,
+      sourceFunctionVersionOid: sourceVersion.oid
+    }
+  });
+
+  try {
     if (
       sourceVersion.functionBundle.status !== 'available' ||
       !sourceVersion.functionBundle.bucket ||
@@ -111,12 +127,9 @@ export let processEnclaveOverrideClone = async (data: {
       }));
 
     let cloneVersionId = await ID.generateId('functionVersion');
-    let envVars = JSON.parse(
-      await encryption.decrypt({
-        entityId: sourceVersion.id,
-        encrypted: sourceVersion.encryptedEnvironmentVariables
-      })
-    );
+    let envVars = await decryptFunctionVersionEnvironmentVariables({
+      functionVersion: sourceVersion
+    });
     let bundle = await storage.getObject(
       sourceVersion.functionBundle.bucket,
       sourceVersion.functionBundle.storageKey
@@ -167,7 +180,7 @@ export let processEnclaveOverrideClone = async (data: {
       data: { currentVersionOid: cloneVersion.oid }
     });
 
-    await db.enclaveFunctionOverride.upsert({
+    let override = await db.enclaveFunctionOverride.upsert({
       where: {
         enclaveOid_sourceFunctionOid_sourceFunctionVersionOid: {
           enclaveOid: enclave.oid,
@@ -185,7 +198,27 @@ export let processEnclaveOverrideClone = async (data: {
         overrideFunctionVersionOid: cloneVersion.oid
       }
     });
-  };
+
+    await db.enclaveFunctionOverrideDeployment.update({
+      where: { oid: overrideDeployment.oid },
+      data: {
+        status: 'succeeded',
+        overrideFunctionOid: cloneFunction.oid,
+        overrideFunctionVersionOid: cloneVersion.oid,
+        enclaveFunctionOverrideOid: override.oid
+      }
+    });
+  } catch (err) {
+    await db.enclaveFunctionOverrideDeployment.update({
+      where: { oid: overrideDeployment.oid },
+      data: {
+        status: 'failed',
+        errorMessage: getErrorMessage(err)
+      }
+    });
+    throw err;
+  }
+};
 
 export let enclaveOverrideCloneQueueProcessor = enclaveOverrideCloneQueue.process(
   processEnclaveOverrideClone


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes secret decryption paths and enclave clone persistence; behavior is covered by new tests but touches encrypted environment variables and async clone flow.
> 
> **Overview**
> Adds **deployment tracking** for enclave function override clones via a new `EnclaveFunctionOverrideDeployment` model (pending / succeeded / failed) and `befod_` IDs, with the clone queue creating a pending row up front and updating it with override links or `errorMessage` on success or failure.
> 
> Introduces **`decryptFunctionVersionEnvironmentVariables`**, which decrypts env vars with the function version id and, on crypto `OperationError`, retries using the latest **`FunctionDeployment`** id so legacy ciphertext still works. **Enclave override cloning** and **local invoke** now use this helper instead of decrypting only against the version id.
> 
> Tests cover successful deployment records, legacy env decryption during clone, and failed clone status persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 804d58c47b87ad3405b3174a4aeda4280b5baca7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->