### PR TITLE
Add integration linked provider templates

### DIFF
--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-templates/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-templates/create.ts
@@ -29,17 +29,20 @@ export type DashboardInstanceProviderTemplatesCreateBody = {
   name: string;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
-  providers: {
-    providerId: string;
-    providerDeploymentId?: string | null | undefined;
-    providerAuthMethodId?: string | null | undefined;
-    providerAuthCredentialsId?: string | null | undefined;
-    providerConfigId?: string | null | undefined;
-    name?: string | undefined;
-    description?: string | null | undefined;
-    metadata?: Record<string, any> | null | undefined;
-    toolFilters?: any | undefined;
-  }[];
+  providers?:
+    | {
+        providerId: string;
+        providerDeploymentId?: string | null | undefined;
+        providerAuthMethodId?: string | null | undefined;
+        providerAuthCredentialsId?: string | null | undefined;
+        providerConfigId?: string | null | undefined;
+        name?: string | undefined;
+        description?: string | null | undefined;
+        metadata?: Record<string, any> | null | undefined;
+        toolFilters?: any | undefined;
+      }[]
+    | undefined;
+  integrationId?: string | undefined;
 };
 
 export let mapDashboardInstanceProviderTemplatesCreateBody =
@@ -74,6 +77,7 @@ export let mapDashboardInstanceProviderTemplatesCreateBody =
           toolFilters: mtMap.objectField('tool_filters', mtMap.passthrough())
         })
       )
-    )
+    ),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough())
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-templates/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-templates/create.ts
@@ -29,17 +29,20 @@ export type ManagementInstanceProviderTemplatesCreateBody = {
   name: string;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
-  providers: {
-    providerId: string;
-    providerDeploymentId?: string | null | undefined;
-    providerAuthMethodId?: string | null | undefined;
-    providerAuthCredentialsId?: string | null | undefined;
-    providerConfigId?: string | null | undefined;
-    name?: string | undefined;
-    description?: string | null | undefined;
-    metadata?: Record<string, any> | null | undefined;
-    toolFilters?: any | undefined;
-  }[];
+  providers?:
+    | {
+        providerId: string;
+        providerDeploymentId?: string | null | undefined;
+        providerAuthMethodId?: string | null | undefined;
+        providerAuthCredentialsId?: string | null | undefined;
+        providerConfigId?: string | null | undefined;
+        name?: string | undefined;
+        description?: string | null | undefined;
+        metadata?: Record<string, any> | null | undefined;
+        toolFilters?: any | undefined;
+      }[]
+    | undefined;
+  integrationId?: string | undefined;
 };
 
 export let mapManagementInstanceProviderTemplatesCreateBody =
@@ -74,6 +77,7 @@ export let mapManagementInstanceProviderTemplatesCreateBody =
           toolFilters: mtMap.objectField('tool_filters', mtMap.passthrough())
         })
       )
-    )
+    ),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough())
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-templates/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-templates/create.ts
@@ -29,17 +29,20 @@ export type ProviderTemplatesCreateBody = {
   name: string;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
-  providers: {
-    providerId: string;
-    providerDeploymentId?: string | null | undefined;
-    providerAuthMethodId?: string | null | undefined;
-    providerAuthCredentialsId?: string | null | undefined;
-    providerConfigId?: string | null | undefined;
-    name?: string | undefined;
-    description?: string | null | undefined;
-    metadata?: Record<string, any> | null | undefined;
-    toolFilters?: any | undefined;
-  }[];
+  providers?:
+    | {
+        providerId: string;
+        providerDeploymentId?: string | null | undefined;
+        providerAuthMethodId?: string | null | undefined;
+        providerAuthCredentialsId?: string | null | undefined;
+        providerConfigId?: string | null | undefined;
+        name?: string | undefined;
+        description?: string | null | undefined;
+        metadata?: Record<string, any> | null | undefined;
+        toolFilters?: any | undefined;
+      }[]
+    | undefined;
+  integrationId?: string | undefined;
 };
 
 export let mapProviderTemplatesCreateBody =
@@ -74,6 +77,7 @@ export let mapProviderTemplatesCreateBody =
           toolFilters: mtMap.objectField('tool_filters', mtMap.passthrough())
         })
       )
