### PR TITLE
Fix net request table

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-deployment/network.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-deployment/network.tsx
@@ -161,8 +161,8 @@ export let ProviderDeploymentNetworkPage = () => {
                       <Text size="2">{record.ip}</Text>,
                       <Text size="2">{record.port}</Text>,
                       <Text size="2">{record.count}</Text>,
-                      <Text size="2">{record.firstSeenAt}</Text>,
-                      <Text size="2">{record.lastSeenAt}</Text>
+                      <RenderDate date={record.firstSeenAt} />,
+                      <RenderDate date={record.lastSeenAt} />
                     ]
                   }))}
                 />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI-only change to date display in an existing table; no API, auth, or data logic changes.
> 
> **Overview**
> The **Network Logs** table on the provider deployment network page now formats **First Seen** and **Last Seen** with `RenderDate` instead of rendering raw timestamp strings in plain `Text`.
> 
> This aligns those columns with the enclave and firewall tables on the same page, which already use `RenderDate` for dates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 102c6c24195d677411b95d40ae776ca55a98f036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->