### PR TITLE
Add previous slugs for projects and orgs

### DIFF
--- a/src/backend/db/prisma/schema/organization/organization.prisma
+++ b/src/backend/db/prisma/schema/organization/organization.prisma
@@ -29,8 +29,9 @@ model Organization {
 
   ignoreAndDoNotUse_canCreateGlobalOauthApps Boolean @default(false) @map("canCreateGlobalOauthApps")
 
-  slug String @unique
-  name String
+  slug          String   @unique
+  previousSlugs String[]
+  name          String
 
   /// [EntityImage]
   image Json
@@ -88,4 +89,5 @@ model Organization {
   consumerAuthTestAuthorizations ConsumerAuthTestAuthorization[]
 
   @@index([authVersion])
+  @@index([previousSlugs])
 }

--- a/src/backend/db/prisma/schema/organization/project.prisma
+++ b/src/backend/db/prisma/schema/organization/project.prisma
@@ -9,8 +9,9 @@ model Project {
 
   status ProjectStatus
 
-  slug String @unique
-  name String
+  slug          String   @unique
+  previousSlugs String[]
+  name          String
 
   onlyAllowTrustedProviders      Boolean @default(false)
   magicMcpSessionDurationMinutes Int     @default(1440)
@@ -39,4 +40,6 @@ model Project {
   accessPolicyProjects AccessPolicyProject[]
   brand                ProjectBrand?
   teams                TeamProject[]
+
+  @@index([previousSlugs])
 }

--- a/src/backend/modules/organization/src/services/instance.ts
+++ b/src/backend/modules/organization/src/services/instance.ts
@@ -37,6 +37,16 @@ let getInstanceSlug = createSlugGenerator(
     }))
 );
 
+let getNextPreviousSlugs = (d: {
+  previousSlugs: string[];
+  currentSlug: string;
+  nextSlug: string;
+}) => {
+  return Array.from(
+    new Set([...d.previousSlugs.filter(slug => slug !== d.nextSlug), d.currentSlug])
+  );
+};
+
 type InstanceWithRelations = Instance & {
   organization: Organization;
   project: Project;
@@ -68,22 +78,42 @@ class InstanceService {
     }
   }
 
