### PR TITLE
Add deflector killswitch

### DIFF
--- a/src/systems/function-bay/deflector/cmd/deflector/main.go
+++ b/src/systems/function-bay/deflector/cmd/deflector/main.go
@@ -23,8 +23,9 @@ func main() {
 	if addr == "" {
 		addr = ":8080"
 	}
+	disableProxyAuthentication := envBool("DEFLECTOR_DISABLE_PROXY_AUTHENTICATION", false)
 	jwtSecret := os.Getenv("DEFLECTOR_JWT_SECRET")
-	if jwtSecret == "" {
+	if jwtSecret == "" && !disableProxyAuthentication {
 		logger.Error("DEFLECTOR_JWT_SECRET is required")
 		os.Exit(1)
 	}
@@ -82,9 +83,13 @@ func main() {
 		)
 	}
 
+	if disableProxyAuthentication {
+		logger.Warn("proxy authentication disabled by DEFLECTOR_DISABLE_PROXY_AUTHENTICATION")
+	}
+
 	srv := &http.Server{
 		Addr:              addr,
-		Handler:           &proxy.Server{Logger: logger, Verifier: auth.NewVerifier(jwtSecret, jwtAudience), Recorder: recorder},
+		Handler:           &proxy.Server{Logger: logger, Verifier: auth.NewVerifier(jwtSecret, jwtAudience), Recorder: recorder, DisableAuthentication: disableProxyAuthentication},
 		ReadHeaderTimeout: 5 * time.Second,
 		IdleTimeout:       90 * time.Second,
 		MaxHeaderBytes:    32 << 10,
@@ -95,6 +100,18 @@ func main() {
 		logger.Error("deflector exited", "error", err)
 		os.Exit(1)
 	}
+}
+
+func envBool(name string, fallback bool) bool {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.ParseBool(raw)
+	if err != nil {
+		return fallback
+	}
+	return value
 }
 
 func envDurationSeconds(name string, fallback time.Duration) time.Duration {

--- a/src/systems/function-bay/deflector/cmd/deflector/main_test.go
+++ b/src/systems/function-bay/deflector/cmd/deflector/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+func TestEnvBool(t *testing.T) {
+	t.Setenv("DEFLECTOR_TEST_BOOL", "true")
+	if !envBool("DEFLECTOR_TEST_BOOL", false) {
+		t.Fatal("expected true value to be parsed")
+	}
+
+	t.Setenv("DEFLECTOR_TEST_BOOL", "false")
+	if envBool("DEFLECTOR_TEST_BOOL", true) {
+		t.Fatal("expected false value to be parsed")
+	}
+
+	t.Setenv("DEFLECTOR_TEST_BOOL", "not-bool")
+	if !envBool("DEFLECTOR_TEST_BOOL", true) {
+		t.Fatal("expected invalid value to return fallback")
+	}
+}

--- a/src/systems/function-bay/deflector/internal/proxy/server.go
+++ b/src/systems/function-bay/deflector/internal/proxy/server.go
@@ -30,10 +30,11 @@ var (
 )
 
 type Server struct {
-	Logger   *slog.Logger
-	Dialer   *net.Dialer
-	Verifier *auth.Verifier
-	Recorder *observer.Recorder
+	Logger                *slog.Logger
+	Dialer                *net.Dialer
+	Verifier              *auth.Verifier
+	Recorder              *observer.Recorder
+	DisableAuthentication bool
 }
 
 type requestPolicy struct {
@@ -67,6 +68,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) policyFromRequest(r *http.Request) (*requestPolicy, error) {
+	if s.DisableAuthentication {
+		claims := policy.Claims{LegacyFallback: true}
+		compiled, err := policy.Compile(claims)
+		if err != nil {
+			return nil, errors.Join(errInvalidEgressPolicy, err)
+		}
+		return &requestPolicy{Claims: claims, Compiled: compiled}, nil
+	}
+
 	if s.Verifier == nil {
 		return nil, errVerifierRequired
 	}

--- a/src/systems/function-bay/deflector/internal/proxy/server_test.go
+++ b/src/systems/function-bay/deflector/internal/proxy/server_test.go
@@ -81,6 +81,25 @@ func TestPolicyFromRequestRequiresValidToken(t *testing.T) {
 	}
 }
 
+func TestPolicyFromRequestAllowsAllWhenAuthenticationDisabled(t *testing.T) {
+	server := &Server{DisableAuthentication: true}
+	request := httptest.NewRequest("GET", "http://example.com", nil)
+
+	requestPolicy, err := server.policyFromRequest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !requestPolicy.Claims.LegacyFallback {
+		t.Fatal("expected disabled auth to use legacy fallback claims")
+	}
+	if !requestPolicy.Compiled.AllowsDestination(net.ParseIP("10.0.0.1"), 443) {
+		t.Fatal("expected disabled auth to allow private destinations")
+	}
+	if !requestPolicy.Compiled.AllowsDestination(net.ParseIP("169.254.169.254"), 80) {
+		t.Fatal("expected disabled auth to allow metadata destination")
+	}
+}
+
 func TestExplicitPrivateIPAllowlistOverridesDefaultBlock(t *testing.T) {
 	compiled, err := policy.Compile(policy.Claims{
 		EgressPolicy: &policy.CompiledNetworkAllowList{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> When enabled, the egress proxy accepts unauthenticated traffic with allow-all policy, bypassing JWT identity and network restrictions—misconfiguration in production is critical.
> 
> **Overview**
> Adds an operational **killswitch** so deflector can run without proxy JWT auth when `DEFLECTOR_DISABLE_PROXY_AUTHENTICATION` is set.
> 
> Startup no longer requires `DEFLECTOR_JWT_SECRET` when that flag is on, logs a warning, and passes `DisableAuthentication` into the proxy. In that mode, `policyFromRequest` skips `Proxy-Authorization` verification and applies **legacy fallback** claims that compile to **allow-all** egress (same permissive path as legacy JWT fallback), including private and metadata destinations.
> 
> A small `envBool` helper and unit tests cover env parsing and disabled-auth behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 600fd4b745fbbc08cb1618a5640ea9c6b1851e87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->