### PR TITLE
Improve redeploy in slates admin

### DIFF
--- a/src/systems/slates/apps/hub/admin/src/App.tsx
+++ b/src/systems/slates/apps/hub/admin/src/App.tsx
@@ -6,6 +6,7 @@ import { DeploymentList } from './pages/deployments/DeploymentList';
 import { DiscoveryDetail } from './pages/discoveries/DiscoveryDetail';
 import { DiscoveryList } from './pages/discoveries/DiscoveryList';
 import { EventList } from './pages/events/EventList';
+import { SlateBulkRedeploy } from './pages/slates/SlateBulkRedeploy';
 import { SlateDetail } from './pages/slates/SlateDetail';
 import { SlateList } from './pages/slates/SlateList';
 import { VersionDetail } from './pages/versions/VersionDetail';
@@ -20,6 +21,7 @@ export let App = () => {
         <Route path="/" element={<Navigate to="/slates" replace />} />
 
         <Route path="/slates" element={<SlateList />} />
+        <Route path="/slates/redeploy" element={<SlateBulkRedeploy />} />
         <Route path="/slates/:slateId" element={<SlateDetail />} />
 
         <Route path="/slates/:slateId/versions" element={<VersionList />} />

--- a/src/systems/slates/apps/hub/admin/src/components/Layout.tsx
+++ b/src/systems/slates/apps/hub/admin/src/components/Layout.tsx
@@ -5,7 +5,13 @@ import {
   SidebarPane
 } from '@metorial-io/layout';
 import { Logo } from '@metorial-io/ui';
-import { RiFileList3Line, RiRocketLine, RiSearchEyeLine, RiTimeLine } from '@remixicon/react';
+import {
+  RiFileList3Line,
+  RiRefreshLine,
+  RiRocketLine,
+  RiSearchEyeLine,
+  RiTimeLine
+} from '@remixicon/react';
 import { Outlet, useLocation, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { useSlate } from '../state';
@@ -28,7 +34,13 @@ export let Layout = () => {
       icon: <RiFileList3Line />,
       label: 'Slates',
       to: '/slates',
-      isActive: isPrefixMatch(pathname, '/slates')
+      isActive: isPrefixMatch(pathname, '/slates') && pathname !== '/slates/redeploy'
+    },
+    {
+      icon: <RiRefreshLine />,
+      label: 'Bulk Redeploy',
+      to: '/slates/redeploy',
+      isActive: pathname === '/slates/redeploy'
     },
     {
       icon: <RiRocketLine />,

--- a/src/systems/slates/apps/hub/admin/src/pages/deployments/DeploymentDetail.tsx
+++ b/src/systems/slates/apps/hub/admin/src/pages/deployments/DeploymentDetail.tsx
@@ -10,9 +10,16 @@ import {
   Text
 } from '@metorial-io/ui';
 import { useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { deploymentStatusColors } from '../../constants/statusColors.js';
-import { redeploySlateDeployment, useBuildOutput, useInternalLogs, useSlate, useSlateDeployment } from '../../state/index.js';
+import {
+  redeploySlateDeployment,
+  useBuildOutput,
+  useInternalLogs,
+  useSlate,
+  useSlateDeployment,
+  waitForRedeployDeployment
+} from '../../state/index.js';
 import { BackLink } from '../../components/BackLink.js';
 import {
   LogViewer,
@@ -53,6 +60,7 @@ let BuildStepView = ({ step }: { step: BuildStep }) => {
 
 export let DeploymentDetail = () => {
   let { slateId, deploymentId } = useParams<{ slateId: string; deploymentId: string }>();
+  let navigate = useNavigate();
   let slate = useSlate(slateId);
   let deployment = useSlateDeployment(slateId, deploymentId);
   let buildOutput = useBuildOutput(slateId, deploymentId);
@@ -65,7 +73,14 @@ export let DeploymentDetail = () => {
     if (!confirm('This will cancel any ongoing deployments for this version and start a new one. Continue?')) return;
     setRedeploying(true);
     try {
-      await redeploySlateDeployment(slateId, deploymentId);
+      let result = await redeploySlateDeployment(slateId, deploymentId);
+      let deployment = await waitForRedeployDeployment({
+        slateId,
+        versionId: result.versionId,
+        queuedAt: result.queuedAt
+      });
+
+      if (deployment) navigate(`/slates/${slateId}/deployments/${deployment.id}`);
     } finally {
       setRedeploying(false);
     }

--- a/src/systems/slates/apps/hub/admin/src/pages/slates/SlateBulkRedeploy.tsx
+++ b/src/systems/slates/apps/hub/admin/src/pages/slates/SlateBulkRedeploy.tsx
@@ -1,0 +1,425 @@
+import { renderWithPagination } from '@metorial-io/data-hooks';
+import {
+  Badge,
+  Button,
+  Checkbox,
+  Flex,
+  Group,
+  Input,
+  Spacer,
+  Text,
+  Title
+} from '@metorial-io/ui';
+import { Table } from '@metorial-io/ui-product';
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { EmptyState, SlateLogoPlaceholder } from '../../components/styled.js';
+import {
+  deploymentStatusColors,
+  versionStatusColors
+} from '../../constants/statusColors.js';
+import {
+  bulkRedeployLatestSlates,
+  listRedeployDeployments,
+  redeployLatestSlate,
+  waitForRedeployDeployment,
+  useSlates
+} from '../../state/index.js';
+
+type Slate = NonNullable<ReturnType<typeof useSlates>['data']>['items'][number];
+type RedeployOverviewItem = {
+  slateId: string;
+  slateName: string;
+  versionId?: string;
+  queuedAt?: Date | string;
+  queueStatus: 'queued' | 'failed';
+  deploymentId?: string;
+  deploymentStatus?: 'pending' | 'running' | 'succeeded' | 'failed';
+  error?: string;
+};
+
+export let SlateBulkRedeploy = () => {
+  let navigate = useNavigate();
+  let [search, setSearch] = useState('');
+  let [debouncedSearch, setDebouncedSearch] = useState(search);
+  let [selectedSlateIds, setSelectedSlateIds] = useState<Set<string>>(new Set());
+  let [bulkRedeploying, setBulkRedeploying] = useState(false);
+  let [rowRedeploying, setRowRedeploying] = useState<Set<string>>(new Set());
+  let [overviewItems, setOverviewItems] = useState<RedeployOverviewItem[]>([]);
+  let [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let timeout = window.setTimeout(() => setDebouncedSearch(search), 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [search]);
+
+  let searchQuery = debouncedSearch.trim() || undefined;
+  let slates = useSlates(searchQuery);
+  let selectedCount = selectedSlateIds.size;
+  let slateNameById = new Map(
+    (slates.data?.items ?? []).map(slate => [slate.id, slate.name || slate.identifier])
+  );
+
+  useEffect(() => {
+    setSelectedSlateIds(new Set());
+  }, [searchQuery]);
+
+  let emptyState = (
+    <EmptyState direction="column" align="center">
+      <Title size="4" weight="strong">
+        No slates found
+      </Title>
+      <Spacer size={8} />
+      <Text size="2" color="gray600">
+        {searchQuery
+          ? `No slates match "${searchQuery}".`
+          : 'No slates have been registered in the hub yet.'}
+      </Text>
+    </EmptyState>
+  );
+
+  let setSlateSelected = (slateId: string, selected: boolean) => {
+    setSelectedSlateIds(current => {
+      let next = new Set(current);
+      if (selected) next.add(slateId);
+      else next.delete(slateId);
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    let pollableItems = overviewItems.filter(
+      item =>
+        item.queueStatus === 'queued' &&
+        item.versionId &&
+        item.queuedAt &&
+        (!item.deploymentId ||
+          item.deploymentStatus === 'pending' ||
+          item.deploymentStatus === 'running')
+    );
+    if (pollableItems.length === 0) return;
+
+    let isCancelled = false;
+    let poll = async () => {
+      try {
+        let deployments = await listRedeployDeployments(
+          pollableItems.map(item => ({
+            slateId: item.slateId,
+            versionId: item.versionId!,
+            queuedAt: item.queuedAt!
+          }))
+        );
+        if (isCancelled) return;
+
+        setOverviewItems(current =>
+          current.map(item => {
+            let deployment = deployments.find(
+              d => d.slate?.id === item.slateId && d.version?.id === item.versionId
+            );
+            if (!deployment) return item;
+
+            return {
+              ...item,
+              deploymentId: deployment.id,
+              deploymentStatus: deployment.status
+            };
+          })
+        );
+      } catch (error) {
+        if (!isCancelled) {
+          setMessage(
+            error instanceof Error ? error.message : 'Failed to poll redeploy statuses.'
+          );
+        }
+      }
+    };
+
+    poll();
+    let interval = window.setInterval(poll, 2000);
+
+    return () => {
+      isCancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [overviewItems]);
+
+  let redeploySlate = async (slate: Slate) => {
+    setMessage(null);
+    let slateId = slate.id;
+    setRowRedeploying(current => new Set(current).add(slateId));
+    try {
+      let result = await redeployLatestSlate(slateId);
+      setOverviewItems(current => [
+        {
+          slateId,
+          slateName: slate.name || slate.identifier,
+          versionId: result.versionId,
+          queuedAt: result.queuedAt,
+          queueStatus: 'queued'
+        },
+        ...current.filter(item => item.slateId !== slateId)
+      ]);
+
+      let deployment = await waitForRedeployDeployment({
+        slateId,
+        versionId: result.versionId,
+        queuedAt: result.queuedAt
+      });
+
+      if (!deployment) {
+        setMessage('Redeploy queued, but the deployment page is not ready yet.');
+        return;
+      }
+
+      navigate(`/slates/${slateId}/deployments/${deployment.id}`);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Failed to redeploy slate.');
+    } finally {
+      setRowRedeploying(current => {
+        let next = new Set(current);
+        next.delete(slateId);
+        return next;
+      });
+    }
+  };
+
+  let redeploySelected = async () => {
+    let slateIds = [...selectedSlateIds];
+    if (slateIds.length === 0) return;
+
+    setMessage(null);
+    setBulkRedeploying(true);
+    try {
+      let result = await bulkRedeployLatestSlates(slateIds);
+      let failed = result.results.filter(r => r.status === 'failed');
+      let queued = result.results.length - failed.length;
+      setOverviewItems(
+        result.results.map(result => ({
+          slateId: result.slateId,
+          slateName: slateNameById.get(result.slateId) ?? result.slateId,
+          versionId: result.status === 'queued' ? result.versionId : undefined,
+          queuedAt: result.status === 'queued' ? result.queuedAt : undefined,
+          queueStatus: result.status,
+          error: result.error?.message
+        }))
+      );
+      setMessage(
+        failed.length
+          ? `Queued ${queued} redeploys. ${failed.length} failed.`
+          : `Queued ${queued} redeploys.`
+      );
+      if (failed.length === 0) setSelectedSlateIds(new Set());
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Failed to redeploy selected slates.');
+    } finally {
+      setBulkRedeploying(false);
+    }
+  };
+
+  return (
+    <Flex direction="column" gap={32}>
+      <Flex justify="space-between" align="end" gap={16} style={{ flexWrap: 'wrap' }}>
+        <div>
+          <Title size="6" weight="strong">
+            Bulk Redeploy Slates
+          </Title>
+          <Spacer size={4} />
+          <Text size="2" color="gray600">
+            Search slates and queue redeploys for their newest versions.
+          </Text>
+        </div>
+        <Flex align="end" gap={12} style={{ flexWrap: 'wrap' }}>
+          <div style={{ width: '100%', maxWidth: 320 }}>
+            <Input
+              label="Search slates"
+              hideLabel
+              placeholder="Search by slate name"
+              value={search}
+              onInput={value => setSearch(value)}
+            />
+          </div>
+          <Button
+            color="blue"
+            disabled={selectedCount === 0 || bulkRedeploying}
+            loading={bulkRedeploying}
+            onClick={redeploySelected}
+          >
+            Redeploy selected{selectedCount ? ` (${selectedCount})` : ''}
+          </Button>
+        </Flex>
+      </Flex>
+
+      {message && (
+        <Text size="2" color="gray600">
+          {message}
+        </Text>
+      )}
+
+      {overviewItems.length > 0 && (
+        <Group.Wrapper>
+          <Group.Header title="Redeploy Status" />
+          <Table
+            padding={{ sides: '20px' }}
+            headers={['Slate', 'Version', 'Status', 'Deployment']}
+            data={overviewItems.map(item => {
+              let status = item.error
+                ? 'failed to queue'
+                : item.deploymentStatus ?? 'waiting for deployment';
+
+              return {
+                data: [
+                  <Text size="2" weight="strong">
+                    {item.slateName}
+                  </Text>,
+                  item.versionId ? (
+                    <Text size="2" style={{ fontFamily: 'monospace' }}>
+                      {item.versionId}
+                    </Text>
+                  ) : (
+                    <Text size="2" color="gray600">
+                      -
+                    </Text>
+                  ),
+                  <Badge
+                    color={
+                      item.deploymentStatus
+                        ? deploymentStatusColors[item.deploymentStatus] || 'gray'
+                        : item.error
+                          ? 'red'
+                          : 'gray'
+                    }
+                  >
+                    {status}
+                  </Badge>,
+                  item.deploymentId ? (
+                    <Link
+                      to={`/slates/${item.slateId}/deployments/${item.deploymentId}`}
+                      style={{ textDecoration: 'none' }}
+                    >
+                      <Button as="span" size="2" variant="outline">
+                        View deployment
+                      </Button>
+                    </Link>
+                  ) : item.error ? (
+                    <Text size="1" color="red600">
+                      {item.error}
+                    </Text>
+                  ) : (
+                    <Text size="2" color="gray600">
+                      Polling...
+                    </Text>
+                  )
+                ]
+              };
+            })}
+          />
+        </Group.Wrapper>
+      )}
+
+      {renderWithPagination(slates, { emptyState })(({ data }) => {
+        let items = data.items;
+        let visibleSlateIds = items.map(slate => slate.id);
+        let allVisibleSelected =
+          visibleSlateIds.length > 0 &&
+          visibleSlateIds.every(slateId => selectedSlateIds.has(slateId));
+
+        return (
+          <Group.Wrapper>
+            <Group.Content>
+              <Checkbox
+                label="Select all visible slates"
+                checked={allVisibleSelected}
+                onCheckedChange={checked => {
+                  setSelectedSlateIds(current => {
+                    let next = new Set(current);
+                    for (let slateId of visibleSlateIds) {
+                      if (checked) next.add(slateId);
+                      else next.delete(slateId);
+                    }
+                    return next;
+                  });
+                }}
+              />
+            </Group.Content>
+            <Table
+              padding={{ sides: '20px' }}
+              headers={[
+                'Select',
+                'Slate',
+                'Newest Version',
+                'Current Version',
+                'Status',
+                'Actions'
+              ]}
+              data={items.map((slate: Slate) => {
+                let displayName = slate.name || slate.identifier;
+                let latestVersion = slate.latestVersion;
+                let currentVersion = slate.currentVersion;
+                let isRedeploying = rowRedeploying.has(slate.id);
+
+                return {
+                  data: [
+                    <Checkbox
+                      label={`Select ${displayName}`}
+                      hideLabel
+                      checked={selectedSlateIds.has(slate.id)}
+                      onCheckedChange={checked => setSlateSelected(slate.id, checked)}
+                    />,
+                    <Flex align="center" gap={14}>
+                      <SlateLogoPlaceholder align="center" justify="center">
+                        {displayName.charAt(0).toUpperCase()}
+                      </SlateLogoPlaceholder>
+                      <Flex direction="column">
+                        <Link to={`/slates/${slate.id}`} style={{ textDecoration: 'none' }}>
+                          <Text size="2" weight="strong">
+                            {displayName}
+                          </Text>
+                        </Link>
+                        <Text size="1" color="gray600">
+                          {slate.slate?.fullIdentifier || slate.identifier}
+                        </Text>
+                      </Flex>
+                    </Flex>,
+                    latestVersion ? (
+                      <Badge color="blue">v{latestVersion.version}</Badge>
+                    ) : (
+                      <Text size="2" color="gray500">
+                        -
+                      </Text>
+                    ),
+                    currentVersion ? (
+                      <Badge color="green">v{currentVersion.version}</Badge>
+                    ) : (
+                      <Text size="2" color="gray500">
+                        -
+                      </Text>
+                    ),
+                    <Badge
+                      color={
+                        latestVersion?.status
+                          ? versionStatusColors[latestVersion.status] || 'gray'
+                          : 'gray'
+                      }
+                    >
+                      {latestVersion?.status ?? 'no version'}
+                    </Badge>,
+                    <Button
+                      size="2"
+                      variant="outline"
+                      disabled={!latestVersion || isRedeploying || bulkRedeploying}
+                      loading={isRedeploying}
+                      onClick={() => redeploySlate(slate)}
+                    >
+                      Redeploy
+                    </Button>
+                  ]
+                };
+              })}
+            />
+          </Group.Wrapper>
+        );
+      })}
+    </Flex>
+  );
+};

--- a/src/systems/slates/apps/hub/admin/src/pages/slates/SlateDetail.tsx
+++ b/src/systems/slates/apps/hub/admin/src/pages/slates/SlateDetail.tsx
@@ -1,6 +1,16 @@
 import { renderWithLoader } from '@metorial-io/data-hooks';
-import { Badge, Datalist, Flex, Group, InlineCopy, RenderDate, Text } from '@metorial-io/ui';
-import { Link, useParams } from 'react-router-dom';
+import {
+  Badge,
+  Button,
+  Datalist,
+  Flex,
+  Group,
+  InlineCopy,
+  RenderDate,
+  Text
+} from '@metorial-io/ui';
+import { useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { styled } from 'styled-components';
 import {
   deploymentStatusColors,
@@ -16,6 +26,7 @@ import {
   useSlateStats,
   useSlateVersions
 } from '../../state/index.js';
+import { redeployLatestSlate, waitForRedeployDeployment } from '../../state/deployments.js';
 import { BackLink } from '../../components/BackLink.js';
 import { MonoCode, SlateLogoPlaceholder } from '../../components/styled.js';
 
@@ -100,6 +111,9 @@ let ViewAllLink = styled(Link)`
 
 export let SlateDetail = () => {
   let { slateId } = useParams<{ slateId: string }>();
+  let navigate = useNavigate();
+  let [isRedeploying, setIsRedeploying] = useState(false);
+  let [redeployError, setRedeployError] = useState<string | null>(null);
   let slate = useSlate(slateId);
   let stats = useSlateStats(slateId);
   let versions = useSlateVersions(slateId);
@@ -127,9 +141,47 @@ export let SlateDetail = () => {
                   S
                 </LargeLogoPlaceholder>
                 <Flex direction="column" style={{ flex: 1 }}>
-                  <Text size="5" weight="bold" style={{ marginBottom: 8 }}>
-                    {slateData.name || slateData.identifier}
-                  </Text>
+                  <Flex align="center" justify="space-between" gap={16}>
+                    <Text size="5" weight="bold" style={{ marginBottom: 8 }}>
+                      {slateData.name || slateData.identifier}
+                    </Text>
+                    <Button
+                      size="2"
+                      color="blue"
+                      disabled={!versionItems.length || isRedeploying}
+                      loading={isRedeploying}
+                      onClick={async () => {
+                        if (!slateId) return;
+                        setRedeployError(null);
+                        setIsRedeploying(true);
+                        try {
+                          let result = await redeployLatestSlate(slateId);
+                          let deployment = await waitForRedeployDeployment({
+                            slateId,
+                            versionId: result.versionId,
+                            queuedAt: result.queuedAt
+                          });
+
+                          if (!deployment) {
+                            setRedeployError(
+                              'Redeploy queued, but the deployment page is not ready yet.'
+                            );
+                            return;
+                          }
+
+                          navigate(`/slates/${slateId}/deployments/${deployment.id}`);
+                        } catch (error) {
+                          setRedeployError(
+                            error instanceof Error ? error.message : 'Failed to redeploy slate'
+                          );
+                        } finally {
+                          setIsRedeploying(false);
+                        }
+                      }}
+                    >
+                      Redeploy latest version
+                    </Button>
+                  </Flex>
                   <Flex align="center" gap={6} style={{ marginBottom: 12 }}>
                     <MonoCode>
                       {slateData.slate?.fullIdentifier || slateData.identifier}
@@ -141,6 +193,16 @@ export let SlateDetail = () => {
                   {slateData.description && (
                     <Text size="2" color="gray600">
                       {slateData.description}
+                    </Text>
+                  )}
+                  {redeployError && (
+                    <Text size="1" color="red600" style={{ marginTop: 8 }}>
+                      {redeployError}
+                    </Text>
+                  )}
+                  {!versionItems.length && (
+                    <Text size="1" color="gray600" style={{ marginTop: 8 }}>
+                      Add a version before redeploying this slate.
                     </Text>
                   )}
                 </Flex>

--- a/src/systems/slates/apps/hub/admin/src/pages/slates/SlateList.tsx
+++ b/src/systems/slates/apps/hub/admin/src/pages/slates/SlateList.tsx
@@ -1,7 +1,8 @@
 import { renderWithPagination } from '@metorial-io/data-hooks';
-import { Badge, Flex, Group, Input, Spacer, Text, Title } from '@metorial-io/ui';
+import { Badge, Button, Flex, Group, Input, Spacer, Text, Title } from '@metorial-io/ui';
 import { Table } from '@metorial-io/ui-product';
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { EmptyState, SlateLogoPlaceholder } from '../../components/styled.js';
 import { versionStatusColors } from '../../constants/statusColors.js';
@@ -52,15 +53,22 @@ export let SlateList = () => {
             All slates registered in the hub. View versions, deployments, and events.
           </Text>
         </div>
-        <div style={{ width: '100%', maxWidth: 320 }}>
-          <Input
-            label="Search slates"
-            hideLabel
-            placeholder="Search by slate name"
-            value={search}
-            onInput={value => setSearch(value)}
-          />
-        </div>
+        <Flex align="end" gap={12} style={{ flexWrap: 'wrap' }}>
+          <div style={{ width: '100%', maxWidth: 320 }}>
+            <Input
+              label="Search slates"
+              hideLabel
+              placeholder="Search by slate name"
+              value={search}
+              onInput={value => setSearch(value)}
+            />
+          </div>
+          <Link to="/slates/redeploy" style={{ textDecoration: 'none' }}>
+            <Button as="span" variant="outline">
+              Bulk redeploy
+            </Button>
+          </Link>
+        </Flex>
       </Flex>
 
       {renderWithPagination(slates, { emptyState })(({ data }) => {

--- a/src/systems/slates/apps/hub/admin/src/state/deployments.ts
+++ b/src/systems/slates/apps/hub/admin/src/state/deployments.ts
@@ -1,5 +1,7 @@
 import { createLoader } from '@metorial-io/data-hooks';
 import { adminClient, withAuthRedirect } from '../hooks/client.js';
+import { slateStatsLoader, slateLoader, slatesLoader } from './slates.js';
+import { slateVersionsLoader } from './versions.js';
 import { usePaginatedLoader } from './usePaginatedLoader.js';
 
 export let allDeploymentsLoader = createLoader({
@@ -28,6 +30,56 @@ export let slateDeploymentsLoader = createLoader({
 
 export let useSlateDeployments = (slateId: string | undefined, versionIds?: string[]) =>
   usePaginatedLoader(slateDeploymentsLoader, slateId ? { slateId, versionIds } : null);
+
+let isAfterQueuedAt = (createdAt: Date | string, queuedAt: Date | string) =>
+  new Date(createdAt).getTime() >= new Date(queuedAt).getTime();
+
+export let listRedeployDeployments = async (
+  redeploys: {
+    slateId: string;
+    versionId: string;
+    queuedAt: Date | string;
+  }[]
+) => {
+  if (redeploys.length === 0) return [];
+
+  let byVersionId = new Map(redeploys.map(redeploy => [redeploy.versionId, redeploy]));
+  let list = await withAuthRedirect(() =>
+    adminClient.slateDeployment.list({
+      versionIds: [...byVersionId.keys()]
+    })
+  );
+
+  return list.items.filter(deployment => {
+    if (!deployment.version?.id) return false;
+
+    let redeploy = byVersionId.get(deployment.version.id);
+    if (!redeploy) return false;
+    if (deployment.slate?.id !== redeploy.slateId) return false;
+
+    return isAfterQueuedAt(deployment.createdAt, redeploy.queuedAt);
+  });
+};
+
+export let waitForRedeployDeployment = async (d: {
+  slateId: string;
+  versionId: string;
+  queuedAt: Date | string;
+  timeoutMs?: number;
+}) => {
+  let startedAt = Date.now();
+  let timeoutMs = d.timeoutMs ?? 30_000;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    let deployments = await listRedeployDeployments([d]);
+    let deployment = deployments[0];
+    if (deployment) return deployment;
+
+    await new Promise(resolve => window.setTimeout(resolve, 1000));
+  }
+
+  return null;
+};
 
 export let slateDeploymentLoader = createLoader({
   name: 'slateDeployment',
@@ -70,10 +122,46 @@ export let useInternalLogs = (slateId: string | undefined, deploymentId: string 
   );
 
 export let redeploySlateDeployment = async (slateId: string, slateDeploymentId: string) => {
-  await withAuthRedirect(() =>
+  let result = await withAuthRedirect(() =>
     adminClient.slateDeployment.redeploy({ slateId, slateDeploymentId })
   );
+  slateLoader.refetchAll();
+  slatesLoader.refetchAll();
+  slateStatsLoader.refetchAll();
+  slateVersionsLoader.refetchAll();
   slateDeploymentLoader.refetchAll();
   allDeploymentsLoader.refetchAll();
   slateDeploymentsLoader.refetchAll();
+
+  return result;
+};
+
+export let redeployLatestSlate = async (slateId: string) => {
+  let result = await withAuthRedirect(() =>
+    adminClient.slateDeployment.redeployLatest({ slateId })
+  );
+  slateLoader.refetchAll();
+  slatesLoader.refetchAll();
+  slateStatsLoader.refetchAll();
+  slateVersionsLoader.refetchAll();
+  slateDeploymentLoader.refetchAll();
+  allDeploymentsLoader.refetchAll();
+  slateDeploymentsLoader.refetchAll();
+
+  return result;
+};
+
+export let bulkRedeployLatestSlates = async (slateIds: string[]) => {
+  let result = await withAuthRedirect(() =>
+    adminClient.slateDeployment.bulkRedeployLatest({ slateIds })
+  );
+  slateLoader.refetchAll();
+  slatesLoader.refetchAll();
+  slateStatsLoader.refetchAll();
+  slateVersionsLoader.refetchAll();
+  slateDeploymentLoader.refetchAll();
+  allDeploymentsLoader.refetchAll();
+  slateDeploymentsLoader.refetchAll();
+
+  return result;
 };

--- a/src/systems/slates/apps/hub/src/apis/admin/controllers/slateDeployment.ts
+++ b/src/systems/slates/apps/hub/src/apis/admin/controllers/slateDeployment.ts
@@ -86,6 +86,54 @@ export let slateDeploymentController = authedApp.controller({
       });
     }),
 
+  redeployLatest: slateApp
+    .handler()
+    .input(
+      v.object({
+        slateId: v.string()
+      })
+    )
+    .do(async ctx => {
+      let { version, queuedAt } = await slateDeploymentService.redeployLatestSlateVersion({
+        slate: ctx.slate
+      });
+
+      return {
+        object: 'slate.deployment.redeploy_result',
+        slateId: ctx.slate.id,
+        versionId: version.id,
+        queuedAt,
+        status: 'queued'
+      };
+    }),
+
+  bulkRedeployLatest: authedApp
+    .handler()
+    .input(
+      v.object({
+        slateIds: v.array(v.string())
+      })
+    )
+    .do(async ctx => {
+      let slates = await slateService.getManySlatesByIds({
+        ids: [...new Set(ctx.input.slateIds)]
+      });
+      let foundSlateIds = new Set(slates.map(slate => slate.id));
+      let missingResults = ctx.input.slateIds
+        .filter(slateId => !foundSlateIds.has(slateId))
+        .map(slateId => ({
+          slateId,
+          status: 'failed' as const,
+          error: { message: 'Slate not found' }
+        }));
+      let results = await slateDeploymentService.bulkRedeployLatestSlateVersions({ slates });
+
+      return {
+        object: 'slate.deployment.bulk_redeploy_result',
+        results: [...results, ...missingResults]
+      };
+    }),
+
   redeploy: slateDeploymentApp
     .handler()
     .input(
@@ -95,9 +143,16 @@ export let slateDeploymentController = authedApp.controller({
       })
     )
     .do(async ctx => {
-      await slateDeploymentService.redeploy({
+      let { version, queuedAt } = await slateDeploymentService.redeploy({
         slateDeployment: ctx.slateDeployment
       });
-      return {};
+
+      return {
+        object: 'slate.deployment.redeploy_result',
+        slateId: ctx.slate.id,
+        versionId: version.id,
+        queuedAt,
+        status: 'queued'
+      };
     })
 });

--- a/src/systems/slates/apps/hub/src/presenters/slate.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slate.ts
@@ -14,6 +14,9 @@ export let slatePresenter = (
           specification: SlateSpecification | null;
         })
       | null;
+    slateVersions?: (SlateVersion & {
+      specification: SlateSpecification | null;
+    })[];
   }
 ) => ({
   object: 'slate',
@@ -29,6 +32,13 @@ export let slatePresenter = (
   currentVersion: slate.currentVersion
     ? slateVersionPresenter({
         ...slate.currentVersion,
+        slate: slate
+      })
+    : null,
+
+  latestVersion: slate.slateVersions?.[0]
+    ? slateVersionPresenter({
+        ...slate.slateVersions[0],
         slate: slate
       })
     : null,

--- a/src/systems/slates/apps/hub/src/services/slate.ts
+++ b/src/systems/slates/apps/hub/src/services/slate.ts
@@ -12,6 +12,13 @@ let include = {
     include: {
       specification: true
     }
+  },
+  slateVersions: {
+    orderBy: [{ createdAt: 'desc' as const }, { oid: 'desc' as const }],
+    take: 1,
+    include: {
+      specification: true
+    }
   }
 };
 
@@ -77,6 +84,7 @@ class slateServiceImpl {
                   }
                 : {})
             },
+            orderBy: [{ createdAt: 'desc' }, { oid: 'desc' }],
             include
           })
       )

--- a/src/systems/slates/apps/hub/src/services/slateDeployment.ts
+++ b/src/systems/slates/apps/hub/src/services/slateDeployment.ts
@@ -61,13 +61,13 @@ class slateDeploymentServiceImpl {
     });
   }
 
-  async redeploy(d: { slateDeployment: SlateDeployment }) {
-    let versionOid = d.slateDeployment.slateVersionOid;
+  private async redeployVersion(d: { versionOid: bigint }) {
+    let queuedAt = new Date();
 
     // Cancel all ongoing deployments for this version
     await db.slateDeployment.updateMany({
       where: {
-        slateVersionOid: versionOid,
+        slateVersionOid: d.versionOid,
         status: { in: ['pending', 'running'] }
       },
       data: {
@@ -80,10 +80,56 @@ class slateDeploymentServiceImpl {
 
     // Find the version to queue a new deployment
     let version = await db.slateVersion.findUniqueOrThrow({
-      where: { oid: versionOid }
+      where: { oid: d.versionOid }
     });
 
     await deploySlateVersionQueue.add({ versionId: version.id });
+
+    return { version, queuedAt };
+  }
+
+  async redeploy(d: { slateDeployment: SlateDeployment }) {
+    return this.redeployVersion({ versionOid: d.slateDeployment.slateVersionOid });
+  }
+
+  async redeployLatestSlateVersion(d: { slate: Slate }) {
+    let version = await db.slateVersion.findFirst({
+      where: { slateOid: d.slate.oid },
+      orderBy: [{ createdAt: 'desc' }, { oid: 'desc' }]
+    });
+    if (!version) throw new ServiceError(notFoundError('slate.version'));
+
+    return this.redeployVersion({ versionOid: version.oid });
+  }
+
+  async bulkRedeployLatestSlateVersions(d: { slates: Slate[] }) {
+    let results: {
+      slateId: string;
+      status: 'queued' | 'failed';
+      versionId?: string;
+      queuedAt?: Date;
+      error?: { message: string };
+    }[] = [];
+
+    for (let slate of d.slates) {
+      try {
+        let { version, queuedAt } = await this.redeployLatestSlateVersion({ slate });
+        results.push({
+          slateId: slate.id,
+          status: 'queued',
+          versionId: version.id,
+          queuedAt
+        });
+      } catch (error) {
+        results.push({
+          slateId: slate.id,
+          status: 'failed',
+          error: { message: error instanceof Error ? error.message : 'Unknown error' }
+        });
+      }
+    }
+
+    return results;
   }
 
   async listSlateDeployments(d: {
@@ -114,6 +160,7 @@ class slateDeploymentServiceImpl {
               slateVersionOid: versions ? { in: versions.map(v => v.oid) } : undefined,
               status: d.status
             },
+            orderBy: [{ createdAt: 'desc' }, { oid: 'desc' }],
             include
           })
       )

--- a/src/systems/slates/apps/hub/src/services/slateDiscovery.ts
+++ b/src/systems/slates/apps/hub/src/services/slateDiscovery.ts
@@ -97,6 +97,7 @@ class slateVersionDiscoveryServiceImpl {
               slateVersionOid: versions ? { in: versions.map(v => v.oid) } : undefined,
               status: d.status
             },
+            orderBy: [{ createdAt: 'desc' }, { oid: 'desc' }],
             include
           })
       )

--- a/src/systems/slates/apps/hub/src/services/slateEvent.ts
+++ b/src/systems/slates/apps/hub/src/services/slateEvent.ts
@@ -79,6 +79,7 @@ class slateEventServiceImpl {
               slateVersion: versions ? { oid: { in: versions.map(v => v.oid) } } : undefined,
               type: d.type as any
             },
+            orderBy: [{ createdAt: 'desc' }, { oid: 'desc' }],
             include
           })
       )

--- a/src/systems/slates/apps/hub/src/services/slateSpecificationChange.ts
+++ b/src/systems/slates/apps/hub/src/services/slateSpecificationChange.ts
@@ -66,6 +66,7 @@ class slateSpecificationChangeServiceImpl {
                   ]
                 : undefined
             },
+            orderBy: [{ createdAt: 'desc' }, { oid: 'desc' }],
             include
           })
       )

--- a/src/systems/slates/apps/hub/src/services/slateVersion.ts
+++ b/src/systems/slates/apps/hub/src/services/slateVersion.ts
@@ -61,7 +61,7 @@ class slateVersionServiceImpl {
             where: {
               slateOid: d.slate.oid
             },
-            orderBy: { createdAt: 'desc' },
+            orderBy: [{ createdAt: 'desc' }, { oid: 'desc' }],
             include
           })
       )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Redeploy now cancels pending/running deployments and queues new deploys at scale via bulk admin actions; mistakes could disrupt many slates, though behavior is confined to existing admin auth and deployment queues.
> 
> **Overview**
> This PR extends **slates hub admin redeploy** from a fire-and-forget action into a tracked workflow with **latest-version** and **bulk** redeploy support, backed by new hub APIs and richer slate list data.
> 
> **Backend:** Redeploy endpoints now return `versionId`, `queuedAt`, and `status: 'queued'` instead of an empty body. New handlers **`redeployLatest`** (per slate) and **`bulkRedeployLatest`** (many slates, per-slate success/failure) queue deployments via shared `redeployVersion` logic (cancel in-flight deployments for that version, enqueue deploy). Slate payloads gain **`latestVersion`** (newest version, not only `currentVersion`), and list queries use consistent **`createdAt` / `oid` desc** ordering across deployments, events, discoveries, and related lists.
> 
> **Admin UI:** A **`/slates/redeploy`** bulk page lets operators search, multi-select, queue bulk redeploys, and poll deployment status; nav and slate list link to it. **Slate detail** and **deployment detail** redeploy buttons wait for the new deployment (client polling) and navigate to the deployment page when ready. Admin state adds `redeployLatestSlate`, `bulkRedeployLatestSlates`, `listRedeployDeployments`, and `waitForRedeployDeployment`, with cache refetch after redeploy mutations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d7bfdda71f1b2e3ecb5277a04042323842546b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->