### PR TITLE
Expose auth errors

### DIFF
--- a/src/systems/slates/apps/hub/src/services/slateInstanceAuthHandler.ts
+++ b/src/systems/slates/apps/hub/src/services/slateInstanceAuthHandler.ts
@@ -14,6 +14,17 @@ let include = { secret: true, authMethod: true };
 
 let Sentry = getSentry();
 
+let throwStoredAuthConfigError = (d: { errorCode: string; errorMessage?: string | null }) => {
+  throw new ServiceError(
+    badRequestError({
+      code: 'invalid_provider_authentication_configuration',
+      message: `Provider authentication configuration has an error: ${
+        d.errorMessage ?? d.errorCode
+      }`
+    })
+  );
+};
+
 class slateAuthHandlerServiceImpl {
   async getSlateInstanceAuth(d: {
     tenant: Tenant;
@@ -57,6 +68,13 @@ class slateAuthHandlerServiceImpl {
           })
         );
       }
+    }
+
+    if (authConfig.errorCode) {
+      throwStoredAuthConfigError({
+        errorCode: authConfig.errorCode,
+        errorMessage: authConfig.errorMessage
+      });
     }
 
     if (d.slateInstance) {

--- a/src/systems/slates/apps/hub/src/services/slateSessionToolCall.ts
+++ b/src/systems/slates/apps/hub/src/services/slateSessionToolCall.ts
@@ -45,6 +45,15 @@ type SlateToolCallAttachment = {
 
 let ATTACHMENT_EXPIRATION_DAYS = 7;
 
+let throwStoredConfigError = (d: { errorCode: string; errorMessage?: string | null }) => {
+  throw new ServiceError(
+    badRequestError({
+      code: 'invalid_provider_configuration',
+      message: `Provider instance configuration has an error: ${d.errorMessage ?? d.errorCode}`
+    })
+  );
+};
+
 class slateSessionToolCallServiceImpl {
   async createSlateToolCall(d: {
     input: {
@@ -86,6 +95,12 @@ class slateSessionToolCallServiceImpl {
           message: 'Provider instance does not have a current configuration set.'
         })
       );
+    }
+    if (session.slateInstance.currentConfig.errorCode) {
+      throwStoredConfigError({
+        errorCode: session.slateInstance.currentConfig.errorCode,
+        errorMessage: session.slateInstance.currentConfig.errorMessage
+      });
     }
 
     let lastActiveOrCreatedAt = session.lastActiveAt ?? session.createdAt;

--- a/src/systems/subspace/modules/auth/src/queues/lifecycle/providerAuthConfig.ts
+++ b/src/systems/subspace/modules/auth/src/queues/lifecycle/providerAuthConfig.ts
@@ -1,8 +1,27 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db, getId } from '@metorial-subspace/db';
 import { integrationInstanceProviderCredentialSyncQueue } from '@metorial-subspace/module-identity/src/queues/lifecycle/integrationInstanceProviderCredential';
+import { getBackend } from '@metorial-subspace/provider';
 import { env } from '../../env';
 import { indexProviderAuthConfigQueue } from '../search/providerAuthConfig';
+
+let notifyBackendAuthConfigVersionCreated = async (d: { providerAuthConfigId: string }) => {
+  let providerAuthConfig = await db.providerAuthConfig.findUnique({
+    where: { id: d.providerAuthConfigId },
+    include: {
+      tenant: true,
+      currentVersion: true
+    }
+  });
+  if (!providerAuthConfig?.currentVersion) return;
+
+  let backend = await getBackend({ entity: providerAuthConfig });
+  await backend.auth.onProviderAuthConfigVersionCreated({
+    tenant: providerAuthConfig.tenant,
+    authConfig: providerAuthConfig,
+    authConfigVersion: providerAuthConfig.currentVersion
+  });
+};
 
 export let providerAuthConfigCreatedQueue = createQueue<{
   providerAuthConfigId: string;
@@ -18,6 +37,9 @@ export let providerAuthConfigCreatedQueueProcessor = providerAuthConfigCreatedQu
     });
 
     await indexProviderAuthConfigQueue.add({
+      providerAuthConfigId: data.providerAuthConfigId
+    });
+    await notifyBackendAuthConfigVersionCreated({
       providerAuthConfigId: data.providerAuthConfigId
     });
 
@@ -60,6 +82,9 @@ export let providerAuthConfigUpdatedQueue = createQueue<{
 export let providerAuthConfigUpdatedQueueProcessor = providerAuthConfigUpdatedQueue.process(
   async data => {
     await indexProviderAuthConfigQueue.add({
+      providerAuthConfigId: data.providerAuthConfigId
+    });
+    await notifyBackendAuthConfigVersionCreated({
       providerAuthConfigId: data.providerAuthConfigId
     });
   }

--- a/src/systems/subspace/provider-backends/provider-slates/src/impl/auth.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/impl/auth.ts
@@ -10,6 +10,8 @@ import type {
   ProviderAuthConfigCreateRes,
   ProviderAuthConfigDeleteParam,
   ProviderAuthConfigDeleteRes,
+  ProviderAuthConfigVersionCreatedParam,
+  ProviderAuthConfigVersionCreatedRes,
   ProviderAuthCredentialsCreateParam,
   ProviderAuthCredentialsCreateRes,
   ProviderAuthCredentialsDeleteParam,
@@ -25,8 +27,22 @@ import type {
 } from '@metorial-subspace/provider-utils';
 import { IProviderAuth } from '@metorial-subspace/provider-utils';
 import { getTenantForSlates, slates } from '../client';
+import { enqueueAuthConfigProcessingSync } from '../queues/sync/authConfigProcessing';
 
 export class ProviderAuth extends IProviderAuth {
+  override async onProviderAuthConfigVersionCreated(
+    data: ProviderAuthConfigVersionCreatedParam
+  ): Promise<ProviderAuthConfigVersionCreatedRes> {
+    if (!data.authConfigVersion.slateAuthConfigOid) return {};
+
+    await enqueueAuthConfigProcessingSync({
+      providerAuthConfigId: data.authConfig.id,
+      providerAuthConfigVersionId: data.authConfigVersion.id
+    });
+
+    return {};
+  }
+
   override async createProviderAuthCredentials(
     data: ProviderAuthCredentialsCreateParam
   ): Promise<ProviderAuthCredentialsCreateRes> {

--- a/src/systems/subspace/provider-backends/provider-slates/src/queues/sync/authConfigProcessing.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/queues/sync/authConfigProcessing.ts
@@ -1,0 +1,239 @@
+import { canonicalize } from '@lowerdeck/canonicalize';
+import { Hash } from '@lowerdeck/hash';
+import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { db, getId } from '@metorial-subspace/db';
+import { createProviderInvocationId } from '@metorial-subspace/provider-utils';
+import { getTenantForSlates, slates } from '../../client';
+import { env } from '../../env';
+
+let INITIAL_DELAY_MS = 5 * 1000;
+let RETRY_DELAY_MS = 15 * 1000;
+let MAX_ATTEMPTS = 200;
+
+let getAuthConfigProcessingJobId = (d: {
+  providerAuthConfigVersionId: string;
+  attempt: number;
+}) => `${d.providerAuthConfigVersionId}-attempt-${d.attempt}`;
+
+export let syncAuthConfigProcessingQueue = createQueue<{
+  providerAuthConfigId: string;
+  providerAuthConfigVersionId: string;
+  attempt: number;
+}>({
+  name: 'sub/slt/authCfg/proc',
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: { concurrency: 10 }
+});
+
+export let enqueueAuthConfigProcessingSync = async (d: {
+  providerAuthConfigId: string;
+  providerAuthConfigVersionId: string;
+}) => {
+  await syncAuthConfigProcessingQueue.add(
+    {
+      providerAuthConfigId: d.providerAuthConfigId,
+      providerAuthConfigVersionId: d.providerAuthConfigVersionId,
+      attempt: 1
+    },
+    {
+      delay: INITIAL_DELAY_MS,
+      id: getAuthConfigProcessingJobId({
+        providerAuthConfigVersionId: d.providerAuthConfigVersionId,
+        attempt: 1
+      })
+    }
+  );
+};
+
+let getProviderInvocationId = (slateInvocationId: string | null | undefined) =>
+  slateInvocationId ? createProviderInvocationId('slate.invocation', slateInvocationId) : null;
+
+type AuthConfigVersionForSync = NonNullable<
+  Awaited<ReturnType<typeof getAuthConfigVersionForSync>>
+> & {
+  slateAuthConfig: NonNullable<
+    NonNullable<Awaited<ReturnType<typeof getAuthConfigVersionForSync>>>['slateAuthConfig']
+  >;
+};
+
+let createErrorForAuthConfig = async (d: {
+  authConfigVersion: AuthConfigVersionForSync;
+  record: Awaited<ReturnType<typeof slates.slateAuthConfig.get>>;
+}) => {
+  let sourceId = d.authConfigVersion.slateAuthConfig.id;
+
+  let authConfigEvent = await db.providerAuthConfigEvent.findUnique({
+    where: {
+      sourceType_sourceId: {
+        sourceType: 'slates.auth_config',
+        sourceId
+      }
+    }
+  });
+
+  let errorCode = d.record.error?.code ?? 'auth_processing_failed';
+  let errorMessage =
+    d.record.error?.message ??
+    'An unknown error occurred while processing the authentication configuration.';
+  let providerInvocationId = getProviderInvocationId(d.record.error?.invocationId);
+
+  if (!authConfigEvent) {
+    authConfigEvent = await db.providerAuthConfigEvent.create({
+      data: {
+        ...getId('providerAuthConfigEvent'),
+        type: 'auth_processing_failed',
+        status: 'failed',
+        sourceType: 'slates.auth_config',
+        sourceId,
+        providerInvocationId,
+        payload: d.record,
+        authConfigOid: d.authConfigVersion.authConfigOid,
+        authCredentialsOid:
+          d.authConfigVersion.authCredentialsOid ??
+          d.authConfigVersion.authConfig.authCredentialsOid,
+        providerOid: d.authConfigVersion.authConfig.providerOid,
+        tenantOid: d.authConfigVersion.authConfig.tenantOid,
+        environmentOid: d.authConfigVersion.authConfig.environmentOid,
+        solutionOid: d.authConfigVersion.authConfig.solutionOid
+      }
+    });
+  }
+
+  let existingError = await db.providerAuthConfigError.findUnique({
+    where: {
+      sourceType_sourceId: {
+        sourceType: 'slates.auth_config',
+        sourceId
+      }
+    }
+  });
+  if (existingError) return;
+
+  let error = await db.providerAuthConfigError.create({
+    data: {
+      ...getId('providerAuthConfigError'),
+      type: 'auth_processing_failed',
+      sourceType: 'slates.auth_config',
+      sourceId,
+      isProcessing: true,
+      code: errorCode,
+      message: errorMessage,
+      payload: d.record,
+      providerInvocationId,
+      authConfigEventOid: authConfigEvent.oid,
+      authConfigOid: d.authConfigVersion.authConfigOid,
+      authCredentialsOid:
+        d.authConfigVersion.authCredentialsOid ??
+        d.authConfigVersion.authConfig.authCredentialsOid,
+      providerOid: d.authConfigVersion.authConfig.providerOid,
+      tenantOid: d.authConfigVersion.authConfig.tenantOid,
+      environmentOid: d.authConfigVersion.authConfig.environmentOid,
+      solutionOid: d.authConfigVersion.authConfig.solutionOid
+    }
+  });
+
+  let hash = await Hash.sha256(
+    canonicalize([
+      error.type,
+      String(error.providerOid),
+      String(error.tenantOid),
+      error.code,
+      error.message
+    ])
+  );
+
+  let group = await db.providerAuthConfigErrorGlobal.upsert({
+    where: {
+      type_hash_tenantOid: {
+        type: error.type,
+        hash,
+        tenantOid: error.tenantOid
+      }
+    },
+    create: {
+      ...getId('providerAuthConfigErrorGlobal'),
+      type: error.type,
+      code: error.code,
+      message: error.message,
+      hash,
+      providerOid: error.providerOid,
+      tenantOid: error.tenantOid,
+      environmentOid: error.environmentOid,
+      firstOccurrenceOid: error.oid
+    },
+    update: {}
+  });
+
+  await db.providerAuthConfigErrorGlobal.updateMany({
+    where: { oid: group.oid },
+    data: { occurrenceCount: { increment: 1 } }
+  });
+
+  await db.providerAuthConfigError.update({
+    where: { oid: error.oid },
+    data: {
+      isProcessing: false,
+      groupOid: group.oid
+    }
+  });
+};
+
+let getAuthConfigVersionForSync = async (d: { providerAuthConfigVersionId: string }) =>
+  await db.providerAuthConfigVersion.findUnique({
+    where: { id: d.providerAuthConfigVersionId },
+    include: {
+      authConfig: {
+        include: {
+          tenant: true
+        }
+      },
+      slateAuthConfig: true
+    }
+  });
+
+export let syncAuthConfigProcessingQueueProcessor = syncAuthConfigProcessingQueue.process(
+  async data => {
+    let authConfigVersion = await getAuthConfigVersionForSync({
+      providerAuthConfigVersionId: data.providerAuthConfigVersionId
+    });
+    if (!authConfigVersion) throw new QueueRetryError();
+    if (!authConfigVersion.slateAuthConfig) return;
+
+    let tenant = await getTenantForSlates(authConfigVersion.authConfig.tenant);
+    let record = await slates.slateAuthConfig.get({
+      tenantId: tenant.id,
+      slateAuthConfigId: authConfigVersion.slateAuthConfig.id
+    });
+
+    if (record.status === 'processing') {
+      if (data.attempt >= MAX_ATTEMPTS) return;
+
+      let nextAttempt = data.attempt + 1;
+      await syncAuthConfigProcessingQueue.add(
+        {
+          providerAuthConfigId: data.providerAuthConfigId,
+          providerAuthConfigVersionId: data.providerAuthConfigVersionId,
+          attempt: nextAttempt
+        },
+        {
+          delay: RETRY_DELAY_MS,
+          id: getAuthConfigProcessingJobId({
+            providerAuthConfigVersionId: data.providerAuthConfigVersionId,
+            attempt: nextAttempt
+          })
+        }
+      );
+      return;
+    }
+
+    if (record.status === 'failed') {
+      await createErrorForAuthConfig({
+        authConfigVersion: {
+          ...authConfigVersion,
+          slateAuthConfig: authConfigVersion.slateAuthConfig
+        },
+        record
+      });
+    }
+  }
+);

--- a/src/systems/subspace/provider-backends/provider-slates/src/queues/sync/index.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/queues/sync/index.ts
@@ -3,6 +3,7 @@ import {
   syncAuthConfigEventQueueProcessor,
   syncAuthConfigEventsQueueProcessor
 } from './authConfigEvents';
+import { syncAuthConfigProcessingQueueProcessor } from './authConfigProcessing';
 import { syncChangeNotificationsQueueProcessor } from './changeNotifications';
 import {
   syncAuthConfigEventsCron,
@@ -17,6 +18,7 @@ import { syncSlatesQueueProcessor } from './syncSlates';
 export let syncQueues = combineQueueProcessors([
   syncAuthConfigEventsQueueProcessor,
   syncAuthConfigEventQueueProcessor,
+  syncAuthConfigProcessingQueueProcessor,
   syncAuthConfigEventsCron,
   syncChangeNotificationsQueueProcessor,
   syncChangeNotificationsCron,

--- a/src/systems/subspace/provider-backends/provider-utils/src/interfaces/providerAuth.ts
+++ b/src/systems/subspace/provider-backends/provider-utils/src/interfaces/providerAuth.ts
@@ -60,6 +60,12 @@ export abstract class IProviderAuth extends IProviderFunctionality {
     data: GetProviderAuthConfigScopesParam
   ): Promise<GetProviderAuthScopesRes>;
 
+  async onProviderAuthConfigVersionCreated(
+    data: ProviderAuthConfigVersionCreatedParam
+  ): Promise<ProviderAuthConfigVersionCreatedRes> {
+    return {};
+  }
+
   async getManyProviderAuthCredentialsScopes(
     data: ProviderAuthCredentialsScopesParam
   ): Promise<ProviderAuthCredentialsScopesRes> {
@@ -140,6 +146,14 @@ export interface ProviderAuthConfigCreateRes {
   shuttleAuthConfig?: ShuttleAuthConfig;
   expiresAt: Date | null;
 }
+
+export interface ProviderAuthConfigVersionCreatedParam {
+  tenant: Tenant;
+  authConfig: ProviderAuthConfig;
+  authConfigVersion: ProviderAuthConfigVersion;
+}
+
+export interface ProviderAuthConfigVersionCreatedRes {}
 
 export interface ProviderAuthConfigDeleteBacking {
   slateAuthConfigOid?: bigint | null;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication configuration paths and async error persistence; runtime behavior changes when configs are in a failed state, but changes are additive guards and background sync rather than credential handling refactors.
> 
> **Overview**
> Surfaces **stored Slate auth and instance configuration failures** to API callers instead of failing opaquely during tool calls or auth resolution.
> 
> The **Slates hub** now rejects requests when `slateAuthConfig` or the instance `currentConfig` has `errorCode`, returning `invalid_provider_authentication_configuration` or `invalid_provider_configuration` with the stored message.
> 
> **Subspace** wires a new **`onProviderAuthConfigVersionCreated`** hook (default no-op on `IProviderAuth`) from provider auth config create/update lifecycle queues. The **Slates provider backend** enqueues **`syncAuthConfigProcessing`**, which polls Slate auth config status, retries while `processing`, and on `failed` persists **`providerAuthConfigEvent`**, **`providerAuthConfigError`**, and deduplicated **`providerAuthConfigErrorGlobal`** records for observability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a42ad00ae797acb342c4adeecef7eddc182ab6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->