### PR TITLE
Add better function tracing

### DIFF
--- a/src/systems/function-bay/service/src/providers/_lib.ts
+++ b/src/systems/function-bay/service/src/providers/_lib.ts
@@ -3,6 +3,7 @@ import type {
   FunctionBayRuntimeConfig,
   FunctionBayRuntimeSpec
 } from '@function-bay/types';
+import { getSentry } from '@lowerdeck/sentry';
 import type {
   Function,
   FunctionBundle,
@@ -13,6 +14,8 @@ import type {
 } from '../../prisma/generated/client';
 import type { ForgeWorkflowStep } from '../forge';
 import type { FunctionInvocationResult } from '../lib/presentInvokeResponse';
+
+let Sentry = getSentry();
 
 export interface ProviderRuntimeResult {
   runtime: Runtime;
@@ -205,6 +208,20 @@ export let parseInvocationPayload = (d: {
       };
     }
 
+    console.warn('Function returned an unrecognized response format', {
+      payload: d.payload,
+      decodedPayload,
+      body
+    });
+
+    Sentry.captureMessage('Function returned unrecognized response format', {
+      extra: {
+        payload: d.payload,
+        decodedPayload,
+        body
+      }
+    });
+
     return {
       type: 'error',
       error: {
@@ -215,6 +232,18 @@ export let parseInvocationPayload = (d: {
       ...d.outputs
     };
   } catch (err) {
+    Sentry.captureException(err, {
+      extra: {
+        payload: d.payload,
+        error: String(err)
+      }
+    });
+
+    console.warn('Failed to parse function invocation response', {
+      payload: d.payload,
+      error: String(err)
+    });
+
     return {
       type: 'error',
       error: {

--- a/src/systems/function-bay/service/src/providers/aws-lambda/invoke.ts
+++ b/src/systems/function-bay/service/src/providers/aws-lambda/invoke.ts
@@ -102,6 +102,20 @@ export let invokeFunction = async (d: {
       })
     );
   } catch (err) {
+    Sentry.captureException(err, {
+      extra: {
+        error: String(err),
+        functionVersionId: d.functionVersion.id,
+        functionId: d.function.id
+      }
+    });
+
+    console.warn('Failed to invoke Lambda function', {
+      error: String(err),
+      functionVersionId: d.functionVersion.id,
+      functionId: d.function.id
+    });
+
     return {
       type: 'error' as const,
       error: {

--- a/src/systems/function-bay/service/src/providers/local/invoke.ts
+++ b/src/systems/function-bay/service/src/providers/local/invoke.ts
@@ -1,3 +1,4 @@
+import { getSentry } from '@lowerdeck/sentry';
 import { spawn } from 'child_process';
 import { promises as fs } from 'fs';
 import JSZip from 'jszip';
@@ -8,6 +9,8 @@ import { decryptFunctionVersionEnvironmentVariables } from '../../lib/decryptFun
 import { storage } from '../../storage';
 import type { FunctionInvocationParams } from '../_lib';
 import { parseInvocationPayload } from '../_lib';
+
+let Sentry = getSentry();
 
 let RUNNER_FILE_NAME = '__metorial_local_runner__.cjs';
 
@@ -257,6 +260,20 @@ export let invokeFunction = async (d: FunctionInvocationParams) => {
       internalError: exitCode === 0 ? undefined : `Local runtime exited with code ${exitCode}`
     });
   } catch (err) {
+    Sentry.captureException(err, {
+      extra: {
+        error: String(err),
+        functionVersionId: d.functionVersion.id,
+        functionId: d.function.id
+      }
+    });
+
+    console.warn('Failed to invoke local function', {
+      error: String(err),
+      functionVersionId: d.functionVersion.id,
+      functionId: d.function.id
+    });
+
     outputs.computeTimeMs = Date.now() - startedAt;
     outputs.billedTimeMs = outputs.computeTimeMs;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only changes; API error codes and messages are unchanged, though Sentry may receive invocation payload snippets in extras.
> 
> **Overview**
> Improves **observability** when Function Bay runs or parses invocations, without changing the error responses clients already get.
> 
> **`parseInvocationPayload`** (`_lib.ts`) now logs and reports to Sentry when a function returns an unrecognized shape or when JSON parsing fails, including payload/decoded body in Sentry extras. **AWS Lambda** and **local** invoke paths report provider-level failures the same way (`captureException` plus `console.warn` with `functionId` / `functionVersionId`). Local invoke wires in `@lowerdeck/sentry` for the first time in that file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d14ff6e38e0abdd709b57b6d4608996734fc5ff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->