### PR TITLE
Harden clone zip handling

### DIFF
--- a/src/systems/function-bay/service/src/providers/aws-lambda/invoke.deflector.test.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/invoke.deflector.test.ts
@@ -50,6 +50,7 @@ describe('aws lambda deflector invocation token selection', () => {
       } as any,
       payload: { value: 'hello' },
       providerData: {
+        functionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-name',
         functionName: 'lambda-name'
       }
     });

--- a/src/systems/function-bay/service/src/queues/build.ts
+++ b/src/systems/function-bay/service/src/queues/build.ts
@@ -2,7 +2,7 @@ import { functionBayRuntimeConfig, type FunctionBayRuntimeConfig } from '@functi
 import { generatePlainId } from '@lowerdeck/id';
 import { combineQueueProcessors, createQueue, QueueRetryError } from '@lowerdeck/queue';
 import { v } from '@lowerdeck/validation';
-import { Readable } from 'stream';
+import JSZip from 'jszip';
 import { db } from '../db';
 import { encryption } from '../encryption';
 import { env } from '../env';
@@ -413,12 +413,15 @@ let uploadBundleQueueProcessor = uploadBundleQueue.process(async data => {
   let bucket = env.storage.BUNDLE_BUCKET_NAME;
 
   try {
-    await storage.putObject(
-      bucket,
-      storageKey,
-      await fetch(data.outputUrl).then(res => Readable.fromWeb(res.body! as any) as any),
-      'application/zip'
-    );
+    let res = await fetch(data.outputUrl);
+    if (!res.ok) {
+      throw new Error(`Failed to download function bundle: ${res.status} ${res.statusText}`);
+    }
+
+    let zipFile = Buffer.from(await res.arrayBuffer());
+    await JSZip.loadAsync(zipFile);
+
+    await storage.putObject(bucket, storageKey, zipFile, 'application/zip');
 
     await db.functionBundle.updateMany({
       where: { id: data.bundleId },

--- a/src/systems/function-bay/service/src/queues/enclaveOverride.test.ts
+++ b/src/systems/function-bay/service/src/queues/enclaveOverride.test.ts
@@ -244,4 +244,47 @@ describe('enclave override clone queue', () => {
       enclaveFunctionOverrideOid: null
     });
   });
+
+  it('marks corrupt source bundles as failed without retrying the queue', async () => {
+    providerMocks.cloneFunctionVersion.mockRejectedValueOnce(
+      new Error("Corrupted zip: can't find end of central directory")
+    );
+    let sourceVersion = await f.functionVersion.complete();
+    let enclaveTenant = await f.tenant.default({ hasAutomaticEnclaveOverride: true });
+    let enclave = await testDb.enclave.create({
+      data: {
+        ...getId('enclave'),
+        identifier: 'customer-a',
+        name: 'customer-a',
+        tenantOid: enclaveTenant.oid
+      }
+    });
+
+    let { processEnclaveOverrideClone } = await import('./enclaveOverride');
+    await expect(
+      processEnclaveOverrideClone({
+        enclaveId: enclave.id,
+        functionId: sourceVersion.function.id,
+        sourceFunctionVersionId: sourceVersion.id
+      })
+    ).resolves.toBeUndefined();
+
+    await expect(
+      testDb.enclaveFunctionOverrideDeployment.findFirstOrThrow({
+        where: {
+          enclaveOid: enclave.oid,
+          sourceFunctionOid: sourceVersion.function.oid,
+          sourceFunctionVersionOid: sourceVersion.oid
+        }
+      })
+    ).resolves.toMatchObject({
+      status: 'failed',
+      errorMessage: "Corrupted zip: can't find end of central directory"
+    });
+    await expect(
+      testDb.functionBundle.findUniqueOrThrow({
+        where: { oid: sourceVersion.functionBundleOid }
+      })
+    ).resolves.toMatchObject({ status: 'failed' });
+  });
 });

--- a/src/systems/function-bay/service/src/queues/enclaveOverride.ts
+++ b/src/systems/function-bay/service/src/queues/enclaveOverride.ts
@@ -11,6 +11,9 @@ import { storage } from '../storage';
 let getErrorMessage = (err: unknown) =>
   err instanceof Error ? err.message : String(err);
 
+let isCorruptedZipError = (err: unknown) =>
+  err instanceof Error && err.message.includes("can't find end of central directory");
+
 export let enclaveOverrideCloneQueue = createQueue<{
   enclaveId: string;
   functionId: string;
@@ -80,6 +83,17 @@ export let processEnclaveOverrideClone = async (data: {
   });
 
   try {
+    if (sourceVersion.functionBundle.status === 'failed') {
+      await db.enclaveFunctionOverrideDeployment.update({
+        where: { oid: overrideDeployment.oid },
+        data: {
+          status: 'failed',
+          errorMessage: 'Source function bundle is marked as failed.'
+        }
+      });
+      return;
+    }
+
     if (
       sourceVersion.functionBundle.status !== 'available' ||
       !sourceVersion.functionBundle.bucket ||
@@ -220,6 +234,13 @@ export let processEnclaveOverrideClone = async (data: {
         errorMessage: getErrorMessage(err)
       }
     });
+    if (isCorruptedZipError(err)) {
+      await db.functionBundle.update({
+        where: { oid: sourceVersion.functionBundle.oid },
+        data: { status: 'failed' }
+      });
+      return;
+    }
     throw err;
   }
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect bundle persistence and enclave clone queue behavior for production function artifacts; misclassified zip errors could mark good bundles failed, but scope is limited to build upload and override clone paths.
> 
> **Overview**
> Function bundle handling is tightened so **invalid ZIPs are caught earlier** and **enclave clone jobs stop retrying** on known-bad artifacts.
> 
> The **build upload** step no longer streams the Forge output straight into object storage. It checks the download response, buffers the file, and **parses the ZIP with JSZip** before marking the bundle available—bad HTTP responses or corrupt archives fail upload instead of landing in storage.
> 
> **Enclave override cloning** now **fails fast** when the source bundle is already `failed`, and when cloning hits a **corrupted ZIP** (central-directory error), it marks the **source `functionBundle` as `failed`**, records the deployment failure, and **returns without re-queuing**. Tests cover that path; the Lambda deflector test fixture adds **`functionArn`** to `providerData`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c9e1246aeabc0f9b993dcd45e0bbf5115efc38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->