### PR TITLE
Fix api key emails

### DIFF
--- a/src/backend/modules/machine-access/src/queues/created/sendApiKeyCreatedEmail.ts
+++ b/src/backend/modules/machine-access/src/queues/created/sendApiKeyCreatedEmail.ts
@@ -52,7 +52,8 @@ export let sendApiKeyCreatedEmailQueueProcessor = sendApiKeyCreatedEmailQueue.pr
           role: 'admin',
           status: 'active',
           user: {
-            status: 'active'
+            status: 'active',
+            type: 'user'
           }
         },
         select: {

--- a/src/backend/modules/machine-access/src/queues/created/sendApiKeyCreatedEmailToMember.ts
+++ b/src/backend/modules/machine-access/src/queues/created/sendApiKeyCreatedEmailToMember.ts
@@ -50,6 +50,12 @@ export let sendApiKeyCreatedEmailToMemberQueueProcessor =
 
     if (!member) return;
     if (apiKey.machineAccess.organizationOid != organization.oid) return;
+    if (
+      member.role != 'admin' ||
+      member.user.status != 'active' ||
+      member.user.type === 'system'
+    )
+      return;
 
     let existingSend = await db.apiKeyCreatedEmailSend.findFirst({
       where: {

--- a/src/backend/modules/machine-access/src/queues/expired/notifyExpiredApiKeyAdmins.ts
+++ b/src/backend/modules/machine-access/src/queues/expired/notifyExpiredApiKeyAdmins.ts
@@ -33,7 +33,8 @@ export let notifyExpiredApiKeyAdminsQueueProcessor = notifyExpiredApiKeyAdminsQu
         role: 'admin',
         status: 'active',
         user: {
-          status: 'active'
+          status: 'active',
+          type: 'user'
         }
       },
       select: {

--- a/src/backend/modules/machine-access/src/queues/expired/sendExpiredApiKeyEmail.ts
+++ b/src/backend/modules/machine-access/src/queues/expired/sendExpiredApiKeyEmail.ts
@@ -40,7 +40,12 @@ export let sendExpiredApiKeyEmailQueueProcessor = sendExpiredApiKeyEmailQueue.pr
 
     if (!member) return;
     if (apiKey.status != 'expired' || apiKey.machineAccessOid == null) return;
-    if (member.role != 'admin' || member.user.status != 'active') return;
+    if (
+      member.role != 'admin' ||
+      member.user.status != 'active' ||
+      member.user.type === 'system'
+    )
+      return;
 
     let existingSend = await db.apiKeyExpiredEmailSend.findFirst({
       where: {

--- a/src/backend/modules/organization/src/queues/reconcileDefaultPolicies.ts
+++ b/src/backend/modules/organization/src/queues/reconcileDefaultPolicies.ts
@@ -46,9 +46,10 @@ let reconcileDefaultPoliciesManyQueueProcessor = reconcileDefaultPoliciesManyQue
 
     if (accessPolicies.length == 0) return;
 
-    await reconcileDefaultPoliciesSingleQueue.addMany(
+    await reconcileDefaultPoliciesSingleQueue.addManyWithOps(
       accessPolicies.map(accessPolicy => ({
-        accessPolicyId: accessPolicy.id
+        data: { accessPolicyId: accessPolicy.id },
+        opts: { id: accessPolicy.id }
       }))
     );
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow notification filtering and queue deduplication only; no auth or credential logic changes.
> 
> **Overview**
> API key **created** and **expired** notification paths now treat only real human users as email recipients. Admin fan-out queries add `user.type: 'user'`, and per-member send workers skip anyone whose linked user is a **system** account (in addition to existing admin/active checks).
> 
> Default access-policy reconciliation enqueues single-policy jobs via **`addManyWithOps`**, using each policy’s id as the Bull job id so duplicate reconcile jobs for the same policy are less likely during cron pagination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c61e95308d459a0f179fc8319e9b10901e6f9b43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->