### PR TITLE
Fix explorer build

### DIFF
--- a/src/frontend/apps/explorer/src/app.tsx
+++ b/src/frontend/apps/explorer/src/app.tsx
@@ -1036,28 +1036,27 @@ export let ExplorerApp = () => {
     matchesNameSearch(prompt.name, promptSearch)
   );
 
-  let tabs = [
-    { id: 'tools', label: `Tools [${collections.tools.items.length}]` },
-    ...(collections.resourceTemplates.items.length
-      ? [
-          {
-            id: 'resource-templates',
-            label: `Resource Templates [${collections.resourceTemplates.items.length}]`
-          }
-        ]
-      : []),
-    ...(collections.prompts.items.length
-      ? [{ id: 'prompts', label: `Prompts [${collections.prompts.items.length}]` }]
-      : []),
-    ...(collections.resources.items.length
-      ? [
-          {
-            id: 'resources',
-            label: `Resources [${collections.resources.items.length}]`
-          }
-        ]
-      : [])
-  ] satisfies { id: TabId; label: string }[];
+  let tabs: { id: TabId; label: string }[] = [
+    { id: 'tools', label: `Tools [${collections.tools.items.length}]` }
+  ];
+
+  if (collections.resourceTemplates.items.length) {
+    tabs.push({
+      id: 'resource-templates',
+      label: `Resource Templates [${collections.resourceTemplates.items.length}]`
+    });
+  }
+
+  if (collections.prompts.items.length) {
+    tabs.push({ id: 'prompts', label: `Prompts [${collections.prompts.items.length}]` });
+  }
+
+  if (collections.resources.items.length) {
+    tabs.push({
+      id: 'resources',
+      label: `Resources [${collections.resources.items.length}]`
+    });
+  }
 
   let content = (() => {
     if (status === 'connecting' || status === 'idle') {

--- a/src/frontend/apps/explorer/src/components/schemaForm.tsx
+++ b/src/frontend/apps/explorer/src/components/schemaForm.tsx
@@ -111,7 +111,7 @@ let createAjv = () => {
     validateSchema: false
   });
 
-  addFormats(ajv);
+  addFormats(ajv as unknown as Parameters<typeof addFormats>[0]);
 
   return ajv;
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Compile-time-only adjustments with no intended runtime behavior change in the explorer UI.
> 
> **Overview**
> Fixes the **explorer** app TypeScript build with two small, behavior-preserving changes.
> 
> In `app.tsx`, the capability **tabs** list is built with explicit `tabs.push(...)` branches instead of a single array literal using conditional spreads and `satisfies`. Tab order and labels (Tools first, then optional Resource Templates, Prompts, Resources) stay the same.
> 
> In `schemaForm.tsx`, **`addFormats`** is called with a type assertion on the Ajv2020 instance so it matches what `ajv-formats` expects at compile time. Runtime validation behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28dcc4b207ae8378e5e1d0dd9fc3135944cd134b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->