### PR TITLE
Add fabric for consumer profile creation

### DIFF
--- a/src/backend/modules/consumer/src/services/consumers/consumerProfile.ts
+++ b/src/backend/modules/consumer/src/services/consumers/consumerProfile.ts
@@ -548,6 +548,10 @@ class ConsumerProfileServiceImpl {
             };
           }
 
+          await Fabric.fire('consumer.profile.created:before', {
+            surface: d.surface
+          });
+
           let accessTag = await db.accessTag.create({
             data: {
               instanceOid: d.surface.instanceOid

--- a/src/packages/backend/fabric/src/types.ts
+++ b/src/packages/backend/fabric/src/types.ts
@@ -330,6 +330,7 @@ export interface FabricEvents {
   'portal.archived:before': { portal: Portal };
   'portal.archived:after': { portal: Portal };
 
+  'consumer.profile.created:before': { surface: ConsumerSurface };
   'consumer.profile.created:after': { consumerProfile: ConsumerProfile, surface: ConsumerSurface };
 
   'consumer.auth_tenant.created:before': { organization: Organization; instance: Instance };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small additive lifecycle hook with typed payload; no change to create/update logic unless new listeners are registered.
> 
> **Overview**
> Adds a **pre-create** Fabric hook for consumer profiles so extensions can run before persistence, matching patterns like `portal.created:before`.
> 
> `FabricEvents` now declares `consumer.profile.created:before` with `{ surface: ConsumerSurface }`. In `ensureConsumerProfile`, that event fires only on the **new profile** path—inside the DB transaction, after the existing-profile update branch, and immediately before creating the access tag, personal consumer group, and profile row. The existing `consumer.profile.created:after` hook is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b020d31df2140ae650e4bceea712849ba83e72b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->