### PR TITLE
Harden slates tests

### DIFF
--- a/src/backend/apis/core/src/controllers/consumer/session.ts
+++ b/src/backend/apis/core/src/controllers/consumer/session.ts
@@ -19,7 +19,8 @@ export let consumerSessionController = Controller.create(
     getSession: consumerGroup
       .post(consumerPath('session', 'session.get'), {
         name: 'Get consumer session',
-        description: 'Returns the authenticated consumer session.'
+        description: 'Returns the authenticated consumer session.',
+        confidential: true
       })
       .output(consumerSessionPresenter)
       .do(async ctx => {
@@ -31,7 +32,8 @@ export let consumerSessionController = Controller.create(
     logout: consumerGroup
       .post(consumerPath('session/logout', 'session.logout'), {
         name: 'Logout consumer session',
-        description: 'Revokes the authenticated consumer session.'
+        description: 'Revokes the authenticated consumer session.',
+        confidential: true
       })
       .output(consumerSessionPresenter)
       .do(async ctx => {
@@ -47,7 +49,8 @@ export let consumerSessionController = Controller.create(
     getProfile: consumerGroup
       .post(consumerPath('profile', 'profile.get'), {
         name: 'Get consumer profile',
-        description: 'Returns the authenticated consumer profile.'
+        description: 'Returns the authenticated consumer profile.',
+        confidential: true
       })
       .output(consumerProfilePresenter)
       .do(async ctx => {

--- a/src/backend/apis/core/src/controllers/dashboard/oauthAuthorizationRequest.ts
+++ b/src/backend/apis/core/src/controllers/dashboard/oauthAuthorizationRequest.ts
@@ -20,7 +20,8 @@ export let dashboardOAuthAuthorizationRequestController = Controller.create(
         ),
         {
           name: 'Get OAuth authorization request',
-          description: 'Get an oauth authorization request by its url token'
+          description: 'Get an oauth authorization request by its url token',
+          confidential: true
         }
       )
       .output(oauthAuthorizationRequestPresenter)
@@ -44,7 +45,8 @@ export let dashboardOAuthAuthorizationRequestController = Controller.create(
         ),
         {
           name: 'Approve OAuth authorization request',
-          description: 'Approve an oauth authorization request for an organization'
+          description: 'Approve an oauth authorization request for an organization',
+          confidential: true
         }
       )
       .body(
@@ -81,7 +83,8 @@ export let dashboardOAuthAuthorizationRequestController = Controller.create(
         ),
         {
           name: 'Reject OAuth authorization request',
-          description: 'Reject an oauth authorization request'
+          description: 'Reject an oauth authorization request',
+          confidential: true
         }
       )
       .body(

--- a/src/backend/apis/core/src/controllers/dashboard/organizationInvite.ts
+++ b/src/backend/apis/core/src/controllers/dashboard/organizationInvite.ts
@@ -15,7 +15,8 @@ export let dashboardOrganizationInviteController = Controller.create(
       .use(isDashboardGroup())
       .get(Path('/dashboard/organization-join/find', 'dashboard.organizations.join.get'), {
         name: 'Join organization',
-        description: 'Join an organization'
+        description: 'Join an organization',
+        confidential: true
       })
       .query(
         'default',
@@ -38,7 +39,8 @@ export let dashboardOrganizationInviteController = Controller.create(
         Path('/dashboard/organization-join/accept', 'dashboard.organizations.join.accept'),
         {
           name: 'Join organization',
-          description: 'Join an organization'
+          description: 'Join an organization',
+          confidential: true
         }
       )
       .body(
@@ -64,7 +66,8 @@ export let dashboardOrganizationInviteController = Controller.create(
         Path('/dashboard/organization-join/reject', 'dashboard.organizations.join.reject'),
         {
           name: 'Reject organization invite',
-          description: 'Reject an organization invite'
+          description: 'Reject an organization invite',
+          confidential: true
         }
       )
       .body(

--- a/src/backend/apis/core/src/controllers/instance/callbacks/callbackDestination.ts
+++ b/src/backend/apis/core/src/controllers/instance/callbacks/callbackDestination.ts
@@ -35,7 +35,8 @@ export let callbackDestinationController = Controller.create(
     list: instanceGroup
       .get(instancePath('callback-destinations', 'callbacks.destinations.list'), {
         name: 'List callback destinations',
-        description: 'Returns a paginated list of callback destinations.'
+        description: 'Returns a paginated list of callback destinations.',
+        confidential: true
       })
       .use(checkAccess({ possibleScopes: ['instance.callback:read'] }))
       .outputList(callbackDestinationPresenter)
@@ -69,7 +70,8 @@ export let callbackDestinationController = Controller.create(
       .get(
         instancePath(
           'callback-destinations/:callbackDestinationId',
-          'callbacks.destinations.get'
+          'callbacks.destinations.get',
+        confidential: true
         ),
         {
           name: 'Get callback destination',
@@ -85,7 +87,8 @@ export let callbackDestinationController = Controller.create(
     create: instanceGroup
       .post(instancePath('callback-destinations', 'callbacks.destinations.create'), {
         name: 'Create callback destination',
-        description: 'Creates a new callback destination.'
+        description: 'Creates a new callback destination.',
+        confidential: true
       })
       .use(checkAccess({ possibleScopes: ['instance.callback:write'] }))
       .body(
@@ -134,7 +137,8 @@ export let callbackDestinationController = Controller.create(
         ),
         {
           name: 'Update callback destination',
-          description: 'Updates a callback destination.'
+          description: 'Updates a callback destination.',
+        confidential: true
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.callback:write'] }))
@@ -185,7 +189,8 @@ export let callbackDestinationController = Controller.create(
       .delete(
         instancePath(
           'callback-destinations/:callbackDestinationId',
-          'callbacks.destinations.delete'
+          'callbacks.destinations.delete',
+        confidential: true
         ),
         {
           name: 'Delete callback destination',

--- a/src/backend/apis/core/src/controllers/instance/callbacks/callbackDestination.ts
+++ b/src/backend/apis/core/src/controllers/instance/callbacks/callbackDestination.ts
@@ -70,12 +70,12 @@ export let callbackDestinationController = Controller.create(
       .get(
         instancePath(
           'callback-destinations/:callbackDestinationId',
-          'callbacks.destinations.get',
-        confidential: true
+          'callbacks.destinations.get'
         ),
         {
           name: 'Get callback destination',
-          description: 'Retrieves a specific callback destination.'
+          description: 'Retrieves a specific callback destination.',
+          confidential: true
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.callback:read'] }))
@@ -138,7 +138,7 @@ export let callbackDestinationController = Controller.create(
         {
           name: 'Update callback destination',
           description: 'Updates a callback destination.',
-        confidential: true
+          confidential: true
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.callback:write'] }))
@@ -189,12 +189,12 @@ export let callbackDestinationController = Controller.create(
       .delete(
         instancePath(
           'callback-destinations/:callbackDestinationId',
-          'callbacks.destinations.delete',
-        confidential: true
+          'callbacks.destinations.delete'
         ),
         {
           name: 'Delete callback destination',
-          description: 'Archives a callback destination.'
+          description: 'Archives a callback destination.',
+          confidential: true
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.callback:write'] }))

--- a/src/backend/apis/core/src/controllers/instance/callbacks/callbackEvent.ts
+++ b/src/backend/apis/core/src/controllers/instance/callbacks/callbackEvent.ts
@@ -37,7 +37,8 @@ export let callbackEventController = Controller.create(
     list: callbackGroup
       .get(instancePath('callbacks/:callbackId/events', 'callbacks.events.list'), {
         name: 'List callback events',
-        description: 'Returns a paginated list of callback events.'
+        description: 'Returns a paginated list of callback events.',
+        confidential: true
       })
       .use(checkAccess({ possibleScopes: ['instance.callback:read'] }))
       .outputList(callbackEventPresenter)
@@ -76,7 +77,8 @@ export let callbackEventController = Controller.create(
         instancePath('callbacks/:callbackId/events/:callbackEventId', 'callbacks.events.get'),
         {
           name: 'Get callback event',
-          description: 'Retrieves a specific callback event.'
+          description: 'Retrieves a specific callback event.',
+          confidential: true
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.callback:read'] }))

--- a/src/backend/apis/core/src/controllers/instance/callbacks/callbackNotification.ts
+++ b/src/backend/apis/core/src/controllers/instance/callbacks/callbackNotification.ts
@@ -40,7 +40,8 @@ export let callbackNotificationController = Controller.create(
         instancePath('callbacks/:callbackId/notifications', 'callbacks.notifications.list'),
         {
           name: 'List callback notifications',
-          description: 'Returns a paginated list of callback notifications.'
+          description: 'Returns a paginated list of callback notifications.',
+          confidential: true
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.callback:read'] }))
@@ -89,7 +90,8 @@ export let callbackNotificationController = Controller.create(
         ),
         {
           name: 'Get callback notification',
-          description: 'Retrieves a specific callback notification.'
+          description: 'Retrieves a specific callback notification.',
+          confidential: true
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.callback:read'] }))

--- a/src/backend/apis/core/src/controllers/instance/files/document.ts
+++ b/src/backend/apis/core/src/controllers/instance/files/document.ts
@@ -37,7 +37,8 @@ export let documentController = Controller.create(
     list: instanceGroup
       .get(instancePath('documents', 'documents.list'), {
         name: 'List documents',
-        description: 'Returns a paginated list of documents owned by the instance.'
+        description: 'Returns a paginated list of documents owned by the instance.',
+        confidential: true
       })
       .use(
         checkAccess({
@@ -81,7 +82,8 @@ export let documentController = Controller.create(
     create: instanceGroup
       .post(instancePath('documents', 'documents.create'), {
         name: 'Create document',
-        description: 'Creates a new document for the instance.'
+        description: 'Creates a new document for the instance.',
+        confidential: true
       })
       .use(
         checkAccess({
@@ -116,7 +118,8 @@ export let documentController = Controller.create(
     get: documentGroup
       .get(instancePath('documents/:documentId', 'documents.get'), {
         name: 'Get document by ID',
-        description: 'Retrieves a document by its ID.'
+        description: 'Retrieves a document by its ID.',
+        confidential: true
       })
       .use(
         checkAccess({
@@ -155,7 +158,8 @@ export let documentController = Controller.create(
     update: documentGroup
       .patch(instancePath('documents/:documentId', 'documents.update'), {
         name: 'Update document by ID',
-        description: 'Updates a specific document.'
+        description: 'Updates a specific document.',
+        confidential: true
       })
       .use(
         checkAccess({
@@ -191,7 +195,8 @@ export let documentController = Controller.create(
     delete: documentGroup
       .delete(instancePath('documents/:documentId', 'documents.delete'), {
         name: 'Delete document by ID',
-        description: 'Deletes a specific document.'
+        description: 'Deletes a specific document.',
+        confidential: true
       })
       .use(
         checkAccess({
@@ -216,7 +221,8 @@ export let documentController = Controller.create(
     clone: documentGroup
       .post(instancePath('documents/:documentId/clone', 'documents.clone'), {
         name: 'Clone document by ID',
-        description: 'Clones a specific document.'
+        description: 'Clones a specific document.',
+        confidential: true
       })
       .use(checkAccess({ possibleScopes: ['instance.file:write'] }))
       .body(

--- a/src/backend/apis/core/src/controllers/instance/files/documentVersion.ts
+++ b/src/backend/apis/core/src/controllers/instance/files/documentVersion.ts
@@ -43,7 +43,8 @@ export let documentVersionController = Controller.create(
     list: documentGroup
       .get(instancePath('documents/:documentId/versions', 'documents.versions.list'), {
         name: 'List document versions',
-        description: 'Returns a paginated list of versions for a specific document.'
+        description: 'Returns a paginated list of versions for a specific document.',
+        confidential: true
       })
       .use(
         checkAccess({
@@ -89,7 +90,8 @@ export let documentVersionController = Controller.create(
         ),
         {
           name: 'Get document version by ID',
-          description: 'Retrieves a specific document version by its ID.'
+          description: 'Retrieves a specific document version by its ID.',
+          confidential: true
         }
       )
       .use(

--- a/src/backend/apis/core/src/controllers/instance/magic-mcp/magicMcpToken.ts
+++ b/src/backend/apis/core/src/controllers/instance/magic-mcp/magicMcpToken.ts
@@ -118,7 +118,8 @@ export let magicMcpTokenController = Controller.create(
     create: instanceGroup
       .post(instancePath('magic-mcp-tokens', 'magicMcpTokens.create'), {
         name: 'Create magic MCP token',
-        description: 'Creates a new magic MCP token.'
+        description: 'Creates a new magic MCP token.',
+        confidential: true
       })
       .use(
         checkAccess({

--- a/src/backend/apis/core/src/controllers/instance/provider-auth/providerAuthConfig.ts
+++ b/src/backend/apis/core/src/controllers/instance/provider-auth/providerAuthConfig.ts
@@ -155,7 +155,8 @@ export let providerAuthConfigController = Controller.create(
     create: instanceGroup
       .post(instancePath('provider-auth-configs', 'providerDeployments.authConfigs.create'), {
         name: 'Create provider auth config',
-        description: 'Creates a new provider auth config.'
+        description: 'Creates a new provider auth config.',
+        confidential: true
       })
       .use(checkAccess({ possibleScopes: ['instance.provider.auth:write'] }))
       .body(

--- a/src/backend/apis/core/src/controllers/instance/provider-auth/providerAuthCredentials.ts
+++ b/src/backend/apis/core/src/controllers/instance/provider-auth/providerAuthCredentials.ts
@@ -139,7 +139,8 @@ export let providerAuthCredentialsController = Controller.create(
         ),
         {
           name: 'Create provider auth credentials',
-          description: 'Creates new provider auth credentials.'
+          description: 'Creates new provider auth credentials.',
+          confidential: true
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.provider.auth:write'] }))
@@ -207,7 +208,8 @@ export let providerAuthCredentialsController = Controller.create(
         ),
         {
           name: 'Update provider auth credentials',
-          description: 'Updates specific provider auth credentials.'
+          description: 'Updates specific provider auth credentials.',
+          confidential: true
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.provider.auth:write'] }))

--- a/src/backend/apis/core/src/controllers/instance/provider-auth/providerAuthExport.ts
+++ b/src/backend/apis/core/src/controllers/instance/provider-auth/providerAuthExport.ts
@@ -121,7 +121,8 @@ export let providerAuthExportController = Controller.create(
         ),
         {
           name: 'Create provider auth export',
-          description: 'Exports authentication credentials from a provider.'
+          description: 'Exports authentication credentials from a provider.',
+          confidential: true
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.provider.auth:export'] }))

--- a/src/backend/apis/core/src/controllers/instance/provider-auth/providerAuthImport.ts
+++ b/src/backend/apis/core/src/controllers/instance/provider-auth/providerAuthImport.ts
@@ -125,7 +125,8 @@ export let providerAuthImportController = Controller.create(
         ),
         {
           name: 'Create provider auth import',
-          description: 'Imports authentication credentials for a provider.'
+          description: 'Imports authentication credentials for a provider.',
+          confidential: true
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.provider.auth:import'] }))

--- a/src/backend/apis/core/src/controllers/instance/provider-config/providerConfig.ts
+++ b/src/backend/apis/core/src/controllers/instance/provider-config/providerConfig.ts
@@ -138,7 +138,8 @@ export let providerConfigController = Controller.create(
     create: instanceGroup
       .post(instancePath('provider-configs', 'providerDeployments.configs.create'), {
         name: 'Create provider config',
-        description: 'Creates a new provider config.'
+        description: 'Creates a new provider config.',
+        confidential: true
       })
       .use(checkAccess({ possibleScopes: ['instance.provider.config:write'] }))
       .body(

--- a/src/backend/apis/core/src/controllers/instance/provider-config/providerConfigVault.ts
+++ b/src/backend/apis/core/src/controllers/instance/provider-config/providerConfigVault.ts
@@ -121,7 +121,8 @@ export let providerConfigVaultController = Controller.create(
         instancePath('provider-config-vaults', 'providerDeployments.configVaults.create'),
         {
           name: 'Create provider config vault',
-          description: 'Creates a new provider config vault.'
+          description: 'Creates a new provider config vault.',
+          confidential: true
         }
       )
       .use(checkAccess({ possibleScopes: ['instance.provider.config_vault:write'] }))

--- a/src/backend/apis/core/src/controllers/instance/provider-config/providerInvocation.ts
+++ b/src/backend/apis/core/src/controllers/instance/provider-config/providerInvocation.ts
@@ -5,7 +5,10 @@ import { normalizeArrayParam } from '../../../lib/normalizeArrayParam';
 import { checkAccess } from '../../../middleware/checkAccess';
 import { instanceGroup, instancePath } from '../../../middleware/instanceGroup';
 import { isDashboardGroup } from '../../../middleware/isDashboard';
-import { providerInvocationPresenter, providerInvocationsPresenter } from '../../../presenters';
+import {
+  providerInvocationPresenter,
+  providerInvocationsPresenter
+} from '../../../presenters';
 
 export let providerInvocationController = Controller.create(
   {
@@ -16,13 +19,11 @@ export let providerInvocationController = Controller.create(
   {
     get: instanceGroup
       .get(
-        instancePath(
-          'provider-invocations/:providerInvocationId',
-          'providerInvocations.get'
-        ),
+        instancePath('provider-invocations/:providerInvocationId', 'providerInvocations.get'),
         {
           name: 'Get provider invocation',
-          description: 'Returns a single normalized provider invocation by ID.'
+          description: 'Returns a single normalized provider invocation by ID.',
+          confidential: true
         }
       )
       .use(isDashboardGroup())
@@ -45,7 +46,8 @@ export let providerInvocationController = Controller.create(
       .get(instancePath('provider-invocations', 'providerInvocations.list'), {
         name: 'List provider invocations',
         description:
-          'Returns normalized provider invocations and their logs for dashboard diagnostics.'
+          'Returns normalized provider invocations and their logs for dashboard diagnostics.',
+        confidential: true
       })
       .use(isDashboardGroup())
       .use(

--- a/src/backend/apis/core/src/controllers/instance/token.ts
+++ b/src/backend/apis/core/src/controllers/instance/token.ts
@@ -13,7 +13,8 @@ export let tokenController = Controller.create(
     get: apiGroup
       .get(Path('token', 'token.get'), {
         name: 'Get token details',
-        description: 'Retrieves metadata and configuration details for a specific token.'
+        description: 'Retrieves metadata and configuration details for a specific token.',
+        confidential: true
       })
       .output(tokenPresenter)
       .do(async ctx =>

--- a/src/backend/apis/core/src/controllers/management/auth/apiKey.ts
+++ b/src/backend/apis/core/src/controllers/management/auth/apiKey.ts
@@ -217,7 +217,8 @@ export let managementApiKeyController = Controller.create(
     create: organizationGroup
       .post(organizationManagementPath('api-keys', 'apiKeys.create'), {
         name: 'Create API key',
-        description: 'Create a new API key'
+        description: 'Create a new API key',
+        confidential: true
       })
       .body(
         'default',
@@ -414,7 +415,8 @@ export let managementApiKeyController = Controller.create(
     rotate: organizationGroup
       .post(organizationManagementPath('api-keys/:apiKeyId/rotate', 'apiKeys.rotate'), {
         name: 'Rotate API key',
-        description: 'Rotate a specific API key'
+        description: 'Rotate a specific API key',
+        confidential: true
       })
       .body(
         'default',
@@ -465,7 +467,8 @@ export let managementApiKeyController = Controller.create(
     reveal: organizationGroup
       .post(organizationManagementPath('api-keys/:apiKeyId/reveal', 'apiKeys.reveal'), {
         name: 'Reveal API key',
-        description: 'Reveal a specific API key'
+        description: 'Reveal a specific API key',
+        confidential: true
       })
       .use(checkAccess({ possibleScopes: ['organization.api_key:reveal'] }))
       .output(apiKeyPresenter)

--- a/src/backend/apis/core/src/controllers/management/auth/oauthApplication.ts
+++ b/src/backend/apis/core/src/controllers/management/auth/oauthApplication.ts
@@ -311,7 +311,8 @@ export let oauthApplicationManagementController = Controller.create(
         ),
         {
           name: 'Create OAuth application client secret',
-          description: 'Creates a new client secret for an OAuth application.'
+          description: 'Creates a new client secret for an OAuth application.',
+          confidential: true
         }
       )
       .use(checkAccess({ possibleScopes: ['organization.oauth_app:write'] }))

--- a/src/backend/apis/core/src/controllers/management/auth/serviceAccount.ts
+++ b/src/backend/apis/core/src/controllers/management/auth/serviceAccount.ts
@@ -230,7 +230,8 @@ export let serviceAccountManagementController = Controller.create(
         ),
         {
           name: 'Create service account client secret',
-          description: 'Creates a new client secret for a service account.'
+          description: 'Creates a new client secret for a service account.',
+          confidential: true
         }
       )
       .use(checkAccess({ possibleScopes: ['organization.oauth_app:write'] }))

--- a/src/packages/server/rest/src/controller.ts
+++ b/src/packages/server/rest/src/controller.ts
@@ -27,6 +27,7 @@ export type EndpointDescriptor = {
 
   hideInDocs?: boolean;
   deprecated?: boolean;
+  confidential?: boolean;
 };
 
 export type ControllerCategory = {
@@ -40,8 +41,9 @@ export type ControllerDescriptor = EndpointDescriptor & {
   category?: ControllerCategory;
 };
 
-export let createCategory = <Category extends ControllerCategory>(category: Category): Category =>
-  category;
+export let createCategory = <Category extends ControllerCategory>(
+  category: Category
+): Category => category;
 
 export type GetHandlerContext<
   AuthInfo,
@@ -404,6 +406,7 @@ export class Handler<
       name: this.descriptor.name,
       description: this.descriptor.description,
       hideInDocs: this.descriptor.hideInDocs,
+      confidential: this.descriptor.confidential,
       body: this._validationBody
         ? {
             name: 'Body',

--- a/src/packages/server/rest/src/introspect.ts
+++ b/src/packages/server/rest/src/introspect.ts
@@ -74,6 +74,7 @@ export let introspectApi = (version: {
           name: out.name,
           description: out.description,
           hideInDocs: !!out.hideInDocs,
+          confidential: !!out.confidential,
 
           bodyId: out.body
             ? ensureType({

--- a/src/packages/server/rest/src/server.ts
+++ b/src/packages/server/rest/src/server.ts
@@ -12,7 +12,14 @@ import { PresenterContext } from '@metorial/presenter';
 import opentelemetry, { context, propagation, Span } from '@opentelemetry/api';
 import { Hono } from 'hono';
 import qs from 'qs';
-import { EndpointDescriptor, Group, Handler, IController, ServiceRequest } from './controller';
+import {
+  EndpointDescriptor,
+  Group,
+  Handler,
+  IController,
+  Method,
+  ServiceRequest
+} from './controller';
 import { introspectApi } from './introspect';
 import { parseBody } from './parseBody';
 import { RateLimiter } from './ratelimit';
@@ -40,12 +47,56 @@ interface CustomHandler<AuthInfo, ApiVersion extends string> {
   path: RegExp;
 }
 
+export type RestRequestLogEvent<AuthInfo, ApiVersion extends string> = {
+  surface: 'rest';
+  requestId: string;
+  method: Method;
+  url: string;
+  path: string;
+  apiVersion: ApiVersion;
+  endpoint: {
+    name: string;
+    description: string;
+    confidential: boolean;
+    hideInDocs: boolean;
+    paths: Array<{ path: string; sdkPath: string }>;
+  };
+  status: number;
+  durationMs: number;
+  query: any;
+  params: Record<string, string>;
+  body: any;
+  response: any;
+  error?: unknown;
+  auth: AuthInfo;
+  context: Context;
+};
+
+export type RestRequestLogger<AuthInfo, ApiVersion extends string> = (
+  event: RestRequestLogEvent<AuthInfo, ApiVersion>
+) => void | Promise<void>;
+
+let emptyShape = (value: any): any => {
+  if (Array.isArray(value)) return value.map(item => emptyShape(item));
+  if (value instanceof Date) return '';
+  if (value && typeof value == 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, val]) => [key, emptyShape(val)])
+    );
+  }
+  if (typeof value == 'number') return 0;
+  if (typeof value == 'boolean') return false;
+  if (value == null) return value;
+  return '';
+};
+
 export class RestServerBuilder<AuthInfo, ApiVersion extends string> {
   #authenticate?: Authenticator<AuthInfo>;
   #checkCors?: (i: { origin: string; auth: AuthInfo }) => boolean;
   #rateLimiter?: RateLimiter<AuthInfo>;
   #customHandlers: CustomHandler<AuthInfo, ApiVersion>[] = [];
   #getPresenterContext?: (auth: AuthInfo & { apiVersion: ApiVersion }) => PresenterContext;
+  #logger?: RestRequestLogger<AuthInfo, ApiVersion>;
 
   constructor() {}
 
@@ -69,6 +120,11 @@ export class RestServerBuilder<AuthInfo, ApiVersion extends string> {
     return this;
   }
 
+  logger(logger: RestRequestLogger<AuthInfo, ApiVersion>) {
+    this.#logger = logger;
+    return this;
+  }
+
   providePresenterContext(
     getPresenterContext: (auth: AuthInfo & { apiVersion: ApiVersion }) => PresenterContext
   ) {
@@ -85,7 +141,8 @@ export class RestServerBuilder<AuthInfo, ApiVersion extends string> {
       this.#checkCors ?? (() => false),
       this.#rateLimiter,
       this.#customHandlers,
-      this.#getPresenterContext
+      this.#getPresenterContext,
+      this.#logger
     );
   }
 }
@@ -98,7 +155,8 @@ export class RestServer<AuthInfo, ApiVersion extends string> {
     private customHandlers: CustomHandler<AuthInfo, ApiVersion>[],
     private getPresenterContext?: (
       auth: AuthInfo & { apiVersion: ApiVersion }
-    ) => PresenterContext
+    ) => PresenterContext,
+    private logger?: RestRequestLogger<AuthInfo, ApiVersion>
   ) {}
 
   static $$create$$_internal<AuthInfo, ApiVersion extends string>(
@@ -106,14 +164,16 @@ export class RestServer<AuthInfo, ApiVersion extends string> {
     checkCors: (i: { origin: string; auth: AuthInfo }) => boolean,
     rateLimiter: RateLimiter<AuthInfo>,
     customHandlers: CustomHandler<AuthInfo, ApiVersion>[],
-    getPresenterContext?: (auth: AuthInfo & { apiVersion: ApiVersion }) => PresenterContext
+    getPresenterContext?: (auth: AuthInfo & { apiVersion: ApiVersion }) => PresenterContext,
+    logger?: RestRequestLogger<AuthInfo, ApiVersion>
   ) {
     return new RestServer(
       authenticate,
       checkCors,
       rateLimiter,
       customHandlers,
-      getPresenterContext
+      getPresenterContext,
+      logger
     );
   }
 
@@ -194,7 +254,8 @@ export class RestServer<AuthInfo, ApiVersion extends string> {
                         status: 200,
                         body: null
                       };
-                      // let startedAt = new Date();
+                      let error: unknown;
+                      let startedAt = Date.now();
 
                       let body = await parseBody(c);
 
@@ -275,6 +336,7 @@ export class RestServer<AuthInfo, ApiVersion extends string> {
                         };
                         // objects = handlerRes.objects;
                       } catch (e) {
+                        error = e;
                         if (isServiceError(e)) {
                           response = {
                             status: e.data.status,
@@ -290,6 +352,43 @@ export class RestServer<AuthInfo, ApiVersion extends string> {
                             status: 500,
                             body: internalServerError().toResponse()
                           };
+                        }
+                      }
+
+                      if (this.logger) {
+                        let shouldLogShapeOnly =
+                          !!handler.descriptor.confidential && response.status == 200;
+                        try {
+                          await this.logger({
+                            surface: 'rest',
+                            requestId: c.env.requestId,
+                            method: handler.method,
+                            url: shouldLogShapeOnly
+                              ? `${c.env.url.origin}${c.env.url.pathname}`
+                              : c.req.url,
+                            path,
+                            apiVersion,
+                            endpoint: {
+                              name: handler.descriptor.name,
+                              description: handler.descriptor.description,
+                              confidential: !!handler.descriptor.confidential,
+                              hideInDocs: !!handler.descriptor.hideInDocs,
+                              paths: handler.paths
+                            },
+                            status: response.status,
+                            durationMs: Date.now() - startedAt,
+                            query: shouldLogShapeOnly ? emptyShape(query) : query,
+                            params: c.req.param() as any,
+                            body: shouldLogShapeOnly ? emptyShape(request.body) : request.body,
+                            response: shouldLogShapeOnly
+                              ? emptyShape(response.body)
+                              : response.body,
+                            error,
+                            auth: c.env.auth,
+                            context: c.env.context
+                          });
+                        } catch (e) {
+                          console.error('Error in request logger', e);
                         }
                       }
 

--- a/src/systems/slates/apps/hub/src/test/setup.ts
+++ b/src/systems/slates/apps/hub/src/test/setup.ts
@@ -1,18 +1,78 @@
 import { PrismaPg } from '@prisma/adapter-pg';
 import { PrismaClient } from '../../prisma/generated/client';
 import { afterAll } from 'vitest';
-import { setupPrismaTestDb, setupTestGlobals } from '@lowerdeck/testing-tools';
+import { createPrismaTestDb, setupTestGlobals } from '@lowerdeck/testing-tools';
 
 setupTestGlobals({ nodeEnv: 'test' });
 
-const db = await setupPrismaTestDb<PrismaClient>({
+let db = createPrismaTestDb<PrismaClient>({
   guard: 'slates-hub-test',
   prismaClientFactory: url => new PrismaClient({ adapter: new PrismaPg({ connectionString: url }) })
 });
+
+export let testDb: PrismaClient = db.client;
+
+let wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+let isRetryableCleanError = (error: unknown) => {
+  if (!error || typeof error !== 'object') return false;
+
+  let maybeError = error as {
+    code?: string;
+    meta?: { code?: string };
+  };
+
+  return (
+    maybeError.code === '40P01' ||
+    maybeError.code === '40001' ||
+    maybeError.meta?.code === '40P01' ||
+    maybeError.meta?.code === '40001'
+  );
+};
+
+export let cleanDatabase = async () => {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await testDb.$transaction(
+        async tx => {
+          await tx.$executeRaw`SELECT pg_advisory_xact_lock(843728401)`;
+
+          let tables = await tx.$queryRaw<{ tablename: string }[]>`
+            SELECT tablename
+            FROM pg_tables
+            WHERE schemaname = 'public'
+            ORDER BY tablename
+          `;
+
+          let tableNames = tables
+            .map(table => `"${table.tablename.replace(/"/g, '""')}"`)
+            .join(', ');
+
+          if (tableNames.length === 0) return;
+
+          await tx.$executeRawUnsafe(
+            `TRUNCATE TABLE ${tableNames} RESTART IDENTITY CASCADE`
+          );
+        },
+        { timeout: 30_000 }
+      );
+      return;
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableCleanError(error) || attempt === 2) throw error;
+      await wait(100 * 2 ** attempt);
+    }
+  }
+
+  throw lastError;
+};
+
+await db.connect();
+await cleanDatabase();
 
 afterAll(async () => {
   await db.disconnect();
 });
 
-export const testDb: PrismaClient = db.client;
-export const cleanDatabase = db.clean;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches request logging for auth- and secret-bearing endpoints; mis-tagged routes could leak data or over-redact. Test DB cleanup changes affect CI reliability but not production runtime.
> 
> **Overview**
> Adds a **`confidential`** flag on REST endpoint descriptors and threads it through API introspection. The REST server can register an optional **request logger**; for confidential routes with **HTTP 200**, logs use **`emptyShape`** redaction on query, body, and response and omit the query string from the logged URL.
> 
> Marks many sensitive core API operations as confidential (consumer session/profile, OAuth authorization, org invites, callbacks, documents, provider auth/config/vault import/export, token metadata, API key create/rotate/reveal, client secrets, provider invocations, etc.).
> 
> **Slates hub tests** switch from `setupPrismaTestDb` to `createPrismaTestDb` with a custom **`cleanDatabase`**: per-test advisory lock, truncate all public tables with identity restart, and retries on Postgres deadlock/serialization errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f583cf9649fc46f4bb9bf0bdb232208b339d847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->