### PR TITLE
Harden member consumer creation

### DIFF
--- a/src/backend/apis/core/src/controllers/instance/consumer/consumer.ts
+++ b/src/backend/apis/core/src/controllers/instance/consumer/consumer.ts
@@ -203,6 +203,16 @@ export let consumerController = Controller.create(
           );
         }
 
+        if (ctx.auth.type === 'user' && ctx.user.type === 'system') {
+          throw new ServiceError(
+            forbiddenError({
+              message: 'System users cannot use this endpoint',
+              description:
+                'The authenticated user is a system user and cannot use this endpoint.'
+            })
+          );
+        }
+
         let consumerSurface = await consumerSurfaceService.ensureInternalConsumerSurface({
           instance: ctx.instance,
           identifier: ctx.body.surface_identifier,

--- a/src/backend/modules/consumer/src/queues/syncOrgMember.ts
+++ b/src/backend/modules/consumer/src/queues/syncOrgMember.ts
@@ -21,10 +21,12 @@ export let syncOrgMemberQueueProcessor = syncOrgMemberQueue.process(async data =
       },
       include: {
         organization: true,
-        instanceConsumers: true
+        instanceConsumers: true,
+        user: true
       }
     });
     if (!member) throw new QueueRetryError();
+    if (member.user.type === 'system') return;
 
     if (member.instanceConsumers.length) {
       await syncOrgMemberConsumerQueue.addManyWithOps(

--- a/src/backend/modules/consumer/src/services/consumers/consumer.ts
+++ b/src/backend/modules/consumer/src/services/consumers/consumer.ts
@@ -153,8 +153,8 @@ class ConsumerServiceImpl {
       email: string;
     };
   }) {
-    let instanceConsumer = await withTransaction(async tx => {
-      let consumer = await tx.consumer.upsert({
+    let instanceConsumer = await withTransaction(async db => {
+      let consumer = await db.consumer.upsert({
         where: {
           email_organizationOid: {
             email: d.input.email,
@@ -187,7 +187,7 @@ class ConsumerServiceImpl {
         }
       });
 
-      let instanceConsumer = await tx.instanceConsumer.upsert({
+      let instanceConsumer = await db.instanceConsumer.upsert({
         where: {
           instanceOid_consumerOid: {
             instanceOid: d.instance.oid,
@@ -214,7 +214,7 @@ class ConsumerServiceImpl {
         include: getInclude({ instanceOid: d.instance.oid })
       });
 
-      await tx.consumerProfile.updateMany({
+      await db.consumerProfile.updateMany({
         where: {
           instanceOid: d.instance.oid,
           consumerOid: consumer.oid
@@ -246,11 +246,11 @@ class ConsumerServiceImpl {
       email?: string;
     };
   }) {
-    let consumer = await withTransaction(async tx => {
+    let consumer = await withTransaction(async db => {
       let name = d.input.name ?? d.consumer.name;
       let email = d.input.email ?? d.consumer.email;
 
-      await tx.consumer.update({
+      await db.consumer.update({
         where: {
           oid: d.consumer.consumerOid
         },
@@ -270,7 +270,7 @@ class ConsumerServiceImpl {
         }
       });
 
-      let consumer = await tx.instanceConsumer.update({
+      let consumer = await db.instanceConsumer.update({
         where: {
           oid: d.consumer.oid
         },
@@ -284,7 +284,7 @@ class ConsumerServiceImpl {
         include: getInclude({ instanceOid: d.consumer.instanceOid })
       });
 
-      await tx.consumerProfile.updateMany({
+      await db.consumerProfile.updateMany({
         where: {
           instanceOid: d.consumer.instanceOid,
           consumerOid: d.consumer.consumerOid


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches identity-sensitive consumer provisioning paths; behavior change is narrow (system user type only) but affects auth and async member sync.
> 
> **Overview**
> **Blocks system users from member-linked consumer flows** so internal/system accounts cannot obtain or auto-provision org-member consumers.
> 
> `getMemberConsumer` now returns **403** when the session is a user auth with `ctx.user.type === 'system'`. The **`syncOrgMember`** queue loads `user` on the member and **exits early** for system users, so background sync no longer creates or updates instance consumers for those members.
> 
> In **`consumerService`**, transaction callbacks only rename the client parameter from `tx` to `db` inside `createConsumer` / `updateConsumer`—no logic change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c823503ddab29e0ad18ec386c58616b684d13c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->