### PR TITLE
Zero downtime slates redeploy

### DIFF
--- a/src/systems/slates/apps/hub/src/lib/invocation/stack.ts
+++ b/src/systems/slates/apps/hub/src/lib/invocation/stack.ts
@@ -24,6 +24,7 @@ import type {
   InvocationError,
   InvocationResult,
   SlateInvocationBaseParams,
+  SlateInvocationDeploymentTarget,
   SlatesRequest,
   SlatesResponse
 } from './types';
@@ -39,6 +40,7 @@ let errorSchema = z.object({
 export class SlateInvocationStack {
   #initialMessages: SlatesRequest[];
   #slateVersion: SlateVersion;
+  #deploymentTarget?: SlateInvocationDeploymentTarget;
   #participants: SlatesParticipant[];
   #tenant?: SlateInvocationBaseParams['tenant'];
   #enclaveId?: string;
@@ -50,6 +52,7 @@ export class SlateInvocationStack {
   constructor(d: SlateInvocationBaseParams & { initialMessages?: SlatesRequest[] }) {
     this.#initialMessages = d.initialMessages ?? [];
     this.#slateVersion = d.slateVersion;
+    this.#deploymentTarget = d.deploymentTarget;
     this.#participants = d.participants;
     this.#tenant = d.tenant;
     this.#enclaveId = d.enclaveId;
@@ -59,10 +62,13 @@ export class SlateInvocationStack {
   }
 
   private async run() {
-    if (
-      !this.#slateVersion.providerDeploymentInfo ||
-      !this.#slateVersion.activeDeploymentOid
-    ) {
+    let providerDeploymentInfo =
+      this.#deploymentTarget?.providerDeploymentInfo ??
+      this.#slateVersion.providerDeploymentInfo;
+    let activeDeploymentOid =
+      this.#deploymentTarget?.activeDeploymentOid ?? this.#slateVersion.activeDeploymentOid;
+
+    if (!providerDeploymentInfo || !activeDeploymentOid) {
       throw new ServiceError(badRequestError({ message: 'Slate version is not deployed' }));
     }
 
@@ -96,7 +102,7 @@ export class SlateInvocationStack {
       functionBay.function.invoke({
         tenantId: runtimeTenant.id,
         functionTenantId: deploymentTenant.id,
-        functionId: this.#slateVersion.providerDeploymentInfo.functionId,
+        functionId: providerDeploymentInfo.functionId,
         payload: { messages, invocationId },
         enclave:
           this.#enclaveId && runtimeTenant ? { identifier: this.#enclaveId } : undefined,
@@ -106,7 +112,7 @@ export class SlateInvocationStack {
         data: {
           oid: snowflake.nextId(),
           id: invocationId,
-          deploymentOid: this.#slateVersion.activeDeploymentOid,
+          deploymentOid: activeDeploymentOid,
           bucketOid: invocationsBucketRecord.oid,
           isPending: true,
           providerInvocationId: '',

--- a/src/systems/slates/apps/hub/src/lib/invocation/types.ts
+++ b/src/systems/slates/apps/hub/src/lib/invocation/types.ts
@@ -10,12 +10,18 @@ import type z from 'zod';
 import type { SlateInvocation, SlateVersion, Tenant } from '../../../prisma/generated/client';
 import type { SlateInvocationProviderMetadata } from './store';
 
+export interface SlateInvocationDeploymentTarget {
+  providerDeploymentInfo: NonNullable<PrismaJson.SlateDeploymentProviderDeploymentInfo>;
+  activeDeploymentOid: bigint;
+}
+
 export interface SlateInvocationBaseParams {
   tenant?: Pick<
     Tenant,
     'oid' | 'identifier' | 'name' | 'functionBayTenantId' | 'functionBayTenantIdentifier'
   >;
   slateVersion: SlateVersion;
+  deploymentTarget?: SlateInvocationDeploymentTarget;
   participants: SlatesParticipant[];
   enclaveId?: string;
   egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;

--- a/src/systems/slates/apps/hub/src/queues/deployment/deploy.ts
+++ b/src/systems/slates/apps/hub/src/queues/deployment/deploy.ts
@@ -14,6 +14,15 @@ import { getRegistryClient, getRegistryQuery } from '../../registry';
 import { discoverSlateQueue } from '../discovery/discover';
 import { buildSlateDeploymentFiles } from './packageFiles';
 
+export let hasServingSlateDeployment = (version: {
+  status: string;
+  providerDeploymentInfo: PrismaJson.SlateDeploymentProviderDeploymentInfo;
+  activeDeploymentOid: bigint | null;
+}) =>
+  version.status === 'active' &&
+  !!version.providerDeploymentInfo &&
+  !!version.activeDeploymentOid;
+
 let log = (deployment: { id: string } | string, message: string, ...args: any[]) => {
   let deploymentId = typeof deployment === 'string' ? deployment : deployment.id;
 
@@ -77,10 +86,12 @@ export let deploySlateVersionQueueProcessor = deploySlateVersionQueue.process(as
     `Created deployment record with id ${deployment.id} for slate version ${version.version}`
   );
 
-  await db.slateVersion.update({
-    where: { oid: version.oid },
-    data: { status: 'deploying' }
-  });
+  if (!hasServingSlateDeployment(version)) {
+    await db.slateVersion.update({
+      where: { oid: version.oid },
+      data: { status: 'deploying' }
+    });
+  }
 
   await db.slateEvent.create({
     data: {
@@ -335,12 +346,14 @@ export let deploySlateVersionFailedQueueProcessor = deploySlateVersionFailedQueu
         }
       });
 
-      await db.slateVersion.update({
-        where: { oid: deployment.slateVersionOid },
-        data: {
-          status: 'deployment_failed'
-        }
-      });
+      if (!hasServingSlateDeployment(deployment.slateVersion)) {
+        await db.slateVersion.update({
+          where: { oid: deployment.slateVersionOid },
+          data: {
+            status: 'deployment_failed'
+          }
+        });
+      }
 
       await db.slateEvent.create({
         data: {
@@ -396,7 +409,7 @@ export let deploySlateVersionCompletedQueueProcessor =
 
         await log(deployment, `Function deployment status: ${funcDep.status}`);
 
-        let updatedDeployment = await db.slateDeployment.update({
+        await db.slateDeployment.update({
           where: { id: deployment.id },
           data: {
             status: 'succeeded',
@@ -409,14 +422,14 @@ export let deploySlateVersionCompletedQueueProcessor =
           }
         });
 
-        await db.slateVersion.updateMany({
-          where: { oid: deployment.slateVersion.oid },
-          data: {
-            status: 'discovering',
-            providerDeploymentInfo: updatedDeployment.providerDeploymentInfo,
-            activeDeploymentOid: updatedDeployment.oid
-          }
-        });
+        if (!hasServingSlateDeployment(deployment.slateVersion)) {
+          await db.slateVersion.updateMany({
+            where: { oid: deployment.slateVersion.oid },
+            data: {
+              status: 'discovering'
+            }
+          });
+        }
 
         await db.slateEvent.create({
           data: {
@@ -431,8 +444,8 @@ export let deploySlateVersionCompletedQueueProcessor =
         await log(deployment, `Deployment marked as succeeded, adding to discovery queue...`);
 
         await discoverSlateQueue.add(
-          { versionId: deployment.slateVersion.id },
-          { delay: 10_000, id: deployment.slateVersion.id }
+          { versionId: deployment.slateVersion.id, deploymentId: deployment.id },
+          { delay: 10_000, id: deployment.id }
         );
       });
     })

--- a/src/systems/slates/apps/hub/src/queues/discovery/discover.ts
+++ b/src/systems/slates/apps/hub/src/queues/discovery/discover.ts
@@ -158,7 +158,7 @@ let buildAuthMethodUpsertData = async (d: {
     };
   });
 
-export let discoverSlateQueue = createQueue<{ versionId: string }>({
+export let discoverSlateQueue = createQueue<{ versionId: string; deploymentId?: string }>({
   name: 'shub/dis/sing',
   redisUrl: env.service.REDIS_URL,
   workerOpts: {
@@ -175,6 +175,36 @@ let discoverLock = createLock({
   redisUrl: env.service.REDIS_URL
 });
 
+export let getSlateDiscoveryDeploymentTarget = (d: {
+  version: {
+    providerDeploymentInfo: PrismaJson.SlateDeploymentProviderDeploymentInfo;
+    activeDeploymentOid: bigint | null;
+  };
+  stagedDeployment?: {
+    providerDeploymentInfo: PrismaJson.SlateDeploymentProviderDeploymentInfo;
+    oid: bigint;
+  } | null;
+}) => {
+  let providerDeploymentInfo =
+    d.stagedDeployment?.providerDeploymentInfo ?? d.version.providerDeploymentInfo;
+  let activeDeploymentOid = d.stagedDeployment?.oid ?? d.version.activeDeploymentOid;
+
+  if (!providerDeploymentInfo || !activeDeploymentOid) return null;
+
+  return { providerDeploymentInfo, activeDeploymentOid };
+};
+
+export let shouldPreserveActiveVersionOnStagedDiscoveryFailure = (d: {
+  version: {
+    status: string;
+    activeDeploymentOid: bigint | null;
+  };
+  stagedDeployment?: { oid: bigint } | null;
+}) =>
+  !!d.stagedDeployment &&
+  d.version.status === 'active' &&
+  d.version.activeDeploymentOid !== d.stagedDeployment.oid;
+
 export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data => {
   let outerVersion = await db.slateVersion.findFirst({
     where: { id: data.versionId }
@@ -187,9 +217,21 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
       include: { activeDeployment: true, slate: { include: { currentVersion: true } } }
     });
     if (!version) throw new QueueRetryError();
-    if (!version.providerDeploymentInfo || !version.activeDeploymentOid) return;
+    let stagedDeployment = data.deploymentId
+      ? await db.slateDeployment.findFirst({
+          where: {
+            id: data.deploymentId,
+            slateVersionOid: version.oid
+          }
+        })
+      : null;
+    if (data.deploymentId && !stagedDeployment) throw new QueueRetryError();
+
+    let target = getSlateDiscoveryDeploymentTarget({ version, stagedDeployment });
+    if (!target) return;
 
     if (
+      !data.deploymentId &&
       version.lastDiscoveredAt &&
       Math.abs(differenceInMinutes(new Date(), version.lastDiscoveredAt)) < 10
     ) {
@@ -217,6 +259,10 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
     try {
       let stack = await slateInvocationService.createInvocation({
         slateVersion: version,
+        deploymentTarget: {
+          providerDeploymentInfo: target.providerDeploymentInfo,
+          activeDeploymentOid: target.activeDeploymentOid
+        },
         participants: [] // Only the hub
       });
 
@@ -236,6 +282,7 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
 
         await discoverSlateErrorQueue.add({
           versionId: version.id,
+          deploymentId: data.deploymentId,
           invocationOid: invocation.oid,
           error
         });
@@ -392,14 +439,17 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         }
       });
 
-      await db.slateVersion.updateMany({
-        where: { oid: version.oid },
-        data: {
-          status: 'active',
-          specificationOid: specification.oid,
-          lastDiscoveredAt: new Date()
-        }
-      });
+      let versionUpdateData = {
+        status: 'active' as const,
+        specificationOid: specification.oid,
+        lastDiscoveredAt: new Date(),
+        ...(stagedDeployment
+          ? {
+              providerDeploymentInfo: target.providerDeploymentInfo,
+              activeDeploymentOid: target.activeDeploymentOid
+            }
+          : {})
+      };
 
       if (version.specificationOid && version.specificationOid !== specification.oid) {
         await db.slateSpecificationChange.create({
@@ -420,6 +470,11 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         (!slate.currentVersion || semver.gt(version.version, slate.currentVersion.version))
       ) {
         await db.$transaction(async db => {
+          await db.slateVersion.updateMany({
+            where: { oid: version.oid },
+            data: versionUpdateData
+          });
+
           await db.slateSpecification.updateMany({
             where: { oid: specification.oid },
             data: { mostRecentVersionOid: version.oid }
@@ -483,6 +538,11 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
             });
           }
         });
+      } else {
+        await db.slateVersion.updateMany({
+          where: { oid: version.oid },
+          data: versionUpdateData
+        });
       }
 
       await db.changeNotification.create({
@@ -503,6 +563,7 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
 
       await discoverSlateErrorQueue.add({
         versionId: version.id,
+        deploymentId: data.deploymentId,
         error: {
           code: 'discovery/internal_error',
           message: `Internal error during discovery: ${(e as Error).message}`
@@ -514,6 +575,7 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
 
 let discoverSlateErrorQueue = createQueue<{
   versionId: string;
+  deploymentId?: string;
   invocationOid?: bigint;
   error: InvocationError;
 }>({
@@ -527,6 +589,16 @@ export let discoverSlateErrorQueueProcessor = discoverSlateErrorQueue.process(as
     include: { slate: true }
   });
   if (!version) throw new QueueRetryError();
+  let stagedDeployment = data.deploymentId
+    ? await db.slateDeployment.findFirst({
+        where: {
+          id: data.deploymentId,
+          slateVersionOid: version.oid
+        }
+      })
+    : null;
+  let isFailedStagedRedeployOfActiveVersion =
+    shouldPreserveActiveVersionOnStagedDiscoveryFailure({ version, stagedDeployment });
 
   await db.slateEvent.create({
     data: {
@@ -549,11 +621,24 @@ export let discoverSlateErrorQueueProcessor = discoverSlateErrorQueue.process(as
     }
   });
 
-  await db.slateVersion.updateMany({
-    where: { oid: version.oid },
-    data: {
-      status: 'discovery_failed',
-      lastDiscoveredAt: new Date()
-    }
-  });
+  if (stagedDeployment) {
+    await db.slateDeployment.updateMany({
+      where: { oid: stagedDeployment.oid },
+      data: {
+        status: 'failed',
+        errorCode: data.error.code,
+        errorMessage: `Discovery failed: [${data.error.code}] - ${data.error.message}`
+      }
+    });
+  }
+
+  if (!isFailedStagedRedeployOfActiveVersion) {
+    await db.slateVersion.updateMany({
+      where: { oid: version.oid },
+      data: {
+        status: 'discovery_failed',
+        lastDiscoveredAt: new Date()
+      }
+    });
+  }
 });

--- a/src/systems/slates/apps/hub/src/test/deploymentZeroDowntime.test.ts
+++ b/src/systems/slates/apps/hub/src/test/deploymentZeroDowntime.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { hasServingSlateDeployment } from '../queues/deployment/deploy';
+import {
+  getSlateDiscoveryDeploymentTarget,
+  shouldPreserveActiveVersionOnStagedDiscoveryFailure
+} from '../queues/discovery/discover';
+
+describe('zero-downtime slate deployment decisions', () => {
+  it('treats active versions with provider info as currently serving', () => {
+    let providerDeploymentInfo = {
+      functionId: 'fn_old',
+      functionDeploymentId: 'dep_old'
+    };
+
+    expect(
+      hasServingSlateDeployment({
+        status: 'active',
+        providerDeploymentInfo,
+        activeDeploymentOid: 1n
+      })
+    ).toBe(true);
+
+    expect(
+      hasServingSlateDeployment({
+        status: 'deploying',
+        providerDeploymentInfo,
+        activeDeploymentOid: 1n
+      })
+    ).toBe(false);
+
+    expect(
+      hasServingSlateDeployment({
+        status: 'active',
+        providerDeploymentInfo: null,
+        activeDeploymentOid: null
+      })
+    ).toBe(false);
+  });
+
+  it('uses staged deployment pointers for discovery without replacing the serving version', () => {
+    let version = {
+      providerDeploymentInfo: {
+        functionId: 'fn_old',
+        functionDeploymentId: 'dep_old'
+      },
+      activeDeploymentOid: 1n
+    };
+    let stagedDeployment = {
+      oid: 2n,
+      providerDeploymentInfo: {
+        functionId: 'fn_new',
+        functionDeploymentId: 'dep_new'
+      }
+    };
+
+    expect(
+      getSlateDiscoveryDeploymentTarget({ version, stagedDeployment })
+    ).toEqual({
+      providerDeploymentInfo: stagedDeployment.providerDeploymentInfo,
+      activeDeploymentOid: stagedDeployment.oid
+    });
+
+    expect(getSlateDiscoveryDeploymentTarget({ version })).toEqual({
+      providerDeploymentInfo: version.providerDeploymentInfo,
+      activeDeploymentOid: version.activeDeploymentOid
+    });
+  });
+
+  it('keeps the current deployment when staged discovery fails for an active redeploy', () => {
+    expect(
+      shouldPreserveActiveVersionOnStagedDiscoveryFailure({
+        version: {
+          status: 'active',
+          activeDeploymentOid: 1n
+        },
+        stagedDeployment: { oid: 2n }
+      })
+    ).toBe(true);
+
+    expect(
+      shouldPreserveActiveVersionOnStagedDiscoveryFailure({
+        version: {
+          status: 'active',
+          activeDeploymentOid: 2n
+        },
+        stagedDeployment: { oid: 2n }
+      })
+    ).toBe(false);
+
+    expect(
+      shouldPreserveActiveVersionOnStagedDiscoveryFailure({
+        version: {
+          status: 'discovering',
+          activeDeploymentOid: null
+        },
+        stagedDeployment: { oid: 2n }
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes deploy/discovery state transitions and when active deployment pointers flip—incorrect guards could leave traffic on a bad build or block cutover, but scope is hub deployment/discovery paths with targeted tests.
> 
> **Overview**
> Enables **zero-downtime redeploy** of an already-active slate version by staging a new deployment and only cutting traffic over after discovery succeeds.
> 
> **Invocation** accepts an optional `deploymentTarget` so discovery (and related calls) can hit the **new** Function Bay deployment while the version record still points at the **current** serving deployment.
> 
> **Deploy pipeline** no longer flips `slateVersion` into `deploying` / `deployment_failed` / early `discovering` when `hasServingSlateDeployment` is true; it still records per-deployment success/failure. On provider success it queues discovery with **`deploymentId`** (job id is per deployment, not per version) instead of immediately writing `providerDeploymentInfo` / `activeDeploymentOid` onto the version.
> 
> **Discovery** resolves the invoke target via `getSlateDiscoveryDeploymentTarget` (staged deployment overrides version fields). Successful staged discovery **then** updates `providerDeploymentInfo` and `activeDeploymentOid`. Staged discovery failure marks the **deployment** failed and, for active redeploys where the active oid differs from the staged one, **does not** set the version to `discovery_failed` so the old deployment keeps serving.
> 
> Unit tests cover the serving/staged-target/preserve-on-failure decision helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a65d54d71ba44a538560ec086b165f7e13f0191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->