-  private async ensureInstanceSlugAvailable(d: { slug: string; instance?: Instance }) {
+  private async reclaimInstanceSlugOrThrow(d: { slug: string; instance?: Instance }) {
     await withTransaction(
       async db => {
-        let existingInstance = await db.instance.findFirst({
+        let currentSlugInstance = await db.instance.findFirst({
           where: {
-            OR: [{ slug: d.slug }, { previousSlugs: { has: d.slug } }],
+            slug: d.slug,
             id: d.instance ? { not: d.instance.id } : undefined
           }
         });
 
-        if (existingInstance) {
+        if (currentSlugInstance) {
           throw new ServiceError(
             conflictError({
               message: 'An instance with this slug already exists'
             })
           );
+        }
+
+        let previousSlugInstances = await db.instance.findMany({
+          where: {
+            previousSlugs: { has: d.slug },
+            id: d.instance ? { not: d.instance.id } : undefined
+          },
+          select: {
+            oid: true,
+            previousSlugs: true
+          }
+        });
+
+        for (let instance of previousSlugInstances) {
+          await db.instance.update({
+            where: { oid: instance.oid },
+            data: {
+              previousSlugs: instance.previousSlugs.filter(slug => slug !== d.slug)
+            }
+          });
         }
       },
       { ifExists: true }
@@ -305,7 +335,7 @@ class InstanceService {
       });
 
       if (d.input.slug && d.input.slug !== d.instance.slug) {
-        await this.ensureInstanceSlugAvailable({
+        await this.reclaimInstanceSlugOrThrow({
           slug: d.input.slug,
           instance: d.instance
         });
@@ -318,9 +348,11 @@ class InstanceService {
           slug: d.input.slug,
           previousSlugs:
             d.input.slug && d.input.slug !== d.instance.slug
-              ? {
-                  push: d.instance.slug
-                }
+              ? getNextPreviousSlugs({
+                  previousSlugs: d.instance.previousSlugs ?? [],
+                  currentSlug: d.instance.slug,
+                  nextSlug: d.input.slug
+                })
               : undefined,
           type: d.input.type
         },
@@ -486,7 +518,8 @@ class InstanceService {
                         project: {
                           OR: [
                             { id: { in: d.filterProjectIds } },
-                            { slug: { in: d.filterProjectIds } }
+                            { slug: { in: d.filterProjectIds } },
+                            { previousSlugs: { hasSome: d.filterProjectIds } }
                           ]
                         }
                       }
@@ -502,7 +535,8 @@ class InstanceService {
                                   project: {
                                     OR: [
                                       { id: { in: d.projectIds } },
-                                      { slug: { in: d.projectIds } }
+                                      { slug: { in: d.projectIds } },
+                                      { previousSlugs: { hasSome: d.projectIds } }
                                     ]
                                   }
                                 }
@@ -693,7 +727,8 @@ class InstanceService {
                           project: {
                             OR: [
                               { id: { in: d.filterProjectIds } },
-                              { slug: { in: d.filterProjectIds } }
+                              { slug: { in: d.filterProjectIds } },
+                              { previousSlugs: { hasSome: d.filterProjectIds } }
                             ]
                           }
                         }
@@ -709,7 +744,8 @@ class InstanceService {
                                     project: {
                                       OR: [
                                         { id: { in: d.projectIds } },
-                                        { slug: { in: d.projectIds } }
+                                        { slug: { in: d.projectIds } },
+                                        { previousSlugs: { hasSome: d.projectIds } }
                                       ]
                                     }
                                   }
@@ -795,7 +831,11 @@ class InstanceService {
           data: {
             name: 'Production',
             slug,
-            previousSlugs: { push: oldestDevelopmentInstance.slug },
+            previousSlugs: getNextPreviousSlugs({
+              previousSlugs: oldestDevelopmentInstance.previousSlugs ?? [],
+              currentSlug: oldestDevelopmentInstance.slug,
+              nextSlug: slug
+            }),
             type: 'production',
             hasBeenReconciled: true
           },

--- a/src/backend/modules/organization/src/services/organization.ts
+++ b/src/backend/modules/organization/src/services/organization.ts
@@ -33,9 +33,22 @@ import { projectService } from './project';
 
 let getOrgSlug = createSlugGenerator(
   async slug =>
-    !(await db.organization.findFirst({ where: { slug } })) &&
-    !(await db.cellOrganization.findFirst({ where: { slug } }))
+    !(await db.organization.findFirst({
+      where: {
+        OR: [{ slug }, { previousSlugs: { has: slug } }]
+      }
+    })) && !(await db.cellOrganization.findFirst({ where: { slug } }))
 );
+
+let getNextPreviousSlugs = (d: {
+  previousSlugs: string[];
+  currentSlug: string;
+  nextSlug: string;
+}) => {
+  return Array.from(
+    new Set([...d.previousSlugs.filter(slug => slug !== d.nextSlug), d.currentSlug])
+  );
+};
 
 class OrganizationService {
   private async ensureOrganizationActive(organization: Organization) {
@@ -46,6 +59,54 @@ class OrganizationService {
         })
       );
     }
+  }
+
+  private async reclaimOrganizationSlugOrThrow(d: {
+    slug: string;
+    organization?: Organization;
+  }) {
+    await withTransaction(
+      async db => {
+        let currentSlugOrganization = await db.organization.findFirst({
+          where: {
+            slug: d.slug,
+            id: d.organization ? { not: d.organization.id } : undefined
+          }
+        });
+        let existingCellOrganization = await db.cellOrganization.findFirst({
+          where: { slug: d.slug }
+        });
+
+        if (currentSlugOrganization || existingCellOrganization) {
+          throw new ServiceError(
+            conflictError({
+              message: 'An organization with this slug already exists'
+            })
+          );
+        }
+
+        let previousSlugOrganizations = await db.organization.findMany({
+          where: {
+            previousSlugs: { has: d.slug },
+            id: d.organization ? { not: d.organization.id } : undefined
+          },
+          select: {
+            oid: true,
+            previousSlugs: true
+          }
+        });
+
+        for (let organization of previousSlugOrganizations) {
+          await db.organization.update({
+            where: { oid: organization.oid },
+            data: {
+              previousSlugs: organization.previousSlugs.filter(slug => slug !== d.slug)
+            }
+          });
+        }
+      },
+      { ifExists: true }
+    );
   }
 
   async createOrganization(d: {
@@ -137,23 +198,10 @@ class OrganizationService {
 
       let nextImage = d.input.image;
       if (d.input.slug && d.input.slug != d.organization.slug) {
-        let existingOrganization = await db.organization.findFirst({
-          where: {
-            slug: d.input.slug,
-            id: { not: d.organization.id }
-          }
+        await this.reclaimOrganizationSlugOrThrow({
+          slug: d.input.slug,
+          organization: d.organization
         });
-        let existingCellOrganization = await db.cellOrganization.findFirst({
-          where: { slug: d.input.slug }
-        });
-
-        if (existingOrganization || existingCellOrganization) {
-          throw new ServiceError(
-            conflictError({
-              message: 'An organization with this slug already exists'
-            })
-          );
-        }
       }
 
       if (d.input.imageFileId !== undefined) {
@@ -175,6 +223,14 @@ class OrganizationService {
         data: {
           name: d.input.name,
           slug: d.input.slug,
+          previousSlugs:
+            d.input.slug && d.input.slug !== d.organization.slug
+              ? getNextPreviousSlugs({
+                  previousSlugs: d.organization.previousSlugs ?? [],
+                  currentSlug: d.organization.slug,
+                  nextSlug: d.input.slug
+                })
+              : undefined,
           image: nextImage
         }
       });
@@ -225,7 +281,11 @@ class OrganizationService {
   async getOrganizationByIdForUser(d: { organizationId: string; user: { id: string } }) {
     let org = await db.organization.findFirst({
       where: {
-        OR: [{ id: d.organizationId }, { slug: d.organizationId }],
+        OR: [
+          { id: d.organizationId },
+          { slug: d.organizationId },
+          { previousSlugs: { has: d.organizationId } }
+        ],
         members: {
           some: {
             user: { id: d.user.id },

--- a/src/backend/modules/organization/src/services/project.ts
+++ b/src/backend/modules/organization/src/services/project.ts
@@ -26,8 +26,23 @@ import { syncSubspaceTenantQueue } from '../queues/syncSubspaceTenant';
 import { instanceService } from './instance';
 
 let getProjectSlug = createSlugGenerator(
-  async slug => !(await db.project.findFirst({ where: { slug } }))
+  async slug =>
+    !(await db.project.findFirst({
+      where: {
+        OR: [{ slug }, { previousSlugs: { has: slug } }]
+      }
+    }))
 );
+
+let getNextPreviousSlugs = (d: {
+  previousSlugs: string[];
+  currentSlug: string;
+  nextSlug: string;
+}) => {
+  return Array.from(
+    new Set([...d.previousSlugs.filter(slug => slug !== d.nextSlug), d.currentSlug])
+  );
+};
 
 class ProjectService {
   private async ensureProjectActive(project: Project) {
@@ -38,6 +53,48 @@ class ProjectService {
         })
       );
     }
+  }
+
+  private async reclaimProjectSlugOrThrow(d: { slug: string; project?: Project }) {
+    await withTransaction(
+      async db => {
+        let currentSlugProject = await db.project.findFirst({
+          where: {
+            slug: d.slug,
+            id: d.project ? { not: d.project.id } : undefined
+          }
+        });
+
+        if (currentSlugProject) {
+          throw new ServiceError(
+            conflictError({
+              message: 'A project with this slug already exists'
+            })
+          );
+        }
+
+        let previousSlugProjects = await db.project.findMany({
+          where: {
+            previousSlugs: { has: d.slug },
+            id: d.project ? { not: d.project.id } : undefined
+          },
+          select: {
+            oid: true,
+            previousSlugs: true
+          }
+        });
+
+        for (let project of previousSlugProjects) {
+          await db.project.update({
+            where: { oid: project.oid },
+            data: {
+              previousSlugs: project.previousSlugs.filter(slug => slug !== d.slug)
+            }
+          });
+        }
+      },
+      { ifExists: true }
+    );
   }
 
   async createProject(d: {
@@ -110,20 +167,10 @@ class ProjectService {
       await Fabric.fire('organization.project.updated:before', d);
 
       if (d.input.slug && d.input.slug !== d.project.slug) {
-        let existingProject = await db.project.findFirst({
-          where: {
-            slug: d.input.slug,
-            id: { not: d.project.id }
-          }
+        await this.reclaimProjectSlugOrThrow({
+          slug: d.input.slug,
+          project: d.project
         });
-
-        if (existingProject) {
-          throw new ServiceError(
-            conflictError({
-              message: 'A project with this slug already exists'
-            })
-          );
-        }
       }
 
       let project = await db.project.update({
@@ -131,6 +178,14 @@ class ProjectService {
         data: {
           name: d.input.name,
           slug: d.input.slug,
+          previousSlugs:
+            d.input.slug && d.input.slug !== d.project.slug
+              ? getNextPreviousSlugs({
+                  previousSlugs: d.project.previousSlugs ?? [],
+                  currentSlug: d.project.slug,
+                  nextSlug: d.input.slug
+                })
+              : undefined,
           onlyAllowTrustedProviders: d.input.onlyAllowTrustedProviders,
           magicMcpSessionDurationMinutes: d.input.magicMcpSessionDurationMinutes
         },
@@ -182,7 +237,11 @@ class ProjectService {
   }) {
     let project = await db.project.findFirst({
       where: {
-        OR: [{ id: d.projectId }, { slug: d.projectId }],
+        OR: [
+          { id: d.projectId },
+          { slug: d.projectId },
+          { previousSlugs: { has: d.projectId } }
+        ],
         organizationOid: d.organization.oid
       },
       include: {
@@ -209,7 +268,13 @@ class ProjectService {
             where: {
               organizationOid: d.organization.oid,
               status: 'active',
-              id: d.projectIds ? { in: d.projectIds } : undefined
+              OR: d.projectIds
+                ? [
+                    { id: { in: d.projectIds } },
+                    { slug: { in: d.projectIds } },
+                    { previousSlugs: { hasSome: d.projectIds } }
+                  ]
+                : undefined
             },
             include: {
               organization: true
@@ -240,7 +305,11 @@ class ProjectService {
     let projects = await db.project.findMany({
       where: {
         organizationOid: d.organization.oid,
-        OR: [{ id: { in: d.projectIds } }, { slug: { in: d.projectIds } }]
+        OR: [
+          { id: { in: d.projectIds } },
+          { slug: { in: d.projectIds } },
+          { previousSlugs: { hasSome: d.projectIds } }
+        ]
       },
       include: {
         organization: true

--- a/src/backend/modules/organization/test/instance.test.ts
+++ b/src/backend/modules/organization/test/instance.test.ts
@@ -451,6 +451,105 @@ describe('InstanceService', () => {
       // Should still complete without error
       expect(Fabric.fire).toHaveBeenCalled();
     });
+
+    it('should reject slug updates when another instance has the current slug', async () => {
+      let mockInstance = {
+        id: 'inst-1',
+        oid: 1,
+        status: 'active',
+        slug: 'old-slug',
+        previousSlugs: [],
+        project: { id: 'proj-1', oid: 1 }
+      };
+      let update = vi.fn();
+
+      vi.mocked(withTransaction).mockImplementation(async callback => {
+        let mockDb = withCompanionMocks({
+          instance: {
+            findFirst: vi.fn().mockResolvedValue({ id: 'inst-2' }),
+            update
+          }
+        });
+        return callback(mockDb as any);
+      });
+
+      await expect(
+        instanceService.updateInstance({
+          instance: mockInstance as any,
+          organization: { id: 'org-1', oid: 1 } as any,
+          performedBy: { id: 'actor-1', oid: 1 } as any,
+          context: {} as any,
+          input: {
+            slug: 'new-slug'
+          }
+        })
+      ).rejects.toThrow(ServiceError);
+
+      expect(update).not.toHaveBeenCalled();
+    });
+
+    it('should reclaim previous slug conflicts and keep slug history on update', async () => {
+      let mockInstance = {
+        id: 'inst-1',
+        oid: 1,
+        status: 'active',
+        slug: 'old-slug',
+        previousSlugs: ['older-slug', 'new-slug'],
+        project: { id: 'proj-1', oid: 1 }
+      };
+      let updatedInstance = {
+        ...mockInstance,
+        slug: 'new-slug',
+        previousSlugs: ['older-slug', 'old-slug']
+      };
+      let update = vi
+        .fn()
+        .mockResolvedValueOnce({ oid: 2, previousSlugs: ['kept-slug'] })
+        .mockResolvedValueOnce(updatedInstance);
+
+      vi.mocked(withTransaction).mockImplementation(async callback => {
+        let mockDb = withCompanionMocks({
+          instance: {
+            findFirst: vi.fn().mockResolvedValue(null),
+            findMany: vi.fn().mockResolvedValue([
+              {
+                oid: 2,
+                previousSlugs: ['new-slug', 'kept-slug']
+              }
+            ]),
+            update
+          }
+        });
+        return callback(mockDb as any);
+      });
+
+      let result = await instanceService.updateInstance({
+        instance: mockInstance as any,
+        organization: { id: 'org-1', oid: 1 } as any,
+        performedBy: { id: 'actor-1', oid: 1 } as any,
+        context: {} as any,
+        input: {
+          slug: 'new-slug'
+        }
+      });
+
+      expect(result).toEqual(updatedInstance);
+      expect(update).toHaveBeenCalledWith({
+        where: { oid: 2 },
+        data: {
+          previousSlugs: ['kept-slug']
+        }
+      });
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { oid: 1 },
+          data: expect.objectContaining({
+            slug: 'new-slug',
+            previousSlugs: ['older-slug', 'old-slug']
+          })
+        })
+      );
+    });
   });
 
   describe('deleteInstance', () => {
@@ -551,6 +650,38 @@ describe('InstanceService', () => {
       });
 
       expect(result).toEqual(mockInstance);
+    });
+
+    it('should return instance by previous slug', async () => {
+      let mockInstance = {
+        id: 'inst-1',
+        oid: 1,
+        slug: 'current-slug',
+        previousSlugs: ['old-slug'],
+        organizationOid: 1
+      };
+
+      vi.mocked(db.instance.findFirst).mockResolvedValue(mockInstance as any);
+
+      let result = await instanceService.getInstanceById({
+        organization: { id: 'org-1', oid: 1 } as any,
+        instanceId: 'old-slug',
+        actor: { id: 'actor-1', oid: 1 } as any,
+        member: undefined
+      });
+
+      expect(result).toEqual(mockInstance);
+      expect(db.instance.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            OR: [
+              { id: 'old-slug' },
+              { slug: 'old-slug' },
+              { previousSlugs: { has: 'old-slug' } }
+            ]
+          })
+        })
+      );
     });
 
     it('should throw not found error when instance does not exist', async () => {
@@ -820,6 +951,7 @@ describe('InstanceService', () => {
         id: 'inst-1',
         oid: 1,
         slug: 'development',
+        previousSlugs: [],
         name: 'Development',
         type: 'development',
         status: 'active',
@@ -862,7 +994,7 @@ describe('InstanceService', () => {
         data: {
           name: 'Production',
           slug: 'test-slug',
-          previousSlugs: { push: 'development' },
+          previousSlugs: ['development'],
           type: 'production',
           hasBeenReconciled: true
         },

--- a/src/backend/modules/organization/test/organization.test.ts
+++ b/src/backend/modules/organization/test/organization.test.ts
@@ -698,6 +698,107 @@ describe('OrganizationService', () => {
       );
     });
 
+    it('should reject slug updates when another organization has the current slug', async () => {
+      let mockOrg = {
+        id: 'org-1',
+        oid: 1,
+        status: 'active',
+        slug: 'old-slug',
+        previousSlugs: []
+      };
+      let update = vi.fn();
+
+      vi.mocked(withTransaction).mockImplementation(async callback => {
+        let mockDb = {
+          organization: {
+            findFirst: vi.fn().mockResolvedValue({ id: 'org-2' }),
+            update
+          },
+          cellOrganization: {
+            findFirst: vi.fn().mockResolvedValue(null)
+          }
+        };
+        return callback(mockDb as any);
+      });
+
+      await expect(
+        organizationService.updateOrganization({
+          input: {
+            slug: 'new-slug'
+          },
+          organization: mockOrg as any,
+          context: {} as any,
+          performedBy: { id: 'actor-1', oid: 1 } as any
+        })
+      ).rejects.toThrow(ServiceError);
+
+      expect(update).not.toHaveBeenCalled();
+    });
+
+    it('should reclaim previous slug conflicts and keep slug history on update', async () => {
+      let mockOrg = {
+        id: 'org-1',
+        oid: 1,
+        status: 'active',
+        slug: 'old-slug',
+        previousSlugs: ['older-slug', 'new-slug']
+      };
+      let updatedOrg = {
+        ...mockOrg,
+        slug: 'new-slug',
+        previousSlugs: ['older-slug', 'old-slug']
+      };
+      let update = vi
+        .fn()
+        .mockResolvedValueOnce({ oid: 2, previousSlugs: ['kept-slug'] })
+        .mockResolvedValueOnce(updatedOrg);
+
+      vi.mocked(withTransaction).mockImplementation(async callback => {
+        let mockDb = {
+          organization: {
+            findFirst: vi.fn().mockResolvedValue(null),
+            findMany: vi.fn().mockResolvedValue([
+              {
+                oid: 2,
+                previousSlugs: ['new-slug', 'kept-slug']
+              }
+            ]),
+            update
+          },
+          cellOrganization: {
+            findFirst: vi.fn().mockResolvedValue(null)
+          }
+        };
+        return callback(mockDb as any);
+      });
+
+      let result = await organizationService.updateOrganization({
+        input: {
+          slug: 'new-slug'
+        },
+        organization: mockOrg as any,
+        context: {} as any,
+        performedBy: { id: 'actor-1', oid: 1 } as any
+      });
+
+      expect(result).toEqual(updatedOrg);
+      expect(update).toHaveBeenCalledWith({
+        where: { oid: 2 },
+        data: {
+          previousSlugs: ['kept-slug']
+        }
+      });
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'org-1' },
+          data: expect.objectContaining({
+            slug: 'new-slug',
+            previousSlugs: ['older-slug', 'old-slug']
+          })
+        })
+      );
+    });
+
     it('should throw forbidden error when organization is deleted', async () => {
       let mockOrg = {
         id: 'org-1',
@@ -849,7 +950,7 @@ describe('OrganizationService', () => {
       expect(result.actor).toEqual(mockActor);
       expect(db.organization.findFirst).toHaveBeenCalledWith({
         where: {
-          OR: [{ id: 'org-1' }, { slug: 'org-1' }],
+          OR: [{ id: 'org-1' }, { slug: 'org-1' }, { previousSlugs: { has: 'org-1' } }],
           members: {
             some: {
               user: { id: 'user-1' },
@@ -896,7 +997,11 @@ describe('OrganizationService', () => {
       expect(result.organization).toMatchObject(mockOrg);
       expect(db.organization.findFirst).toHaveBeenCalledWith({
         where: {
-          OR: [{ id: 'test-org' }, { slug: 'test-org' }],
+          OR: [
+            { id: 'test-org' },
+            { slug: 'test-org' },
+            { previousSlugs: { has: 'test-org' } }
+          ],
           members: {
             some: {
               user: { id: 'user-1' },
@@ -906,6 +1011,42 @@ describe('OrganizationService', () => {
         },
         include: expect.any(Object)
       });
+    });
+
+    it('should return organization by previous slug', async () => {
+      let mockUser = { id: 'user-1', oid: 1 };
+      let mockOrg = {
+        id: 'org-1',
+        oid: 1,
+        slug: 'current-org',
+        previousSlugs: ['old-org']
+      };
+      let mockActor = { id: 'actor-1', oid: 1 };
+      let mockMember = {
+        id: 'member-1',
+        oid: 1,
+        lastActiveAt: new Date()
+      };
+
+      vi.mocked(db.organization.findFirst).mockResolvedValue({
+        ...mockOrg,
+        members: [{ ...mockMember, actor: mockActor, user: mockUser }]
+      } as any);
+      vi.mocked(differenceInMinutes).mockReturnValue(10);
+
+      let result = await organizationService.getOrganizationByIdForUser({
+        organizationId: 'old-org',
+        user: mockUser
+      });
+
+      expect(result.organization).toMatchObject(mockOrg);
+      expect(db.organization.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            OR: [{ id: 'old-org' }, { slug: 'old-org' }, { previousSlugs: { has: 'old-org' } }]
+          })
+        })
+      );
     });
 
     it('should update lastActiveAt when more than 30 minutes', async () => {

--- a/src/backend/modules/organization/test/project.test.ts
+++ b/src/backend/modules/organization/test/project.test.ts
@@ -360,6 +360,103 @@ describe('ProjectService', () => {
         })
       );
     });
+
+    it('should reject slug updates when another project has the current slug', async () => {
+      let mockProject = {
+        id: 'proj-1',
+        oid: 1,
+        status: 'active',
+        slug: 'old-slug',
+        previousSlugs: []
+      };
+      let update = vi.fn();
+
+      vi.mocked(withTransaction).mockImplementation(async callback => {
+        let mockDb = {
+          project: {
+            findFirst: vi.fn().mockResolvedValue({ id: 'proj-2' }),
+            update
+          }
+        };
+        return callback(mockDb as any);
+      });
+
+      await expect(
+        projectService.updateProject({
+          project: mockProject as any,
+          organization: { id: 'org-1', oid: 1 } as any,
+          performedBy: { id: 'actor-1', oid: 1 } as any,
+          context: {} as any,
+          input: {
+            slug: 'new-slug'
+          }
+        })
+      ).rejects.toThrow(ServiceError);
+
+      expect(update).not.toHaveBeenCalled();
+    });
+
+    it('should reclaim previous slug conflicts and keep slug history on update', async () => {
+      let mockProject = {
+        id: 'proj-1',
+        oid: 1,
+        status: 'active',
+        slug: 'old-slug',
+        previousSlugs: ['older-slug', 'new-slug']
+      };
+      let updatedProject = {
+        ...mockProject,
+        slug: 'new-slug',
+        previousSlugs: ['older-slug', 'old-slug']
+      };
+      let update = vi
+        .fn()
+        .mockResolvedValueOnce({ oid: 2, previousSlugs: ['kept-slug'] })
+        .mockResolvedValueOnce(updatedProject);
+
+      vi.mocked(withTransaction).mockImplementation(async callback => {
+        let mockDb = {
+          project: {
+            findFirst: vi.fn().mockResolvedValue(null),
+            findMany: vi.fn().mockResolvedValue([
+              {
+                oid: 2,
+                previousSlugs: ['new-slug', 'kept-slug']
+              }
+            ]),
+            update
+          }
+        };
+        return callback(mockDb as any);
+      });
+
+      let result = await projectService.updateProject({
+        project: mockProject as any,
+        organization: { id: 'org-1', oid: 1 } as any,
+        performedBy: { id: 'actor-1', oid: 1 } as any,
+        context: {} as any,
+        input: {
+          slug: 'new-slug'
+        }
+      });
+
+      expect(result).toEqual(updatedProject);
+      expect(update).toHaveBeenCalledWith({
+        where: { oid: 2 },
+        data: {
+          previousSlugs: ['kept-slug']
+        }
+      });
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { oid: 1 },
+          data: expect.objectContaining({
+            slug: 'new-slug',
+            previousSlugs: ['older-slug', 'old-slug']
+          })
+        })
+      );
+    });
   });
 
   describe('deleteProject', () => {
@@ -428,7 +525,7 @@ describe('ProjectService', () => {
       expect(result).toEqual(mockProject);
       expect(db.project.findFirst).toHaveBeenCalledWith({
         where: {
-          OR: [{ id: 'proj-1' }, { slug: 'proj-1' }],
+          OR: [{ id: 'proj-1' }, { slug: 'proj-1' }, { previousSlugs: { has: 'proj-1' } }],
           organizationOid: 1
         },
         include: {
@@ -455,6 +552,38 @@ describe('ProjectService', () => {
       });
 
       expect(result).toEqual(mockProject);
+    });
+
+    it('should return project by previous slug', async () => {
+      let mockProject = {
+        id: 'proj-1',
+        oid: 1,
+        slug: 'current-slug',
+        previousSlugs: ['old-slug'],
+        organizationOid: 1
+      };
+
+      vi.mocked(db.project.findFirst).mockResolvedValue(mockProject as any);
+
+      let result = await projectService.getProjectById({
+        organization: { id: 'org-1', oid: 1 } as any,
+        projectId: 'old-slug',
+        actor: { id: 'actor-1', oid: 1 } as any,
+        member: undefined
+      });
+
+      expect(result).toEqual(mockProject);
+      expect(db.project.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            OR: [
+              { id: 'old-slug' },
+              { slug: 'old-slug' },
+              { previousSlugs: { has: 'old-slug' } }
+            ]
+          })
+        })
+      );
     });
 
     it('should throw not found error when project does not exist', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Schema migration plus slug uniqueness/reclaim logic affects routing and lookups for org/project identifiers; behavior is well-tested but touches core tenancy resolution.
> 
> **Overview**
> Adds **`previousSlugs`** on **organizations** and **projects** (with DB indexes), matching the existing **instance** slug-history model.
> 
> On slug rename, services **append the old slug** to history, **block** if another entity still owns the slug as its current `slug`, and **reclaim** the slug by removing it from other entities’ `previousSlugs` when reusing a formerly reserved slug. **Slug generators** and **get/list/filter** paths now treat **previous slugs** like current slugs for resolution and uniqueness.
> 
> **Instance** updates use the same **`getNextPreviousSlugs`** helper and reclaim flow; production reconciliation writes **full** `previousSlugs` arrays instead of Prisma `push`. Tests cover conflict rejection, reclaim behavior, and lookup by previous slug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b52d8d10873c941cbc8629295992775d7aabb0d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->