### PR TITLE
Show provider template integrations

### DIFF
--- a/src/systems/subspace/modules/integration/src/services/integration.ts
+++ b/src/systems/subspace/modules/integration/src/services/integration.ts
@@ -173,7 +173,9 @@ class integrationServiceImpl {
               tenantOid: d.tenant.oid,
               solutionOid: d.solution.oid,
               environmentOid: d.environment.oid,
-              isMagicMcpBacking: d.includeMagicMcpBackings ? undefined : false,
+              OR: d.includeMagicMcpBackings
+                ? undefined
+                : [{ isMagicMcpBacking: false }, { providerTemplateBacking: { isNot: null } }],
 
               ...normalizeStatusForList(d).noParent,
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single Prisma where-clause change on list visibility; no auth or write-path changes.
> 
> **Overview**
> Default **integration list** filtering no longer hides every Magic MCP–backed row. When `includeMagicMcpBackings` is false, results now include integrations that are **not** Magic MCP backings **or** that have a linked **`providerTemplateBacking`**, so provider-template integrations show up in the normal list while other Magic MCP backing integrations stay excluded unless the flag is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe252ab8d3334e359fa80e62c619de8a1c3b15c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->