-    )
+    ),
+    integrationId: mtMap.objectField('integration_id', mtMap.passthrough())
   });
 

--- a/src/backend/apis/core/src/controllers/instance/integrations/providerTemplate.ts
+++ b/src/backend/apis/core/src/controllers/instance/integrations/providerTemplate.ts
@@ -26,7 +26,8 @@ let providerTemplateCreateBodyValidator = v.object({
   name: v.string(),
   description: v.optional(v.string()),
   metadata: v.optional(v.record(v.any())),
-  providers: v.array(providerTemplateProviderValidator)
+  providers: v.optional(v.array(providerTemplateProviderValidator)),
+  integration_id: v.optional(v.string())
 });
 
 let normalizeProviderTemplateProviders = (
@@ -160,6 +161,16 @@ export let providerTemplateController = Controller.create(
       .body('default', providerTemplateCreateBodyValidator)
       .output(providerTemplatePresenter)
       .do(async ctx => {
+        if (!!ctx.body.integration_id === !!ctx.body.providers) {
+          throw new ServiceError(
+            badRequestError({
+              message: 'Provide exactly one of providers or integration_id.',
+              description:
+                'Provider templates can be created from provider definitions or an existing integration, but not both.'
+            })
+          );
+        }
+
         let providerTemplate = await providerTemplateService.createProviderTemplate({
           organization: ctx.organization,
           instance: ctx.instance,
@@ -167,7 +178,11 @@ export let providerTemplateController = Controller.create(
             name: ctx.body.name,
             description: ctx.body.description,
             metadata: ctx.body.metadata,
-            providers: normalizeProviderTemplateProviders(ctx.body.providers)
+            ...(ctx.body.integration_id
+              ? { integrationId: ctx.body.integration_id }
+              : {
+                  providers: normalizeProviderTemplateProviders(ctx.body.providers!)
+                })
           }
         });
 

--- a/src/backend/db/prisma/schema/consumer/providerTemplate.prisma
+++ b/src/backend/db/prisma/schema/consumer/providerTemplate.prisma
@@ -36,4 +36,5 @@ model ProviderTemplate {
   consumerAccessListings       ConsumerAccessListing[]
 
   @@unique([instanceOid, legacyProviderDeploymentId])
+  @@unique([instanceOid, subspaceIntegrationId])
 }

--- a/src/backend/modules/magic/src/lib/backing.ts
+++ b/src/backend/modules/magic/src/lib/backing.ts
@@ -159,6 +159,21 @@ export let ensureProviderTemplateBacking = async (d: {
     return d.providerTemplate;
   });
 
+export let ensureProviderTemplateBackingFromIntegration = async (d: {
+  instance: Instance;
+  providerTemplateId: string;
+  integrationId: string;
+}) =>
+  withLocalBackingLock(
+    `provider-template-integration:${d.integrationId}`,
+    async () =>
+      await subspaceMagicMcpBackingService.upsertProviderTemplateFromIntegration({
+        instance: d.instance,
+        providerTemplateId: d.providerTemplateId,
+        integrationId: d.integrationId
+      })
+  );
+
 export let ensureMagicMcpServerBacking = async (d: {
   instance: Instance;
   server: MagicMcpServer;

--- a/src/backend/modules/magic/src/services/providerTemplate.ts
+++ b/src/backend/modules/magic/src/services/providerTemplate.ts
@@ -6,6 +6,7 @@ import {
   ID,
   Instance,
   Organization,
+  Prisma,
   ProviderTemplate,
   ProviderTemplateStatus,
   withTransaction
@@ -16,7 +17,10 @@ import {
   type AnyAccessTagSelector
 } from '@metorial/module-access';
 import { searchProviderTemplateIds } from '@metorial/module-search';
-import { ensureProviderTemplateBacking } from '../lib/backing';
+import {
+  ensureProviderTemplateBacking,
+  ensureProviderTemplateBackingFromIntegration
+} from '../lib/backing';
 import {
   providerTemplateArchivedQueue,
   providerTemplateCreatedQueue,
@@ -39,7 +43,47 @@ export type ProviderTemplateProviderInput = {
   toolFilters?: any;
 };
 
+type ProviderTemplateCreateInput = {
+  name: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+} & (
+  | {
+      providers: ProviderTemplateProviderInput[];
+      integrationId?: never;
+    }
+  | {
+      providers?: never;
+      integrationId: string;
+    }
+);
+
 class ProviderTemplateServiceImpl {
+  private async getActiveProviderTemplateByIntegrationId(d: {
+    instance: Instance;
+    integrationId: string;
+  }) {
+    return await db.providerTemplate.findFirst({
+      where: {
+        instanceOid: d.instance.oid,
+        subspaceIntegrationId: d.integrationId,
+        status: 'active'
+      }
+    });
+  }
+
+  private async getProviderTemplateByIntegrationId(d: {
+    instance: Instance;
+    integrationId: string;
+  }) {
+    return await db.providerTemplate.findFirst({
+      where: {
+        instanceOid: d.instance.oid,
+        subspaceIntegrationId: d.integrationId
+      }
+    });
+  }
+
   async getProviderTemplateById(d: {
     instance: Instance;
     providerTemplateId: string;
@@ -76,13 +120,60 @@ class ProviderTemplateServiceImpl {
   async createProviderTemplate(d: {
     organization: Organization;
     instance: Instance;
-    input: {
-      name: string;
-      description?: string;
-      metadata?: Record<string, unknown>;
-      providers: ProviderTemplateProviderInput[];
-    };
+    input: ProviderTemplateCreateInput;
   }): Promise<EnrichedProviderTemplate> {
+    if (d.input.integrationId) {
+      let integrationId = d.input.integrationId;
+      let existing = await this.getActiveProviderTemplateByIntegrationId({
+        instance: d.instance,
+        integrationId
+      });
+      if (existing) return existing;
+
+      let backing = await ensureProviderTemplateBackingFromIntegration({
+        instance: d.instance,
+        providerTemplateId: await ID.generateId('providerTemplate'),
+        integrationId
+      });
+
+      existing = await this.getActiveProviderTemplateByIntegrationId({
+        instance: d.instance,
+        integrationId: backing.integrationId
+      });
+      if (existing) return existing;
+
+      try {
+        let providerTemplate = await withTransaction(async db => {
+          return await db.providerTemplate.create({
+            data: {
+              id: backing.id,
+              status: 'active',
+              name: d.input.name,
+              description: d.input.description,
+              metadata: d.input.metadata ?? {},
+              organizationOid: d.organization.oid,
+              instanceOid: d.instance.oid,
+              hasSubspaceBacking: true,
+              subspaceIntegrationId: backing.integrationId
+            }
+          });
+        });
+
+        await providerTemplateCreatedQueue.add({ providerTemplateId: providerTemplate.id });
+        return providerTemplate;
+      } catch (error) {
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+          let providerTemplate = await this.getProviderTemplateByIntegrationId({
+            instance: d.instance,
+            integrationId: backing.integrationId
+          });
+          if (providerTemplate) return providerTemplate;
+        }
+
+        throw error;
+      }
+    }
+
     let providerTemplate = await withTransaction(async db => {
       return await db.providerTemplate.create({
         data: {

--- a/src/backend/modules/subspace/src/services/magicMcpBacking.ts
+++ b/src/backend/modules/subspace/src/services/magicMcpBacking.ts
@@ -6,6 +6,7 @@ export let subspaceMagicMcpBackingService = createSubspaceService(
   [
     'upsertProviderTemplate',
     'reconcileProviderTemplate',
+    'upsertProviderTemplateFromIntegration',
     'upsertServer',
     'upsertEndpoint',
     'getProviderTemplate',

--- a/src/systems/subspace/apps/controller/src/controllers/magicMcpBacking.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/magicMcpBacking.ts
@@ -149,6 +149,31 @@ export let magicMcpBackingController = app.controller({
       return providerTemplateBackingPresenter(backing);
     }),
 
+  upsertProviderTemplateFromIntegration: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        providerTemplateId: v.string(),
+        integrationId: v.string()
+      })
+    )
+    .do(async ctx => {
+      let backing =
+        await providerTemplateBackingService.upsertProviderTemplateBackingFromIntegration({
+          tenant: ctx.tenant,
+          solution: ctx.solution,
+          environment: ctx.environment,
+          input: {
+            providerTemplateId: ctx.input.providerTemplateId,
+            integrationId: ctx.input.integrationId
+          }
+        });
+
+      return providerTemplateBackingPresenter(backing);
+    }),
+
   upsertServer: tenantApp
     .handler()
     .input(

--- a/src/systems/subspace/modules/integration/src/services/integration.ts
+++ b/src/systems/subspace/modules/integration/src/services/integration.ts
@@ -173,9 +173,7 @@ class integrationServiceImpl {
               tenantOid: d.tenant.oid,
               solutionOid: d.solution.oid,
               environmentOid: d.environment.oid,
-              OR: d.includeMagicMcpBackings
-                ? undefined
-                : [{ isMagicMcpBacking: false }, { providerTemplateBacking: { isNot: null } }],
+              isMagicMcpBacking: d.includeMagicMcpBackings ? undefined : false,
 
               ...normalizeStatusForList(d).noParent,
 

--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/providerTemplate.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/providerTemplate.ts
@@ -33,6 +33,16 @@ type UpsertProviderTemplateBackingInput = {
   };
 };
 
+type UpsertProviderTemplateBackingFromIntegrationInput = {
+  tenant: Tenant;
+  solution: Solution;
+  environment: Environment;
+  input: {
+    providerTemplateId: string;
+    integrationId: string;
+  };
+};
+
 type ProviderTemplateBackingProviderInput = {
   providerId: string;
   providerDeploymentId?: string | null;
@@ -213,6 +223,53 @@ class providerTemplateBackingServiceImpl {
     }
 
     return backing;
+  }
+
+  async upsertProviderTemplateBackingFromIntegration(
+    d: UpsertProviderTemplateBackingFromIntegrationInput
+  ) {
+    await withMagicMcpBackingLock(
+      [
+        `provider_template:${d.input.providerTemplateId}`,
+        `provider_template_integration:${d.input.integrationId}`
+      ],
+      async () =>
+        await withTransaction(async db => {
+          let integration = await integrationService.getIntegrationById({
+            tenant: d.tenant,
+            solution: d.solution,
+            environment: d.environment,
+            integrationId: d.input.integrationId
+          });
+
+          let existing = await db.providerTemplateBacking.findUnique({
+            where: { integrationOid: integration.oid },
+            include: magicMcpProviderTemplateBackingInclude
+          });
+          if (existing) return existing;
+
+          return await db.providerTemplateBacking.create({
+            data: {
+              oid: snowflake.nextId(),
+              id: d.input.providerTemplateId,
+              integrationOid: integration.oid
+            },
+            include: magicMcpProviderTemplateBackingInclude
+          });
+        })
+    );
+
+    return await db.providerTemplateBacking.findFirstOrThrow({
+      where: {
+        integration: {
+          id: d.input.integrationId,
+          tenantOid: d.tenant.oid,
+          solutionOid: d.solution.oid,
+          environmentOid: d.environment.oid
+        }
+      },
+      include: magicMcpProviderTemplateBackingInclude
+    });
   }
 
   async getProviderTemplateBackingById(d: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes create semantics and adds DB uniqueness on integration linkage; race handling is present but cross-service backing flows affect consumer-facing templates.
> 
> **Overview**
> Provider templates can now be created from an **existing integration** instead of only from explicit provider definitions.
> 
> The create API accepts optional `integration_id` (and makes `providers` optional), with validation requiring **exactly one** of `providers` or `integration_id`. The magic layer upserts subspace backing from that integration, stores `subspaceIntegrationId`, and **deduplicates** per instance via a new unique constraint and idempotent lookups (including handling concurrent `P2002` creates). Dashboard/management generated clients mirror the new body shape.
> 
> Subspace adds `upsertProviderTemplateFromIntegration` to attach a `providerTemplateBacking` record to an existing integration, and integration listing when hiding magic MCP backings now filters on `isMagicMcpBacking: false` only (dropping the prior exception for integrations that already have provider-template backing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63147902892ec9f09e385bdda37ca66da18cb77d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->