### PR TITLE
Fix rolling scope changes

### DIFF
--- a/src/backend/modules/organization/src/lib/accessControl.ts
+++ b/src/backend/modules/organization/src/lib/accessControl.ts
@@ -47,10 +47,19 @@ export let normalizeScopes = (input: string[] | undefined) => {
   return normalized;
 };
 
-export let normalizePolicyDocument = (document: PolicyDocument): PolicyDocument => ({
+let normalizeStoredScopes = (input: string[] | undefined) => [...new Set(input || [])];
+
+export let normalizePolicyDocument = (
+  document: PolicyDocument,
+  opts?: { validateScopes?: boolean }
+): PolicyDocument => ({
   access: document.access.map(entry => ({
     target: entry.target,
-    scopes: entry.scopes ? normalizeScopes(entry.scopes) : undefined,
+    scopes: entry.scopes
+      ? opts?.validateScopes === false
+        ? normalizeStoredScopes(entry.scopes)
+        : normalizeScopes(entry.scopes)
+      : undefined,
     roles: entry.roles ? [...new Set(entry.roles)] : undefined
   }))
 });

--- a/src/backend/modules/organization/src/services/effectiveAccess.ts
+++ b/src/backend/modules/organization/src/services/effectiveAccess.ts
@@ -100,7 +100,9 @@ let getEntryScopes = (d: {
 };
 
 let resolvePolicyEntries = (accessPolicy: AccessPolicyWithRoles): EffectiveAccessEntry[] => {
-  let document = normalizePolicyDocument(accessPolicy.document as PolicyDocument);
+  let document = normalizePolicyDocument(accessPolicy.document as PolicyDocument, {
+    validateScopes: false
+  });
 
   return document.access
     .map(entry => ({

--- a/src/backend/modules/organization/test/accessControl.test.ts
+++ b/src/backend/modules/organization/test/accessControl.test.ts
@@ -1,0 +1,50 @@
+import { ServiceError } from '@lowerdeck/error';
+import { describe, expect, it } from 'vitest';
+import { normalizePolicyDocument, normalizeScopes } from '../src/lib/accessControl';
+
+describe('accessControl', () => {
+  describe('normalizeScopes', () => {
+    it('rejects input scopes that are not in the available scope set', () => {
+      expect(() => normalizeScopes(['organization:read', 'future.scope:read'])).toThrow(
+        ServiceError
+      );
+    });
+
+    it('still validates dependencies for input scopes', () => {
+      expect(() => normalizeScopes(['organization:write'])).toThrow(
+        /Missing scope dependencies: organization:read/
+      );
+    });
+  });
+
+  describe('normalizePolicyDocument', () => {
+    it('validates scopes by default for input documents', () => {
+      expect(() =>
+        normalizePolicyDocument({
+          access: [
+            {
+              target: 'org_123',
+              scopes: ['organization:read', 'future.scope:read']
+            }
+          ]
+        })
+      ).toThrow(ServiceError);
+    });
+
+    it('accepts already stored scopes without checking this process scope set', () => {
+      let document = normalizePolicyDocument(
+        {
+          access: [
+            {
+              target: 'org_123',
+              scopes: ['organization:read', 'future.scope:read', 'future.scope:read']
+            }
+          ]
+        },
+        { validateScopes: false }
+      );
+
+      expect(document.access[0].scopes).toEqual(['organization:read', 'future.scope:read']);
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authorization policy normalization; stored scopes are no longer re-validated at read time, though create/update paths still enforce the current scope set.
> 
> **Overview**
> Policy documents loaded from the database no longer run scopes through the **current** process scope catalog and dependency checks, which fixes access breaking when new scopes are added or the deployed scope set changes after policies were saved.
> 
> `normalizePolicyDocument` gains an optional `validateScopes` flag (default **on**): write paths still use full `normalizeScopes` validation, while **effective access** resolution passes `validateScopes: false` and only deduplicates stored scope strings. New unit tests cover strict validation on input vs lenient normalization for persisted documents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fa397c8525b204e5c11bce1d2bafcac0376b991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->