### PR TITLE
Make loaders much much smarter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2563,7 +2563,7 @@
         "@remixicon/react": "^4.0.0",
         "@sentry/bun": "^10.36.0",
         "@sentry/cli": "^3.2.0",
-        "@slates/proto": "^1.0.0-rc.10",
+        "@slates/proto": "^1.0.0-rc.11",
         "@types/semver": "^7.7.1",
         "@types/unzipper": "^0.10.11",
         "date-fns": "^4.1.0",
@@ -5258,7 +5258,7 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
-    "@slates/proto": ["@slates/proto@1.0.0-rc.10", "", { "dependencies": { "@lowerdeck/emitter": "^1.0.4", "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-d2ZzchGaF8zzCd/5AvtdeUIi9hkNwIOFj3T38Dh67z/z2R8Evl5/SgkYMhMHZ7C+JqcwSdf1Zz5XAHwkhYpPzA=="],
+    "@slates/proto": ["@slates/proto@1.0.0-rc.11", "", { "dependencies": { "@lowerdeck/emitter": "^1.0.4", "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-g/MMRAciX5D0UmEiwBy9656qEaade2ZMysIRMYoL64PzwfLC2rorOuTfE+kfBhNfH1IeA9UgmfVT8+8vGbQv3Q=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1319,6 +1319,7 @@
       "name": "@metorial/dynamic-component",
       "version": "1.0.0",
       "dependencies": {
+        "@metorial/data-hooks": "^1.0.0",
         "@metorial/ui": "^1.0.0",
         "p-queue": "^8.1.0",
       },
@@ -2562,7 +2563,7 @@
         "@remixicon/react": "^4.0.0",
         "@sentry/bun": "^10.36.0",
         "@sentry/cli": "^3.2.0",
-        "@slates/proto": "^1.0.0-rc.8",
+        "@slates/proto": "^1.0.0-rc.10",
         "@types/semver": "^7.7.1",
         "@types/unzipper": "^0.10.11",
         "date-fns": "^4.1.0",
@@ -3075,8 +3076,13 @@
         "@metorial-platform-systems/origin-client": "^1.0.0",
         "@metorial-subspace/db": "^1.0.0",
         "@metorial-subspace/list-utils": "^1.0.0",
+        "@metorial-subspace/module-auth": "^1.0.0",
+        "@metorial-subspace/module-deployment": "^1.0.0",
+        "@metorial-subspace/module-enclave": "^1.0.0",
+        "@metorial-subspace/module-identity": "^1.0.0",
         "@metorial-subspace/module-provider-internal": "^1.0.0",
         "@metorial-subspace/module-search": "^1.0.0",
+        "@metorial-subspace/module-skills": "^1.0.0",
         "@metorial-subspace/module-tenant": "^1.0.0",
         "@metorial-subspace/provider": "^1.0.0",
       },
@@ -5252,7 +5258,7 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
-    "@slates/proto": ["@slates/proto@1.0.0-rc.8", "", { "dependencies": { "@lowerdeck/emitter": "^1.0.4", "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-3PB2SCFi13mYNkkptX9dbz8xOFgEdtXd6atDtaaIDs8vSxIMWy8C9JoSqtqXDmJOfM8Jk/dCSWxjoTPEYnMfgQ=="],
+    "@slates/proto": ["@slates/proto@1.0.0-rc.10", "", { "dependencies": { "@lowerdeck/emitter": "^1.0.4", "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-d2ZzchGaF8zzCd/5AvtdeUIi9hkNwIOFj3T38Dh67z/z2R8Evl5/SgkYMhMHZ7C+JqcwSdf1Zz5XAHwkhYpPzA=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q=="],
 
@@ -8994,8 +9000,6 @@
 
     "@metorial-subspace/conduit/vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
 
-    "@metorial-subspace/module-monitor/vitest": ["vitest@4.0.17", "", { "dependencies": { "@vitest/expect": "4.0.17", "@vitest/mocker": "4.0.17", "@vitest/pretty-format": "4.0.17", "@vitest/runner": "4.0.17", "@vitest/snapshot": "4.0.17", "@vitest/spy": "4.0.17", "@vitest/utils": "4.0.17", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.17", "@vitest/browser-preview": "4.0.17", "@vitest/browser-webdriverio": "4.0.17", "@vitest/ui": "4.0.17", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg=="],
-
     "@metorial-subspace/module-session/p-queue": ["p-queue@8.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^6.1.2" } }, "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ=="],
 
     "@metorial/app-dashboard/@vitejs/plugin-react": ["@vitejs/plugin-react@4.3.1", "", { "dependencies": { "@babel/core": "^7.24.5", "@babel/plugin-transform-react-jsx-self": "^7.24.5", "@babel/plugin-transform-react-jsx-source": "^7.24.1", "@types/babel__core": "^7.20.5", "react-refresh": "^0.14.2" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0" } }, "sha512-m/V2syj5CuVnaxcUJOQRel/Wr31FFXRFlnOoq1TVtkCxsY5veGMTEmpWHndrhB2U8ScHtCQB1e+4hWYExQc6Lg=="],
@@ -9325,8 +9329,6 @@
     "@sentry/node-core/@sentry/core": ["@sentry/core@10.45.0", "", {}, "sha512-s69UXxvefeQxuZ5nY7/THtTrIEvJxNVCp3ns4kwoCw1qMpgpvn/296WCKVmM7MiwnaAdzEKnAvLAwaxZc2nM7Q=="],
 
     "@sentry/opentelemetry/@sentry/core": ["@sentry/core@10.45.0", "", {}, "sha512-s69UXxvefeQxuZ5nY7/THtTrIEvJxNVCp3ns4kwoCw1qMpgpvn/296WCKVmM7MiwnaAdzEKnAvLAwaxZc2nM7Q=="],
-
-    "@slates/proto/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@smithy/chunked-blob-reader-native/@smithy/util-base64": ["@smithy/util-base64@4.3.1", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.1", "@smithy/util-utf8": "^4.2.1", "tslib": "^2.6.2" } }, "sha512-BKGuawX4Doq/bI/uEmg+Zyc36rJKWuin3py89PquXBIBqmbnJwBBsmKhdHfNEp0+A4TDgLmT/3MSKZ1SxHcR6w=="],
 
@@ -10302,26 +10304,6 @@
 
     "@metorial-subspace/conduit/vitest/vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
 
-    "@metorial-subspace/module-monitor/vitest/@vitest/expect": ["@vitest/expect@4.0.17", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.17", "@vitest/utils": "4.0.17", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ=="],
-
-    "@metorial-subspace/module-monitor/vitest/@vitest/mocker": ["@vitest/mocker@4.0.17", "", { "dependencies": { "@vitest/spy": "4.0.17", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ=="],
-
-    "@metorial-subspace/module-monitor/vitest/@vitest/pretty-format": ["@vitest/pretty-format@4.0.17", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw=="],
-
-    "@metorial-subspace/module-monitor/vitest/@vitest/runner": ["@vitest/runner@4.0.17", "", { "dependencies": { "@vitest/utils": "4.0.17", "pathe": "^2.0.3" } }, "sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ=="],
-
-    "@metorial-subspace/module-monitor/vitest/@vitest/snapshot": ["@vitest/snapshot@4.0.17", "", { "dependencies": { "@vitest/pretty-format": "4.0.17", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ=="],
-
-    "@metorial-subspace/module-monitor/vitest/@vitest/spy": ["@vitest/spy@4.0.17", "", {}, "sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew=="],
-
-    "@metorial-subspace/module-monitor/vitest/@vitest/utils": ["@vitest/utils@4.0.17", "", { "dependencies": { "@vitest/pretty-format": "4.0.17", "tinyrainbow": "^3.0.3" } }, "sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w=="],
-
-    "@metorial-subspace/module-monitor/vitest/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
-
-    "@metorial-subspace/module-monitor/vitest/tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
-
     "@metorial-subspace/module-session/p-queue/p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
 
     "@metorial/app-dashboard/@vitejs/plugin-react/react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
@@ -11256,12 +11238,6 @@
 
     "@metorial-subspace/conduit/vitest/@vitest/spy/tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
 
-    "@metorial-subspace/module-monitor/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
-
-    "@metorial-subspace/module-monitor/vitest/@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
-
     "@metorial/ares/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "@metorial/ares/vitest/@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
@@ -11735,58 +11711,6 @@
     "@metorial-subspace/app-controller/vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
 
     "@metorial-subspace/app-controller/vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
-
-    "@metorial-subspace/module-monitor/vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
     "@metorial/ares/vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/consumers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/consumers/list.ts
@@ -56,7 +56,11 @@ export type ConsumersListQuery = {
   before?: string | undefined;
   cursor?: string | undefined;
   order?: 'asc' | 'desc' | undefined;
-} & { search?: string | undefined; id?: string | undefined };
+} & {
+  search?: string | undefined;
+  email?: string | string[] | undefined;
+  id?: string | undefined;
+};
 
 export let mapConsumersListQuery = mtMap.union([
   mtMap.unionOption(
@@ -68,6 +72,16 @@ export let mapConsumersListQuery = mtMap.union([
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
       order: mtMap.objectField('order', mtMap.passthrough()),
       search: mtMap.objectField('search', mtMap.passthrough()),
+      email: mtMap.objectField(
+        'email',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
       id: mtMap.objectField('id', mtMap.passthrough())
     })
   )

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/consumers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/consumers/list.ts
@@ -60,7 +60,11 @@ export type DashboardInstanceConsumersListQuery = {
   before?: string | undefined;
   cursor?: string | undefined;
   order?: 'asc' | 'desc' | undefined;
-} & { search?: string | undefined; id?: string | undefined };
+} & {
+  search?: string | undefined;
+  email?: string | string[] | undefined;
+  id?: string | undefined;
+};
 
 export let mapDashboardInstanceConsumersListQuery = mtMap.union([
   mtMap.unionOption(
@@ -72,6 +76,16 @@ export let mapDashboardInstanceConsumersListQuery = mtMap.union([
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
       order: mtMap.objectField('order', mtMap.passthrough()),
       search: mtMap.objectField('search', mtMap.passthrough()),
+      email: mtMap.objectField(
+        'email',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
       id: mtMap.objectField('id', mtMap.passthrough())
     })
   )

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-invites/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-invites/list.ts
@@ -81,6 +81,7 @@ export type DashboardInstancePortalsConsumerInvitesListQuery = {
   order?: 'asc' | 'desc' | undefined;
 } & {
   search?: string | undefined;
+  email?: string | string[] | undefined;
   status?: 'pending' | 'accepted' | ('pending' | 'accepted')[] | undefined;
 };
 
@@ -94,6 +95,16 @@ export let mapDashboardInstancePortalsConsumerInvitesListQuery = mtMap.union([
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
       order: mtMap.objectField('order', mtMap.passthrough()),
       search: mtMap.objectField('search', mtMap.passthrough()),
+      email: mtMap.objectField(
+        'email',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
       status: mtMap.objectField(
         'status',
         mtMap.union([mtMap.unionOption('array', mtMap.union([]))])

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/list.ts
@@ -203,6 +203,7 @@ export type DashboardInstancePortalsConsumerProfilesListQuery = {
   order?: 'asc' | 'desc' | undefined;
 } & {
   search?: string | undefined;
+  email?: string | string[] | undefined;
   consumerGroupId?: string | undefined;
   status?: 'active' | 'invited' | ('active' | 'invited')[] | undefined;
 };
@@ -217,6 +218,16 @@ export let mapDashboardInstancePortalsConsumerProfilesListQuery = mtMap.union([
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
       order: mtMap.objectField('order', mtMap.passthrough()),
       search: mtMap.objectField('search', mtMap.passthrough()),
+      email: mtMap.objectField(
+        'email',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
       consumerGroupId: mtMap.objectField(
         'consumer_group_id',
         mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/list.ts
@@ -120,7 +120,7 @@ export type DashboardInstancePortalsListQuery = {
   before?: string | undefined;
   cursor?: string | undefined;
   order?: 'asc' | 'desc' | undefined;
-} & {};
+} & { search?: string | undefined };
 
 export let mapDashboardInstancePortalsListQuery = mtMap.union([
   mtMap.unionOption(
@@ -130,7 +130,8 @@ export let mapDashboardInstancePortalsListQuery = mtMap.union([
       after: mtMap.objectField('after', mtMap.passthrough()),
       before: mtMap.objectField('before', mtMap.passthrough()),
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
-      order: mtMap.objectField('order', mtMap.passthrough())
+      order: mtMap.objectField('order', mtMap.passthrough()),
+      search: mtMap.objectField('search', mtMap.passthrough())
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-listings/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-listings/get.ts
@@ -86,6 +86,22 @@ export type DashboardInstanceProviderListingsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  docs: {
+    provider: { type?: string | undefined; name: string; url: string }[];
+    config: { type?: string | undefined; name: string; url: string }[];
+    authMethods: {
+      key: string;
+      name: string;
+      type: string;
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+    actions: {
+      key: string;
+      name: string;
+      type: 'tool' | 'trigger';
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+  } | null;
   provider: {
     object: 'provider';
     id: string;
@@ -423,7 +439,72 @@ export let mapDashboardInstanceProviderListingsGetOutput = mtMap.union([
         )
       ),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      docs: mtMap.objectField(
+        'docs',
+        mtMap.object({
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          authMethods: mtMap.objectField(
+            'auth_methods',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          ),
+          actions: mtMap.objectField(
+            'actions',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          )
+        })
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-listings/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-listings/list.ts
@@ -87,6 +87,22 @@ export type DashboardInstanceProviderListingsListOutput = {
     createdAt: Date;
     updatedAt: Date;
   } & {
+    docs: {
+      provider: { type?: string | undefined; name: string; url: string }[];
+      config: { type?: string | undefined; name: string; url: string }[];
+      authMethods: {
+        key: string;
+        name: string;
+        type: string;
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+      actions: {
+        key: string;
+        name: string;
+        type: 'tool' | 'trigger';
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+    } | null;
     provider: {
       object: 'provider';
       id: string;
@@ -507,7 +523,84 @@ export let mapDashboardInstanceProviderListingsListOutput =
                 )
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              docs: mtMap.objectField(
+                'docs',
+                mtMap.object({
+                  provider: mtMap.objectField(
+                    'provider',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  authMethods: mtMap.objectField(
+                    'auth_methods',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  ),
+                  actions: mtMap.objectField(
+                    'actions',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  )
+                })
+              )
             })
           )
         ])

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/consumers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/consumers/list.ts
@@ -60,7 +60,11 @@ export type ManagementInstanceConsumersListQuery = {
   before?: string | undefined;
   cursor?: string | undefined;
   order?: 'asc' | 'desc' | undefined;
-} & { search?: string | undefined; id?: string | undefined };
+} & {
+  search?: string | undefined;
+  email?: string | string[] | undefined;
+  id?: string | undefined;
+};
 
 export let mapManagementInstanceConsumersListQuery = mtMap.union([
   mtMap.unionOption(
@@ -72,6 +76,16 @@ export let mapManagementInstanceConsumersListQuery = mtMap.union([
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
       order: mtMap.objectField('order', mtMap.passthrough()),
       search: mtMap.objectField('search', mtMap.passthrough()),
+      email: mtMap.objectField(
+        'email',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
       id: mtMap.objectField('id', mtMap.passthrough())
     })
   )

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-invites/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-invites/list.ts
@@ -81,6 +81,7 @@ export type ManagementInstancePortalsConsumerInvitesListQuery = {
   order?: 'asc' | 'desc' | undefined;
 } & {
   search?: string | undefined;
+  email?: string | string[] | undefined;
   status?: 'pending' | 'accepted' | ('pending' | 'accepted')[] | undefined;
 };
 
@@ -94,6 +95,16 @@ export let mapManagementInstancePortalsConsumerInvitesListQuery = mtMap.union([
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
       order: mtMap.objectField('order', mtMap.passthrough()),
       search: mtMap.objectField('search', mtMap.passthrough()),
+      email: mtMap.objectField(
+        'email',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
       status: mtMap.objectField(
         'status',
         mtMap.union([mtMap.unionOption('array', mtMap.union([]))])

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-profiles/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-profiles/list.ts
@@ -203,6 +203,7 @@ export type ManagementInstancePortalsConsumerProfilesListQuery = {
   order?: 'asc' | 'desc' | undefined;
 } & {
   search?: string | undefined;
+  email?: string | string[] | undefined;
   consumerGroupId?: string | undefined;
   status?: 'active' | 'invited' | ('active' | 'invited')[] | undefined;
 };
@@ -217,6 +218,16 @@ export let mapManagementInstancePortalsConsumerProfilesListQuery = mtMap.union([
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
       order: mtMap.objectField('order', mtMap.passthrough()),
       search: mtMap.objectField('search', mtMap.passthrough()),
+      email: mtMap.objectField(
+        'email',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
       consumerGroupId: mtMap.objectField(
         'consumer_group_id',
         mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/list.ts
@@ -120,7 +120,7 @@ export type ManagementInstancePortalsListQuery = {
   before?: string | undefined;
   cursor?: string | undefined;
   order?: 'asc' | 'desc' | undefined;
-} & {};
+} & { search?: string | undefined };
 
 export let mapManagementInstancePortalsListQuery = mtMap.union([
   mtMap.unionOption(
@@ -130,7 +130,8 @@ export let mapManagementInstancePortalsListQuery = mtMap.union([
       after: mtMap.objectField('after', mtMap.passthrough()),
       before: mtMap.objectField('before', mtMap.passthrough()),
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
-      order: mtMap.objectField('order', mtMap.passthrough())
+      order: mtMap.objectField('order', mtMap.passthrough()),
+      search: mtMap.objectField('search', mtMap.passthrough())
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-listings/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-listings/get.ts
@@ -86,6 +86,22 @@ export type ManagementInstanceProviderListingsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  docs: {
+    provider: { type?: string | undefined; name: string; url: string }[];
+    config: { type?: string | undefined; name: string; url: string }[];
+    authMethods: {
+      key: string;
+      name: string;
+      type: string;
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+    actions: {
+      key: string;
+      name: string;
+      type: 'tool' | 'trigger';
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+  } | null;
   provider: {
     object: 'provider';
     id: string;
@@ -423,7 +439,72 @@ export let mapManagementInstanceProviderListingsGetOutput = mtMap.union([
         )
       ),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      docs: mtMap.objectField(
+        'docs',
+        mtMap.object({
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          authMethods: mtMap.objectField(
+            'auth_methods',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          ),
+          actions: mtMap.objectField(
+            'actions',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          )
+        })
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-listings/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-listings/list.ts
@@ -87,6 +87,22 @@ export type ManagementInstanceProviderListingsListOutput = {
     createdAt: Date;
     updatedAt: Date;
   } & {
+    docs: {
+      provider: { type?: string | undefined; name: string; url: string }[];
+      config: { type?: string | undefined; name: string; url: string }[];
+      authMethods: {
+        key: string;
+        name: string;
+        type: string;
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+      actions: {
+        key: string;
+        name: string;
+        type: 'tool' | 'trigger';
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+    } | null;
     provider: {
       object: 'provider';
       id: string;
@@ -507,7 +523,84 @@ export let mapManagementInstanceProviderListingsListOutput =
                 )
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              docs: mtMap.objectField(
+                'docs',
+                mtMap.object({
+                  provider: mtMap.objectField(
+                    'provider',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  authMethods: mtMap.objectField(
+                    'auth_methods',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  ),
+                  actions: mtMap.objectField(
+                    'actions',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  )
+                })
+              )
             })
           )
         ])

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-invites/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-invites/list.ts
@@ -81,6 +81,7 @@ export type PortalsConsumerInvitesListQuery = {
   order?: 'asc' | 'desc' | undefined;
 } & {
   search?: string | undefined;
+  email?: string | string[] | undefined;
   status?: 'pending' | 'accepted' | ('pending' | 'accepted')[] | undefined;
 };
 
@@ -94,6 +95,16 @@ export let mapPortalsConsumerInvitesListQuery = mtMap.union([
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
       order: mtMap.objectField('order', mtMap.passthrough()),
       search: mtMap.objectField('search', mtMap.passthrough()),
+      email: mtMap.objectField(
+        'email',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
       status: mtMap.objectField(
         'status',
         mtMap.union([mtMap.unionOption('array', mtMap.union([]))])

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-profiles/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-profiles/list.ts
@@ -203,6 +203,7 @@ export type PortalsConsumerProfilesListQuery = {
   order?: 'asc' | 'desc' | undefined;
 } & {
   search?: string | undefined;
+  email?: string | string[] | undefined;
   consumerGroupId?: string | undefined;
   status?: 'active' | 'invited' | ('active' | 'invited')[] | undefined;
 };
@@ -217,6 +218,16 @@ export let mapPortalsConsumerProfilesListQuery = mtMap.union([
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
       order: mtMap.objectField('order', mtMap.passthrough()),
       search: mtMap.objectField('search', mtMap.passthrough()),
+      email: mtMap.objectField(
+        'email',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
       consumerGroupId: mtMap.objectField(
         'consumer_group_id',
         mtMap.passthrough()

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/list.ts
@@ -116,7 +116,7 @@ export type PortalsListQuery = {
   before?: string | undefined;
   cursor?: string | undefined;
   order?: 'asc' | 'desc' | undefined;
-} & {};
+} & { search?: string | undefined };
 
 export let mapPortalsListQuery = mtMap.union([
   mtMap.unionOption(
@@ -126,7 +126,8 @@ export let mapPortalsListQuery = mtMap.union([
       after: mtMap.objectField('after', mtMap.passthrough()),
       before: mtMap.objectField('before', mtMap.passthrough()),
       cursor: mtMap.objectField('cursor', mtMap.passthrough()),
-      order: mtMap.objectField('order', mtMap.passthrough())
+      order: mtMap.objectField('order', mtMap.passthrough()),
+      search: mtMap.objectField('search', mtMap.passthrough())
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-listings/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-listings/get.ts
@@ -86,6 +86,22 @@ export type ProviderListingsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  docs: {
+    provider: { type?: string | undefined; name: string; url: string }[];
+    config: { type?: string | undefined; name: string; url: string }[];
+    authMethods: {
+      key: string;
+      name: string;
+      type: string;
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+    actions: {
+      key: string;
+      name: string;
+      type: 'tool' | 'trigger';
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+  } | null;
   provider: {
     object: 'provider';
     id: string;
@@ -423,7 +439,72 @@ export let mapProviderListingsGetOutput = mtMap.union([
         )
       ),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      docs: mtMap.objectField(
+        'docs',
+        mtMap.object({
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          authMethods: mtMap.objectField(
+            'auth_methods',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          ),
+          actions: mtMap.objectField(
+            'actions',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          )
+        })
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-listings/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-listings/list.ts
@@ -87,6 +87,22 @@ export type ProviderListingsListOutput = {
     createdAt: Date;
     updatedAt: Date;
   } & {
+    docs: {
+      provider: { type?: string | undefined; name: string; url: string }[];
+      config: { type?: string | undefined; name: string; url: string }[];
+      authMethods: {
+        key: string;
+        name: string;
+        type: string;
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+      actions: {
+        key: string;
+        name: string;
+        type: 'tool' | 'trigger';
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+    } | null;
     provider: {
       object: 'provider';
       id: string;
@@ -507,7 +523,84 @@ export let mapProviderListingsListOutput =
                 )
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              docs: mtMap.objectField(
+                'docs',
+                mtMap.object({
+                  provider: mtMap.objectField(
+                    'provider',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  authMethods: mtMap.objectField(
+                    'auth_methods',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  ),
+                  actions: mtMap.objectField(
+                    'actions',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  )
+                })
+              )
             })
           )
         ])

--- a/src/backend/apis/core/src/controllers/instance/consumer/consumer.ts
+++ b/src/backend/apis/core/src/controllers/instance/consumer/consumer.ts
@@ -15,6 +15,7 @@ import {
   consumerPresenter,
   consumerProfilePresenter
 } from '../../../presenters';
+import { normalizeArrayParam } from '../../../lib/normalizeArrayParam';
 
 let getAssignedConsumerGroupsByProfileId = async (d: {
   consumerProfiles: Awaited<
@@ -102,6 +103,12 @@ export let consumerController = Controller.create(
         Paginator.validate(
           v.object({
             search: v.optional(v.string()),
+            email: v.optional(
+              v.union([
+                v.string({ modifiers: [v.email()] }),
+                v.array(v.string({ modifiers: [v.email()] }))
+              ])
+            ),
             id: v.optional(v.string())
           })
         )
@@ -110,6 +117,7 @@ export let consumerController = Controller.create(
         let paginator = await consumerService.listConsumers({
           instance: ctx.instance,
           search: ctx.query.search,
+          emails: normalizeArrayParam(ctx.query.email),
           id: ctx.query.id
         });
         let list = await paginator.run(ctx.query);

--- a/src/backend/apis/core/src/controllers/instance/portal/portal.ts
+++ b/src/backend/apis/core/src/controllers/instance/portal/portal.ts
@@ -54,10 +54,18 @@ export let portalController = Controller.create(
       .use(checkAccess({ possibleScopes: ['instance.portal:read'] }))
       .use(hasFlags(['paid-portals', 'portals-access']))
       .outputList(portalPresenter)
-      .query('default', Paginator.validate(v.object({})))
+      .query(
+        'default',
+        Paginator.validate(
+          v.object({
+            search: v.optional(v.string({ description: 'Search by name or description' }))
+          })
+        )
+      )
       .do(async ctx => {
         let paginator = portalService.listPortals({
-          instance: ctx.instance
+          instance: ctx.instance,
+          search: ctx.query.search
         });
         let list = await paginator.run(ctx.query);
 

--- a/src/backend/apis/core/src/controllers/instance/portal/portalConsumerInvite.ts
+++ b/src/backend/apis/core/src/controllers/instance/portal/portalConsumerInvite.ts
@@ -50,6 +50,12 @@ export let portalConsumerInviteController = Controller.create(
         Paginator.validate(
           v.object({
             search: v.optional(v.string()),
+            email: v.optional(
+              v.union([
+                v.string({ modifiers: [v.email()] }),
+                v.array(v.string({ modifiers: [v.email()] }))
+              ])
+            ),
             status: v.optional(
               v.union([
                 v.enumOf(['pending', 'accepted']),
@@ -63,6 +69,7 @@ export let portalConsumerInviteController = Controller.create(
         let paginator = await consumerInviteService.listConsumerInvites({
           consumerSurface: ctx.portal.surface,
           search: ctx.query.search,
+          emails: normalizeArrayParam(ctx.query.email),
           statuses: normalizeArrayParam(ctx.query.status)
         });
         let list = await paginator.run(ctx.query);

--- a/src/backend/apis/core/src/controllers/instance/portal/portalConsumerProfile.ts
+++ b/src/backend/apis/core/src/controllers/instance/portal/portalConsumerProfile.ts
@@ -50,6 +50,12 @@ export let portalConsumerProfileController = Controller.create(
         Paginator.validate(
           v.object({
             search: v.optional(v.string()),
+            email: v.optional(
+              v.union([
+                v.string({ modifiers: [v.email()] }),
+                v.array(v.string({ modifiers: [v.email()] }))
+              ])
+            ),
             consumer_group_id: v.optional(v.string()),
             status: v.optional(
               v.union([
@@ -64,6 +70,7 @@ export let portalConsumerProfileController = Controller.create(
         let paginator = await consumerProfileService.listConsumerProfiles({
           consumerSurface: ctx.portal.surface,
           search: ctx.query.search,
+          emails: normalizeArrayParam(ctx.query.email),
           consumerGroupId: ctx.query.consumer_group_id,
           statuses: normalizeArrayParam(ctx.query.status)
         });

--- a/src/backend/apis/core/src/presenters/implementation/provider/provider/providerListing.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/provider/providerListing.ts
@@ -7,6 +7,56 @@ import { v1ProviderListingCollectionPresenter } from './collection';
 import { v1ProviderListingGroupPresenter } from './group';
 import { dashboardProviderPresenter, v1ProviderPresenter } from './provider';
 
+let providerListingDocReferenceSchema = v.object({
+  type: v.optional(v.string({ description: 'The protocol-specific documentation type.' })),
+  name: v.string({ description: 'The display name for this documentation reference.' }),
+  url: v.string({ description: 'The documentation URL.' })
+});
+
+let providerListingDocsSchema = v.nullable(
+  v.object({
+    provider: v.array(providerListingDocReferenceSchema),
+    config: v.array(providerListingDocReferenceSchema),
+    auth_methods: v.array(
+      v.object({
+        key: v.string(),
+        name: v.string(),
+        type: v.string(),
+        docs: v.array(providerListingDocReferenceSchema)
+      })
+    ),
+    actions: v.array(
+      v.object({
+        key: v.string(),
+        name: v.string(),
+        type: v.enumOf(['tool', 'trigger']),
+        docs: v.array(providerListingDocReferenceSchema)
+      })
+    )
+  })
+);
+
+let presentProviderListingDocs = (docs: any) => {
+  if (!docs) return null;
+
+  return {
+    provider: docs.provider ?? [],
+    config: docs.config ?? [],
+    auth_methods: (docs.authMethods ?? []).map((authMethod: any) => ({
+      key: authMethod.key,
+      name: authMethod.name,
+      type: authMethod.type,
+      docs: authMethod.docs ?? []
+    })),
+    actions: (docs.actions ?? []).map((action: any) => ({
+      key: action.key,
+      name: action.name,
+      type: action.type,
+      docs: action.docs ?? []
+    }))
+  };
+};
+
 export let v1ProviderListingPresenter = Presenter.create(providerListingType)
   .presenter(async ({ providerListing }, opts) => {
     return {
@@ -153,6 +203,7 @@ export let dashboardProviderListingPresenter = Presenter.create(providerListingT
 
     return {
       ...inner,
+      docs: presentProviderListingDocs((input.providerListing as any).docs),
       provider: await dashboardProviderPresenter
         .present({ provider: input.providerListing.provider }, opts)
         .run()
@@ -162,6 +213,7 @@ export let dashboardProviderListingPresenter = Presenter.create(providerListingT
     v.intersection([
       v1ProviderListingPresenter.schema,
       v.object({
+        docs: providerListingDocsSchema,
         provider: dashboardProviderPresenter.schema
       })
     ])

--- a/src/backend/modules/consumer/src/services/consumers/consumer.ts
+++ b/src/backend/modules/consumer/src/services/consumers/consumer.ts
@@ -31,6 +31,16 @@ let upsertLock = createLock({
   name: 'cons/upsert'
 });
 
+let normalizeEmailFilter = (emails?: string[]) => {
+  let normalizedEmails = (emails ?? [])
+    .map(email => email.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (!normalizedEmails.length) return undefined;
+
+  return Array.from(new Set(normalizedEmails));
+};
+
 type InstanceConsumerWithRelations = InstanceConsumer & {
   consumer: ConsumerWithRelations;
 };
@@ -82,8 +92,14 @@ class ConsumerServiceImpl {
     return consumer;
   }
 
-  async listConsumers(d: { instance: Instance; search?: string; id?: string }) {
+  async listConsumers(d: {
+    instance: Instance;
+    search?: string;
+    emails?: string[];
+    id?: string;
+  }) {
     let search = d.search?.trim();
+    let emails = normalizeEmailFilter(d.emails);
     let id = d.id?.trim();
     let searchedConsumerIds = search
       ? await searchConsumerIds({
@@ -103,6 +119,7 @@ class ConsumerServiceImpl {
                 isPending: false
               },
               ...(search ? [{ id: { in: searchedConsumerIds ?? [] } }] : []),
+              ...(emails?.length ? [{ email: { in: emails } }] : []),
               ...(id ? [{ OR: [{ id }, { consumer: { id } }] }] : [])
             ]
           },

--- a/src/backend/modules/consumer/src/services/consumers/consumerInvite.ts
+++ b/src/backend/modules/consumer/src/services/consumers/consumerInvite.ts
@@ -19,6 +19,16 @@ let include = {
   }
 } as const;
 
+let normalizeEmailFilter = (emails?: string[]) => {
+  let normalizedEmails = (emails ?? [])
+    .map(email => email.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (!normalizedEmails.length) return undefined;
+
+  return Array.from(new Set(normalizedEmails));
+};
+
 class ConsumerInviteServiceImpl {
   async inviteConsumer(d: {
     consumerSurface: ConsumerSurface;
@@ -103,9 +113,11 @@ class ConsumerInviteServiceImpl {
   async listConsumerInvites(d: {
     consumerSurface: ConsumerSurface;
     search?: string;
+    emails?: string[];
     statuses?: string[];
   }) {
     let search = d.search?.trim();
+    let emails = normalizeEmailFilter(d.emails);
     let statuses = d.statuses?.length
       ? Array.from(new Set(d.statuses)).filter(
           (status): status is 'pending' | 'accepted' =>
@@ -150,6 +162,16 @@ class ConsumerInviteServiceImpl {
       andParts.push({
         status: {
           in: statuses
+        }
+      });
+    }
+
+    if (emails?.length) {
+      andParts.push({
+        consumerProfile: {
+          email: {
+            in: emails
+          }
         }
       });
     }

--- a/src/backend/modules/consumer/src/services/consumers/consumerProfile.ts
+++ b/src/backend/modules/consumer/src/services/consumers/consumerProfile.ts
@@ -59,6 +59,16 @@ type EnrichedConsumerProfile<T extends ConsumerProfileWithRelations> = T & {
 let getInstanceConsumerKey = (d: { instanceOid: bigint; consumerOid: bigint }) =>
   `${d.instanceOid.toString()}:${d.consumerOid.toString()}`;
 
+let normalizeEmailFilter = (emails?: string[]) => {
+  let normalizedEmails = (emails ?? [])
+    .map(email => email.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (!normalizedEmails.length) return undefined;
+
+  return Array.from(new Set(normalizedEmails));
+};
+
 export let ensureProfileLock = createLock({
   name: 'cons/ensureProfile'
 });
@@ -202,10 +212,12 @@ class ConsumerProfileServiceImpl {
   async listConsumerProfiles(d: {
     consumerSurface: ConsumerSurface;
     search?: string;
+    emails?: string[];
     consumerGroupId?: string;
     statuses?: Array<'active' | 'invited'>;
   }) {
     let search = d.search?.trim();
+    let emails = normalizeEmailFilter(d.emails);
     let consumerGroupId = d.consumerGroupId?.trim();
     let statuses = d.statuses?.length ? new Set(d.statuses) : null;
     let instance = search
@@ -292,6 +304,7 @@ class ConsumerProfileServiceImpl {
       { surfaceOid: d.consumerSurface.oid },
       ...(groupMembershipWhere ? [groupMembershipWhere] : []),
       ...(inviteStatusWhere ? [inviteStatusWhere] : []),
+      ...(emails?.length ? [{ email: { in: emails } }] : []),
       ...(search ? [{ consumerOid: { in: searchedConsumerOids ?? [] } }] : [])
     ];
 

--- a/src/backend/modules/consumer/src/services/portal.ts
+++ b/src/backend/modules/consumer/src/services/portal.ts
@@ -187,7 +187,10 @@ class PortalServiceImpl {
     });
   }
 
-  listPortals(d: { instance: Instance }) {
+  listPortals(d: { instance: Instance; search?: string }) {
+    let normalizedSearch = d.search?.trim();
+    if (!normalizedSearch?.length) normalizedSearch = undefined;
+
     let paginator = Paginator.create(({ prisma }) =>
       prisma(async opts => {
         return await db.portal.findMany({
@@ -197,7 +200,15 @@ class PortalServiceImpl {
             status: 'active',
             surface: {
               status: 'active'
-            }
+            },
+            OR: normalizedSearch
+              ? [
+                  { id: { contains: normalizedSearch, mode: 'insensitive' } },
+                  { slug: { contains: normalizedSearch, mode: 'insensitive' } },
+                  { name: { contains: normalizedSearch, mode: 'insensitive' } },
+                  { description: { contains: normalizedSearch, mode: 'insensitive' } }
+                ]
+              : undefined
           },
           include
         });

--- a/src/backend/modules/machine-access/src/lib/oauthUrls.ts
+++ b/src/backend/modules/machine-access/src/lib/oauthUrls.ts
@@ -33,14 +33,23 @@ export let validateRedirectUri = (d: {
   }
 };
 
+let isLoopbackHost = (hostname: string) =>
+  hostname == 'localhost' ||
+  hostname == '127.0.0.1' ||
+  hostname == '::1' ||
+  hostname == '[::1]';
+
 export let validateUri = (uri: string) => {
   try {
     let url = new URL(uri);
 
-    if (url.protocol != 'https:') {
+    if (
+      url.protocol != 'https:' &&
+      !(url.protocol == 'http:' && isLoopbackHost(url.hostname))
+    ) {
       throw new ServiceError(
         badRequestError({
-          message: 'URI must use https scheme'
+          message: 'URI must use https scheme unless it targets localhost'
         })
       );
     }

--- a/src/backend/modules/machine-access/src/services/oauthApplication.ts
+++ b/src/backend/modules/machine-access/src/services/oauthApplication.ts
@@ -123,6 +123,22 @@ class OAuthApplicationService {
     }
   }
 
+  private assertGlobalUserFacingApplication(oauthApplication: OAuthApplication) {
+    if (
+      oauthApplication.type == 'user_facing' &&
+      oauthApplication.accessLevel == 'global' &&
+      oauthApplication.organizationOid == null
+    ) {
+      return;
+    }
+
+    throw new ServiceError(
+      forbiddenError({
+        message: 'Only global user-facing oauth applications are supported by this action'
+      })
+    );
+  }
+
   private assertAllowedAccessLevel(d: {
     type: Exclude<OAuthApplicationType, 'cli_auth'>;
     accessLevel: OAuthAuthorizationAccessLevel;
@@ -446,6 +462,207 @@ class OAuthApplicationService {
     });
   }
 
+  async createGlobalUserFacingOAuthApplication(d: {
+    input: {
+      allowClientSecretlessTokenExchange?: boolean;
+      name: string;
+      description?: string;
+      websiteUrl?: string;
+      privacyPolicyUrl?: string;
+      termsOfServiceUrl?: string;
+      redirectUris?: string[];
+      scopes: string[];
+      image?: PrismaJson.EntityImage;
+    };
+  }) {
+    let scopes = validateOAuthScopes(d.input.scopes);
+    let redirectUris = (d.input.redirectUris ?? []).map(uri => {
+      validateUri(uri);
+      return uri;
+    });
+
+    let input = {
+      status: 'active' as const,
+      type: 'user_facing' as const,
+      accessLevel: 'global' as const,
+      allowClientSecretlessTokenExchange: d.input.allowClientSecretlessTokenExchange ?? false,
+      name: d.input.name,
+      description: d.input.description,
+      websiteUrl: d.input.websiteUrl,
+      privacyPolicyUrl: d.input.privacyPolicyUrl,
+      termsOfServiceUrl: d.input.termsOfServiceUrl,
+      redirectUris,
+      scopes,
+      image: d.input.image ?? { type: 'default' as const }
+    };
+
+    return await withTransaction(async db => {
+      await Fabric.fire('machine_access.oauth_application.created:before', {
+        organization: null,
+        performedBy: null,
+        context: null,
+        input,
+        serverSideMachineAccess: null
+      });
+
+      let oauthApplication = await db.oAuthApplication.create({
+        data: {
+          id: await ID.generateId('oauthApplication'),
+          clientId: generateCustomId('mt_oauth_', 32),
+          ...input,
+          organizationOid: null,
+          serverSideMachineAccessOid: null,
+          scopedInstallationOid: null
+        },
+        include
+      });
+
+      addAfterTransactionHook(() =>
+        Fabric.fire('machine_access.oauth_application.created:after', {
+          organization: null,
+          performedBy: null,
+          context: null,
+          input,
+          serverSideMachineAccess: null,
+          oauthApplication
+        })
+      );
+
+      return oauthApplication;
+    });
+  }
+
+  async updateGlobalUserFacingOAuthApplication(d: {
+    oauthApplication: OAuthApplication;
+    input: {
+      allowClientSecretlessTokenExchange?: boolean;
+      name?: string;
+      description?: string | null;
+      websiteUrl?: string | null;
+      privacyPolicyUrl?: string | null;
+      termsOfServiceUrl?: string | null;
+      redirectUris?: string[];
+      scopes?: string[];
+      image?: PrismaJson.EntityImage;
+    };
+  }) {
+    await this.assertApplicationActive(d.oauthApplication);
+    this.assertApplicationOwnedLocally(d.oauthApplication);
+    this.assertGlobalUserFacingApplication(d.oauthApplication);
+
+    let scopes = d.input.scopes ? validateOAuthScopes(d.input.scopes) : undefined;
+    let redirectUris = d.input.redirectUris
+      ? d.input.redirectUris.map(uri => {
+          validateUri(uri);
+          return uri;
+        })
+      : undefined;
+
+    return await withTransaction(async db => {
+      await Fabric.fire('machine_access.oauth_application.updated:before', {
+        oauthApplication: d.oauthApplication,
+        organization: null,
+        performedBy: null,
+        context: null,
+        input: {
+          ...d.input,
+          scopes,
+          redirectUris
+        }
+      });
+
+      let oauthApplication = await db.oAuthApplication.update({
+        where: { oid: d.oauthApplication.oid },
+        data: {
+          allowClientSecretlessTokenExchange: d.input.allowClientSecretlessTokenExchange,
+          name: d.input.name,
+          description: d.input.description,
+          websiteUrl: d.input.websiteUrl,
+          privacyPolicyUrl: d.input.privacyPolicyUrl,
+          termsOfServiceUrl: d.input.termsOfServiceUrl,
+          redirectUris,
+          scopes,
+          image: d.input.image
+        },
+        include
+      });
+
+      addAfterTransactionHook(() =>
+        Fabric.fire('machine_access.oauth_application.updated:after', {
+          oauthApplication,
+          organization: null,
+          performedBy: null,
+          context: null,
+          input: {
+            ...d.input,
+            scopes,
+            redirectUris
+          }
+        })
+      );
+
+      return oauthApplication;
+    });
+  }
+
+  async archiveGlobalUserFacingOAuthApplication(d: { oauthApplication: OAuthApplication }) {
+    await this.assertApplicationActive(d.oauthApplication);
+    this.assertApplicationOwnedLocally(d.oauthApplication);
+    this.assertGlobalUserFacingApplication(d.oauthApplication);
+
+    let now = new Date();
+
+    return await withTransaction(async db => {
+      await Fabric.fire('machine_access.oauth_application.archived:before', {
+        oauthApplication: d.oauthApplication,
+        organization: null,
+        performedBy: null,
+        context: null
+      });
+
+      await db.oAuthAuthorization.updateMany({
+        where: {
+          oauthApplicationOid: d.oauthApplication.oid,
+          status: 'active'
+        },
+        data: {
+          status: 'revoked',
+          revokedAt: now
+        }
+      });
+
+      await db.oAuthInstallation.updateMany({
+        where: {
+          oauthApplicationOid: d.oauthApplication.oid,
+          status: 'active'
+        },
+        data: {
+          status: 'revoked',
+          revokedAt: now
+        }
+      });
+
+      let oauthApplication = await db.oAuthApplication.update({
+        where: { oid: d.oauthApplication.oid },
+        data: {
+          status: 'archived'
+        },
+        include
+      });
+
+      addAfterTransactionHook(() =>
+        Fabric.fire('machine_access.oauth_application.archived:after', {
+          oauthApplication,
+          organization: null,
+          performedBy: null,
+          context: null
+        })
+      );
+
+      return oauthApplication;
+    });
+  }
+
   async getOAuthApplicationById(d: {
     organization: Organization;
     oauthApplicationId: string;
@@ -457,6 +674,23 @@ class OAuthApplicationService {
         type: {
           in: ['user_facing', 'server_side']
         }
+      },
+      include
+    });
+    if (!oauthApplication) {
+      throw new ServiceError(notFoundError('oauth_application', d.oauthApplicationId));
+    }
+
+    return oauthApplication;
+  }
+
+  async getGlobalUserFacingOAuthApplicationById(d: { oauthApplicationId: string }) {
+    let oauthApplication = await db.oAuthApplication.findFirst({
+      where: {
+        id: d.oauthApplicationId,
+        organizationOid: null,
+        type: 'user_facing',
+        accessLevel: 'global'
       },
       include
     });
@@ -482,6 +716,37 @@ class OAuthApplicationService {
               type: {
                 in: ['user_facing']
               }
+            },
+            include
+          })
+      )
+    );
+  }
+
+  async listGlobalUserFacingOAuthApplications(d: {
+    statuses?: OAuthApplicationStatus[];
+    search?: string;
+  }) {
+    let search = d.search?.trim();
+
+    return Paginator.create(({ prisma }) =>
+      prisma(
+        async opts =>
+          await db.oAuthApplication.findMany({
+            ...opts,
+            where: {
+              organizationOid: null,
+              accessLevel: 'global',
+              status: d.statuses ? { in: d.statuses } : 'active',
+              type: 'user_facing',
+              OR: search
+                ? [
+                    { id: { contains: search, mode: 'insensitive' } },
+                    { clientId: { contains: search, mode: 'insensitive' } },
+                    { name: { contains: search, mode: 'insensitive' } },
+                    { description: { contains: search, mode: 'insensitive' } }
+                  ]
+                : undefined
             },
             include
           })

--- a/src/backend/modules/machine-access/test/oauthApplication.test.ts
+++ b/src/backend/modules/machine-access/test/oauthApplication.test.ts
@@ -1,3 +1,4 @@
+import { ServiceError } from '@lowerdeck/error';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let { machineAccessCreateMock, machineAccessUpdateMock, mockDb } = vi.hoisted(() => ({
@@ -174,6 +175,56 @@ describe('oauthApplicationService', () => {
     expect(result.scopedInstallation?.oid).toBe('oauth-installation-oid');
   });
 
+  it('creates an oauth app with local http redirect uris', async () => {
+    await oauthApplicationService.createOAuthApplication({
+      organization: baseOrg,
+      performedBy: baseActor,
+      context: baseContext,
+      input: {
+        type: 'server_side',
+        accessLevel: 'organization',
+        name: 'Server App',
+        redirectUris: [
+          'http://localhost:3000/callback',
+          'http://127.0.0.1:3000/callback',
+          'http://[::1]:3000/callback'
+        ],
+        scopes: ['organization:read']
+      }
+    });
+
+    expect(mockDb.oAuthApplication.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          redirectUris: [
+            'http://localhost:3000/callback',
+            'http://127.0.0.1:3000/callback',
+            'http://[::1]:3000/callback'
+          ]
+        })
+      })
+    );
+  });
+
+  it('rejects creating an oauth app with a non-local http redirect uri', async () => {
+    await expect(
+      oauthApplicationService.createOAuthApplication({
+        organization: baseOrg,
+        performedBy: baseActor,
+        context: baseContext,
+        input: {
+          type: 'server_side',
+          accessLevel: 'organization',
+          name: 'Server App',
+          redirectUris: ['http://example.com/callback'],
+          scopes: ['organization:read']
+        }
+      })
+    ).rejects.toThrow(ServiceError);
+
+    expect(mockDb.oAuthApplication.create).not.toHaveBeenCalled();
+  });
+
   it('updates server-side scopes and syncs them to installation and machine access', async () => {
     await oauthApplicationService.updateOAuthApplication({
       oauthApplication: {
@@ -210,6 +261,60 @@ describe('oauthApplicationService', () => {
         scopes: ['organization:write']
       }
     });
+  });
+
+  it('updates an oauth app with local http redirect uris', async () => {
+    await oauthApplicationService.updateOAuthApplication({
+      oauthApplication: {
+        oid: 'oauth-app-oid',
+        type: 'server_side',
+        status: 'active',
+        accessLevel: 'organization'
+      } as any,
+      organization: baseOrg,
+      performedBy: baseActor,
+      context: baseContext,
+      input: {
+        redirectUris: [
+          'http://localhost:3000/callback',
+          'http://127.0.0.1:3000/callback',
+          'http://[::1]:3000/callback'
+        ]
+      }
+    });
+
+    expect(mockDb.oAuthApplication.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          redirectUris: [
+            'http://localhost:3000/callback',
+            'http://127.0.0.1:3000/callback',
+            'http://[::1]:3000/callback'
+          ]
+        })
+      })
+    );
+  });
+
+  it('rejects updating an oauth app with a non-local http redirect uri', async () => {
+    await expect(
+      oauthApplicationService.updateOAuthApplication({
+        oauthApplication: {
+          oid: 'oauth-app-oid',
+          type: 'server_side',
+          status: 'active',
+          accessLevel: 'organization'
+        } as any,
+        organization: baseOrg,
+        performedBy: baseActor,
+        context: baseContext,
+        input: {
+          redirectUris: ['http://example.com/callback']
+        }
+      })
+    ).rejects.toThrow(ServiceError);
+
+    expect(mockDb.oAuthApplication.update).not.toHaveBeenCalled();
   });
 
   it('archives app by revoking authorizations and installations', async () => {

--- a/src/backend/modules/machine-access/test/oauthApplication.test.ts
+++ b/src/backend/modules/machine-access/test/oauthApplication.test.ts
@@ -225,6 +225,40 @@ describe('oauthApplicationService', () => {
     expect(mockDb.oAuthApplication.create).not.toHaveBeenCalled();
   });
 
+  it('creates a global user-facing oauth app without an organization or scoped installation', async () => {
+    mockDb.oAuthApplication.create.mockImplementationOnce(async ({ data }: any) => ({
+      oid: 'oauth-app-oid',
+      ...data,
+      clientSecrets: [],
+      organization: null,
+      serverSideMachineAccess: null,
+      scopedInstallation: null
+    }));
+
+    let result = await oauthApplicationService.createGlobalUserFacingOAuthApplication({
+      input: {
+        name: 'Global App',
+        redirectUris: ['https://example.com/callback'],
+        scopes: ['organization:read']
+      }
+    });
+
+    expect(machineAccessCreateMock).not.toHaveBeenCalled();
+    expect(mockDb.oAuthInstallation.create).not.toHaveBeenCalled();
+    expect(mockDb.oAuthApplication.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: 'user_facing',
+          accessLevel: 'global',
+          organizationOid: null,
+          scopedInstallationOid: null,
+          serverSideMachineAccessOid: null
+        })
+      })
+    );
+    expect(result.accessLevel).toBe('global');
+  });
+
   it('updates server-side scopes and syncs them to installation and machine access', async () => {
     await oauthApplicationService.updateOAuthApplication({
       oauthApplication: {
@@ -317,6 +351,68 @@ describe('oauthApplicationService', () => {
     expect(mockDb.oAuthApplication.update).not.toHaveBeenCalled();
   });
 
+  it('updates a global user-facing oauth app', async () => {
+    mockDb.oAuthApplication.update.mockImplementationOnce(async ({ data }: any) => ({
+      oid: 'oauth-app-oid',
+      id: 'oauth-app-id',
+      status: 'active',
+      type: 'user_facing',
+      accessLevel: 'global',
+      organization: null,
+      serverSideMachineAccess: null,
+      scopedInstallation: null,
+      clientSecrets: [],
+      ...data
+    }));
+
+    let result = await oauthApplicationService.updateGlobalUserFacingOAuthApplication({
+      oauthApplication: {
+        oid: 'oauth-app-oid',
+        type: 'user_facing',
+        status: 'active',
+        accessLevel: 'global',
+        isImportedFromOtherInstance: false
+      } as any,
+      input: {
+        name: 'Global App 2',
+        redirectUris: ['https://example.com/callback'],
+        scopes: ['organization:write']
+      }
+    });
+
+    expect(machineAccessUpdateMock).not.toHaveBeenCalled();
+    expect(mockDb.oAuthInstallation.update).not.toHaveBeenCalled();
+    expect(mockDb.oAuthApplication.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: 'Global App 2',
+          redirectUris: ['https://example.com/callback'],
+          scopes: ['organization:write']
+        })
+      })
+    );
+    expect(result.name).toBe('Global App 2');
+  });
+
+  it('rejects updating an imported global oauth app', async () => {
+    await expect(
+      oauthApplicationService.updateGlobalUserFacingOAuthApplication({
+        oauthApplication: {
+          oid: 'oauth-app-oid',
+          type: 'user_facing',
+          status: 'active',
+          accessLevel: 'global',
+          isImportedFromOtherInstance: true
+        } as any,
+        input: {
+          name: 'Imported App'
+        }
+      })
+    ).rejects.toThrow(ServiceError);
+
+    expect(mockDb.oAuthApplication.update).not.toHaveBeenCalled();
+  });
+
   it('archives app by revoking authorizations and installations', async () => {
     let result = await oauthApplicationService.archiveOAuthApplication({
       oauthApplication: {
@@ -330,6 +426,29 @@ describe('oauthApplicationService', () => {
     });
 
     expect(mockDb.oAuthAuthorization.updateMany).toHaveBeenCalled();
+    expect(mockDb.oAuthInstallation.updateMany).toHaveBeenCalled();
+    expect(result.status).toBe('archived');
+  });
+
+  it('archives a global user-facing oauth app', async () => {
+    let result = await oauthApplicationService.archiveGlobalUserFacingOAuthApplication({
+      oauthApplication: {
+        oid: 'oauth-app-oid',
+        type: 'user_facing',
+        status: 'active',
+        accessLevel: 'global',
+        isImportedFromOtherInstance: false
+      } as any
+    });
+
+    expect(mockDb.oAuthAuthorization.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          oauthApplicationOid: 'oauth-app-oid',
+          status: 'active'
+        })
+      })
+    );
     expect(mockDb.oAuthInstallation.updateMany).toHaveBeenCalled();
     expect(result.status).toBe('archived');
   });

--- a/src/backend/modules/machine-access/test/oauthUrls.test.ts
+++ b/src/backend/modules/machine-access/test/oauthUrls.test.ts
@@ -1,0 +1,73 @@
+import { ServiceError } from '@lowerdeck/error';
+import { describe, expect, it } from 'vitest';
+import { urlsMatch, validateRedirectUri, validateUri } from '../src/lib/oauthUrls';
+
+describe('oauthUrls', () => {
+  describe('validateUri', () => {
+    it('allows https uris', () => {
+      expect(() => validateUri('https://example.com/oauth/callback')).not.toThrow();
+    });
+
+    it.each([
+      'http://localhost:3000/oauth/callback',
+      'http://127.0.0.1:3000/oauth/callback',
+      'http://[::1]:3000/oauth/callback'
+    ])('allows local http uri %s', uri => {
+      expect(() => validateUri(uri)).not.toThrow();
+    });
+
+    it('rejects non-local http uris', () => {
+      expect(() => validateUri('http://example.com/oauth/callback')).toThrow(ServiceError);
+    });
+
+    it('rejects invalid uris', () => {
+      expect(() => validateUri('not a url')).toThrow(ServiceError);
+    });
+
+    it('rejects uris with username or password', () => {
+      expect(() => validateUri('https://user:password@example.com/oauth/callback')).toThrow(
+        ServiceError
+      );
+    });
+  });
+
+  describe('urlsMatch', () => {
+    it('matches protocol, hostname, port, and pathname', () => {
+      expect(
+        urlsMatch(
+          'http://localhost:3000/oauth/callback?registered=1',
+          'http://localhost:3000/oauth/callback?requested=1'
+        )
+      ).toBe(true);
+    });
+
+    it('rejects protocol mismatches', () => {
+      expect(
+        urlsMatch(
+          'https://localhost:3000/oauth/callback',
+          'http://localhost:3000/oauth/callback'
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('validateRedirectUri', () => {
+    it('allows redirect uris that match a registered uri', () => {
+      expect(() =>
+        validateRedirectUri({
+          redirectUri: 'http://localhost:3000/oauth/callback',
+          allowedRedirectUris: ['http://localhost:3000/oauth/callback']
+        })
+      ).not.toThrow();
+    });
+
+    it('rejects redirect uris that do not match a registered uri', () => {
+      expect(() =>
+        validateRedirectUri({
+          redirectUri: 'http://localhost:3000/oauth/other',
+          allowedRedirectUris: ['http://localhost:3000/oauth/callback']
+        })
+      ).toThrow(ServiceError);
+    });
+  });
+});

--- a/src/frontend/apps/dashboard/src/components/table/components/index.tsx
+++ b/src/frontend/apps/dashboard/src/components/table/components/index.tsx
@@ -731,11 +731,13 @@ export let TableComponent = reactMemo(
                                 <Menu
                                   items={[
                                     ...(to ? [{ id: '$$open$$', label: 'Open' }] : []),
-                                    ...(props.rowActions ?? []).map(action => ({
-                                      id: action.id,
-                                      label: action.label,
-                                      disabled: action.disabled?.(row)
-                                    }))
+                                    ...(props.rowActions ?? [])
+                                      .filter(action => !action.hidden?.(row))
+                                      .map(action => ({
+                                        id: action.id,
+                                        label: action.label,
+                                        disabled: action.disabled?.(row)
+                                      }))
                                   ]}
                                   onItemClick={id => {
                                     if (id == '$$open$$') return navigate(to!);

--- a/src/frontend/apps/dashboard/src/components/table/type.ts
+++ b/src/frontend/apps/dashboard/src/components/table/type.ts
@@ -46,6 +46,7 @@ export type TableActions<Item, HooksState> = {
 export type TableItemAction<Item, Actions extends TableActions<any, any>> = {
   id: string;
   label: string;
+  hidden?: (row: Item) => boolean;
   icon: React.ReactNode;
   disabled?: (row: Item) => boolean;
   action: keyof Actions;

--- a/src/frontend/apps/dashboard/src/slices/product/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/index.tsx
@@ -97,24 +97,9 @@ let ProviderDeploymentConfigsPage = dynamicPage(() =>
     c => c.ProviderDeploymentConfigsPage
   )
 );
-let ProviderDeploymentConfigVaultsPage = dynamicPage(() =>
-  import('./pages/(deployments)/provider-deployment/config-vaults').then(
-    c => c.ProviderDeploymentConfigVaultsPage
-  )
-);
-let ProviderDeploymentAuthMethodsPage = dynamicPage(() =>
-  import('./pages/(deployments)/provider-deployment/auth-methods').then(
-    c => c.ProviderDeploymentAuthMethodsPage
-  )
-);
 let ProviderDeploymentAuthConfigsPage = dynamicPage(() =>
   import('./pages/(deployments)/provider-deployment/auth-configs').then(
     c => c.ProviderDeploymentAuthConfigsPage
-  )
-);
-let ProviderDeploymentAuthCredentialsPage = dynamicPage(() =>
-  import('./pages/(deployments)/provider-deployment/auth-credentials').then(
-    c => c.ProviderDeploymentAuthCredentialsPage
   )
 );
 let ProviderDeploymentSettingsPage = dynamicPage(() =>
@@ -1398,20 +1383,8 @@ export let productInfrastructureSlice = createSlice([
                 element: <ProviderDeploymentConfigsPage />
               },
               {
-                path: 'config-vaults',
-                element: <ProviderDeploymentConfigVaultsPage />
-              },
-              {
-                path: 'auth-methods',
-                element: <ProviderDeploymentAuthMethodsPage />
-              },
-              {
                 path: 'auth-configs',
                 element: <ProviderDeploymentAuthConfigsPage />
-              },
-              {
-                path: 'auth-credentials',
-                element: <ProviderDeploymentAuthCredentialsPage />
               },
               {
                 path: 'settings',

--- a/src/frontend/apps/dashboard/src/slices/product/lib/jsonSchema.ts
+++ b/src/frontend/apps/dashboard/src/slices/product/lib/jsonSchema.ts
@@ -1,4 +1,4 @@
-import { JSONSchema7 } from 'json-schema';
+import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 
 export type JsonSchemaEnvelope = {
   type: 'json_schema';
@@ -38,6 +38,98 @@ export let getJsonSchemaObject = (
   if (!schema || typeof schema !== 'object') return null;
   if (schema.type && schema.type !== 'object') return null;
   return schema as JsonSchemaObject;
+};
+
+let isJsonSchemaObjectDefinition = (
+  value: JSONSchema7Definition
+): value is JSONSchema7 => typeof value === 'object' && value !== null;
+
+let cloneJsonSchemaDefault = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(cloneJsonSchemaDefault);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, cloneJsonSchemaDefault(entry)])
+    );
+  }
+
+  return value;
+};
+
+let inferJsonSchemaDefault = (
+  schema: JSONSchema7,
+  forceObjectPresence = false
+): { hasValue: boolean; value: unknown } => {
+  if (schema.default !== undefined) {
+    return { hasValue: true, value: cloneJsonSchemaDefault(schema.default) };
+  }
+
+  if (schema.type !== 'object' && !schema.properties) {
+    return { hasValue: false, value: undefined };
+  }
+
+  let required = schema.required ?? [];
+  let value: Record<string, unknown> = {};
+
+  for (let [key, property] of Object.entries(schema.properties ?? {})) {
+    if (!isJsonSchemaObjectDefinition(property)) continue;
+
+    let inferred = inferJsonSchemaDefault(property, required.includes(key));
+    if (inferred.hasValue) value[key] = inferred.value;
+  }
+
+  if (Object.keys(value).length === 0 && !forceObjectPresence) {
+    return { hasValue: false, value: undefined };
+  }
+
+  return { hasValue: true, value };
+};
+
+let areJsonSchemaRequiredFieldsDefaultSatisfied = (schema: JSONSchema7): boolean => {
+  if (schema.default !== undefined) return true;
+  if (schema.type !== 'object' && !schema.properties) return false;
+
+  let properties = schema.properties ?? {};
+
+  for (let requiredKey of schema.required ?? []) {
+    let property = properties[requiredKey];
+    if (!property || !isJsonSchemaObjectDefinition(property)) return false;
+    if (property.default !== undefined) continue;
+
+    if (
+      (property.type === 'object' || property.properties) &&
+      areJsonSchemaRequiredFieldsDefaultSatisfied(property)
+    ) {
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
+};
+
+export let getJsonSchemaDefaultObject = (
+  value: JsonSchemaEnvelope | Record<string, unknown> | null | undefined
+): Record<string, unknown> => {
+  let schema = getJsonSchemaObject(value);
+  if (!schema) return {};
+
+  let inferred = inferJsonSchemaDefault(schema, true);
+
+  if (inferred.value && typeof inferred.value === 'object' && !Array.isArray(inferred.value)) {
+    return inferred.value as Record<string, unknown>;
+  }
+
+  return {};
+};
+
+export let areJsonSchemaRequiredFieldsDefaulted = (
+  value: JsonSchemaEnvelope | Record<string, unknown> | null | undefined
+) => {
+  let schema = getJsonSchemaObject(value);
+  if (!schema) return true;
+
+  return areJsonSchemaRequiredFieldsDefaultSatisfied(schema);
 };
 
 export let hasJsonSchemaProperties = (

--- a/src/frontend/apps/dashboard/src/slices/product/lib/providerCreationCapabilities.ts
+++ b/src/frontend/apps/dashboard/src/slices/product/lib/providerCreationCapabilities.ts
@@ -5,7 +5,13 @@ import {
   useProviderDeployment,
   useProviderDeploymentConfigSchema
 } from '@metorial/state';
-import { getJsonSchemaObject, hasJsonSchemaProperties, hasRequiredJsonSchemaFields } from './jsonSchema';
+import {
+  areJsonSchemaRequiredFieldsDefaulted,
+  getJsonSchemaDefaultObject,
+  getJsonSchemaObject,
+  hasJsonSchemaProperties,
+  hasRequiredJsonSchemaFields
+} from './jsonSchema';
 import { getProviderOAuthAutoRegistrationEnabled } from './providerOAuthAutoRegistration';
 
 let getAuthMethodOrderRank = (type: string | null | undefined) => {
@@ -58,12 +64,14 @@ export let getProviderConfigSchemaCapabilities = (d: {
   let hasSchemaObject = !!schemaObject;
   let hasSchemaFields = hasJsonSchemaProperties(d.schemaValue);
   let hasRequiredFields = hasRequiredJsonSchemaFields(d.schemaValue);
+  let requiredFieldsHaveDefaults = areJsonSchemaRequiredFieldsDefaulted(d.schemaValue);
+  let defaultConfigValue = getJsonSchemaDefaultObject(d.schemaValue);
   let hasExplicitEmptySchema = Boolean(
     schemaObject && !hasSchemaFields && schemaObject.additionalProperties === false
   );
   let canCreateConfig = hasSchemaFields || hasExplicitEmptySchema || d.hasVaults;
   let canCreateConfigVault = hasSchemaFields || hasExplicitEmptySchema;
-  let canAutoCreateEmptyConfig = !hasRequiredFields;
+  let canAutoCreateEmptyConfig = !hasRequiredFields || requiredFieldsHaveDefaults;
   let isLoading = !!d.isLoading;
   let configDisabledReason = isLoading
     ? 'Loading configuration options...'
@@ -81,6 +89,8 @@ export let getProviderConfigSchemaCapabilities = (d: {
     hasSchemaObject,
     hasSchemaFields,
     hasRequiredFields,
+    requiredFieldsHaveDefaults,
+    defaultConfigValue,
     hasExplicitEmptySchema,
     hasVaults: d.hasVaults,
     isLoading,

--- a/src/frontend/apps/dashboard/src/slices/product/lib/providerDocs.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/lib/providerDocs.tsx
@@ -1,0 +1,105 @@
+import { theme } from '@metorial/ui';
+import React from 'react';
+import styled from 'styled-components';
+
+export type ProviderDocReference = {
+  type?: string | null;
+  name: string;
+  url: string;
+};
+
+type ProviderListingDocs = {
+  provider?: ProviderDocReference[] | null;
+  config?: ProviderDocReference[] | null;
+  auth_methods?:
+    | {
+        key?: string | null;
+        name?: string | null;
+        type?: string | null;
+        docs?: ProviderDocReference[] | null;
+      }[]
+    | null;
+};
+
+type AuthMethodDocTarget = {
+  key?: string | null;
+  name?: string | null;
+  type?: string | null;
+};
+
+let DocsLink = styled.a`
+  display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
+  color: ${theme.colors.gray600};
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.2;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  white-space: nowrap;
+
+  &:hover {
+    color: ${theme.colors.gray900};
+  }
+`;
+
+let getDocs = (providerListing: unknown): ProviderListingDocs | null => {
+  let docs = (providerListing as any)?.docs;
+  if (!docs || typeof docs !== 'object') return null;
+  return docs as ProviderListingDocs;
+};
+
+let getFirstDoc = (docs: ProviderDocReference[] | null | undefined) =>
+  (docs ?? []).find(doc => !!doc?.url) ?? null;
+
+let matchesAuthMethod = (
+  docMethod: AuthMethodDocTarget,
+  authMethod?: AuthMethodDocTarget | null
+) => {
+  if (!authMethod) return false;
+
+  if (docMethod.key && authMethod.key && docMethod.key === authMethod.key) return true;
+  if (docMethod.name && authMethod.name && docMethod.name === authMethod.name) return true;
+  if (docMethod.type && authMethod.type && docMethod.type === authMethod.type) return true;
+
+  return false;
+};
+
+export let getProviderDoc = (providerListing: unknown) =>
+  getFirstDoc(getDocs(providerListing)?.provider);
+
+export let getConfigDoc = (providerListing: unknown) =>
+  getFirstDoc(getDocs(providerListing)?.config);
+
+export let getAuthMethodDoc = (
+  providerListing: unknown,
+  authMethod?: AuthMethodDocTarget | null
+) => {
+  let docs = getDocs(providerListing);
+  let authMethodDocs = docs?.auth_methods ?? [];
+  let exactMatch = authMethodDocs.find(docMethod => matchesAuthMethod(docMethod, authMethod));
+
+  return (
+    getFirstDoc(exactMatch?.docs) ?? getFirstDoc(authMethodDocs.flatMap(m => m.docs ?? []))
+  );
+};
+
+export let getScopeDoc = (providerListing: unknown, authMethod?: AuthMethodDocTarget | null) =>
+  getAuthMethodDoc(providerListing, authMethod) ?? getProviderDoc(providerListing);
+
+export let ProviderDocsLink = ({
+  doc,
+  children
+}: {
+  doc?: ProviderDocReference | null;
+  children?: React.ReactNode;
+}) => {
+  if (!doc?.url) return null;
+
+  return (
+    <DocsLink href={doc.url} target="_blank" rel="noopener noreferrer">
+      {children ?? doc.name}
+    </DocsLink>
+  );
+};

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(callbacks)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(callbacks)/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -70,7 +70,9 @@ export let CallbackLayout = () => {
             ]}
           />
 
-          <Outlet />
+          <InitialLoadBoundary>
+            <Outlet />
+          </InitialLoadBoundary>
         </>
       ))}
     </ContentLayout>

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/components/scopePicker.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/components/scopePicker.tsx
@@ -1,5 +1,7 @@
-import { Checkbox, Flex, OptionToggle, Text, theme } from '@metorial/ui';
+import { Checkbox, Flex, InputLabel, OptionToggle, Text, theme } from '@metorial/ui';
+import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
+import styled from 'styled-components';
 
 type ScopePermissionMode = 'allow' | 'reject' | 'mixed';
 type ScopeSectionId = 'read' | 'write' | 'dangerous';
@@ -10,6 +12,39 @@ export type ScopePickerScope = {
   name?: string | null;
   description?: string | null;
 };
+
+let ScopeFieldHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+  margin-bottom: 5px;
+
+  ${InputLabel} {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 0;
+  }
+`;
+
+let ScopeFieldHelp = styled.div`
+  min-width: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+let ScopeFieldBox = styled.div`
+  width: 100%;
+  min-width: 0;
+  overflow: auto;
+  border: 1px solid ${theme.colors.gray300};
+  border-radius: 10px;
+  padding: 10px 12px;
+`;
 
 let dangerousScopeKeywords = [
   'admin',
@@ -56,12 +91,14 @@ export let ScopePicker = ({
   scopes,
   selectedScopes,
   onSelectedScopesChange,
-  disabled
+  disabled,
+  flushScrollPadding = true
 }: {
   scopes: ScopePickerScope[];
   selectedScopes: string[];
   onSelectedScopesChange: (scopes: string[]) => void;
   disabled?: boolean;
+  flushScrollPadding?: boolean;
 }) => {
   let [sectionModeOverrides, setSectionModeOverrides] = useState<
     Partial<Record<ScopeSectionId, ScopePermissionMode>>
@@ -145,8 +182,8 @@ export let ScopePicker = ({
   return (
     <div
       style={{
-        marginRight: -20,
-        paddingRight: 20
+        marginRight: flushScrollPadding ? -20 : 0,
+        paddingRight: flushScrollPadding ? 20 : 0
       }}
     >
       <Flex direction="column" gap={12}>
@@ -219,6 +256,31 @@ export let ScopePicker = ({
             </div>
           ))}
       </Flex>
+    </div>
+  );
+};
+
+export let ScopePickerField = ({
+  label = 'Scopes',
+  help,
+  maxHeight = 260,
+  ...props
+}: {
+  label?: ReactNode;
+  help?: ReactNode;
+  maxHeight?: number | string;
+} & Omit<Parameters<typeof ScopePicker>[0], 'flushScrollPadding'>) => {
+  if (props.scopes.length === 0) return null;
+
+  return (
+    <div>
+      <ScopeFieldHeader>
+        <InputLabel>{label}</InputLabel>
+        {help && <ScopeFieldHelp>{help}</ScopeFieldHelp>}
+      </ScopeFieldHeader>
+      <ScopeFieldBox style={{ maxHeight }}>
+        <ScopePicker {...props} flushScrollPadding={false} />
+      </ScopeFieldBox>
     </div>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/settings.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/settings.tsx
@@ -4,12 +4,14 @@ import {
   useCurrentInstance,
   useProvider,
   useProviderAuthCredential,
-  useProviderAuthMethods
+  useProviderAuthMethods,
+  useProviderListing
 } from '@metorial/state';
 import { Button, Callout, Input, Spacer } from '@metorial/ui';
 import { Box } from '@metorial/ui-product';
 import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { getScopeDoc, ProviderDocsLink } from '../../../lib/providerDocs';
 import { DeleteResourceDangerZone } from '../../../scenes/deleteResourceDangerZone';
 import { ScopePicker } from './components/scopePicker';
 
@@ -20,16 +22,19 @@ export let ProviderAuthCredentialSettingsPage = () => {
   let { providerAuthCredentialsId } = useParams();
   let credential = useProviderAuthCredential(instance.data?.id, providerAuthCredentialsId);
   let provider = useProvider(instance.data?.id, credential.data?.providerId);
+  let providerListing = useProviderListing(instance.data?.id, credential.data?.providerId);
   let versionId = provider.data?.currentVersion?.id;
   let authMethods = useProviderAuthMethods(
     instance.data?.id,
     versionId ? { providerVersionId: versionId } : null
   );
 
-  let availableScopes = useMemo(() => {
-    let oauthMethod = (authMethods.data?.items ?? []).find(m => m.type === 'oauth');
-    return oauthMethod?.scopes ?? [];
-  }, [authMethods.data?.items]);
+  let oauthMethod = useMemo(
+    () => (authMethods.data?.items ?? []).find(m => m.type === 'oauth'),
+    [authMethods.data?.items]
+  );
+  let availableScopes = oauthMethod?.scopes ?? [];
+  let scopeDoc = getScopeDoc(providerListing.data, oauthMethod);
 
   let [selectedScopes, setSelectedScopes] = useState<string[] | null>(null);
 
@@ -103,6 +108,7 @@ export let ProviderAuthCredentialSettingsPage = () => {
           <Box
             title="Scopes"
             description="Select which OAuth scopes this credential should request."
+            rightActions={<ProviderDocsLink doc={scopeDoc}>Scope docs</ProviderDocsLink>}
           >
             <ScopePicker
               scopes={availableScopes}

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/actor/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/actor/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -73,68 +73,70 @@ export let IdentityActorLayout = () => {
         ]}
       />
 
-      {renderWithLoader({ instance, organization, project, actor })(
-        ({ instance, organization, project, actor }) => (
-          <>
-            <LinkTabs
-              current={location.pathname}
-              links={[
-                {
-                  label: 'Overview',
-                  to: Paths.instance.identity.actor(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    actor.data.id
-                  )
-                },
-                {
-                  label: 'Operations',
-                  to: Paths.instance.identity.actor(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    actor.data.id,
-                    'operations'
-                  )
-                },
-                {
-                  label: 'Connections',
-                  to: Paths.instance.identity.actor(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    actor.data.id,
-                    'connections'
-                  )
-                },
-                {
-                  label: 'Delegations',
-                  to: Paths.instance.identity.actor(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    actor.data.id,
-                    'delegations'
-                  )
-                },
-                {
-                  label: 'Settings',
-                  to: Paths.instance.identity.actor(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    actor.data.id,
-                    'settings'
-                  )
-                }
-              ]}
-            />
+      <InitialLoadBoundary>
+        {renderWithLoader({ instance, organization, project, actor })(
+          ({ instance, organization, project, actor }) => (
+            <>
+              <LinkTabs
+                current={location.pathname}
+                links={[
+                  {
+                    label: 'Overview',
+                    to: Paths.instance.identity.actor(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      actor.data.id
+                    )
+                  },
+                  {
+                    label: 'Operations',
+                    to: Paths.instance.identity.actor(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      actor.data.id,
+                      'operations'
+                    )
+                  },
+                  {
+                    label: 'Connections',
+                    to: Paths.instance.identity.actor(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      actor.data.id,
+                      'connections'
+                    )
+                  },
+                  {
+                    label: 'Delegations',
+                    to: Paths.instance.identity.actor(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      actor.data.id,
+                      'delegations'
+                    )
+                  },
+                  {
+                    label: 'Settings',
+                    to: Paths.instance.identity.actor(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      actor.data.id,
+                      'settings'
+                    )
+                  }
+                ]}
+              />
 
-            <Outlet />
-          </>
-        )
-      )}
+              <Outlet />
+            </>
+          )
+        )}
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/agent/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/agent/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -44,58 +44,60 @@ export let AgentLayout = () => {
         ]}
       />
 
-      {renderWithLoader({ instance, organization, project, agent })(
-        ({ instance, organization, project, agent }) => (
-          <>
-            <LinkTabs
-              current={location.pathname}
-              links={[
-                {
-                  label: 'Overview',
-                  to: Paths.instance.identity.agent(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    agent.data.id
-                  )
-                },
-                {
-                  label: 'Operations',
-                  to: Paths.instance.identity.agent(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    agent.data.id,
-                    'operations'
-                  )
-                },
-                {
-                  label: 'Connections',
-                  to: Paths.instance.identity.agent(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    agent.data.id,
-                    'connections'
-                  )
-                },
-                {
-                  label: 'Delegations',
-                  to: Paths.instance.identity.agent(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    agent.data.id,
-                    'delegations'
-                  )
-                }
-              ]}
-            />
+      <InitialLoadBoundary>
+        {renderWithLoader({ instance, organization, project, agent })(
+          ({ instance, organization, project, agent }) => (
+            <>
+              <LinkTabs
+                current={location.pathname}
+                links={[
+                  {
+                    label: 'Overview',
+                    to: Paths.instance.identity.agent(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      agent.data.id
+                    )
+                  },
+                  {
+                    label: 'Operations',
+                    to: Paths.instance.identity.agent(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      agent.data.id,
+                      'operations'
+                    )
+                  },
+                  {
+                    label: 'Connections',
+                    to: Paths.instance.identity.agent(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      agent.data.id,
+                      'connections'
+                    )
+                  },
+                  {
+                    label: 'Delegations',
+                    to: Paths.instance.identity.agent(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      agent.data.id,
+                      'delegations'
+                    )
+                  }
+                ]}
+              />
 
-            <Outlet />
-          </>
-        )
-      )}
+              <Outlet />
+            </>
+          )
+        )}
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/consumer/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/consumer/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -44,78 +44,80 @@ export let ConsumerLayout = () => {
         ]}
       />
 
-      {renderWithLoader({ instance, organization, project, consumer })(
-        ({ instance, organization, project, consumer }) => (
-          <>
-            <LinkTabs
-              current={pathname}
-              links={[
-                {
-                  label: 'Overview',
-                  to: Paths.instance.identity.consumer(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    consumer.data.id
-                  )
-                },
-                {
-                  label: 'Operations',
-                  to: Paths.instance.identity.consumer(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    consumer.data.id,
-                    'operations'
-                  )
-                },
-                {
-                  label: 'Connections',
-                  to: Paths.instance.identity.consumer(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    consumer.data.id,
-                    'connections'
-                  )
-                },
-                {
-                  label: 'Delegations',
-                  to: Paths.instance.identity.consumer(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    consumer.data.id,
-                    'delegations'
-                  )
-                },
-                {
-                  label: 'Magic MCP Servers',
-                  to: Paths.instance.identity.consumer(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    consumer.data.id,
-                    'magic-mcp-servers'
-                  )
-                },
-                {
-                  label: 'Settings',
-                  to: Paths.instance.identity.consumer(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    consumer.data.id,
-                    'settings'
-                  )
-                }
-              ]}
-            />
+      <InitialLoadBoundary>
+        {renderWithLoader({ instance, organization, project, consumer })(
+          ({ instance, organization, project, consumer }) => (
+            <>
+              <LinkTabs
+                current={pathname}
+                links={[
+                  {
+                    label: 'Overview',
+                    to: Paths.instance.identity.consumer(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      consumer.data.id
+                    )
+                  },
+                  {
+                    label: 'Operations',
+                    to: Paths.instance.identity.consumer(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      consumer.data.id,
+                      'operations'
+                    )
+                  },
+                  {
+                    label: 'Connections',
+                    to: Paths.instance.identity.consumer(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      consumer.data.id,
+                      'connections'
+                    )
+                  },
+                  {
+                    label: 'Delegations',
+                    to: Paths.instance.identity.consumer(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      consumer.data.id,
+                      'delegations'
+                    )
+                  },
+                  {
+                    label: 'Magic MCP Servers',
+                    to: Paths.instance.identity.consumer(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      consumer.data.id,
+                      'magic-mcp-servers'
+                    )
+                  },
+                  {
+                    label: 'Settings',
+                    to: Paths.instance.identity.consumer(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      consumer.data.id,
+                      'settings'
+                    )
+                  }
+                ]}
+              />
 
-            <Outlet />
-          </>
-        )
-      )}
+              <Outlet />
+            </>
+          )
+        )}
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/consumer/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/consumer/index.tsx
@@ -8,7 +8,7 @@ import {
   useCurrentProject,
   useIdentityActors
 } from '@metorial/state';
-import { Attributes, Badge, RenderDate, Spacer, Text } from '@metorial/ui';
+import { Attributes, Avatar, Badge, RenderDate, Spacer, Text } from '@metorial/ui';
 import { Box, ID, Table } from '@metorial/ui-product';
 import { useParams } from 'react-router-dom';
 
@@ -68,7 +68,7 @@ export let ConsumerPage = () => {
 
         <Spacer size={20} />
 
-        {/* <Box
+        <Box
           title="Profiles"
           description="Profiles linked to this account across account portals."
         >
@@ -82,9 +82,18 @@ export let ConsumerPage = () => {
                       {profile.name}
                     </Text>,
                     <Text size="2">{profile.email}</Text>,
-                    <Text size="2" weight="strong">
-                      {profile.surface.name}
-                    </Text>,
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <Avatar
+                        entity={{ name: profile.surface.name }}
+                        size={26}
+                        radius={8}
+                        withInitials
+                        noTooltip
+                      />
+                      <Text size="2" weight="strong">
+                        {profile.surface.name}
+                      </Text>
+                    </div>,
                     profile.groups?.length ? (
                       <Text>{profile.groups.length} groups</Text>
                     ) : (
@@ -107,7 +116,7 @@ export let ConsumerPage = () => {
           ))}
         </Box>
 
-        <Spacer size={20} /> */}
+        <Spacer size={20} />
 
         <Box title="Agents" description="Agents that were used by this account.">
           {renderWithPagination(actors)(actors => {

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/delegation-config/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/delegation-config/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -42,9 +42,11 @@ export let IdentityDelegationConfigLayout = () => {
         ]}
       />
 
-      {renderWithLoader({ instance, organization, project, config })(() => (
-        <Outlet />
-      ))}
+      <InitialLoadBoundary>
+        {renderWithLoader({ instance, organization, project, config })(() => (
+          <Outlet />
+        ))}
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/delegation/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/delegation/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -54,9 +54,11 @@ export let IdentityDelegationLayout = () => {
         ]}
       />
 
-      {renderWithLoader({ instance, organization, project, delegation })(() => (
-        <Outlet />
-      ))}
+      <InitialLoadBoundary>
+        {renderWithLoader({ instance, organization, project, delegation })(() => (
+          <Outlet />
+        ))}
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/identity/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(identity)/identity/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -105,58 +105,60 @@ export let IdentityLayout = () => {
         ]}
       />
 
-      {renderWithLoader({ instance, organization, project, identity: _identity })(
-        ({ instance, organization, project, identity }) => (
-          <>
-            <LinkTabs
-              current={pathname}
-              links={[
-                {
-                  label: 'Overview',
-                  to: Paths.instance.identity.identity(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    identity.data.id
-                  )
-                },
-                {
-                  label: 'Delegations',
-                  to: Paths.instance.identity.identity(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    identity.data.id,
-                    'delegations'
-                  )
-                },
-                {
-                  label: 'Delegation Requests',
-                  to: Paths.instance.identity.identity(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    identity.data.id,
-                    'delegation-requests'
-                  )
-                },
-                {
-                  label: 'Settings',
-                  to: Paths.instance.identity.identity(
-                    organization.data,
-                    project.data,
-                    instance.data,
-                    identity.data.id,
-                    'settings'
-                  )
-                }
-              ]}
-            />
+      <InitialLoadBoundary>
+        {renderWithLoader({ instance, organization, project, identity: _identity })(
+          ({ instance, organization, project, identity }) => (
+            <>
+              <LinkTabs
+                current={pathname}
+                links={[
+                  {
+                    label: 'Overview',
+                    to: Paths.instance.identity.identity(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      identity.data.id
+                    )
+                  },
+                  {
+                    label: 'Delegations',
+                    to: Paths.instance.identity.identity(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      identity.data.id,
+                      'delegations'
+                    )
+                  },
+                  {
+                    label: 'Delegation Requests',
+                    to: Paths.instance.identity.identity(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      identity.data.id,
+                      'delegation-requests'
+                    )
+                  },
+                  {
+                    label: 'Settings',
+                    to: Paths.instance.identity.identity(
+                      organization.data,
+                      project.data,
+                      instance.data,
+                      identity.data.id,
+                      'settings'
+                    )
+                  }
+                ]}
+              />
 
-            <Outlet />
-          </>
-        )
-      )}
+              <Outlet />
+            </>
+          )
+        )}
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration-instance/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration-instance/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -27,8 +27,7 @@ export let IntegrationInstanceLayout = () => {
   let pathname = useLocation().pathname;
 
   let handleOpenExplorer = async () => {
-    let activeIntegrationInstanceId =
-      integrationInstance.data?.id ?? integrationInstanceId;
+    let activeIntegrationInstanceId = integrationInstance.data?.id ?? integrationInstanceId;
     if (
       isCreatingSession ||
       !instance.data ||
@@ -95,9 +94,7 @@ export let IntegrationInstanceLayout = () => {
                 size="2"
                 variant="outline"
                 onClick={handleOpenExplorer}
-                disabled={
-                  isCreatingSession || integrationInstance.data?.status !== 'active'
-                }
+                disabled={isCreatingSession || integrationInstance.data?.status !== 'active'}
                 loading={isCreatingSession}
               >
                 Open Explorer
@@ -107,26 +104,28 @@ export let IntegrationInstanceLayout = () => {
         }
       />
 
-      {renderWithLoader({ integrationInstance })(({ integrationInstance }) => (
-        <>
-          <DeletedRecordCallout status={integrationInstance.data.status} />
+      <InitialLoadBoundary>
+        {renderWithLoader({ integrationInstance })(({ integrationInstance }) => (
+          <>
+            <DeletedRecordCallout status={integrationInstance.data.status} />
 
-          <LinkTabs
-            current={pathname}
-            links={[
-              {
-                label: 'Overview',
-                to: Paths.instance.integrationInstance(...instancePathParams)
-              },
-              {
-                label: 'Settings',
-                to: Paths.instance.integrationInstance(...instancePathParams, 'settings')
-              }
-            ]}
-          />
-          <Outlet />
-        </>
-      ))}
+            <LinkTabs
+              current={pathname}
+              links={[
+                {
+                  label: 'Overview',
+                  to: Paths.instance.integrationInstance(...instancePathParams)
+                },
+                {
+                  label: 'Settings',
+                  to: Paths.instance.integrationInstance(...instancePathParams, 'settings')
+                }
+              ]}
+            />
+            <Outlet />
+          </>
+        ))}
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader, useForm } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader, useForm } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -212,29 +212,31 @@ export let IntegrationLayout = () => {
         }
       />
 
-      {renderWithLoader({ integration })(({ integration }) => (
-        <>
-          <DeletedRecordCallout status={integration.data.status} />
-          <LinkTabs
-            current={pathname}
-            links={[
-              {
-                label: 'Overview',
-                to: Paths.instance.integration(...params)
-              },
-              {
-                label: 'Instances',
-                to: Paths.instance.integration(...params, 'instances')
-              },
-              {
-                label: 'Settings',
-                to: Paths.instance.integration(...params, 'settings')
-              }
-            ]}
-          />
-          <Outlet />
-        </>
-      ))}
+      <InitialLoadBoundary>
+        {renderWithLoader({ integration })(({ integration }) => (
+          <>
+            <DeletedRecordCallout status={integration.data.status} />
+            <LinkTabs
+              current={pathname}
+              links={[
+                {
+                  label: 'Overview',
+                  to: Paths.instance.integration(...params)
+                },
+                {
+                  label: 'Instances',
+                  to: Paths.instance.integration(...params, 'instances')
+                },
+                {
+                  label: 'Settings',
+                  to: Paths.instance.integration(...params, 'settings')
+                }
+              ]}
+            />
+            <Outlet />
+          </>
+        ))}
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/alert/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/alert/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentPanelLayout, ExtraHeaderLayout } from '@metorial/layout';
 import {
@@ -161,9 +161,11 @@ export let AlertLayout = () => {
               ]
             }}
           >
-            <OutletWrapper>
-              <Outlet />
-            </OutletWrapper>
+            <InitialLoadBoundary>
+              <OutletWrapper>
+                <Outlet />
+              </OutletWrapper>
+            </InitialLoadBoundary>
           </ContentPanelLayout>
         );
       })}

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/monitor/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/monitor/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentPanelLayout, ExtraHeaderLayout } from '@metorial/layout';
 import {
@@ -61,9 +61,11 @@ export let MonitorLayout = () => {
             }
           ]}
         >
-          <OutletWrapper>
-            <Outlet />
-          </OutletWrapper>
+          <InitialLoadBoundary>
+            <OutletWrapper>
+              <Outlet />
+            </OutletWrapper>
+          </InitialLoadBoundary>
         </ContentPanelLayout>
       ))}
     </ExtraHeaderLayout>

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/protoguard/filter/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/protoguard/filter/_layout.tsx
@@ -1,4 +1,8 @@
-import { PaginationSearchParamsProvider, renderWithLoader } from '@metorial/data-hooks';
+import {
+  InitialLoadBoundary,
+  PaginationSearchParamsProvider,
+  renderWithLoader
+} from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentPanelLayout, ExtraHeaderLayout } from '@metorial/layout';
 import {
@@ -94,11 +98,13 @@ export let ProtoGuardFilterLayout = () => {
               ]
             }}
           >
-            <OutletWrapper>
-              <PaginationSearchParamsProvider enabled={true}>
-                <Outlet />
-              </PaginationSearchParamsProvider>
-            </OutletWrapper>
+            <InitialLoadBoundary>
+              <OutletWrapper>
+                <PaginationSearchParamsProvider enabled={true}>
+                  <Outlet />
+                </PaginationSearchParamsProvider>
+              </OutletWrapper>
+            </InitialLoadBoundary>
           </ContentPanelLayout>
         );
       })}

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/provider-auth-error/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/provider-auth-error/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentPanelLayout, ExtraHeaderLayout } from '@metorial/layout';
 import {
@@ -148,14 +148,16 @@ export let ProviderAuthErrorLayout = () => {
           ]
         }}
       >
-        {renderWithLoader(
-          { group },
-          { spaceTop: 20 }
-        )(({ group: _group }) => (
-          <OutletWrapper>
-            <Outlet />
-          </OutletWrapper>
-        ))}
+        <InitialLoadBoundary>
+          {renderWithLoader(
+            { group },
+            { spaceTop: 20 }
+          )(({ group: _group }) => (
+            <OutletWrapper>
+              <Outlet />
+            </OutletWrapper>
+          ))}
+        </InitialLoadBoundary>
       </ContentPanelLayout>
     </ExtraHeaderLayout>
   );

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/provider-auth-event/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/provider-auth-event/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import {
   ContentPanelLayout,
@@ -105,9 +105,11 @@ export let ProviderAuthEventLayout = () => {
         }}
       >
         <ContentPanelLayoutInner>
-          {renderWithLoader({ event })(({ event: _event }) => (
-            <Outlet />
-          ))}
+          <InitialLoadBoundary>
+            {renderWithLoader({ event })(({ event: _event }) => (
+              <Outlet />
+            ))}
+          </InitialLoadBoundary>
         </ContentPanelLayoutInner>
       </ContentPanelLayout>
     </ExtraHeaderLayout>

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/provider-error/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/provider-error/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentPanelLayout, ExtraHeaderLayout } from '@metorial/layout';
 import {
@@ -122,14 +122,16 @@ export let ProviderErrorLayout = () => {
           ]
         }}
       >
-        {renderWithLoader(
-          { error },
-          { spaceTop: 20 }
-        )(({ error }) => (
-          <OutletWrapper>
-            <Outlet />
-          </OutletWrapper>
-        ))}
+        <InitialLoadBoundary>
+          {renderWithLoader(
+            { error },
+            { spaceTop: 20 }
+          )(({ error }) => (
+            <OutletWrapper>
+              <Outlet />
+            </OutletWrapper>
+          ))}
+        </InitialLoadBoundary>
       </ContentPanelLayout>
     </ExtraHeaderLayout>
   );

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/provider-run/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/provider-run/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import {
   ContentPanelLayout,
@@ -119,9 +119,11 @@ export let ProviderRunLayout = () => {
         }}
       >
         <ContentPanelLayoutInner>
-          {renderWithLoader({ run })(({ run: _run }) => (
-            <Outlet />
-          ))}
+          <InitialLoadBoundary>
+            {renderWithLoader({ run })(({ run: _run }) => (
+              <Outlet />
+            ))}
+          </InitialLoadBoundary>
         </ContentPanelLayoutInner>
       </ContentPanelLayout>
     </ExtraHeaderLayout>

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/provider-session/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/provider-session/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentPanelLayout, ExtraHeaderLayout } from '@metorial/layout';
 import {
@@ -46,11 +46,7 @@ export let ProviderSessionLayout = () => {
     <ExtraHeaderLayout
       header={
         <Link
-          to={Paths.instance.providerSessions(
-            organization.data,
-            project.data,
-            instance.data
-          )}
+          to={Paths.instance.providerSessions(organization.data, project.data, instance.data)}
         >
           <Button size="2" variant="outline" iconLeft={<RiArrowLeftSLine />}>
             Back to all sessions
@@ -95,14 +91,16 @@ export let ProviderSessionLayout = () => {
           ]
         }}
       >
-        {renderWithLoader(
-          { session },
-          { spaceTop: 20 }
-        )(({ session }) => (
-          <OutletWrapper>
-            <Outlet />
-          </OutletWrapper>
-        ))}
+        <InitialLoadBoundary>
+          {renderWithLoader(
+            { session },
+            { spaceTop: 20 }
+          )(({ session }) => (
+            <OutletWrapper>
+              <Outlet />
+            </OutletWrapper>
+          ))}
+        </InitialLoadBoundary>
       </ContentPanelLayout>
     </ExtraHeaderLayout>
   );

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(network)/firewall/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(network)/firewall/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -28,7 +28,11 @@ export let NetworkFirewallPageLayout = () => {
             pagination={[
               {
                 label: 'Firewalls',
-                href: Paths.instance.networkFirewalls(organization.data, project.data, instance.data)
+                href: Paths.instance.networkFirewalls(
+                  organization.data,
+                  project.data,
+                  instance.data
+                )
               },
               {
                 label: firewall.data.name,
@@ -67,7 +71,9 @@ export let NetworkFirewallPageLayout = () => {
             ]}
           />
 
-          <Outlet />
+          <InitialLoadBoundary>
+            <Outlet />
+          </InitialLoadBoundary>
         </>
       ))}
     </ContentLayout>

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(session)/session-template/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(session)/session-template/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -105,27 +105,29 @@ export let SessionTemplateLayout = () => {
         }
       />
 
-      {renderWithLoader({ template })(({ template }) => (
-        <>
-          <DeletedRecordCallout status={template.data?.status} />
+      <InitialLoadBoundary>
+        {renderWithLoader({ template })(({ template }) => (
+          <>
+            <DeletedRecordCallout status={template.data?.status} />
 
-          <LinkTabs
-            current={pathname}
-            links={[
-              {
-                label: 'Overview',
-                to: Paths.instance.sessionTemplate(...templatePathParams)
-              },
-              {
-                label: 'Settings',
-                to: Paths.instance.sessionTemplate(...templatePathParams, 'settings')
-              }
-            ]}
-          />
+            <LinkTabs
+              current={pathname}
+              links={[
+                {
+                  label: 'Overview',
+                  to: Paths.instance.sessionTemplate(...templatePathParams)
+                },
+                {
+                  label: 'Settings',
+                  to: Paths.instance.sessionTemplate(...templatePathParams, 'settings')
+                }
+              ]}
+            />
 
-          <Outlet />
-        </>
-      ))}
+            <Outlet />
+          </>
+        ))}
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-group/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-group/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -42,25 +42,27 @@ export let SkillGroupLayout = () => {
         ]}
       />
 
-      {renderWithLoader({ skillGroup })(() => (
-        <>
-          <LinkTabs
-            current={pathname}
-            links={[
-              {
-                label: 'Overview',
-                to: Paths.instance.skillGroup(...skillGroupPathParams)
-              },
-              {
-                label: 'Settings',
-                to: Paths.instance.skillGroup(...skillGroupPathParams, 'settings')
-              }
-            ]}
-          />
+      <InitialLoadBoundary>
+        {renderWithLoader({ skillGroup })(() => (
+          <>
+            <LinkTabs
+              current={pathname}
+              links={[
+                {
+                  label: 'Overview',
+                  to: Paths.instance.skillGroup(...skillGroupPathParams)
+                },
+                {
+                  label: 'Settings',
+                  to: Paths.instance.skillGroup(...skillGroupPathParams, 'settings')
+                }
+              ]}
+            />
 
-          <Outlet />
-        </>
-      ))}
+            <Outlet />
+          </>
+        ))}
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-marketplace/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-marketplace/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -107,57 +107,59 @@ export let SkillMarketplaceLayout = () => {
         }
       />
 
-      {renderWithLoader({ marketplace })(() => (
-        <>
-          <LinkTabs
-            current={pathname}
-            links={[
-              {
-                label: 'Overview',
-                to: Paths.instance.skillMarketplace(...marketplacePathParams)
-              },
-              {
-                label: 'Preview',
-                to: Paths.instance.skillMarketplace(...marketplacePathParams, 'editor')
-              },
-              {
-                label: 'Syncs',
-                to: Paths.instance.skillMarketplace(...marketplacePathParams, 'syncs')
-              },
-              {
-                label: 'Settings',
-                to: Paths.instance.skillMarketplace(...marketplacePathParams, 'settings')
-              }
-            ]}
-          />
+      <InitialLoadBoundary>
+        {renderWithLoader({ marketplace })(() => (
+          <>
+            <LinkTabs
+              current={pathname}
+              links={[
+                {
+                  label: 'Overview',
+                  to: Paths.instance.skillMarketplace(...marketplacePathParams)
+                },
+                {
+                  label: 'Preview',
+                  to: Paths.instance.skillMarketplace(...marketplacePathParams, 'editor')
+                },
+                {
+                  label: 'Syncs',
+                  to: Paths.instance.skillMarketplace(...marketplacePathParams, 'syncs')
+                },
+                {
+                  label: 'Settings',
+                  to: Paths.instance.skillMarketplace(...marketplacePathParams, 'settings')
+                }
+              ]}
+            />
 
-          {marketplace.data?.syncStatus !== 'synced' && (
-            <>
-              <Callout color="blue">
-                <span>
-                  <strong>Upcoming changes:</strong> Plugins or skills linked to this
-                  marketplace have changed. Metorial is processing these changes and updating
-                  the marketplace.
-                </span>
-                {marketplace.data?.syncStatus === 'pending' && (
-                  <Button
-                    size="2"
-                    loading={syncMarketplace.isLoading}
-                    onClick={() => syncMarketplace.mutate({})}
-                    style={{ marginLeft: 16 }}
-                  >
-                    Sync Now
-                  </Button>
-                )}
-              </Callout>
+            {marketplace.data?.syncStatus !== 'synced' && (
+              <>
+                <Callout color="blue">
+                  <span>
+                    <strong>Upcoming changes:</strong> Plugins or skills linked to this
+                    marketplace have changed. Metorial is processing these changes and updating
+                    the marketplace.
+                  </span>
+                  {marketplace.data?.syncStatus === 'pending' && (
+                    <Button
+                      size="2"
+                      loading={syncMarketplace.isLoading}
+                      onClick={() => syncMarketplace.mutate({})}
+                      style={{ marginLeft: 16 }}
+                    >
+                      Sync Now
+                    </Button>
+                  )}
+                </Callout>
 
-              <Spacer height={20} />
-            </>
-          )}
+                <Spacer height={20} />
+              </>
+            )}
 
-          <Outlet />
-        </>
-      ))}
+            <Outlet />
+          </>
+        ))}
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-plugin/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-plugin/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -103,57 +103,59 @@ export let SkillPluginLayout = () => {
         }
       />
 
-      {renderWithLoader({ plugin })(() => (
-        <>
-          <LinkTabs
-            current={pathname}
-            links={[
-              {
-                label: 'Overview',
-                to: Paths.instance.skillPlugin(...pluginPathParams)
-              },
-              {
-                label: 'Preview',
-                to: Paths.instance.skillPlugin(...pluginPathParams, 'editor')
-              },
-              {
-                label: 'Syncs',
-                to: Paths.instance.skillPlugin(...pluginPathParams, 'syncs')
-              },
-              {
-                label: 'Settings',
-                to: Paths.instance.skillPlugin(...pluginPathParams, 'settings')
-              }
-            ]}
-          />
+      <InitialLoadBoundary>
+        {renderWithLoader({ plugin })(() => (
+          <>
+            <LinkTabs
+              current={pathname}
+              links={[
+                {
+                  label: 'Overview',
+                  to: Paths.instance.skillPlugin(...pluginPathParams)
+                },
+                {
+                  label: 'Preview',
+                  to: Paths.instance.skillPlugin(...pluginPathParams, 'editor')
+                },
+                {
+                  label: 'Syncs',
+                  to: Paths.instance.skillPlugin(...pluginPathParams, 'syncs')
+                },
+                {
+                  label: 'Settings',
+                  to: Paths.instance.skillPlugin(...pluginPathParams, 'settings')
+                }
+              ]}
+            />
 
-          {plugin.data?.syncStatus !== 'synced' && (
-            <>
-              <Callout color="blue">
-                <span>
-                  <strong>Upcoming changes:</strong> Skills or configurations linked to this
-                  plugin have changed. Metorial is processing these changes and updating the
-                  plugin.
-                </span>
-                {plugin.data?.syncStatus === 'pending' && (
-                  <Button
-                    size="2"
-                    loading={syncPlugin.isLoading}
-                    onClick={() => syncPlugin.mutate({})}
-                    style={{ marginLeft: 16 }}
-                  >
-                    Sync Now
-                  </Button>
-                )}
-              </Callout>
+            {plugin.data?.syncStatus !== 'synced' && (
+              <>
+                <Callout color="blue">
+                  <span>
+                    <strong>Upcoming changes:</strong> Skills or configurations linked to this
+                    plugin have changed. Metorial is processing these changes and updating the
+                    plugin.
+                  </span>
+                  {plugin.data?.syncStatus === 'pending' && (
+                    <Button
+                      size="2"
+                      loading={syncPlugin.isLoading}
+                      onClick={() => syncPlugin.mutate({})}
+                      style={{ marginLeft: 16 }}
+                    >
+                      Sync Now
+                    </Button>
+                  )}
+                </Callout>
 
-              <Spacer height={20} />
-            </>
-          )}
+                <Spacer height={20} />
+              </>
+            )}
 
-          <Outlet />
-        </>
-      ))}
+            <Outlet />
+          </>
+        ))}
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-template/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-template/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -81,25 +81,27 @@ export let SkillTemplateLayout = () => {
         }
       />
 
-      {renderWithLoader({ skillTemplate })(() => (
-        <>
-          <LinkTabs
-            current={pathname}
-            links={[
-              {
-                label: 'Overview',
-                to: Paths.instance.skillTemplate(...skillTemplatePathParams)
-              },
-              {
-                label: 'Settings',
-                to: Paths.instance.skillTemplate(...skillTemplatePathParams, 'settings')
-              }
-            ]}
-          />
+      <InitialLoadBoundary>
+        {renderWithLoader({ skillTemplate })(() => (
+          <>
+            <LinkTabs
+              current={pathname}
+              links={[
+                {
+                  label: 'Overview',
+                  to: Paths.instance.skillTemplate(...skillTemplatePathParams)
+                },
+                {
+                  label: 'Settings',
+                  to: Paths.instance.skillTemplate(...skillTemplatePathParams, 'settings')
+                }
+              ]}
+            />
 
-          <Outlet />
-        </>
-      ))}
+            <Outlet />
+          </>
+        ))}
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(skills)/skill/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -131,33 +131,33 @@ export let SkillLayout = () => {
         }
       />
 
-      {renderWithLoader({ skill })(() => (
-        <>
-          <LinkTabs
-            current={pathname}
-            links={[
-              {
-                label: 'Overview',
-                to: Paths.instance.skill(...skillPathParams)
-              },
-              {
-                label: 'Participants',
-                to: `${Paths.instance.skill(...skillPathParams)}/participants`
-              },
-              {
-                label: 'Versions',
-                to: `${Paths.instance.skill(...skillPathParams)}/versions`
-              },
-              {
-                label: 'Settings',
-                to: `${Paths.instance.skill(...skillPathParams)}/settings`
-              }
-            ]}
-          />
+      <LinkTabs
+        current={pathname}
+        links={[
+          {
+            label: 'Overview',
+            to: Paths.instance.skill(...skillPathParams)
+          },
+          {
+            label: 'Participants',
+            to: `${Paths.instance.skill(...skillPathParams)}/participants`
+          },
+          {
+            label: 'Versions',
+            to: `${Paths.instance.skill(...skillPathParams)}/versions`
+          },
+          {
+            label: 'Settings',
+            to: `${Paths.instance.skill(...skillPathParams)}/settings`
+          }
+        ]}
+      />
 
+      <InitialLoadBoundary>
+        {renderWithLoader({ skill })(() => (
           <Outlet />
-        </>
-      ))}
+        ))}
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/developer/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/developer/index.tsx
@@ -12,7 +12,7 @@ export let ProjectDeveloperPage = () => {
         <>
           <ApiKeysScene
             header={{
-              title: 'Developer',
+              title: 'API Keys',
               description: 'Manage your API keys and applications.'
             }}
             filter={{

--- a/src/frontend/apps/dashboard/src/slices/product/pages/explorer/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/explorer/index.tsx
@@ -50,7 +50,8 @@ type ProviderSelection =
 
 let Wrapper = styled.div`
   display: flex;
-  height: calc(100vh - 78px);
+  height: 100%;
+  min-height: 0;
 `;
 
 let Aside = styled(motion.aside)`

--- a/src/frontend/apps/dashboard/src/slices/product/pages/explorer/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/explorer/index.tsx
@@ -7,10 +7,12 @@ import { renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import {
   useCreateProviderDeployment,
+  useCreateProviderConfig,
   useCreateSession,
   useCurrentInstance,
   useProvider,
   useProviderConfigs,
+  useProviderConfigSchemaTarget,
   useProviderConfigVaults,
   useProviderDeployment,
   useProviderDeployments,
@@ -39,6 +41,7 @@ import {
   emptyConfigurationSelection,
   type ConfigurationSelection
 } from '../../lib/configSelection';
+import { getProviderConfigSchemaCapabilities } from '../../lib/providerCreationCapabilities';
 import { ProviderSearch } from '../../scenes/providers/search';
 import { ProviderSetupSections } from '../../scenes/sessionTemplates/addProviderPanelFlow';
 import { SessionTracingScene } from '../../scenes/sessionTracing';
@@ -182,6 +185,7 @@ export let ExplorerPage = () => {
 
   let instance = useCurrentInstance();
   let createSession = useCreateSession(instance.data?.id);
+  let createProviderConfig = useCreateProviderConfig();
 
   useEffect(() => {
     if (sessionIdParam) setSessionId(sessionIdParam);
@@ -354,6 +358,20 @@ export let ExplorerPage = () => {
   let providerConfigVaults = useProviderConfigVaults(instance.data?.id, {
     providerDeploymentId: providerDeploymentId ?? undefined
   });
+  let providerSupportsConfig = activeProvider.data?.type.config.status == 'enabled';
+  let providerConfigSchema = useProviderConfigSchemaTarget(
+    instance.data?.id,
+    providerDeploymentId
+      ? { providerDeploymentId }
+      : activeProviderId
+        ? { providerId: activeProviderId }
+        : null
+  );
+  let configCapabilities = getProviderConfigSchemaCapabilities({
+    schemaValue: providerConfigSchema.data?.schema,
+    hasVaults: (providerConfigVaults.data?.items ?? []).length > 0,
+    isLoading: providerSupportsConfig ? providerConfigSchema.isLoading : false
+  });
   let createMutation = useCreateProviderDeployment();
 
   useEffect(() => {
@@ -482,7 +500,16 @@ export let ExplorerPage = () => {
     setSearch
   ]);
 
-  let requiresProviderConfig = activeProvider.data?.type.config.status == 'enabled';
+  let canAutoCreateProviderConfig =
+    !!providerSupportsConfig &&
+    !configCapabilities.isLoading &&
+    configCapabilities.canAutoCreateEmptyConfig;
+  let showConfigSection =
+    !!providerSupportsConfig &&
+    (configCapabilities.hasSchemaFields || !canAutoCreateProviderConfig);
+  let configRequirement: 'required' | 'optional' =
+    providerSupportsConfig && !canAutoCreateProviderConfig ? 'required' : 'optional';
+  let requiresProviderConfig = providerSupportsConfig && !canAutoCreateProviderConfig;
   let requiresAuthConfig = activeProvider.data?.type.auth.status == 'enabled';
   let isResolvingProviderDeployment =
     !!providerIdToResolve &&
@@ -493,6 +520,57 @@ export let ExplorerPage = () => {
       createMutation.isPending ||
       resolvingProviderIdRef.current === providerIdToResolve);
 
+  let createSessionWithSelectedSetup = useCallback(
+    async (deploymentId: string, options?: { name?: string }) => {
+      let providerConfigId =
+        selectedConfiguration.kind === 'config' ? selectedConfiguration.id : undefined;
+      let providerConfigVaultId =
+        selectedConfiguration.kind === 'vault' ? selectedConfiguration.id : undefined;
+
+      if (
+        !providerConfigId &&
+        !providerConfigVaultId &&
+        canAutoCreateProviderConfig &&
+        activeProviderId &&
+        instance.data
+      ) {
+        setIsCreatingSession(true);
+        let [config] = await createProviderConfig.mutate({
+          instanceId: instance.data.id,
+          providerId: activeProviderId,
+          providerDeploymentId: deploymentId,
+          name: `${activeProvider.data?.name ?? provider.data?.name ?? 'Provider'} Config`,
+          value: configCapabilities.defaultConfigValue
+        });
+
+        providerConfigId = config?.id;
+        if (!providerConfigId) {
+          setIsCreatingSession(false);
+          return;
+        }
+      }
+
+      await createSessionForDeployment(deploymentId, {
+        name: options?.name,
+        providerConfigId,
+        providerConfigVaultId,
+        providerAuthConfigId: selectedAuthConfigId || undefined
+      });
+    },
+    [
+      activeProvider.data?.name,
+      activeProviderId,
+      canAutoCreateProviderConfig,
+      configCapabilities.defaultConfigValue,
+      createProviderConfig,
+      createSessionForDeployment,
+      instance.data,
+      provider.data?.name,
+      selectedAuthConfigId,
+      selectedConfiguration
+    ]
+  );
+
   useEffect(() => {
     if (
       providerDeploymentId &&
@@ -500,10 +578,10 @@ export let ExplorerPage = () => {
       !isCreatingSession &&
       !!activeProvider.data &&
       !activeProvider.isLoading &&
-      !requiresProviderConfig &&
+      !showConfigSection &&
       !requiresAuthConfig
     ) {
-      createSessionForDeployment(providerDeploymentId, {
+      createSessionWithSelectedSetup(providerDeploymentId, {
         name: `Explorer Session - ${new Date().toLocaleString()}`
       });
     }
@@ -513,9 +591,9 @@ export let ExplorerPage = () => {
     isCreatingSession,
     activeProvider.data,
     activeProvider.isLoading,
-    requiresProviderConfig,
+    showConfigSection,
     requiresAuthConfig,
-    createSessionForDeployment
+    createSessionWithSelectedSetup
   ]);
 
   let renderSetupPanel = () => {
@@ -570,6 +648,8 @@ export let ExplorerPage = () => {
             selectedAuthConfigId={selectedAuthConfigId}
             onSelectedAuthConfigIdChange={setSelectedAuthConfigId}
             showToolFilters={false}
+            showConfigSection={showConfigSection}
+            configRequirement={configRequirement}
             configError={
               providerConfigs.error || providerConfigVaults.error ? (
                 <Text size="2" color="red500">
@@ -580,9 +660,14 @@ export let ExplorerPage = () => {
               ) : null
             }
             emptyState={null}
-            supplementaryContent={<createSession.RenderError />}
+            supplementaryContent={
+              <>
+                <createProviderConfig.RenderError />
+                <createSession.RenderError />
+              </>
+            }
             footer={
-              (requiresProviderConfig || requiresAuthConfig) && (
+              (showConfigSection || requiresAuthConfig) && (
                 <Flex gap={10}>
                   <Button
                     type="button"
@@ -590,18 +675,8 @@ export let ExplorerPage = () => {
                     onClick={() => {
                       if (!canOpenExplorer) return;
 
-                      createSessionForDeployment(providerDeploymentId, {
-                        name: `Explorer Session - ${new Date().toLocaleString()}`,
-
-                        providerConfigId:
-                          selectedConfiguration.kind === 'config'
-                            ? selectedConfiguration.id
-                            : undefined,
-                        providerConfigVaultId:
-                          selectedConfiguration.kind === 'vault'
-                            ? selectedConfiguration.id
-                            : undefined,
-                        providerAuthConfigId: selectedAuthConfigId || undefined
+                      createSessionWithSelectedSetup(providerDeploymentId, {
+                        name: `Explorer Session - ${new Date().toLocaleString()}`
                       });
                     }}
                     loading={isCreatingSession}

--- a/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/(list)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/(list)/_layout.tsx
@@ -1,4 +1,4 @@
-import { PaginationSearchParamsProvider } from '@metorial/data-hooks';
+import { InitialLoadBoundary, PaginationSearchParamsProvider } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -80,9 +80,11 @@ export let MagicMcpListLayout = () => {
         ]}
       />
 
-      <PaginationSearchParamsProvider enabled={true}>
-        <Outlet />
-      </PaginationSearchParamsProvider>
+      <InitialLoadBoundary>
+        <PaginationSearchParamsProvider enabled={true}>
+          <Outlet />
+        </PaginationSearchParamsProvider>
+      </InitialLoadBoundary>
     </ContentLayout>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/connection/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/connection/_layout.tsx
@@ -1,3 +1,4 @@
+import { InitialLoadBoundary } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -118,7 +119,9 @@ export let MagicMcpConnectionLayout = () => {
                   }
                 ]}
               >
-                <Outlet />
+                <InitialLoadBoundary>
+                  <Outlet />
+                </InitialLoadBoundary>
               </AttributesLayout>
             </>
           );

--- a/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/group/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/group/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -65,7 +65,9 @@ export let MagicMcpGroupLayout = () => {
               ]}
             />
 
-            <Outlet />
+            <InitialLoadBoundary>
+              <Outlet />
+            </InitialLoadBoundary>
           </>
         );
       })}

--- a/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/_layout.tsx
@@ -1,4 +1,4 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -178,7 +178,9 @@ export let MagicMcpServerLayout = () => {
               ]}
             />
 
-            <Outlet />
+            <InitialLoadBoundary>
+              <Outlet />
+            </InitialLoadBoundary>
           </>
         );
       })}

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/auth-methods.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/auth-methods.tsx
@@ -33,19 +33,6 @@ export let ProviderAuthMethodsPage = () => {
                 <Text size="2" weight="strong">
                   {method.name}
                 </Text>
-                <Text
-                  size="2"
-                  color="gray600"
-                  style={{
-                    display: 'block',
-                    maxWidth: '100%',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis'
-                  }}
-                >
-                  {description}
-                </Text>
               </Flex>,
               <Flex gap={6} style={{ alignItems: 'center', flexWrap: 'wrap' }}>
                 <Badge color={getProviderAuthMethodTypeColor(method.type)} size="1">

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/index.tsx
@@ -111,19 +111,6 @@ export let ProviderToolsPage = () => {
                 <Text size="2" weight="strong">
                   {tool.name}
                 </Text>
-                <Text
-                  size="2"
-                  color="gray600"
-                  style={{
-                    display: 'block',
-                    maxWidth: '100%',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis'
-                  }}
-                >
-                  {description}
-                </Text>
               </Flex>,
               <Flex gap={6} style={{ alignItems: 'center', flexWrap: 'wrap' }}>
                 {modeBadges.length > 0 ? (

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/triggers.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/triggers.tsx
@@ -131,19 +131,6 @@ export let ProviderTriggersPage = () => {
                 <Text size="2" weight="strong">
                   {trigger.name}
                 </Text>
-                <Text
-                  size="2"
-                  color="gray600"
-                  style={{
-                    display: 'block',
-                    maxWidth: '100%',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis'
-                  }}
-                >
-                  {description}
-                </Text>
               </Flex>,
               <Badge color={invocationBadge.color} size="1">
                 {invocationBadge.label}

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/_layout.tsx
@@ -3,7 +3,7 @@ import type {
   DashboardInstanceProvidersGetOutput,
   DashboardInstanceProvidersVersionsListOutput
 } from '@metorial/dashboard-sdk';
-import { renderWithLoader } from '@metorial/data-hooks';
+import { InitialLoadBoundary, renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
 import {
@@ -194,98 +194,100 @@ export let ProviderLayout = () => {
           }
         />
 
-        {renderWithLoader({ provider })(({ provider }) => (
-          <>
-            {provider.data.access == 'tenant' ? (
-              <>
-                <Callout color="blue">
-                  <span>
-                    This provider is managed and run by your organization. View{' '}
-                    <Link
-                      to={
-                        customProvider.data
-                          ? Paths.instance.customProvider(
-                              organization.data,
-                              project.data,
-                              instance.data,
-                              customProvider.data.id
-                            )
-                          : '#'
-                      }
-                      style={{
-                        color: 'inherit',
-                        textDecoration: 'underline'
-                      }}
-                    >
-                      custom provider
-                    </Link>{' '}
-                    for details.
-                  </span>
-                </Callout>
+        <InitialLoadBoundary>
+          {renderWithLoader({ provider })(({ provider }) => (
+            <>
+              {provider.data.access == 'tenant' ? (
+                <>
+                  <Callout color="blue">
+                    <span>
+                      This provider is managed and run by your organization. View{' '}
+                      <Link
+                        to={
+                          customProvider.data
+                            ? Paths.instance.customProvider(
+                                organization.data,
+                                project.data,
+                                instance.data,
+                                customProvider.data.id
+                              )
+                            : '#'
+                        }
+                        style={{
+                          color: 'inherit',
+                          textDecoration: 'underline'
+                        }}
+                      >
+                        custom provider
+                      </Link>{' '}
+                      for details.
+                    </span>
+                  </Callout>
 
-                <Spacer height={20} />
-              </>
-            ) : (
-              <>
-                {provider.data.type.backend == 'mcp.remote' &&
-                  !listing?.attributes.isOfficial && (
+                  <Spacer height={20} />
+                </>
+              ) : (
+                <>
+                  {provider.data.type.backend == 'mcp.remote' &&
+                    !listing?.attributes.isOfficial && (
+                      <>
+                        <Callout color="blue">
+                          <span>
+                            This provider is managed and run by{' '}
+                            <strong>{listing?.provider.publisher.name}</strong>. Data you send
+                            to it will leave Metorial's platform.
+                          </span>
+                        </Callout>
+
+                        <Spacer height={20} />
+                      </>
+                    )}
+
+                  {provider.data.type.backend == 'mcp.container' && (
                     <>
                       <Callout color="blue">
                         <span>
-                          This provider is managed and run by{' '}
-                          <strong>{listing?.provider.publisher.name}</strong>. Data you send to
-                          it will leave Metorial's platform.
+                          This provider is not managed by Metorial. Make sure to verify the
+                          provider's trustworthiness. Contact{' '}
+                          <a
+                            href="https://metorial.com/support"
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            Metorial Support
+                          </a>{' '}
+                          if you have questions.
                         </span>
                       </Callout>
 
                       <Spacer height={20} />
                     </>
                   )}
+                </>
+              )}
 
-                {provider.data.type.backend == 'mcp.container' && (
-                  <>
-                    <Callout color="blue">
-                      <span>
-                        This provider is not managed by Metorial. Make sure to verify the
-                        provider's trustworthiness. Contact{' '}
-                        <a
-                          href="https://metorial.com/support"
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          Metorial Support
-                        </a>{' '}
-                        if you have questions.
-                      </span>
-                    </Callout>
+              <LinkTabs
+                current={pathname}
+                links={[
+                  {
+                    label: 'Overview',
+                    to: Paths.instance.provider(...providerPathParams)
+                  },
+                  {
+                    label: 'Tools & Capabilities',
+                    to: Paths.instance.provider(...providerPathParams, 'capabilities')
+                  },
+                  {
+                    label: 'Versions',
+                    to: Paths.instance.provider(...providerPathParams, 'versions')
+                  }
+                ]}
+              />
 
-                    <Spacer height={20} />
-                  </>
-                )}
-              </>
-            )}
-
-            <LinkTabs
-              current={pathname}
-              links={[
-                {
-                  label: 'Overview',
-                  to: Paths.instance.provider(...providerPathParams)
-                },
-                {
-                  label: 'Tools & Capabilities',
-                  to: Paths.instance.provider(...providerPathParams, 'capabilities')
-                },
-                {
-                  label: 'Versions',
-                  to: Paths.instance.provider(...providerPathParams, 'versions')
-                }
-              ]}
-            />
-
-            <Outlet />
-          </>
-        ))}
+              <Outlet />
+            </>
+          ))}
+        </InitialLoadBoundary>
       </ContentLayout>
     </ProviderVersionContext.Provider>
   );

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/index.tsx
@@ -35,7 +35,8 @@ export let ProviderOverviewPage = () => {
     {
       providerId,
       status: ['active'],
-      limit: 3
+      limit: 15,
+      order: 'desc'
     }
   );
   let magicMcpServers = useMagicMcpServers(
@@ -43,7 +44,8 @@ export let ProviderOverviewPage = () => {
     {
       providerId,
       status: ['active'],
-      limit: 3
+      limit: 15,
+      order: 'desc'
     }
   );
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/updateForm.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/customProvider/updateForm.tsx
@@ -1,4 +1,3 @@
-import { RiDeleteBinLine } from '@remixicon/react';
 import { CustomProvidersGetOutput } from '@metorial/dashboard-sdk';
 import { useForm } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
@@ -8,7 +7,8 @@ import {
   useCustomProvider,
   useCustomProviderEnv
 } from '@metorial/state';
-import { Button, Group, Input, Select, Spacer, Text, theme, toast } from '@metorial/ui';
+import { Button, Group, Input, Select, Spacer, Text, toast } from '@metorial/ui';
+import { RiDeleteBinLine } from '@remixicon/react';
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -39,13 +39,6 @@ let EnvRow = styled.div`
   grid-template-columns: minmax(180px, 1fr) minmax(220px, 1.2fr) auto;
   gap: 12px;
   align-items: end;
-`;
-
-let EnvActions = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
 `;
 
 let SaveActions = styled.div`
@@ -87,8 +80,10 @@ export let CustomProviderUpdateForm = (p: { customProvider?: CustomProvidersGetO
   let customProvider = useCustomProvider(instance.data?.id, p.customProvider?.id);
   let navigate = useNavigate();
   let updateMutator = customProvider.useUpdateMutator();
-  let createVersionMutator = useCreateCustomProviderVersion();
+  let remoteVersionMutator = useCreateCustomProviderVersion();
+  let envVersionMutator = useCreateCustomProviderVersion();
   let customProviderData = customProvider.data ?? p.customProvider;
+  let isArchived = customProviderData?.status === 'archived';
   let isFunctionProvider = customProviderData?.type === 'function';
   let customProviderEnv = useCustomProviderEnv(
     isFunctionProvider ? instance.data?.id : null,
@@ -99,98 +94,136 @@ export let CustomProviderUpdateForm = (p: { customProvider?: CustomProvidersGetO
   let currentRemoteProtocol =
     customProviderData?.draft?.remoteMcpServer?.transport ??
     getCustomProviderRemoteProtocolFromUrl(currentRemoteUrl);
-  let isSaving = updateMutator.isLoading || createVersionMutator.isLoading;
-  let isSaved = !isSaving && (updateMutator.isSuccess || createVersionMutator.isSuccess);
   let currentEnv = useMemo(
     () => normalizeEnvRecord(customProviderEnv.data?.env),
     [customProviderEnv.data?.env]
   );
   let initialEnvRows = useMemo(() => envRecordToRows(currentEnv), [currentEnv]);
 
-  let form = useForm({
+  let generalForm = useForm({
     initialValues: {
       name: customProviderData?.name ?? '',
-      description: customProviderData?.description ?? '',
+      description: customProviderData?.description ?? ''
+    },
+    updateInitialValues: true,
+    onSubmit: async values => {
+      if (!instance.data) return;
+      if (!customProviderData) return;
+      if (isArchived) return;
+
+      await updateMutator.mutate({
+        name: values.name.trim(),
+        description: values.description.trim() || undefined
+      });
+      await customProvider.refetch();
+    },
+    schema: yup =>
+      yup.object({
+        name: yup.string().trim().required('Name is required'),
+        description: yup.string()
+      })
+  });
+
+  let remoteForm = useForm({
+    initialValues: {
       remoteUrl: currentRemoteUrl,
-      remoteProtocol: currentRemoteProtocol,
+      remoteProtocol: currentRemoteProtocol
+    },
+    updateInitialValues: true,
+    onSubmit: async values => {
+      if (!instance.data) return;
+      if (!customProviderData) return;
+      if (isArchived) return;
+      if (!isExternalProvider) return;
+
+      let nextRemoteUrl = values.remoteUrl.trim();
+      let nextRemoteProtocol: 'sse' | 'streamable_http' =
+        values.remoteProtocol == 'sse' ? 'sse' : 'streamable_http';
+      let didUpdateRemote =
+        nextRemoteUrl !== currentRemoteUrl || nextRemoteProtocol !== currentRemoteProtocol;
+      if (!didUpdateRemote) return;
+
+      let [version] = await remoteVersionMutator.mutate({
+        instanceId: instance.data.id,
+        customProviderId: customProviderData.id,
+        from: {
+          type: 'remote',
+          remoteUrl: nextRemoteUrl,
+          protocol: nextRemoteProtocol
+        }
+      });
+
+      if (version) {
+        toast.success('External provider update started');
+        await customProvider.refetch();
+
+        navigate(
+          Paths.instance.customProvider(
+            instance.data.organization,
+            instance.data.project,
+            instance.data,
+            customProviderData.id,
+            'versions',
+            { version_id: version.id }
+          ),
+          {
+            state: {
+              category: 'external'
+            }
+          }
+        );
+      }
+    },
+    schema: yup =>
+      yup.object({
+        remoteUrl: yup
+          .string()
+          .trim()
+          .url('Remote URL must be a valid URL')
+          .required('Remote URL is required'),
+        remoteProtocol: yup
+          .mixed<CustomProviderRemoteProtocol>()
+          .oneOf(['sse', 'streamable_http'])
+          .required('Transport protocol is required')
+      })
+  });
+
+  let envForm = useForm({
+    initialValues: {
       envRows: initialEnvRows
     },
     updateInitialValues: true,
     onSubmit: async values => {
       if (!instance.data) return;
       if (!customProviderData) return;
+      if (isArchived) return;
+      if (!isFunctionProvider) return;
 
-      let nextRemoteUrl = values.remoteUrl.trim();
-      let nextRemoteProtocol: 'sse' | 'streamable_http' =
-        values.remoteProtocol == 'sse' ? 'sse' : 'streamable_http';
       let nextEnv = rowsToEnvRecord(values.envRows);
-      let didUpdateRemote =
-        isExternalProvider &&
-        (nextRemoteUrl !== currentRemoteUrl || nextRemoteProtocol !== currentRemoteProtocol);
-      let didUpdateEnv =
-        isFunctionProvider && stringifyEnvRecord(nextEnv) !== stringifyEnvRecord(currentEnv);
+      let didUpdateEnv = stringifyEnvRecord(nextEnv) !== stringifyEnvRecord(currentEnv);
+      if (!didUpdateEnv) return;
 
-      await updateMutator.mutate({
-        name: values.name.trim(),
-        description: values.description.trim() || undefined
+      let [version] = await envVersionMutator.mutate({
+        instanceId: instance.data.id,
+        customProviderId: customProviderData.id,
+        from: getFunctionProviderVersionFrom(customProviderData, nextEnv)
       });
 
-      if (didUpdateRemote) {
-        let [version] = await createVersionMutator.mutate({
-          instanceId: instance.data.id,
-          customProviderId: customProviderData.id,
-          from: {
-            type: 'remote',
-            remoteUrl: values.remoteUrl.trim(),
-            protocol: nextRemoteProtocol
-          }
-        });
+      if (version) {
+        toast.success('Environment variable update started');
+        await customProvider.refetch();
+        await customProviderEnv.refetch();
 
-        if (version) {
-          toast.success('External provider update started');
-          await customProvider.refetch();
-
-          navigate(
-            Paths.instance.customProvider(
-              instance.data.organization,
-              instance.data.project,
-              instance.data,
-              customProviderData.id,
-              'versions',
-              { version_id: version.id }
-            ),
-            {
-              state: {
-                category: 'external'
-              }
-            }
-          );
-        }
-      }
-
-      if (didUpdateEnv) {
-        let [version] = await createVersionMutator.mutate({
-          instanceId: instance.data.id,
-          customProviderId: customProviderData.id,
-          from: getFunctionProviderVersionFrom(customProviderData, nextEnv)
-        });
-
-        if (version) {
-          toast.success('Environment variable update started');
-          await customProvider.refetch();
-          await customProviderEnv.refetch();
-
-          navigate(
-            Paths.instance.customProvider(
-              instance.data.organization,
-              instance.data.project,
-              instance.data,
-              customProviderData.id,
-              'versions',
-              { version_id: version.id }
-            )
-          );
-        }
+        navigate(
+          Paths.instance.customProvider(
+            instance.data.organization,
+            instance.data.project,
+            instance.data,
+            customProviderData.id,
+            'versions',
+            { version_id: version.id }
+          )
+        );
       }
     },
     schema: yup => {
@@ -211,113 +244,148 @@ export let CustomProviderUpdateForm = (p: { customProvider?: CustomProvidersGetO
           return (rows ?? []).every(row => row.key?.trim() || !row.value);
         });
 
-      return isExternalProvider
-        ? yup.object({
-            name: yup.string().trim().required('Name is required'),
-            description: yup.string(),
-            remoteUrl: isExternalProvider
-              ? yup
-                  .string()
-                  .trim()
-                  .url('Remote URL must be a valid URL')
-                  .required('Remote URL is required')
-              : yup.string(),
-            remoteProtocol: yup
-              .mixed<CustomProviderRemoteProtocol>()
-              .oneOf(['sse', 'streamable_http'])
-              .required('Transport protocol is required'),
-            envRows
-          })
-        : (yup.object({
-            name: yup.string().trim().required('Name is required'),
-            description: yup.string(),
-            remoteUrl: yup.string().optional(),
-            remoteProtocol: yup.mixed<CustomProviderRemoteProtocol>().optional(),
-            envRows
-          }) as any);
+      return yup.object({ envRows });
     }
   });
 
   let addEnvRow = () => {
-    form.setFieldValue('envRows', [
-      ...form.values.envRows,
+    envForm.setFieldValue('envRows', [
+      ...envForm.values.envRows,
       { id: `env-${Date.now()}`, key: '', value: '' }
     ]);
   };
 
   let updateEnvRow = (id: string, values: Partial<EnvVarRow>) => {
-    form.setFieldValue(
+    envForm.setFieldValue(
       'envRows',
-      form.values.envRows.map(row => (row.id === id ? { ...row, ...values } : row))
+      envForm.values.envRows.map(row => (row.id === id ? { ...row, ...values } : row))
     );
   };
 
   let removeEnvRow = (id: string) => {
-    form.setFieldValue(
+    envForm.setFieldValue(
       'envRows',
-      form.values.envRows.filter(row => row.id !== id)
+      envForm.values.envRows.filter(row => row.id !== id)
     );
   };
 
   return (
     <FormPage>
-      <form onSubmit={form.handleSubmit}>
+      <form onSubmit={generalForm.handleSubmit}>
         <Group.Wrapper>
           <Group.Header
             title="General"
             description={
               isExternalProvider
-                ? 'Update the details of your external provider. Changing the remote URL publishes a new version.'
+                ? 'Update the display details of your external provider.'
                 : 'Update the details of your custom provider.'
             }
           />
 
           <Group.Content>
-            <Input label="Name" {...form.getFieldProps('name')} />
-            <form.RenderError field="name" />
+            <Input label="Name" disabled={isArchived} {...generalForm.getFieldProps('name')} />
+            <generalForm.RenderError field="name" />
 
             <Spacer size={15} />
 
-            <Input label="Description" {...form.getFieldProps('description')} />
-            <form.RenderError field="description" />
+            <Input
+              label="Description"
+              disabled={isArchived}
+              {...generalForm.getFieldProps('description')}
+            />
+            <generalForm.RenderError field="description" />
 
-            {isExternalProvider && (
-              <>
-                <Spacer size={15} />
+            <Spacer size={15} />
 
+            <SaveActions>
+              <Button
+                size="2"
+                type="submit"
+                loading={updateMutator.isLoading}
+                success={updateMutator.isSuccess}
+                disabled={isArchived}
+              >
+                Save
+              </Button>
+            </SaveActions>
+
+            {updateMutator.error && <updateMutator.RenderError />}
+          </Group.Content>
+        </Group.Wrapper>
+      </form>
+
+      {isExternalProvider && (
+        <>
+          <form onSubmit={remoteForm.handleSubmit}>
+            <Group.Wrapper>
+              <Group.Header
+                title="Remote Provider"
+                description="Update the remote MCP endpoint. Changes publish a new provider version."
+              />
+
+              <Group.Content>
                 <Input
                   label="Remote URL"
                   description="Changing this URL publishes a new version for the external provider."
-                  {...form.getFieldProps('remoteUrl')}
+                  disabled={isArchived}
+                  {...remoteForm.getFieldProps('remoteUrl')}
                 />
-                <form.RenderError field="remoteUrl" />
+                <remoteForm.RenderError field="remoteUrl" />
 
                 <Spacer size={15} />
 
                 <Select
-                  value={String(form.values.remoteProtocol || '')}
+                  value={String(remoteForm.values.remoteProtocol || '')}
                   label="MCP Transport Protocol"
                   description="Use the protocol supported by the remote MCP provider."
+                  disabled={isArchived}
                   items={[
                     { label: 'SSE (Server-Sent Events)', id: 'sse' },
                     { label: 'Streamable HTTP', id: 'streamable_http' }
                   ]}
-                  onChange={v => form.setFieldValue('remoteProtocol', v)}
+                  onChange={v => remoteForm.setFieldValue('remoteProtocol', v)}
                 />
-                <form.RenderError field="remoteProtocol" />
-              </>
-            )}
-          </Group.Content>
-        </Group.Wrapper>
+                <remoteForm.RenderError field="remoteProtocol" />
 
-        {isFunctionProvider && (
-          <>
-            <Spacer size={15} />
+                <Spacer size={15} />
 
+                <SaveActions>
+                  <Button
+                    size="2"
+                    type="submit"
+                    loading={remoteVersionMutator.isLoading}
+                    success={remoteVersionMutator.isSuccess}
+                    disabled={isArchived}
+                  >
+                    Save
+                  </Button>
+                </SaveActions>
+
+                {remoteVersionMutator.error && <remoteVersionMutator.RenderError />}
+              </Group.Content>
+            </Group.Wrapper>
+          </form>
+        </>
+      )}
+
+      {isFunctionProvider && (
+        <>
+          <form onSubmit={envForm.handleSubmit}>
             <Group.Wrapper>
               <Group.Header
                 title="Environment Variables"
                 description="Set custom environment variables for your provider. Use configs and auth configs for sensitive and user-specific data."
+                actions={
+                  <Button
+                    size="2"
+                    variant="outline"
+                    type="button"
+                    disabled={isArchived}
+                    onClick={addEnvRow}
+                  >
+                    Add Variable
+                  </Button>
+                }
               />
 
               <Group.Content>
@@ -327,14 +395,15 @@ export let CustomProviderUpdateForm = (p: { customProvider?: CustomProvidersGetO
                   </Text>
                 ) : (
                   <>
-                    {form.values.envRows.length > 0 && (
+                    {envForm.values.envRows.length > 0 && (
                       <EnvRows>
-                        {form.values.envRows.map((row, idx) => (
+                        {envForm.values.envRows.map((row, idx) => (
                           <EnvRow key={row.id}>
                             <Input
                               label="Name"
                               hideLabel={idx !== 0}
                               placeholder="DATABASE_URL"
+                              disabled={isArchived}
                               value={row.key}
                               onChange={e => updateEnvRow(row.id, { key: e.target.value })}
                             />
@@ -344,6 +413,7 @@ export let CustomProviderUpdateForm = (p: { customProvider?: CustomProvidersGetO
                               hideLabel={idx !== 0}
                               placeholder="Enter value"
                               type="password"
+                              disabled={isArchived}
                               value={row.value}
                               onChange={e => updateEnvRow(row.id, { value: e.target.value })}
                             />
@@ -352,6 +422,7 @@ export let CustomProviderUpdateForm = (p: { customProvider?: CustomProvidersGetO
                               variant="soft"
                               color="red"
                               type="button"
+                              disabled={isArchived}
                               onClick={() => removeEnvRow(row.id)}
                               iconRight={<RiDeleteBinLine />}
                             />
@@ -360,36 +431,41 @@ export let CustomProviderUpdateForm = (p: { customProvider?: CustomProvidersGetO
                       </EnvRows>
                     )}
 
-                    <EnvActions>
-                      <Button size="2" variant="outline" type="button" onClick={addEnvRow}>
-                        Add variable
-                      </Button>
-                    </EnvActions>
+                    {envForm.values.envRows.length === 0 && (
+                      <Text size="2" color="gray600">
+                        No environment variables configured.
+                      </Text>
+                    )}
                   </>
                 )}
 
-                <form.RenderError field="envRows" />
+                <envForm.RenderError field="envRows" />
                 {customProviderEnv.error && (
                   <Text size="2" color="red600">
                     {customProviderEnv.error.message}
                   </Text>
                 )}
+
+                <Spacer size={15} />
+
+                <SaveActions>
+                  <Button
+                    size="2"
+                    type="submit"
+                    loading={envVersionMutator.isLoading}
+                    success={envVersionMutator.isSuccess}
+                    disabled={isArchived || customProviderEnv.isLoading}
+                  >
+                    Save
+                  </Button>
+                </SaveActions>
+
+                {envVersionMutator.error && <envVersionMutator.RenderError />}
               </Group.Content>
             </Group.Wrapper>
-          </>
-        )}
-
-        <Spacer size={15} />
-
-        <SaveActions>
-          <Button size="2" type="submit" loading={isSaving} success={isSaved}>
-            Save
-          </Button>
-        </SaveActions>
-
-        {updateMutator.error && <updateMutator.RenderError />}
-        {createVersionMutator.error && <createVersionMutator.RenderError />}
-      </form>
+          </form>
+        </>
+      )}
     </FormPage>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
@@ -682,7 +682,7 @@ let IntegrationProviderSetupStep = (p: {
         !isConfigSelectionComplete(values.selectedConfiguration)
       ) {
         form.setFieldTouched('selectedConfiguration', true, false);
-        form.setFieldError('selectedConfiguration', 'Select a config or config vault');
+        form.setFieldError('selectedConfiguration', 'Select a config');
         return;
       }
 
@@ -1236,7 +1236,7 @@ let IntegrationInstanceProviderPanel = (p: {
         !isConfigSelectionComplete(values.selectedConfiguration)
       ) {
         form.setFieldTouched('selectedConfiguration', true, false);
-        form.setFieldError('selectedConfiguration', 'Select a config or config vault');
+        form.setFieldError('selectedConfiguration', 'Select a config');
         return;
       }
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
@@ -39,6 +39,7 @@ import {
   emptyConfigurationSelection
 } from '../../lib/configSelection';
 import { getProviderConfigSchemaCapabilities } from '../../lib/providerCreationCapabilities';
+import { getProviderOAuthAutoRegistrationEnabled } from '../../lib/providerOAuthAutoRegistration';
 import { AuthMethodPicker } from '../providerAuthConfigs/authMethodPicker';
 import { showProviderAuthCredentialsFormModal } from '../providerAuthCredentials/modal';
 import {
@@ -123,7 +124,8 @@ let useProviderSetupVisibility = (p: {
   if (p.respectIntegrationToolFilterPolicy === false) allowToolFilters = true;
   let providerSupportsAuth = provider.data?.type.auth.status === 'enabled';
   let requiresProviderConfig =
-    providerSupportsConfig && configCapabilities.hasRequiredFields;
+    providerSupportsConfig && !configCapabilities.canAutoCreateEmptyConfig;
+  let hasEditableConfigFields = configCapabilities.hasSchemaFields;
   let isInstanceProviderPanel =
     p.inheritedConfigId !== undefined || p.instanceConfigId !== undefined;
   let satisfiedConfigId = isInstanceProviderPanel
@@ -148,7 +150,9 @@ let useProviderSetupVisibility = (p: {
   let showConfig = p.isUpdate
     ? allowCustomConfigs
     : mustRequestInstanceConfig ||
-      (allowCustomConfigs && providerSupportsConfig && !shouldAutoCreateEmptyConfig);
+      (allowCustomConfigs &&
+        providerSupportsConfig &&
+        (hasEditableConfigFields || !shouldAutoCreateEmptyConfig));
   let configRequirement: 'required' | 'optional' = isInstanceProviderPanel
     ? mustRequestInstanceConfig
       ? 'required'
@@ -164,6 +168,7 @@ let useProviderSetupVisibility = (p: {
     showAuth: (p.allowAuthConfig ?? true) && providerSupportsAuth,
     showToolFilters: allowToolFilters,
     shouldAutoCreateEmptyConfig,
+    defaultConfigValue: configCapabilities.defaultConfigValue,
     configRequirement,
     mustRequestInstanceConfig,
     providerName: getProviderName(provider.data, p.providerId ?? undefined),
@@ -362,10 +367,13 @@ let IntegrationProviderAuthSection = (p: {
   selectedAuthCredentialsId: string;
   selectedAuthCredentialsLabel?: string;
   onSelectedAuthCredentialsIdChange: (value: string) => void;
+  oauthAutoRegistrationEnabled?: boolean;
   authMethodError?: React.ReactNode;
   authCredentialsError?: React.ReactNode;
 }) => {
   let authMethodItems = p.authMethods.data?.items ?? [];
+  let showAuthCredentials =
+    p.selectedAuthMethod?.type === 'oauth' && !p.oauthAutoRegistrationEnabled;
 
   return (
     <Flex direction="column" gap={12}>
@@ -394,11 +402,16 @@ let IntegrationProviderAuthSection = (p: {
                 }))}
               />
               {p.authMethodError}
+              {p.selectedAuthMethod?.type === 'oauth' && p.oauthAutoRegistrationEnabled ? (
+                <Callout color="gray">
+                  OAuth credentials will be registered automatically for this provider.
+                </Callout>
+              ) : null}
             </Flex>
           </ConfigureSectionCard>
 
           <AnimatePresence initial={false}>
-            {p.selectedAuthMethod?.type === 'oauth' ? (
+            {showAuthCredentials ? (
               <motion.div
                 key="oauth-auth-credentials"
                 initial={{ opacity: 0, y: -8, height: 0 }}
@@ -532,6 +545,9 @@ let IntegrationProviderSetupStep = (p: {
   let effectiveShowAuth =
     visibility.showAuth &&
     (!isUpdate || (!authMethods.isLoading && (authMethods.data?.items.length ?? 0) > 0));
+  let oauthAutoRegistrationEnabled = getProviderOAuthAutoRegistrationEnabled(
+    visibility.provider.data
+  );
 
   let submitProviderSetup = async (values: IntegrationProviderFormValues) => {
     if (!instance.data) return false;
@@ -550,13 +566,16 @@ let IntegrationProviderSetupStep = (p: {
         instanceId: instance.data.id,
         providerId: p.providerId,
         name: `${visibility.providerName} Config`,
-        value: {}
+        value: visibility.defaultConfigValue
       });
       providerConfigId = config?.id;
     }
 
     let providerAuthMethodId = values.selectedAuthMethodId || undefined;
-    let providerAuthCredentialsId = values.selectedAuthCredentialsId || undefined;
+    let providerAuthCredentialsId =
+      selectedAuthMethod?.type === 'oauth' && !oauthAutoRegistrationEnabled
+        ? values.selectedAuthCredentialsId || undefined
+        : undefined;
 
     let toolFilters = getToolFilters(values);
 
@@ -647,7 +666,11 @@ let IntegrationProviderSetupStep = (p: {
           return;
         }
 
-        if (selectedAuthMethod?.type === 'oauth' && !values.selectedAuthCredentialsId) {
+        if (
+          selectedAuthMethod?.type === 'oauth' &&
+          !oauthAutoRegistrationEnabled &&
+          !values.selectedAuthCredentialsId
+        ) {
           form.setFieldTouched('selectedAuthCredentialsId', true, false);
           form.setFieldError('selectedAuthCredentialsId', 'Select auth credentials');
           return;
@@ -678,9 +701,11 @@ let IntegrationProviderSetupStep = (p: {
   let selectedAuthMethod = authMethods.data?.items.find(
     method => method.id === form.values.selectedAuthMethodId
   );
+  let requiresAuthCredentials =
+    selectedAuthMethod?.type === 'oauth' && !oauthAutoRegistrationEnabled;
   let authCredentials = useProviderAuthCredentials(
     instance.data?.id,
-    effectiveShowAuth
+    effectiveShowAuth && requiresAuthCredentials
       ? {
           providerId: p.providerId,
           ...(form.values.selectedAuthMethodId
@@ -711,13 +736,18 @@ let IntegrationProviderSetupStep = (p: {
 
   useEffect(() => {
     if (authMethods.isLoading) return;
-    if (selectedAuthMethod?.type === 'oauth') return;
+    if (selectedAuthMethod?.type === 'oauth' && !oauthAutoRegistrationEnabled) return;
     if (!form.values.selectedAuthCredentialsId) return;
 
     form.setFieldValue('selectedAuthCredentialsId', '');
     form.setFieldTouched('selectedAuthCredentialsId', false, false);
     form.setFieldError('selectedAuthCredentialsId', undefined);
-  }, [authMethods.isLoading, selectedAuthMethod?.type, form.values.selectedAuthCredentialsId]);
+  }, [
+    authMethods.isLoading,
+    oauthAutoRegistrationEnabled,
+    selectedAuthMethod?.type,
+    form.values.selectedAuthCredentialsId
+  ]);
 
   useEffect(() => {
     if (!effectiveShowAuth) return;
@@ -747,7 +777,7 @@ let IntegrationProviderSetupStep = (p: {
       isConfigSelectionComplete(form.values.selectedConfiguration)) &&
     (!effectiveShowAuth ||
       (Boolean(form.values.selectedAuthMethodId) &&
-        (selectedAuthMethod?.type !== 'oauth' || Boolean(form.values.selectedAuthCredentialsId))));
+        (!requiresAuthCredentials || Boolean(form.values.selectedAuthCredentialsId))));
   let isSaving =
     createDeployment.isPending ||
     createConfig.isLoading ||
@@ -835,6 +865,7 @@ let IntegrationProviderSetupStep = (p: {
               form.setFieldTouched('selectedAuthCredentialsId', false, false);
               form.setFieldError('selectedAuthCredentialsId', undefined);
             }}
+            oauthAutoRegistrationEnabled={oauthAutoRegistrationEnabled}
             authMethodError={<form.RenderError field="selectedAuthMethodId" />}
             authCredentialsError={<form.RenderError field="selectedAuthCredentialsId" />}
           />
@@ -1158,7 +1189,7 @@ let IntegrationInstanceProviderPanel = (p: {
         instanceId: instance.data.id,
         providerId,
         name: `${visibility.providerName} Config`,
-        value: {}
+        value: visibility.defaultConfigValue
       });
       providerConfigId = config?.id;
     }

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createManualModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createManualModal.tsx
@@ -6,10 +6,12 @@ export let ProviderAuthConfigManualCreateContent = (p: {
   providerDeploymentId?: string;
   providerId?: string;
   initialAuthMethodId: string;
+  defaultAuthConfigName?: string;
   close: () => void;
-  onCreate?: (authConfig: { id: string }) => void;
+  onCreate?: (authConfig: { id: string; name?: string | null }) => void;
   onBack?: () => void;
   embedded?: boolean;
+  hideDetailsInputs?: boolean;
 }) => {
   let useFlatLayout = true;
 
@@ -33,10 +35,12 @@ export let ProviderAuthConfigManualCreateContent = (p: {
         hideAuthMethodStep
         flattenCreateStep={useFlatLayout}
         hideProviderContext={useFlatLayout}
+        defaultName={p.defaultAuthConfigName}
+        hideDetailsInputs={p.hideDetailsInputs}
         close={p.close}
         onBack={p.onBack}
         onCreate={authConfig => {
-          p.onCreate?.({ id: authConfig.id });
+          p.onCreate?.({ id: authConfig.id, name: authConfig.name });
         }}
       />
     </>

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createModal.tsx
@@ -17,6 +17,7 @@ export type ProviderAuthConfigCreateModalProps = {
   autoStartManagedCredentialSetup?: boolean;
   onCreate?: (authConfig: { id: string; name?: string | null }) => void;
   onBack?: () => void;
+  hideDetailsInputs?: boolean;
 };
 
 let ProviderAuthConfigCreateModalContent = (
@@ -183,10 +184,12 @@ export let ProviderAuthConfigCreateFlowContent = (
           providerDeploymentId={p.providerDeploymentId}
           providerId={providerId}
           initialAuthMethodId={method.id}
+          defaultAuthConfigName={p.defaultAuthConfigName}
           close={p.close}
           onBack={p.onBack}
           onCreate={p.onCreate}
           embedded={p.embedded}
+          hideDetailsInputs={p.hideDetailsInputs}
         />
       );
     }

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/form.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/form.tsx
@@ -74,6 +74,8 @@ export type ProviderAuthConfigFormProps =
       showAuthMethodStepInStepper?: boolean;
       flattenCreateStep?: boolean;
       hideProviderContext?: boolean;
+      defaultName?: string;
+      hideDetailsInputs?: boolean;
     }
   | {
       type: 'update';
@@ -129,7 +131,7 @@ export let ProviderAuthConfigForm = (
 
   let form = useForm({
     initialValues: {
-      name: '',
+      name: props.type === 'create' ? (props.defaultName ?? '') : '',
       description: '',
       authMethodId: props.type === 'create' ? (props.initialAuthMethodId ?? '') : '',
       credentialsDataJson: '{}',
@@ -142,12 +144,9 @@ export let ProviderAuthConfigForm = (
       if (!values.authMethodId) return;
 
       if (props.type === 'create' && props.flattenCreateStep && skipAuthMethodStep) {
-        form.setFieldTouched('name', true, false);
-        await form.validateField('name');
         let credentialsValid = await validateCredentialsForContinuation();
-        let nameValid = !!values.name.trim();
 
-        if (!credentialsValid || !nameValid) return;
+        if (!credentialsValid) return;
       }
 
       let parsedCredentials: Record<string, unknown> = {};
@@ -169,13 +168,16 @@ export let ProviderAuthConfigForm = (
 
       if (props.type !== 'create' || !instanceId) return;
 
+      let name = values.name.trim() || props.defaultName?.trim();
+      let description = props.hideDetailsInputs ? undefined : values.description || undefined;
+
       let [result] = await createMutation.mutate({
         instanceId,
         ...(props.providerDeploymentId
           ? { providerDeploymentId: props.providerDeploymentId }
           : {}),
-        name: values.name.trim(),
-        description: values.description || undefined,
+        ...(name ? { name } : {}),
+        ...(description ? { description } : {}),
         providerAuthMethodId: values.authMethodId,
         value: parsedCredentials
       });
@@ -188,7 +190,7 @@ export let ProviderAuthConfigForm = (
     schemaDependencies: [authMethods.data?.items, oauthAutoRegistrationEnabled],
     schema: yup =>
       yup.object({
-        name: yup.string().trim().required('Name is required'),
+        name: yup.string().trim(),
         description: yup.string().ensure(),
         authMethodId: yup.string().required('Authentication method is required'),
         credentialsData: yup.mixed<Record<string, unknown>>().defined(),
@@ -402,6 +404,7 @@ export let ProviderAuthConfigForm = (
   if (props.type === 'create') {
     let credentialsStepIndex = includeAuthMethodStep ? 1 : 0;
     let detailsStepIndex = includeAuthMethodStep ? 2 : 1;
+    let hideDetailsInputs = !!props.hideDetailsInputs;
 
     let goToCredentialsStep = async () => {
       form.setFieldTouched('authMethodId', true, false);
@@ -425,28 +428,32 @@ export let ProviderAuthConfigForm = (
 
           <form noValidate onSubmit={form.handleSubmit}>
             <FlatCreateSections>
-              <Input
-                label="Auth Config Name"
-                {...form.getFieldProps('name')}
-                description="Name this auth config so your team can identify it quickly."
-                placeholder={
-                  useOAuthAuthConfigNameHints
-                    ? 'e.g. John Doe'
-                    : 'e.g. CRM Production Connection'
-                }
-              />
-              <form.RenderError field="name" />
+              {!hideDetailsInputs ? (
+                <>
+                  <Input
+                    label="Auth Config Name"
+                    {...form.getFieldProps('name')}
+                    description="Name this auth config so your team can identify it quickly."
+                    placeholder={
+                      useOAuthAuthConfigNameHints
+                        ? 'e.g. John Doe'
+                        : 'e.g. CRM Production Connection'
+                    }
+                  />
+                  <form.RenderError field="name" />
 
-              <Spacer size={10} />
+                  <Spacer size={10} />
 
-              <Input
-                label="Auth Config Description"
-                {...authConfigDescriptionInputHints}
-                {...form.getFieldProps('description')}
-              />
-              <form.RenderError field="description" />
+                  <Input
+                    label="Auth Config Description"
+                    {...authConfigDescriptionInputHints}
+                    {...form.getFieldProps('description')}
+                  />
+                  <form.RenderError field="description" />
 
-              <Spacer size={15} />
+                  <Spacer size={15} />
+                </>
+              ) : null}
 
               <FlatCreateSectionGroup>
                 <InputLabel>Credentials</InputLabel>

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/modal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/modal.tsx
@@ -7,7 +7,8 @@ import {
   useCreateProviderAuthCredentials,
   useProvider,
   useProviderAuthMethods,
-  useProviderDeployment
+  useProviderDeployment,
+  useProviderListing
 } from '@metorial/state';
 import {
   Button,
@@ -16,12 +17,19 @@ import {
   Copy,
   Dialog,
   Input,
+  showModal,
   Spacer,
-  Text,
-  showModal
+  Text
 } from '@metorial/ui';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useProviderAuthCreationCapabilities } from '../../lib/providerCreationCapabilities';
+import {
+  getConfigDoc,
+  getProviderDoc,
+  getScopeDoc,
+  ProviderDocsLink
+} from '../../lib/providerDocs';
+import { ScopePickerField } from '../../pages/(deployments)/provider-auth-credential/components/scopePicker';
 import { ProviderContextCard } from '../providerContextCard';
 
 type AuthMethod = DashboardInstanceProvidersAuthMethodsListOutput['items'][number];
@@ -65,6 +73,17 @@ export let ProviderAuthCredentialsForm = ({
   let providerName = deployment.data?.name ?? provider.data?.name ?? providerId;
   let oauthMethodName = oauthMethod?.name ?? 'OAuth';
   let authCreation = useProviderAuthCreationCapabilities(instanceId, deploymentId, providerId);
+  let providerListing = useProviderListing(instanceId, providerId);
+  let providerDoc = getProviderDoc(providerListing.data);
+  let configDoc = getConfigDoc(providerListing.data);
+  let scopeDoc = getScopeDoc(providerListing.data, oauthMethod);
+  let availableScopes = oauthMethod?.scopes ?? [];
+  let defaultScopes = useMemo(
+    () => availableScopes.map(scope => scope.scope),
+    [availableScopes]
+  );
+  let [selectedScopes, setSelectedScopes] = useState<string[] | null>(null);
+  let effectiveScopes = selectedScopes ?? defaultScopes;
 
   let createCredentials = useCreateProviderAuthCredentials();
 
@@ -83,7 +102,7 @@ export let ProviderAuthCredentialsForm = ({
           type: 'oauth',
           clientId: values.clientId,
           clientSecret: values.clientSecret,
-          scopes: oauthMethod?.scopes?.map(scope => scope.scope) ?? []
+          scopes: effectiveScopes
         }
       });
 
@@ -99,6 +118,10 @@ export let ProviderAuthCredentialsForm = ({
         clientSecret: yup.string().required('Client Secret is required')
       })
   });
+
+  useEffect(() => {
+    setSelectedScopes(null);
+  }, [oauthMethod?.id]);
 
   if (authCreation.isLoading) {
     return (
@@ -194,6 +217,11 @@ export let ProviderAuthCredentialsForm = ({
             </Text>
             <Text size="1" color="gray600" style={{ marginBottom: 5 }}>
               You must configure this redirect URI in your OAuth app.
+              {configDoc ? (
+                <>
+                  <ProviderDocsLink doc={configDoc}>View config docs</ProviderDocsLink>
+                </>
+              ) : null}
             </Text>
             <Copy value={redirectUri} />
             <Spacer size={10} />
@@ -213,6 +241,7 @@ export let ProviderAuthCredentialsForm = ({
         <Input
           label="Client ID"
           placeholder="Enter client ID from provider"
+          help={<ProviderDocsLink doc={providerDoc}>Provider docs</ProviderDocsLink>}
           required
           {...form.getFieldProps('clientId')}
         />
@@ -228,6 +257,18 @@ export let ProviderAuthCredentialsForm = ({
           {...form.getFieldProps('clientSecret')}
         />
         <form.RenderError field="clientSecret" />
+
+        {availableScopes.length > 0 && (
+          <>
+            <Spacer size={10} />
+            <ScopePickerField
+              scopes={availableScopes}
+              selectedScopes={effectiveScopes}
+              onSelectedScopesChange={setSelectedScopes}
+              help={<ProviderDocsLink doc={scopeDoc}>Scope docs</ProviderDocsLink>}
+            />
+          </>
+        )}
 
         <createCredentials.RenderError />
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerConfigs/form.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerConfigs/form.tsx
@@ -42,6 +42,8 @@ export type ProviderConfigFormProps = {
   providerDeploymentId?: string;
   instanceId?: string;
   embedded?: boolean;
+  defaultName?: string;
+  hideDetailsInputs?: boolean;
 };
 
 export let ProviderConfigForm = (
@@ -100,11 +102,14 @@ export let ProviderConfigForm = (
       return;
     }
 
+    let name = values.name.trim() || props.defaultName?.trim();
+    let description = props.hideDetailsInputs ? undefined : values.description || undefined;
+
     if (values.sourceMode === 'vault') {
       let [result] = await createMutation.mutate({
         instanceId,
-        name: values.name.trim(),
-        description: values.description || undefined,
+        ...(name ? { name } : {}),
+        ...(description ? { description } : {}),
         providerId,
         ...(props.providerDeploymentId
           ? { providerDeploymentId: props.providerDeploymentId }
@@ -121,8 +126,8 @@ export let ProviderConfigForm = (
 
     let [result] = await createMutation.mutate({
       instanceId,
-      name: values.name.trim(),
-      description: values.description || undefined,
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
       providerId,
       ...(props.providerDeploymentId
         ? { providerDeploymentId: props.providerDeploymentId }
@@ -138,17 +143,17 @@ export let ProviderConfigForm = (
 
   let form = useForm({
     initialValues: {
-      name: '',
+      name: props.defaultName ?? '',
       description: '',
       sourceMode: '' as ConfigSourceMode,
       providerConfigVaultId: '',
-      configData: {} as Record<string, unknown>
+      configData: schemaCapabilities.defaultConfigValue
     },
     onSubmit: async () => undefined,
     schemaDependencies: [canCreateFromVault, schemaCapabilities.hasSchemaFields],
     schema: yup =>
       yup.object({
-        name: yup.string().trim().required('Name is required'),
+        name: yup.string().trim(),
         description: yup.string(),
         sourceMode: yup
           .string()
@@ -189,6 +194,18 @@ export let ProviderConfigForm = (
     }
   }, [canCreateFromVault, canCreateManualConfig, form, form.values.sourceMode]);
 
+  let defaultConfigValueKey = JSON.stringify(schemaCapabilities.defaultConfigValue);
+
+  useEffect(() => {
+    if (!canCreateManualConfig) return;
+    if (Object.keys(form.values.configData).length > 0) return;
+
+    let defaultConfigValue = schemaCapabilities.defaultConfigValue;
+    if (Object.keys(defaultConfigValue).length === 0) return;
+
+    form.setFieldValue('configData', defaultConfigValue);
+  }, [canCreateManualConfig, defaultConfigValueKey, form, form.values.configData]);
+
   if (props.providerDeploymentId && deployment.isLoading) {
     return <CenteredSpinner />;
   }
@@ -227,10 +244,6 @@ export let ProviderConfigForm = (
   let closeAction = props.onBack ?? props.close;
 
   let createConfig = async () => {
-    form.setFieldTouched('name', true, false);
-    await form.validateField('name');
-    if (form.getFieldMeta('name').error || !form.values.name.trim()) return;
-
     form.setFieldTouched('sourceMode', true, false);
     await form.validateField('sourceMode');
     if (form.getFieldMeta('sourceMode').error || !form.values.sourceMode) return;
@@ -250,6 +263,7 @@ export let ProviderConfigForm = (
     ...(canCreateFromVault ? [{ id: 'vault', label: 'Use config vault' }] : [])
   ];
   let hideSourceSelectInFlatCreate = canCreateManualConfig && !canCreateFromVault;
+  let hideDetailsInputs = !!props.hideDetailsInputs;
 
   return (
     <>
@@ -260,15 +274,19 @@ export let ProviderConfigForm = (
             void createConfig();
           }}
         >
-          <Input label="Name" {...form.getFieldProps('name')} />
-          <form.RenderError field="name" />
+          {!hideDetailsInputs ? (
+            <>
+              <Input label="Name" {...form.getFieldProps('name')} />
+              <form.RenderError field="name" />
 
-          <Spacer size={8} />
+              <Spacer size={8} />
 
-          <Input label="Description" {...form.getFieldProps('description')} />
-          <form.RenderError field="description" />
+              <Input label="Description" {...form.getFieldProps('description')} />
+              <form.RenderError field="description" />
 
-          <Spacer size={10} />
+              <Spacer size={10} />
+            </>
+          ) : null}
 
           {!hideSourceSelectInFlatCreate ? (
             <>
@@ -342,7 +360,6 @@ export let ProviderConfigForm = (
               loading={createMutation.isLoading}
               disabled={
                 !form.values.sourceMode ||
-                !form.values.name.trim() ||
                 (form.values.sourceMode === 'vault' && !form.values.providerConfigVaultId)
               }
             >

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerConfigs/selection.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerConfigs/selection.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../lib/configSelection';
 import { getProviderConfigSchemaCapabilities } from '../../lib/providerCreationCapabilities';
 import { showProviderConfigVaultFormModal } from '../providerConfigVaults/modal';
+import { ProviderConfigForm } from './form';
 import { showProviderConfigFormModal } from './modal';
 
 type ConfigItem = DashboardInstanceProviderDeploymentsConfigsListOutput['items'][number];
@@ -40,7 +41,10 @@ export let ProviderConfigurationSelection = ({
   createConfigButtonLabel,
   showExistingOptions = true,
   filterAvailableResources = false,
-  disabled = false
+  disabled = false,
+  inlineCreateConfig = false,
+  defaultConfigName,
+  hideCreateConfigDetails = false
 }: {
   instanceId: string;
   providerDeploymentId?: string;
@@ -53,6 +57,9 @@ export let ProviderConfigurationSelection = ({
   showExistingOptions?: boolean;
   filterAvailableResources?: boolean;
   disabled?: boolean;
+  inlineCreateConfig?: boolean;
+  defaultConfigName?: string;
+  hideCreateConfigDetails?: boolean;
 }) => {
   let query = filterAvailableResources
     ? {
@@ -95,9 +102,11 @@ export let ProviderConfigurationSelection = ({
   let scopeKey = providerDeploymentId ?? providerId ?? '__none__';
   let handledAutoSelectionRef = useRef<string | null>(null);
   let [createdSelection, setCreatedSelection] = useState<CreatedSelectionState | null>(null);
+  let [isCreatingInlineConfig, setIsCreatingInlineConfig] = useState(false);
 
   useEffect(() => {
     handledAutoSelectionRef.current = null;
+    setIsCreatingInlineConfig(false);
   }, [scopeKey]);
 
   useEffect(() => {
@@ -136,6 +145,14 @@ export let ProviderConfigurationSelection = ({
       : effectiveValue.kind === 'vault'
         ? (selectedVault.data?.name ?? selectedVault.data?.id)
         : undefined);
+  let handleConfigCreated = async (config: { id: string; name?: string | null }) => {
+    let label = config.name ?? config.id;
+    onChange({ kind: 'config', id: config.id });
+    setCreatedSelection({ kind: 'config', id: config.id, label });
+    setIsCreatingInlineConfig(false);
+    await Promise.resolve(configs.refetch?.());
+    onChange({ kind: 'config', id: config.id });
+  };
 
   return (
     <Flex direction="column" gap={8}>
@@ -156,6 +173,17 @@ export let ProviderConfigurationSelection = ({
             </Button>
           </Flex>
         </Callout>
+      ) : isCreatingInlineConfig ? (
+        <ProviderConfigForm
+          type="create"
+          instanceId={instanceId}
+          providerDeploymentId={providerDeploymentId}
+          providerId={providerId}
+          defaultName={defaultConfigName}
+          hideDetailsInputs={hideCreateConfigDetails}
+          close={() => setIsCreatingInlineConfig(false)}
+          onCreate={handleConfigCreated}
+        />
       ) : (
         <Flex gap={8} align="end">
           {showExistingOptions ? (
@@ -224,21 +252,20 @@ export let ProviderConfigurationSelection = ({
                 size="3"
                 iconLeft={<RiAddLine />}
                 disabled={disabled || !configCreation.canCreateConfig}
-                onClick={() =>
+                onClick={() => {
+                  if (inlineCreateConfig) {
+                    setIsCreatingInlineConfig(true);
+                    return;
+                  }
+
                   showProviderConfigFormModal({
                     type: 'create',
                     instanceId,
                     ...(providerDeploymentId ? { providerDeploymentId } : {}),
                     ...(providerId ? { providerId } : {}),
-                    onCreate: async config => {
-                      let label = config.name ?? config.id;
-                      onChange({ kind: 'config', id: config.id });
-                      setCreatedSelection({ kind: 'config', id: config.id, label });
-                      await Promise.resolve(configs.refetch?.());
-                      onChange({ kind: 'config', id: config.id });
-                    }
-                  })
-                }
+                    onCreate: handleConfigCreated
+                  });
+                }}
               >
                 {createConfigButtonLabel}
               </Button>

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/index.tsx
@@ -8,12 +8,14 @@ import {
   useProvider,
   useProviderAuthCredentials,
   useProviderAuthMethods,
-  useProviderDeployment
+  useProviderDeployment,
+  useProviderListing
 } from '@metorial/state';
 import { Button, Flex, Text } from '@metorial/ui';
 import { sortBy } from 'lodash';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Stepper } from '../../../../../components/stepper';
+import { getConfigDoc, getProviderDoc, getScopeDoc } from '../../../lib/providerDocs';
 import { getProviderOAuthAutoRegistrationEnabled } from '../../../lib/providerOAuthAutoRegistration';
 import {
   ConnectStep,
@@ -59,6 +61,7 @@ export let ProviderSetupSessionEmbed = ({
   let deployment = useProviderDeployment(instanceId, deploymentId);
   let lockedVersionId = deployment.data?.lockedVersion?.id;
   let provider = useProvider(instanceId, providerId);
+  let providerListing = useProviderListing(instanceId, providerId);
   let project = useCurrentProject();
   let projectBrand = useProjectBrand(project.data?.organization.id, project.data?.id);
   let effectiveVersionId = lockedVersionId ?? provider.data?.currentVersion?.id;
@@ -110,7 +113,8 @@ export let ProviderSetupSessionEmbed = ({
       selectedCredentialId: fixedCredentialId ?? '',
       newCredName: '',
       newCredClientId: '',
-      newCredClientSecret: ''
+      newCredClientSecret: '',
+      newCredScopes: [] as string[]
     },
     onSubmit: async () => {
       let providerAuthCredentialsId = await resolveSelectedCredentialId();
@@ -201,6 +205,11 @@ export let ProviderSetupSessionEmbed = ({
     () => (authMethods.data?.items ?? []).find(method => method.id === selectedMethodId),
     [authMethods.data?.items, selectedMethodId]
   );
+  let selectedMethodScopes = useMemo(
+    () => selectedMethod?.scopes?.map(scope => scope.scope) ?? [],
+    [selectedMethod?.scopes]
+  );
+  let selectedMethodScopeKey = selectedMethodScopes.join('\n');
 
   let providerName = deployment.data?.name ?? provider.data?.name ?? providerId;
   let oauthMethodName = selectedMethod?.name ?? 'OAuth';
@@ -210,6 +219,9 @@ export let ProviderSetupSessionEmbed = ({
   let projectBrandImageUrl = projectBrand.data?.imageUrl;
   let projectBrandName = projectBrand.data?.name ?? project.data?.name ?? 'Metorial';
   let providerImageUrl = provider.data?.publisher.imageUrl;
+  let providerDoc = getProviderDoc(providerListing.data);
+  let configDoc = getConfigDoc(providerListing.data);
+  let scopeDoc = getScopeDoc(providerListing.data, selectedMethod);
 
   let visibleAuthCredentials = sortBy(authCredentials.data?.items ?? [], [
     credential => Number(!credential.isManaged),
@@ -360,6 +372,10 @@ export let ProviderSetupSessionEmbed = ({
   };
 
   useEffect(() => {
+    void credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
+  }, [selectedMethod?.id, selectedMethodScopeKey]);
+
+  useEffect(() => {
     if (!collectAuthConfigDetails || !onAuthConfigDetailsChange) return;
 
     onAuthConfigDetailsChange({
@@ -484,7 +500,8 @@ export let ProviderSetupSessionEmbed = ({
   ]);
 
   let handleCreateCredentials = async (): Promise<string | null> => {
-    let { newCredClientId, newCredClientSecret, newCredName } = credentialsForm.values;
+    let { newCredClientId, newCredClientSecret, newCredName, newCredScopes } =
+      credentialsForm.values;
     if (!newCredName || !newCredClientId || !newCredClientSecret || !selectedMethod) return null;
 
     setError(null);
@@ -497,7 +514,7 @@ export let ProviderSetupSessionEmbed = ({
         type: 'oauth',
         clientId: newCredClientId,
         clientSecret: newCredClientSecret,
-        scopes: selectedMethod.scopes?.map(scope => scope.scope) ?? []
+        scopes: newCredScopes
       }
     });
 
@@ -514,6 +531,7 @@ export let ProviderSetupSessionEmbed = ({
     await credentialsForm.setFieldValue('newCredName', '');
     await credentialsForm.setFieldValue('newCredClientId', '');
     await credentialsForm.setFieldValue('newCredClientSecret', '');
+    await credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
 
     return result.id;
   };
@@ -529,6 +547,7 @@ export let ProviderSetupSessionEmbed = ({
     if (value === '__create_new__') {
       void credentialsForm.setFieldValue('credentialMode', 'new');
       void credentialsForm.setFieldValue('selectedCredentialId', '');
+      void credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
       return;
     }
 
@@ -877,6 +896,10 @@ export let ProviderSetupSessionEmbed = ({
     isManagedSelected,
     error,
     createCredentials,
+    selectedMethod,
+    providerDoc,
+    configDoc,
+    scopeDoc,
     showHiddenMethodStep,
     includeMethodStep,
     skipMethodStep,
@@ -899,6 +922,10 @@ export let ProviderSetupSessionEmbed = ({
     hasManagedVisibleCredentials,
     createCredentials,
     createSetupSession,
+    selectedMethod,
+    providerDoc,
+    configDoc,
+    scopeDoc,
     error,
     setupSession,
     setupWindowBlocked,

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/stepContent.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/stepContent.tsx
@@ -11,6 +11,8 @@ import {
   Text
 } from '@metorial/ui';
 import type { ReactNode } from 'react';
+import { ProviderDocsLink, type ProviderDocReference } from '../../../lib/providerDocs';
+import { ScopePickerField } from '../../../pages/(deployments)/provider-auth-credential/components/scopePicker';
 import { AuthMethodPicker } from '../../providerAuthConfigs/authMethodPicker';
 import {
   FlatConnectForm,
@@ -32,7 +34,7 @@ import {
   SummaryFieldMeta,
   SummaryFieldValue
 } from './styled';
-import type { SetupSessionState } from './types';
+import type { AuthMethod, SetupSessionState } from './types';
 
 type AnyForm = any;
 
@@ -127,7 +129,10 @@ export let AuthConfigDetailsFields = (p: {
   );
 };
 
-let RedirectUriField = (p: { redirectUri: string }) => {
+let RedirectUriField = (p: {
+  redirectUri: string;
+  configDoc?: ProviderDocReference | null;
+}) => {
   return (
     <>
       <Spacer size={12} />
@@ -136,13 +141,29 @@ let RedirectUriField = (p: { redirectUri: string }) => {
       </Text>
       <Text size="1" color="gray600" style={{ marginBottom: 5 }}>
         You must configure this redirect URI in your OAuth app.
+        {p.configDoc ? (
+          <>
+            {' '}
+            <ProviderDocsLink doc={p.configDoc}>View config docs</ProviderDocsLink>
+          </>
+        ) : null}
       </Text>
       <Copy value={p.redirectUri} />
     </>
   );
 };
 
-let NewCredentialsFields = (p: { credentialsForm: AnyForm; disabled?: boolean }) => {
+let NewCredentialsFields = (p: {
+  credentialsForm: AnyForm;
+  selectedMethod?: AuthMethod;
+  providerDoc?: ProviderDocReference | null;
+  scopeDoc?: ProviderDocReference | null;
+  disabled?: boolean;
+}) => {
+  let availableScopes = p.selectedMethod?.scopes ?? [];
+  let selectedScopes =
+    p.credentialsForm.values.newCredScopes ?? availableScopes.map(scope => scope.scope);
+
   return (
     <>
       <Spacer size={12} />
@@ -164,6 +185,7 @@ let NewCredentialsFields = (p: { credentialsForm: AnyForm; disabled?: boolean })
         disabled={p.disabled}
         onChange={e => p.credentialsForm.setFieldValue('newCredClientId', e.target.value)}
         placeholder="Enter client ID from provider"
+        help={<ProviderDocsLink doc={p.providerDoc}>Provider docs</ProviderDocsLink>}
       />
       <p.credentialsForm.RenderError field="newCredClientId" />
 
@@ -178,6 +200,21 @@ let NewCredentialsFields = (p: { credentialsForm: AnyForm; disabled?: boolean })
         type="password"
       />
       <p.credentialsForm.RenderError field="newCredClientSecret" />
+
+      {availableScopes.length > 0 && (
+        <>
+          <Spacer size={8} />
+          <ScopePickerField
+            scopes={availableScopes}
+            selectedScopes={selectedScopes}
+            onSelectedScopesChange={scopes =>
+              p.credentialsForm.setFieldValue('newCredScopes', scopes)
+            }
+            help={<ProviderDocsLink doc={p.scopeDoc}>Scope docs</ProviderDocsLink>}
+            disabled={p.disabled}
+          />
+        </>
+      )}
     </>
   );
 };
@@ -190,6 +227,10 @@ let CredentialsSelector = (p: {
   hasManagedVisibleCredentials: boolean;
   isCreatingCredentials: boolean;
   redirectUri?: string;
+  selectedMethod?: AuthMethod;
+  providerDoc?: ProviderDocReference | null;
+  configDoc?: ProviderDocReference | null;
+  scopeDoc?: ProviderDocReference | null;
   isCustomSelected: boolean;
   disableCredentialSelection?: boolean;
   disabled?: boolean;
@@ -231,11 +272,17 @@ let CredentialsSelector = (p: {
       )}
 
       {shouldShowRedirectUri && p.redirectUri && (
-        <RedirectUriField redirectUri={p.redirectUri} />
+        <RedirectUriField redirectUri={p.redirectUri} configDoc={p.configDoc} />
       )}
 
       {p.isCreatingCredentials && !p.disableCredentialSelection && (
-        <NewCredentialsFields credentialsForm={p.credentialsForm} disabled={p.disabled} />
+        <NewCredentialsFields
+          credentialsForm={p.credentialsForm}
+          selectedMethod={p.selectedMethod}
+          providerDoc={p.providerDoc}
+          scopeDoc={p.scopeDoc}
+          disabled={p.disabled}
+        />
       )}
     </>
   );
@@ -438,6 +485,10 @@ export let CredentialsSelectionStep = (p: {
   handleCredentialSelectionChange: (value: string) => void;
   hasManagedVisibleCredentials: boolean;
   redirectUri?: string;
+  selectedMethod?: AuthMethod;
+  providerDoc?: ProviderDocReference | null;
+  configDoc?: ProviderDocReference | null;
+  scopeDoc?: ProviderDocReference | null;
   isCustomSelected: boolean;
   isCreatingCredentials: boolean;
   disableCredentialSelection?: boolean;
@@ -484,6 +535,10 @@ export let CredentialsSelectionStep = (p: {
                 hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
                 isCreatingCredentials={p.isCreatingCredentials}
                 redirectUri={p.redirectUri}
+                selectedMethod={p.selectedMethod}
+                providerDoc={p.providerDoc}
+                configDoc={p.configDoc}
+                scopeDoc={p.scopeDoc}
                 isCustomSelected={p.isCustomSelected}
                 disableCredentialSelection={p.disableCredentialSelection}
               />
@@ -509,6 +564,10 @@ export let CredentialsSelectionStep = (p: {
             hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
             isCreatingCredentials={p.isCreatingCredentials}
             redirectUri={p.redirectUri}
+            selectedMethod={p.selectedMethod}
+            providerDoc={p.providerDoc}
+            configDoc={p.configDoc}
+            scopeDoc={p.scopeDoc}
             isCustomSelected={p.isCustomSelected}
             disableCredentialSelection={p.disableCredentialSelection}
           />
@@ -579,6 +638,10 @@ export let FlatOAuthConnectStep = (p: {
   hasManagedVisibleCredentials: boolean;
   createCredentials: { isPending: boolean; RenderError: () => ReactNode };
   createSetupSession: { isPending: boolean; RenderError: () => ReactNode };
+  selectedMethod?: AuthMethod;
+  providerDoc?: ProviderDocReference | null;
+  configDoc?: ProviderDocReference | null;
+  scopeDoc?: ProviderDocReference | null;
   error: string | null;
   setupSession: SetupSessionState | null;
   setupWindowBlocked: boolean;
@@ -631,6 +694,10 @@ export let FlatOAuthConnectStep = (p: {
                 handleCredentialSelectionChange={p.handleCredentialSelectionChange}
                 hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
                 redirectUri={p.redirectUri}
+                selectedMethod={p.selectedMethod}
+                providerDoc={p.providerDoc}
+                configDoc={p.configDoc}
+                scopeDoc={p.scopeDoc}
                 isCreatingCredentials={p.isCreatingCredentials}
                 isCustomSelected={p.isCustomSelected}
                 disableCredentialSelection={p.disableCredentialSelection}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
@@ -6,6 +6,7 @@ import {
   useProvider,
   useProviderAuthConfig,
   useProviderAuthConfigs,
+  useProviderConfigSchemaTarget,
   useProviderListing,
   useProviderTools
 } from '@metorial/state';
@@ -20,8 +21,11 @@ import {
   Dialog,
   Entity,
   Flex,
+  Menu,
   OptionToggle,
   Text,
+  Tooltip,
+  type ButtonSize,
   theme
 } from '@metorial/ui';
 import { RiAddLine, RiArrowDownSLine, RiCheckLine } from '@remixicon/react';
@@ -32,7 +36,18 @@ import {
   emptyConfigurationSelection,
   type ConfigurationSelection
 } from '../../lib/configSelection';
-import { ProviderAuthConfigCreateButton } from '../providerAuthConfigs/modal';
+import {
+  getProviderConfigSchemaCapabilities,
+  useProviderAuthCreationCapabilities
+} from '../../lib/providerCreationCapabilities';
+import {
+  ProviderAuthConfigCreateFlowContent,
+  showProviderAuthConfigCreateModal
+} from '../providerAuthConfigs/createModal';
+import {
+  getCreateMethodDescription,
+  isSetupFlowAuthMethod
+} from '../providerAuthConfigs/modalHelpers';
 import { ProviderConfigurationSelection } from '../providerConfigs/selection';
 import {
   ProviderCreationPanelShell,
@@ -113,6 +128,13 @@ type AddProviderPanelFlowProps = {
   onComplete: () => void;
 };
 
+let getProviderSetupGeneratedName = (providerName: string | null | undefined) => {
+  let normalizedProviderName = providerName?.trim() || 'Provider';
+  let date = new Date().toISOString().slice(0, 10);
+
+  return `${normalizedProviderName} - ${date}`;
+};
+
 export let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
   let createConfigMutation = useCreateProviderConfig();
   let createMutation = useCreateSessionTemplateProvider();
@@ -162,18 +184,19 @@ export let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
       setSubmitError(null);
       let fallbackProviderConfigId: string | undefined;
       let needsFallbackConfig =
-        !values.selectedDeploymentId &&
+        canAutoCreateEmptyConfig &&
         values.selectedConfiguration.kind === 'none' &&
-        !values.selectedAuthConfigId;
+        values.selectedProviderId;
 
       if (needsFallbackConfig) {
-        let fallbackConfigName = `${values.selectedProviderName || 'Provider'} Config`;
         let [config, configError] = await createConfigMutation.mutate({
           instanceId: p.instanceId,
           providerId: values.selectedProviderId,
-          name: fallbackConfigName,
-          description: 'Automatically created for session template provider setup.',
-          value: {}
+          ...(values.selectedDeploymentId
+            ? { providerDeploymentId: values.selectedDeploymentId }
+            : {}),
+          name: getProviderSetupGeneratedName(values.selectedProviderName),
+          value: selectedConfigCapabilities.defaultConfigValue
         });
 
         if (!config || configError) {
@@ -285,6 +308,30 @@ export let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
         selectedToolKeys: yup.array().of(yup.string().required()).defined()
       })
   });
+
+  let configuredProvider = useProvider(
+    p.instanceId,
+    form.values.selectedProviderId || p.providerId || null
+  );
+  let configuredProviderRequiresConfig =
+    configuredProvider.data?.type.config.status == 'enabled';
+  let selectedConfigSchema = useProviderConfigSchemaTarget(
+    p.instanceId,
+    form.values.selectedDeploymentId
+      ? { providerDeploymentId: form.values.selectedDeploymentId }
+      : form.values.selectedProviderId
+        ? { providerId: form.values.selectedProviderId }
+        : null
+  );
+  let selectedConfigCapabilities = getProviderConfigSchemaCapabilities({
+    schemaValue: selectedConfigSchema.data?.schema,
+    hasVaults: false,
+    isLoading: selectedConfigSchema.isLoading
+  });
+  let canAutoCreateEmptyConfig =
+    !!configuredProviderRequiresConfig &&
+    !selectedConfigSchema.isLoading &&
+    selectedConfigCapabilities.canAutoCreateEmptyConfig;
 
   useEffect(() => {
     if (!p.providerId) return;
@@ -426,30 +473,29 @@ export let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
       title: 'Configure',
       render: () =>
         form.values.selectedProviderId ? (
-          <form onSubmit={form.handleSubmit}>
-            <ConfigureStep
-              form={form}
-              instanceId={p.instanceId}
-              providerId={form.values.selectedProviderId}
-              providerName={form.values.selectedProviderName}
-              saving={
-                createConfigMutation.isLoading ||
-                isSubmitting ||
-                createMutation.isPending ||
-                deleteMutation.isPending
-              }
-              mutationError={
-                <>
-                  <createConfigMutation.RenderError />
-                  <createMutation.RenderError />
-                  <deleteMutation.RenderError />
-                </>
-              }
-              submitLabel={p.action || 'Add Provider'}
-              filterAvailableResources={p.filterAvailableResources}
-              onBack={p.hideProviderStep ? p.close : () => setStep(0)}
-            />
-          </form>
+          <ConfigureStep
+            form={form}
+            instanceId={p.instanceId}
+            providerId={form.values.selectedProviderId}
+            providerName={form.values.selectedProviderName}
+            canAutoCreateEmptyConfig={canAutoCreateEmptyConfig}
+            saving={
+              createConfigMutation.isLoading ||
+              isSubmitting ||
+              createMutation.isPending ||
+              deleteMutation.isPending
+            }
+            mutationError={
+              <>
+                <createConfigMutation.RenderError />
+                <createMutation.RenderError />
+                <deleteMutation.RenderError />
+              </>
+            }
+            submitLabel={p.action || 'Add Provider'}
+            filterAvailableResources={p.filterAvailableResources}
+            onBack={p.hideProviderStep ? p.close : () => setStep(0)}
+          />
         ) : (
           <CenteredSpinner />
         )
@@ -484,6 +530,7 @@ export let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
     submitError,
     createMutation.isPending,
     deleteMutation.isPending,
+    canAutoCreateEmptyConfig,
     form.handleSubmit,
     p.action,
     p.hideProviderStep,
@@ -753,6 +800,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
     id: string;
     label: string;
   } | null>(null);
+  let [inlineAuthMethodId, setInlineAuthMethodId] = useState<string | null>(null);
   let scrollContainerRef = useRef<HTMLDivElement | null>(null);
   let [scrollIndicators, setScrollIndicators] = useState({
     canScrollUp: false,
@@ -850,6 +898,10 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
   }, [createdAuthConfigSelection, p.selectedAuthConfigId]);
 
   useEffect(() => {
+    setInlineAuthMethodId(null);
+  }, [p.providerId, p.providerDeploymentId, p.fixedAuthMethodId]);
+
+  useEffect(() => {
     if (!showToolFilters || toolItems.length === 0) return;
     if (!p.onSelectedToolKeysChange || !p.onToolFilterModeChange) return;
     if (toolFilterMode !== 'all') return;
@@ -916,6 +968,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
     ? 'Create Auth Config'
     : `Log in with ${providerDisplayName}`;
   let providerImageUrl = providerListing.data?.imageUrl;
+  let generatedResourceName = getProviderSetupGeneratedName(providerDisplayName);
 
   if (showProviderSummary) {
     sectionItems.push(
@@ -962,6 +1015,9 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
             createConfigButtonLabel="Create Config"
             showExistingOptions={showExistingConfigOptions}
             filterAvailableResources={filterAvailableResources}
+            inlineCreateConfig
+            defaultConfigName={generatedResourceName}
+            hideCreateConfigDetails
             disabled={p.disabled}
           />
           {p.configError}
@@ -995,6 +1051,29 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
                 Choose another
               </Button>
             </Flex>
+          ) : inlineAuthMethodId ? (
+            <ProviderAuthConfigCreateFlowContent
+              instanceId={p.instanceId}
+              providerDeploymentId={p.providerDeploymentId ?? undefined}
+              providerId={p.providerId}
+              initialAuthMethodId={inlineAuthMethodId}
+              fixedAuthCredentialsId={p.fixedAuthCredentialsId}
+              defaultAuthConfigName={generatedResourceName}
+              autoStartManagedCredentialSetup={autoStartManagedCredentialSetup}
+              close={() => setInlineAuthMethodId(null)}
+              onBack={() => setInlineAuthMethodId(null)}
+              embedded
+              hideDetailsInputs
+              onCreate={authConfig => {
+                pendingCreatedAuthConfigIdRef.current = authConfig.id;
+                setCreatedAuthConfigSelection({
+                  id: authConfig.id,
+                  label: authConfig.name ?? generatedResourceName
+                });
+                setInlineAuthMethodId(null);
+                p.onSelectedAuthConfigIdChange(authConfig.id);
+              }}
+            />
           ) : (
             <Flex gap={8} align="end">
               {showExistingAuthOptions ? (
@@ -1040,7 +1119,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
                 </div>
               ) : null}
 
-              <ProviderAuthConfigCreateButton
+              <ProviderAuthConfigCreateAction
                 instanceId={p.instanceId}
                 providerDeploymentId={p.providerDeploymentId ?? undefined}
                 providerId={p.providerId}
@@ -1048,6 +1127,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
                 fixedAuthCredentialsId={p.fixedAuthCredentialsId}
                 defaultAuthConfigName={p.defaultAuthConfigName}
                 autoStartManagedCredentialSetup={autoStartManagedCredentialSetup}
+                onInlineCreate={authMethodId => setInlineAuthMethodId(authMethodId)}
                 onCreate={async authConfig => {
                   pendingCreatedAuthConfigIdRef.current = authConfig.id;
                   setCreatedAuthConfigSelection({
@@ -1062,7 +1142,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
                 disabled={p.disabled}
               >
                 {createAuthConfigLabel}
-              </ProviderAuthConfigCreateButton>
+              </ProviderAuthConfigCreateAction>
             </Flex>
           )}
 
@@ -1325,6 +1405,137 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
   );
 };
 
+let ProviderAuthConfigCreateAction = (p: {
+  instanceId: string;
+  providerDeploymentId?: string;
+  providerId?: string;
+  fixedAuthMethodId?: string;
+  fixedAuthCredentialsId?: string;
+  defaultAuthConfigName?: string;
+  autoStartManagedCredentialSetup?: boolean;
+  onInlineCreate: (authMethodId: string) => void;
+  onCreate?: (authConfig: { id: string; name?: string | null }) => void;
+  onBack?: () => void;
+  size?: ButtonSize;
+  iconLeft?: ReactNode;
+  children: ReactNode;
+  ariaLabel?: string;
+  disabled?: boolean;
+}) => {
+  let authCreation = useProviderAuthCreationCapabilities(
+    p.instanceId,
+    p.providerDeploymentId,
+    p.providerId
+  );
+
+  let openCreateFlow = (authMethodId: string) => {
+    let method = authCreation.authMethodItems.find(method => method.id === authMethodId);
+
+    if (method && !isSetupFlowAuthMethod(method)) {
+      p.onInlineCreate(authMethodId);
+      return;
+    }
+
+    showProviderAuthConfigCreateModal({
+      instanceId: p.instanceId,
+      providerDeploymentId: p.providerDeploymentId,
+      providerId: p.providerId,
+      initialAuthMethodId: authMethodId,
+      fixedAuthCredentialsId: p.fixedAuthCredentialsId,
+      defaultAuthConfigName: p.defaultAuthConfigName,
+      autoStartManagedCredentialSetup: p.autoStartManagedCredentialSetup,
+      onCreate: p.onCreate,
+      onBack: p.onBack
+    });
+  };
+
+  let disabledReason = authCreation.isLoading
+    ? 'Loading authentication options...'
+    : authCreation.authConfigDisabledReason;
+  let isDisabled = p.disabled || authCreation.isLoading || !authCreation.canCreateAuthConfig;
+
+  if (p.fixedAuthMethodId) {
+    return (
+      <Tooltip content={disabledReason ?? ''} enabled={!p.disabled && isDisabled}>
+        <div style={{ display: 'inline-flex' }}>
+          <Button
+            type="button"
+            size={p.size}
+            iconLeft={p.iconLeft}
+            aria-label={p.ariaLabel}
+            disabled={isDisabled}
+            onClick={() => openCreateFlow(p.fixedAuthMethodId!)}
+          >
+            {p.children}
+          </Button>
+        </div>
+      </Tooltip>
+    );
+  }
+
+  if (isDisabled) {
+    return (
+      <Tooltip
+        content={disabledReason ?? ''}
+        enabled={!p.disabled && !authCreation.canCreateAuthConfig}
+        delayDuration={0}
+      >
+        <div style={{ display: 'inline-flex' }}>
+          <Button
+            type="button"
+            size={p.size}
+            iconLeft={p.iconLeft}
+            aria-label={p.ariaLabel}
+            disabled
+          >
+            {p.children}
+          </Button>
+        </div>
+      </Tooltip>
+    );
+  }
+
+  if (authCreation.authMethodItems.length <= 1) {
+    let method = authCreation.authMethodItems[0];
+
+    return (
+      <Button
+        type="button"
+        size={p.size}
+        iconLeft={p.iconLeft}
+        aria-label={p.ariaLabel}
+        disabled={p.disabled || !method}
+        onClick={() => method && openCreateFlow(method.id)}
+      >
+        {p.children}
+      </Button>
+    );
+  }
+
+  return (
+    <Menu
+      label={typeof p.children === 'string' ? p.children : p.ariaLabel}
+      title="Choose authentication method"
+      items={authCreation.authMethodItems.map(method => ({
+        id: method.id,
+        label: method.name,
+        description: getCreateMethodDescription(method)
+      }))}
+      onItemClick={authMethodId => openCreateFlow(authMethodId)}
+    >
+      <Button
+        type="button"
+        size={p.size}
+        iconLeft={p.iconLeft}
+        aria-label={p.ariaLabel}
+        disabled={p.disabled}
+      >
+        {p.children}
+      </Button>
+    </Menu>
+  );
+};
+
 let PickProviderStep = (p: {
   instanceId: string;
   excludeProviderIds?: string[];
@@ -1384,6 +1595,7 @@ let ConfigureStep = (p: {
   instanceId: string;
   providerId: string;
   providerName: string;
+  canAutoCreateEmptyConfig: boolean;
   saving: boolean;
   mutationError: ReactNode;
   submitLabel: string;
@@ -1393,10 +1605,17 @@ let ConfigureStep = (p: {
   let provider = useProvider(p.instanceId, p.providerId);
   let requiresProviderConfig = provider.data?.type.config.status == 'enabled';
   let requiresAuthConfig = provider.data?.type.auth.status == 'enabled';
+  let configRequirement: 'required' | 'optional' = p.canAutoCreateEmptyConfig
+    ? 'optional'
+    : 'required';
   let validateRequiredSelections = () => {
     let isValid = true;
 
-    if (requiresProviderConfig && p.form.values.selectedConfiguration.kind === 'none') {
+    if (
+      requiresProviderConfig &&
+      !p.canAutoCreateEmptyConfig &&
+      p.form.values.selectedConfiguration.kind === 'none'
+    ) {
       p.form.setFieldTouched('selectedConfiguration', true, false);
       p.form.setFieldError('selectedConfiguration', 'Select a config or config vault');
       isValid = false;
@@ -1412,7 +1631,9 @@ let ConfigureStep = (p: {
   };
 
   let canSubmit =
-    (!requiresProviderConfig || p.form.values.selectedConfiguration.kind !== 'none') &&
+    (!requiresProviderConfig ||
+      p.canAutoCreateEmptyConfig ||
+      p.form.values.selectedConfiguration.kind !== 'none') &&
     (!requiresAuthConfig || Boolean(p.form.values.selectedAuthConfigId));
 
   let handleSubmitClick = async () => {
@@ -1429,6 +1650,7 @@ let ConfigureStep = (p: {
       providerName={p.providerName}
       providerDeploymentId={p.form.values.selectedDeploymentId || undefined}
       filterAvailableResources={p.filterAvailableResources}
+      configRequirement={configRequirement}
       selectedConfiguration={p.form.values.selectedConfiguration}
       onSelectedConfigurationChange={value => {
         p.form.setFieldValue('selectedConfiguration', value);

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
@@ -999,7 +999,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
       <ConfigureSectionCard
         key="config"
         title="Config"
-        description="Choose the provider configuration or vault this setup should use."
+        description="Choose the provider configuration this setup should use."
         requirement={configRequirement}
         completed={isConfigCompleted}
       >
@@ -1011,7 +1011,6 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
             value={p.selectedConfiguration}
             onChange={p.onSelectedConfigurationChange}
             label="Config"
-            includeVaults
             createConfigButtonLabel="Create Config"
             showExistingOptions={showExistingConfigOptions}
             filterAvailableResources={filterAvailableResources}
@@ -1617,7 +1616,7 @@ let ConfigureStep = (p: {
       p.form.values.selectedConfiguration.kind === 'none'
     ) {
       p.form.setFieldTouched('selectedConfiguration', true, false);
-      p.form.setFieldError('selectedConfiguration', 'Select a config or config vault');
+      p.form.setFieldError('selectedConfiguration', 'Select a config');
       isValid = false;
     }
 

--- a/src/frontend/layout/src/applicationLayout/layouts/largePane.tsx
+++ b/src/frontend/layout/src/applicationLayout/layouts/largePane.tsx
@@ -20,8 +20,8 @@ let Outer = styled('div')`
   animation: ${fadeIn} 0.2s cubic-bezier(0.26, 1.11, 0.87, 1.25);
 `;
 
-let Wrapper = styled('div')`
-  height: calc(100dvh - 70px);
+let Wrapper = styled('div')<{ $bottomOffset?: string }>`
+  height: calc(100dvh - 70px - ${({ $bottomOffset }) => $bottomOffset ?? '0px'});
   background: ${theme.colors.background};
   border-radius: 10px;
   box-shadow: ${theme.shadows.large};
@@ -30,15 +30,17 @@ let Wrapper = styled('div')`
 
 export let LargePaneLayout = ({
   children,
+  bottomOffset,
   Nav
 }: {
   children: React.ReactNode;
+  bottomOffset?: string;
   Nav: () => React.ReactNode;
 }) => {
   return (
     <RootLayout Nav={Nav}>
       <Outer>
-        <Wrapper>{children}</Wrapper>
+        <Wrapper $bottomOffset={bottomOffset}>{children}</Wrapper>
       </Outer>
     </RootLayout>
   );

--- a/src/frontend/layout/src/applicationLayout/layouts/largePane.tsx
+++ b/src/frontend/layout/src/applicationLayout/layouts/largePane.tsx
@@ -31,14 +31,16 @@ let Wrapper = styled('div')<{ $bottomOffset?: string }>`
 export let LargePaneLayout = ({
   children,
   bottomOffset,
+  height,
   Nav
 }: {
   children: React.ReactNode;
   bottomOffset?: string;
+  height?: number | string;
   Nav: () => React.ReactNode;
 }) => {
   return (
-    <RootLayout Nav={Nav}>
+    <RootLayout Nav={Nav} height={height}>
       <Outer>
         <Wrapper $bottomOffset={bottomOffset}>{children}</Wrapper>
       </Outer>

--- a/src/frontend/scenes/skills/src/scenes/skillParticipants.tsx
+++ b/src/frontend/scenes/skills/src/scenes/skillParticipants.tsx
@@ -1,7 +1,7 @@
 import { renderWithPagination } from '@metorial/data-hooks';
 import { useSkillParticipants } from '@metorial/state';
 import { Avatar, Badge, Entity, Flex, RenderDate, Text } from '@metorial/ui';
-import { Box, ID } from '@metorial/ui-product';
+import { Box } from '@metorial/ui-product';
 import styled from 'styled-components';
 
 let EmptyState = styled.div`
@@ -62,14 +62,14 @@ export let SkillParticipantsScene = (p: {
                   description={participant.actor.email ?? undefined}
                 />
 
-                <Entity.Field
+                {/* <Entity.Field
                   title="Type"
                   value={
                     <Badge color="gray" size="1">
                       {actorTypeLabels[participant.actor.type] ?? participant.actor.type}
                     </Badge>
                   }
-                />
+                /> */}
 
                 <Entity.Field
                   title="Roles"
@@ -88,7 +88,6 @@ export let SkillParticipantsScene = (p: {
                   title="Created"
                   value={<RenderDate date={participant.createdAt} />}
                 />
-                <Entity.Field title="ID" value={<ID id={participant.id} />} />
               </Entity.Content>
             </Entity.Wrapper>
           ))}

--- a/src/packages/backend/fabric/src/types.ts
+++ b/src/packages/backend/fabric/src/types.ts
@@ -471,6 +471,8 @@ export interface FabricEvents {
   'provider.custom_provider.created:after': ProviderEventBase & { customProvider: SubspaceCustomProvider };
   'provider.custom_provider.updated:before': ProviderEventBase;
   'provider.custom_provider.updated:after': ProviderEventBase & { customProvider: SubspaceCustomProvider };
+  'provider.custom_provider.archived:before': ProviderEventBase;
+  'provider.custom_provider.archived:after': ProviderEventBase & { customProvider: SubspaceCustomProvider };
 
   'provider.custom_provider.version.created:before': ProviderEventBase;
   'provider.custom_provider.version.created:after': ProviderEventBase & { customProviderVersion: SubspaceCustomProviderVersion };

--- a/src/packages/backend/fabric/src/types.ts
+++ b/src/packages/backend/fabric/src/types.ts
@@ -78,23 +78,29 @@ export type MachineAccessInput =
     };
 
 export type OAuthApplicationCreateInput = {
+  status?: 'active' | 'archived';
   type: 'user_facing' | 'server_side' | 'cli_auth';
   accessLevel: 'organization' | 'global';
+  allowClientSecretlessTokenExchange?: boolean;
   name: string;
   description?: string;
   websiteUrl?: string;
   privacyPolicyUrl?: string;
   termsOfServiceUrl?: string;
+  redirectUris?: string[];
   scopes: string[];
   image?: PrismaJson.EntityImage;
 };
 
 export type OAuthApplicationUpdateInput = {
+  accessLevel?: 'organization' | 'global';
+  allowClientSecretlessTokenExchange?: boolean;
   name?: string;
   description?: string | null;
   websiteUrl?: string | null;
   privacyPolicyUrl?: string | null;
   termsOfServiceUrl?: string | null;
+  redirectUris?: string[];
   scopes?: string[];
   image?: PrismaJson.EntityImage;
 };
@@ -285,8 +291,8 @@ export interface FabricEvents {
   'machine_access.oauth_application.created:after': { organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; input: OAuthApplicationCreateInput; serverSideMachineAccess: MachineAccess | null; oauthApplication: OAuthApplication; };
   'machine_access.oauth_application.updated:before': { oauthApplication: OAuthApplication; organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; input: OAuthApplicationUpdateInput; };
   'machine_access.oauth_application.updated:after': { oauthApplication: OAuthApplication; organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; input: OAuthApplicationUpdateInput; };
-  'machine_access.oauth_application.archived:before': { oauthApplication: OAuthApplication; organization: Organization; performedBy: OrganizationActor; context: Context; };
-  'machine_access.oauth_application.archived:after': { oauthApplication: OAuthApplication; organization: Organization; performedBy: OrganizationActor; context: Context; };
+  'machine_access.oauth_application.archived:before': { oauthApplication: OAuthApplication; organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; };
+  'machine_access.oauth_application.archived:after': { oauthApplication: OAuthApplication; organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; };
   'machine_access.oauth_application.client_secret.create:after': { oauthApplication: OAuthApplication; };
   'machine_access.oauth_application.client_secret.revoked:after': { oauthApplication: OAuthApplication; };
 

--- a/src/packages/frontend/data-hooks/src/index.ts
+++ b/src/packages/frontend/data-hooks/src/index.ts
@@ -1,5 +1,6 @@
 export * from './lib/atom';
 export * from './lib/emitter';
+export * from './lib/initialLoad';
 export * from './lib/listeners';
 export * from './lib/onFocus';
 export * from './lib/paginationSearchParams';

--- a/src/packages/frontend/data-hooks/src/lib/initialLoad.test.tsx
+++ b/src/packages/frontend/data-hooks/src/lib/initialLoad.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+
+import React, { act, useState } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { InitialLoadBoundary, useInitialLoadRegistration } from './initialLoad';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+let getByTestId = (container: HTMLElement, testId: string) =>
+  container.querySelector(`[data-testid="${testId}"]`);
+
+let getContentWrapper = (container: HTMLElement, testId: string) =>
+  getByTestId(container, testId)!.parentElement as HTMLElement;
+
+let getSpinnerWrapper = (container: HTMLElement) =>
+  getByTestId(container, 'boundary-loading')!.parentElement as HTMLElement;
+
+let expectContentHiddenButMeasurable = (container: HTMLElement, testId: string) => {
+  let wrapper = getContentWrapper(container, testId);
+  expect(wrapper.style.display).toBe('block');
+  expect(wrapper.style.height).toBe('0px');
+  expect(wrapper.style.overflow).toBe('hidden');
+  expect(wrapper.style.pointerEvents).toBe('none');
+  expect(wrapper.style.visibility).toBe('hidden');
+};
+
+let advance = async (ms: number) => {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+  });
+};
+
+let RegisteredContent = (p: { pending: boolean; testId: string }) => {
+  useInitialLoadRegistration(p.pending);
+  return <div data-testid={p.testId}>Content</div>;
+};
+
+let NullWhilePendingContent = (p: { pending: boolean }) => {
+  useInitialLoadRegistration(p.pending);
+  if (p.pending) return null;
+  return <div data-testid="ready">Ready</div>;
+};
+
+describe('InitialLoadBoundary', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it('hides initial content until all pending work has settled', async () => {
+    let controls: {
+      setFileLoaded: (loaded: boolean) => void;
+      setAgentsLoaded: (loaded: boolean) => void;
+    };
+
+    let App = () => {
+      let [fileLoaded, setFileLoaded] = useState(false);
+      let [agentsLoaded, setAgentsLoaded] = useState(false);
+      controls = { setFileLoaded, setAgentsLoaded };
+
+      return (
+        <InitialLoadBoundary loading={() => <div data-testid="boundary-loading">Loading</div>}>
+          <RegisteredContent pending={!fileLoaded} testId="files" />
+          <RegisteredContent pending={!agentsLoaded} testId="agents" />
+        </InitialLoadBoundary>
+      );
+    };
+
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    expectContentHiddenButMeasurable(container, 'files');
+    expect(getSpinnerWrapper(container).style.visibility).toBe('visible');
+
+    await act(async () => {
+      controls.setFileLoaded(true);
+    });
+    await advance(20);
+
+    expectContentHiddenButMeasurable(container, 'files');
+    expect(getSpinnerWrapper(container).style.visibility).toBe('visible');
+
+    await act(async () => {
+      controls.setAgentsLoaded(true);
+    });
+    await advance(9);
+
+    expectContentHiddenButMeasurable(container, 'files');
+
+    await advance(1);
+
+    expect(getContentWrapper(container, 'files').style.display).toBe('contents');
+    expect(getSpinnerWrapper(container).style.display).toBe('none');
+  });
+
+  it('keeps pending content measurable while hiding it visually', async () => {
+    let rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        let parent = this.parentElement as HTMLElement | null;
+        let width = parent?.style.display == 'none' ? 0 : 120;
+
+        return {
+          bottom: 20,
+          height: 20,
+          left: 0,
+          right: width,
+          toJSON: () => ({}),
+          top: 0,
+          width,
+          x: 0,
+          y: 0
+        };
+      });
+
+    try {
+      await act(async () => {
+        root.render(
+          <InitialLoadBoundary
+            loading={() => <div data-testid="boundary-loading">Loading</div>}
+          >
+            <RegisteredContent pending={true} testId="measurable" />
+          </InitialLoadBoundary>
+        );
+      });
+
+      expectContentHiddenButMeasurable(container, 'measurable');
+      expect(getByTestId(container, 'measurable')!.getBoundingClientRect().width).toBe(120);
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('renders cached content immediately when no pending work appears', async () => {
+    await act(async () => {
+      root.render(
+        <InitialLoadBoundary loading={() => <div data-testid="boundary-loading">Loading</div>}>
+          <RegisteredContent pending={false} testId="cached" />
+        </InitialLoadBoundary>
+      );
+    });
+
+    expect(getContentWrapper(container, 'cached').style.display).toBe('contents');
+    expect(getSpinnerWrapper(container).style.display).toBe('none');
+
+    await advance(20);
+
+    expect(getContentWrapper(container, 'cached').style.display).toBe('contents');
+    expect(getSpinnerWrapper(container).style.display).toBe('none');
+  });
+
+  it('shows the boundary spinner when pending children render no local content', async () => {
+    await act(async () => {
+      root.render(
+        <InitialLoadBoundary loading={() => <div data-testid="boundary-loading">Loading</div>}>
+          <NullWhilePendingContent pending={true} />
+        </InitialLoadBoundary>
+      );
+    });
+
+    expect(getByTestId(container, 'ready')).toBeNull();
+    expect(getSpinnerWrapper(container).style.visibility).toBe('visible');
+  });
+
+  it('does not hide content or show the boundary spinner after the first reveal', async () => {
+    let controls: {
+      setPending: (pending: boolean) => void;
+    };
+
+    let App = () => {
+      let [pending, setPending] = useState(false);
+      controls = { setPending };
+
+      return (
+        <InitialLoadBoundary loading={() => <div data-testid="boundary-loading">Loading</div>}>
+          <RegisteredContent pending={pending} testId="ready" />
+        </InitialLoadBoundary>
+      );
+    };
+
+    await act(async () => {
+      root.render(<App />);
+    });
+    await advance(20);
+
+    expect(getContentWrapper(container, 'ready').style.display).toBe('contents');
+
+    await act(async () => {
+      controls.setPending(true);
+    });
+    await advance(100);
+
+    expect(getContentWrapper(container, 'ready').style.display).toBe('contents');
+    expect(getSpinnerWrapper(container).style.display).toBe('none');
+  });
+});

--- a/src/packages/frontend/data-hooks/src/lib/initialLoad.tsx
+++ b/src/packages/frontend/data-hooks/src/lib/initialLoad.tsx
@@ -1,0 +1,177 @@
+import { CenteredSpinner } from '@metorial/ui';
+import React, {
+  Fragment,
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore
+} from 'react';
+
+type InitialLoadCoordinatorContextValue = {
+  isAccepting: () => boolean;
+  register: (id: symbol, isPending: boolean) => void;
+};
+
+let INITIAL_LOAD_SPINNER_DELAY_MS = 100;
+let INITIAL_LOAD_SETTLE_MS = 10;
+
+let InitialLoadCoordinatorContext = createContext<InitialLoadCoordinatorContextValue | null>(
+  null
+);
+
+let createInitialLoadStore = () => {
+  let pending = new Set<symbol>();
+  let listeners = new Set<() => void>();
+  let accepting = true;
+
+  let emit = () => {
+    for (let listener of listeners) listener();
+  };
+
+  return {
+    getSnapshot: () => pending.size,
+    isAccepting: () => accepting,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    register: (id: symbol, isPending: boolean) => {
+      if (!accepting && isPending && !pending.has(id)) return;
+      if (pending.has(id) == isPending) return;
+
+      if (isPending) pending.add(id);
+      else pending.delete(id);
+
+      emit();
+    },
+    stopAccepting: () => {
+      accepting = false;
+    }
+  };
+};
+
+export let useInitialLoadBoundaryState = () => useContext(InitialLoadCoordinatorContext);
+
+export let useInitialLoadRegistration = (isPending: boolean) => {
+  let coordinator = useInitialLoadBoundaryState();
+  let idRef = useRef(Symbol('initialLoad'));
+  let register = coordinator?.register;
+
+  useEffect(() => {
+    register?.(idRef.current, isPending);
+    return () => register?.(idRef.current, false);
+  }, [isPending, register]);
+};
+
+let renderBoundarySpinner = (p: {
+  active: boolean;
+  loading?: () => React.ReactNode;
+  visible: boolean;
+}) =>
+  React.createElement('div', {
+    style: {
+      display: p.active ? undefined : 'none',
+      opacity: p.visible ? 1 : 0,
+      visibility: p.visible ? 'visible' : 'hidden',
+      pointerEvents: p.visible ? undefined : 'none'
+    },
+    children: p.loading ? p.loading() : React.createElement(CenteredSpinner)
+  });
+
+type InitialLoadPhase = 'watching' | 'pending' | 'revealed';
+
+let InitialLoadBody = (p: {
+  children: React.ReactNode;
+  loading?: () => React.ReactNode;
+  store: ReturnType<typeof createInitialLoadStore>;
+}) => {
+  let pendingCount = useSyncExternalStore(
+    p.store.subscribe,
+    p.store.getSnapshot,
+    p.store.getSnapshot
+  );
+  let [phase, setPhase] = useState<InitialLoadPhase>('watching');
+  let [spinnerDelayComplete, setSpinnerDelayComplete] = useState(false);
+  let isPending = phase == 'pending' || (phase == 'watching' && pendingCount > 0);
+
+  useEffect(() => {
+    if (phase == 'revealed') return;
+
+    if (pendingCount > 0) {
+      if (phase != 'pending') setPhase('pending');
+      return;
+    }
+
+    let timeout = setTimeout(() => {
+      p.store.stopAccepting();
+      setPhase('revealed');
+    }, INITIAL_LOAD_SETTLE_MS);
+    return () => clearTimeout(timeout);
+  }, [p.store, pendingCount, phase]);
+
+  useEffect(() => {
+    if (!isPending) {
+      if (spinnerDelayComplete) setSpinnerDelayComplete(false);
+      return;
+    }
+
+    if (spinnerDelayComplete) return;
+
+    let timeout = setTimeout(
+      () => setSpinnerDelayComplete(true),
+      INITIAL_LOAD_SPINNER_DELAY_MS
+    );
+    return () => clearTimeout(timeout);
+  }, [isPending, spinnerDelayComplete]);
+
+  return React.createElement(Fragment, {
+    children: [
+      React.createElement(Fragment, {
+        key: 'initial-load-spinner',
+        children: renderBoundarySpinner({
+          active: isPending,
+          loading: p.loading,
+          visible: isPending && (pendingCount > 0 || spinnerDelayComplete)
+        })
+      }),
+      React.createElement('div', {
+        key: 'initial-load-content',
+        style: {
+          display: isPending ? 'block' : 'contents',
+          height: isPending ? 0 : undefined,
+          opacity: isPending ? 0 : undefined,
+          overflow: isPending ? 'hidden' : undefined,
+          pointerEvents: isPending ? 'none' : undefined,
+          visibility: isPending ? 'hidden' : undefined
+        },
+        children: p.children
+      })
+    ]
+  });
+};
+
+export let InitialLoadBoundary = (p: {
+  children: React.ReactNode;
+  loading?: () => React.ReactNode;
+}) => {
+  let storeRef = useRef<ReturnType<typeof createInitialLoadStore> | null>(null);
+  if (!storeRef.current) storeRef.current = createInitialLoadStore();
+
+  let store = storeRef.current;
+  let value = useMemo<InitialLoadCoordinatorContextValue>(
+    () => ({ isAccepting: store.isAccepting, register: store.register }),
+    [store]
+  );
+
+  return React.createElement(InitialLoadCoordinatorContext.Provider, {
+    value,
+    children: React.createElement(InitialLoadBody, {
+      loading: p.loading,
+      store,
+      children: p.children
+    })
+  });
+};

--- a/src/packages/frontend/data-hooks/src/lib/renderWithLoader.test.tsx
+++ b/src/packages/frontend/data-hooks/src/lib/renderWithLoader.test.tsx
@@ -1,0 +1,400 @@
+// @vitest-environment jsdom
+
+import React, { act, useState } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { InitialLoadBoundary } from './initialLoad';
+import { renderWithLoader, renderWithPagination } from './renderWithLoader';
+
+let routerMock = vi.hoisted(() => ({
+  setSearchParams: () => {}
+}));
+
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [new URLSearchParams(), routerMock.setSearchParams]
+}));
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+let loader = (isLoaded: boolean) => ({
+  input: undefined,
+  data: isLoaded ? { loaded: true } : null,
+  error: null,
+  isLoading: !isLoaded,
+  mutators: {},
+  refetch: () => {}
+});
+
+let paginationLoader = (isLoaded: boolean) => ({
+  input: undefined,
+  data: isLoaded
+    ? {
+        items: [{ id: 'item-1' }],
+        pagination: {
+          hasMoreBefore: false,
+          hasMoreAfter: false
+        }
+      }
+    : null,
+  error: null,
+  isLoading: !isLoaded,
+  mutators: {},
+  next: () => {},
+  previous: () => {},
+  refetch: () => {}
+});
+
+let getByTestId = (container: HTMLElement, testId: string) =>
+  container.querySelector(`[data-testid="${testId}"]`);
+
+let expectLoaderHidden = (container: HTMLElement, testId: string) => {
+  let loader = getByTestId(container, testId);
+  expect(loader).not.toBeNull();
+  expect((loader!.parentElement as HTMLElement).style.visibility).toBe('hidden');
+};
+
+let expectLoaderVisible = (container: HTMLElement, testId: string) => {
+  let loader = getByTestId(container, testId);
+  expect(loader).not.toBeNull();
+  expect((loader!.parentElement as HTMLElement).style.visibility).toBe('visible');
+};
+
+let advance = async (ms: number) => {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+  });
+};
+
+describe('renderWithLoader', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it('keeps the root initial spinner until nested loaders finish their first load', async () => {
+    let controls: {
+      setParentLoaded: (loaded: boolean) => void;
+      setChildLoaded: (loaded: boolean) => void;
+      setGrandchildLoaded: (loaded: boolean) => void;
+    };
+
+    let Grandchild = ({ loaded }: { loaded: boolean }) =>
+      renderWithLoader(
+        { grandchild: loader(loaded) },
+        { loading: () => <div data-testid="grandchild-loading">Grandchild loading</div> }
+      )(() => <div data-testid="ready">Ready</div>);
+
+    let Child = ({
+      childLoaded,
+      grandchildLoaded
+    }: {
+      childLoaded: boolean;
+      grandchildLoaded: boolean;
+    }) =>
+      renderWithLoader(
+        { child: loader(childLoaded) },
+        { loading: () => <div data-testid="child-loading">Child loading</div> }
+      )(() => <Grandchild loaded={grandchildLoaded} />);
+
+    let App = () => {
+      let [parentLoaded, setParentLoaded] = useState(false);
+      let [childLoaded, setChildLoaded] = useState(false);
+      let [grandchildLoaded, setGrandchildLoaded] = useState(false);
+
+      controls = { setParentLoaded, setChildLoaded, setGrandchildLoaded };
+
+      return renderWithLoader(
+        { parent: loader(parentLoaded) },
+        { loading: () => <div data-testid="root-loading">Root loading</div> }
+      )(() => <Child childLoaded={childLoaded} grandchildLoaded={grandchildLoaded} />);
+    };
+
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    expectLoaderHidden(container, 'root-loading');
+    expect(getByTestId(container, 'child-loading')).toBeNull();
+
+    await advance(100);
+    expectLoaderVisible(container, 'root-loading');
+
+    await act(async () => {
+      controls.setParentLoaded(true);
+    });
+
+    expectLoaderVisible(container, 'root-loading');
+    expect(getByTestId(container, 'ready')).toBeNull();
+
+    await act(async () => {
+      controls.setChildLoaded(true);
+    });
+
+    expectLoaderVisible(container, 'root-loading');
+    expect(getByTestId(container, 'ready')).toBeNull();
+
+    await act(async () => {
+      controls.setGrandchildLoaded(true);
+    });
+
+    await advance(9);
+    expectLoaderVisible(container, 'root-loading');
+
+    await advance(30);
+    expect(getByTestId(container, 'root-loading')).toBeNull();
+    expect(getByTestId(container, 'child-loading')).toBeNull();
+    expect(getByTestId(container, 'grandchild-loading')).toBeNull();
+    expect(getByTestId(container, 'ready')).not.toBeNull();
+  });
+
+  it('does not show the root spinner for nested reloads after the first reveal', async () => {
+    let controls: {
+      setChildLoaded: (loaded: boolean) => void;
+    };
+
+    let Child = ({ loaded }: { loaded: boolean }) =>
+      renderWithLoader(
+        { child: loader(loaded) },
+        { loading: () => <div data-testid="child-loading">Child loading</div> }
+      )(() => <div data-testid="ready">Ready</div>);
+
+    let App = () => {
+      let [childLoaded, setChildLoaded] = useState(true);
+      controls = { setChildLoaded };
+
+      return renderWithLoader(
+        { parent: loader(true) },
+        { loading: () => <div data-testid="root-loading">Root loading</div> }
+      )(() => <Child loaded={childLoaded} />);
+    };
+
+    await act(async () => {
+      root.render(<App />);
+    });
+    await advance(10);
+
+    expect(getByTestId(container, 'root-loading')).toBeNull();
+    expect(getByTestId(container, 'ready')).not.toBeNull();
+
+    await act(async () => {
+      controls.setChildLoaded(false);
+    });
+
+    expect(getByTestId(container, 'root-loading')).toBeNull();
+    expectLoaderHidden(container, 'child-loading');
+
+    await advance(100);
+    expect(getByTestId(container, 'root-loading')).toBeNull();
+    expectLoaderVisible(container, 'child-loading');
+    expect(getByTestId(container, 'ready')).toBeNull();
+  });
+
+  it('does not accept nested registrations after the parent has revealed', async () => {
+    let controls: {
+      setChildLoaded: (loaded: boolean) => void;
+    };
+    let parentChildrenRenderCount = 0;
+
+    let Child = ({ loaded }: { loaded: boolean }) =>
+      renderWithLoader(
+        { child: loader(loaded) },
+        { loading: () => <div data-testid="child-loading">Child loading</div> }
+      )(() => <div data-testid="ready">Ready</div>);
+
+    let App = () => {
+      let [childLoaded, setChildLoaded] = useState(true);
+      controls = { setChildLoaded };
+
+      return renderWithLoader(
+        { parent: loader(true) },
+        { loading: () => <div data-testid="root-loading">Root loading</div> }
+      )(() => {
+        parentChildrenRenderCount++;
+
+        return <Child loaded={childLoaded} />;
+      });
+    };
+
+    await act(async () => {
+      root.render(<App />);
+    });
+    await advance(10);
+
+    let countAfterReveal = parentChildrenRenderCount;
+    expect(getByTestId(container, 'root-loading')).toBeNull();
+    expect(getByTestId(container, 'ready')).not.toBeNull();
+
+    await act(async () => {
+      controls.setChildLoaded(false);
+    });
+
+    expect(parentChildrenRenderCount).toBe(countAfterReveal + 1);
+    expect(getByTestId(container, 'root-loading')).toBeNull();
+    expectLoaderHidden(container, 'child-loading');
+
+    await advance(100);
+    expect(parentChildrenRenderCount).toBe(countAfterReveal + 1);
+    expect(getByTestId(container, 'root-loading')).toBeNull();
+    expectLoaderVisible(container, 'child-loading');
+  });
+
+  it('does not show a spinner for initial loading that resolves before the delay', async () => {
+    let controls: {
+      setLoaded: (loaded: boolean) => void;
+    };
+
+    let App = () => {
+      let [loaded, setLoaded] = useState(false);
+      controls = { setLoaded };
+
+      return renderWithLoader(
+        { parent: loader(loaded) },
+        { loading: () => <div data-testid="root-loading">Root loading</div> }
+      )(() => <div data-testid="ready">Ready</div>);
+    };
+
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    expectLoaderHidden(container, 'root-loading');
+
+    await advance(50);
+    await act(async () => {
+      controls.setLoaded(true);
+    });
+    await advance(50);
+
+    expect(getByTestId(container, 'root-loading')).toBeNull();
+    expect(getByTestId(container, 'ready')).not.toBeNull();
+  });
+
+  it('keeps the spinner mounted while moving from local load to nested discovery', async () => {
+    let controls: {
+      setParentLoaded: (loaded: boolean) => void;
+      setChildLoaded: (loaded: boolean) => void;
+    };
+    let spinnerMounts = 0;
+
+    class Loading extends React.Component {
+      componentDidMount() {
+        spinnerMounts++;
+      }
+
+      render() {
+        return <div data-testid="root-loading">Root loading</div>;
+      }
+    }
+
+    let Child = ({ loaded }: { loaded: boolean }) =>
+      renderWithLoader(
+        { child: loader(loaded) },
+        { loading: () => <div data-testid="child-loading">Child loading</div> }
+      )(() => <div data-testid="ready">Ready</div>);
+
+    let App = () => {
+      let [parentLoaded, setParentLoaded] = useState(false);
+      let [childLoaded, setChildLoaded] = useState(false);
+      controls = { setParentLoaded, setChildLoaded };
+
+      return renderWithLoader(
+        { parent: loader(parentLoaded) },
+        { loading: () => <Loading /> }
+      )(() => <Child loaded={childLoaded} />);
+    };
+
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    expect(spinnerMounts).toBe(1);
+    expectLoaderHidden(container, 'root-loading');
+
+    await advance(100);
+    expect(spinnerMounts).toBe(1);
+    expectLoaderVisible(container, 'root-loading');
+
+    await act(async () => {
+      controls.setParentLoaded(true);
+    });
+    await act(async () => {
+      controls.setChildLoaded(true);
+    });
+
+    expect(spinnerMounts).toBe(1);
+
+    await advance(30);
+    expect(getByTestId(container, 'root-loading')).toBeNull();
+    expect(getByTestId(container, 'ready')).not.toBeNull();
+  });
+
+  it('renders cached data immediately without running hidden discovery', async () => {
+    let App = () =>
+      renderWithLoader(
+        { parent: loader(true) },
+        { loading: () => <div data-testid="root-loading">Root loading</div> }
+      )(() => <div data-testid="ready">Ready</div>);
+
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    expect(getByTestId(container, 'root-loading')).toBeNull();
+    expect(getByTestId(container, 'ready')).not.toBeNull();
+  });
+
+  it('shows local pagination loading after a boundary has revealed', async () => {
+    let controls: {
+      setShowPagination: (showPagination: boolean) => void;
+    };
+
+    let PaginationPage = () =>
+      renderWithPagination(paginationLoader(false), {
+        loading: () => <div data-testid="pagination-loading">Pagination loading</div>
+      })(() => <div data-testid="pagination-ready">Pagination ready</div>);
+
+    let App = () => {
+      let [showPagination, setShowPagination] = useState(false);
+      controls = { setShowPagination };
+
+      return (
+        <InitialLoadBoundary
+          loading={() => <div data-testid="boundary-loading">Boundary loading</div>}
+        >
+          {showPagination ? <PaginationPage /> : <div data-testid="ready">Ready</div>}
+        </InitialLoadBoundary>
+      );
+    };
+
+    await act(async () => {
+      root.render(<App />);
+    });
+    await advance(20);
+
+    expect(getByTestId(container, 'ready')).not.toBeNull();
+    expect(
+      (getByTestId(container, 'boundary-loading')!.parentElement as HTMLElement).style.display
+    ).toBe('none');
+
+    await act(async () => {
+      controls.setShowPagination(true);
+    });
+
+    expect(
+      (getByTestId(container, 'boundary-loading')!.parentElement as HTMLElement).style.display
+    ).toBe('none');
+    expect(getByTestId(container, 'pagination-loading')).not.toBeNull();
+    expect(getByTestId(container, 'pagination-ready')).toBeNull();
+  });
+});

--- a/src/packages/frontend/data-hooks/src/lib/renderWithLoader.ts
+++ b/src/packages/frontend/data-hooks/src/lib/renderWithLoader.ts
@@ -1,83 +1,254 @@
 import { ServiceError } from '@lowerdeck/error';
 import { Button, CenteredSpinner, Error } from '@metorial/ui';
 import { MetorialSDKError } from '@metorial/util-endpoint';
-import React, { Fragment, useEffect, useRef, useState } from 'react';
+import React, {
+  Fragment,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useInitialLoadBoundaryState, useInitialLoadRegistration } from './initialLoad';
 import { usePaginationSearchParamsEnabled } from './paginationSearchParams';
 
-export let renderWithLoader =
-  <
-    Loaders extends {
-      [key: string]:
-        | {
-            input?: any;
-            data: any;
-            error: ServiceError<any> | MetorialSDKError | null | undefined;
-            isLoading: boolean;
-            mutators?: {
-              [key: string]: (...args: any[]) => Promise<any>;
-            };
-            refetch?: () => void;
-          }
-        | boolean;
-    }
-  >(
-    loaders: Loaders,
-    opts: {
-      spaceTop?: number | string;
-      spaceBottom?: number | string;
-      loading?: () => React.ReactNode;
-      error?: (error: ServiceError<any> | MetorialSDKError) => React.ReactNode;
-    } = {}
-  ) =>
-  (
-    children: (loaders: {
-      [K in keyof Loaders]: Loaders[K] extends object
-        ? {
-            input: Loaders[K]['input'];
-            mutators: Loaders[K]['mutators'];
-            data: NonNullable<Loaders[K]['data']>;
-            refetch: () => void;
-          }
-        : undefined;
-    }) => React.ReactNode
-  ) => {
-    let normalizedLoaders = Object.values(loaders).map(loader =>
-      typeof loader == 'boolean' ? { isLoading: loader, error: undefined } : loader
-    );
-
-    let isLoading = Object.values(normalizedLoaders).some(loader => loader.isLoading);
-    let error = Object.values(normalizedLoaders).find(loader => loader.error !== null)?.error;
-
-    if (isLoading) {
-      return React.createElement(Fragment, {
-        children: [
-          opts.spaceTop
-            ? React.createElement('div', { style: { height: opts.spaceTop } })
-            : null,
-          opts.loading ? opts.loading() : React.createElement(CenteredSpinner),
-          opts.spaceBottom
-            ? React.createElement('div', { style: { height: opts.spaceBottom } })
-            : null
-        ].map((el, i) => React.createElement(Fragment, { key: `l-${i}`, children: el }))
-      });
-    }
-
-    if (error) {
-      return opts.error
-        ? opts.error(error)
-        : React.createElement(Error, {
-            children:
-              ('data' in error ? error.data.message : error.message) ??
-              error.message ??
-              'An error occurred'
-          });
-    }
-
-    // return children(loaders as any);
-
-    return React.createElement(Fragment, { children: children(loaders as any) });
+type LoaderLike = {
+  input?: any;
+  data: any;
+  error: ServiceError<any> | MetorialSDKError | null | undefined;
+  isLoading: boolean;
+  mutators?: {
+    [key: string]: (...args: any[]) => Promise<any>;
   };
+  refetch?: () => void;
+};
+
+type RenderWithLoaderLoaders = {
+  [key: string]: LoaderLike | boolean;
+};
+
+type RenderWithLoaderOptions = {
+  spaceTop?: number | string;
+  spaceBottom?: number | string;
+  loading?: () => React.ReactNode;
+  error?: (error: ServiceError<any> | MetorialSDKError) => React.ReactNode;
+};
+
+type LoaderError = ServiceError<any> | MetorialSDKError;
+
+type RenderWithLoaderChildren<Loaders extends RenderWithLoaderLoaders> = (loaders: {
+  [K in keyof Loaders]: Loaders[K] extends object
+    ? {
+        input: Loaders[K]['input'];
+        mutators: Loaders[K]['mutators'];
+        data: NonNullable<Loaders[K]['data']>;
+        refetch: () => void;
+      }
+    : undefined;
+}) => React.ReactNode;
+
+type InitialLoaderGate = {
+  register: (id: symbol, isPending: boolean) => void;
+};
+
+type InitialRevealPhase = 'localLoading' | 'discovering' | 'revealed';
+
+let LOADER_SPINNER_DELAY_MS = 100;
+
+let InitialLoaderGateContext = createContext<InitialLoaderGate | null>(null);
+
+let renderLoadingContent = (opts: RenderWithLoaderOptions) =>
+  React.createElement(Fragment, {
+    children: [
+      opts.spaceTop ? React.createElement('div', { style: { height: opts.spaceTop } }) : null,
+      opts.loading ? opts.loading() : React.createElement(CenteredSpinner),
+      opts.spaceBottom
+        ? React.createElement('div', { style: { height: opts.spaceBottom } })
+        : null
+    ].map((el, i) => React.createElement(Fragment, { key: `l-${i}`, children: el }))
+  });
+
+let renderLoaderSpinner = (opts: RenderWithLoaderOptions, visible: boolean) =>
+  React.createElement('div', {
+    style: {
+      opacity: visible ? 1 : 0,
+      visibility: visible ? 'visible' : 'hidden',
+      pointerEvents: visible ? undefined : 'none'
+    },
+    children: renderLoadingContent(opts)
+  });
+
+let renderLoaderError = (error: LoaderError, opts: RenderWithLoaderOptions) =>
+  opts.error
+    ? opts.error(error)
+    : React.createElement(Error, {
+        children:
+          ('data' in error ? error.data.message : error.message) ??
+          error.message ??
+          'An error occurred'
+      });
+
+let RenderWithLoaderInner = <Loaders extends RenderWithLoaderLoaders>({
+  loaders,
+  opts,
+  children
+}: {
+  loaders: Loaders;
+  opts: RenderWithLoaderOptions;
+  children: RenderWithLoaderChildren<Loaders>;
+}) => {
+  let parentGate = useContext(InitialLoaderGateContext);
+  let boundary = useInitialLoadBoundaryState();
+  let idRef = useRef(Symbol('renderWithLoader'));
+  let normalizedLoaders = Object.values(loaders).map(loader =>
+    typeof loader == 'boolean' ? { isLoading: loader, error: undefined } : loader
+  );
+
+  let isLoading = Object.values(normalizedLoaders).some(loader => loader.isLoading);
+  let error = Object.values(normalizedLoaders).find(loader => loader.error != null)?.error;
+  let hasError = !!error;
+  let [phase, setPhase] = useState<InitialRevealPhase>(() =>
+    isLoading ? 'localLoading' : 'revealed'
+  );
+  let phaseRef = useRef(phase);
+  let nestedPendingRef = useRef(new Set<symbol>());
+  let discoveryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  let [nestedPendingCount, setNestedPendingCount] = useState(0);
+  let [spinnerDelayComplete, setSpinnerDelayComplete] = useState(false);
+
+  phaseRef.current = phase;
+
+  let clearDiscoveryTimeout = useCallback(() => {
+    if (!discoveryTimeoutRef.current) return;
+
+    clearTimeout(discoveryTimeoutRef.current);
+    discoveryTimeoutRef.current = null;
+  }, []);
+
+  let scheduleDiscoveryReveal = useCallback(() => {
+    clearDiscoveryTimeout();
+    discoveryTimeoutRef.current = setTimeout(() => {
+      discoveryTimeoutRef.current = null;
+      if (phaseRef.current == 'discovering') setPhase('revealed');
+    }, 10);
+  }, [clearDiscoveryTimeout]);
+
+  let register = useCallback(
+    (id: symbol, isPending: boolean) => {
+      let phase = phaseRef.current;
+      if (phase == 'revealed') return;
+      if (nestedPendingRef.current.has(id) == isPending) return;
+
+      let nextNestedPending = new Set(nestedPendingRef.current);
+
+      if (isPending) nextNestedPending.add(id);
+      else nextNestedPending.delete(id);
+
+      nestedPendingRef.current = nextNestedPending;
+      setNestedPendingCount(nextNestedPending.size);
+
+      if (phase != 'discovering') return;
+
+      if (nextNestedPending.size > 0) clearDiscoveryTimeout();
+      else scheduleDiscoveryReveal();
+    },
+    [clearDiscoveryTimeout, scheduleDiscoveryReveal]
+  );
+
+  let gate = useMemo<InitialLoaderGate>(() => ({ register }), [register]);
+
+  let hasNotRevealed = phase != 'revealed';
+  let usesSharedBoundary = boundary?.isAccepting() ?? false;
+  let isPendingForParent =
+    !usesSharedBoundary &&
+    !hasError &&
+    (phase == 'localLoading' || (phase == 'discovering' && nestedPendingCount > 0));
+  let isPendingForBoundary = hasNotRevealed && !hasError;
+  let isVisiblyPending = (hasNotRevealed && !hasError) || (phase == 'revealed' && isLoading);
+  let shouldRenderOwnSpinner = isVisiblyPending && !(usesSharedBoundary && hasNotRevealed);
+  let providedGate = !usesSharedBoundary && hasNotRevealed ? gate : null;
+
+  useInitialLoadRegistration(isPendingForBoundary);
+
+  useEffect(() => {
+    if (phase != 'localLoading' || isLoading || hasError) return;
+
+    if (usesSharedBoundary) {
+      setPhase('revealed');
+    } else {
+      setPhase('discovering');
+      if (nestedPendingRef.current.size == 0) scheduleDiscoveryReveal();
+    }
+  }, [hasError, isLoading, phase, scheduleDiscoveryReveal, usesSharedBoundary]);
+
+  useEffect(() => {
+    parentGate?.register(idRef.current, isPendingForParent);
+    return () => parentGate?.register(idRef.current, false);
+  }, [isPendingForParent, parentGate]);
+
+  useEffect(() => {
+    if (!isVisiblyPending) {
+      setSpinnerDelayComplete(false);
+      return;
+    }
+
+    setSpinnerDelayComplete(false);
+    let timeout = setTimeout(() => setSpinnerDelayComplete(true), LOADER_SPINNER_DELAY_MS);
+    return () => clearTimeout(timeout);
+  }, [isVisiblyPending]);
+
+  useEffect(() => {
+    if (hasError || phase == 'revealed') clearDiscoveryTimeout();
+  }, [clearDiscoveryTimeout, hasError, phase]);
+
+  useEffect(() => {
+    if (phase != 'revealed' || nestedPendingRef.current.size == 0) return;
+
+    nestedPendingRef.current = new Set();
+    setNestedPendingCount(0);
+  }, [phase]);
+
+  useEffect(() => () => clearDiscoveryTimeout(), [clearDiscoveryTimeout]);
+
+  if (error) {
+    return renderLoaderError(error, opts);
+  }
+
+  let canRenderChildren = !isLoading && !hasError && phase != 'localLoading';
+  let inner = canRenderChildren
+    ? React.createElement('div', {
+        key: 'content',
+        style: { display: phase == 'revealed' ? 'contents' : 'none' },
+        children: children(loaders as any)
+      })
+    : null;
+
+  return React.createElement(InitialLoaderGateContext.Provider, {
+    value: providedGate,
+    children: React.createElement(Fragment, {
+      children: [
+        shouldRenderOwnSpinner
+          ? React.createElement(Fragment, {
+              key: 'spinner',
+              children: renderLoaderSpinner(opts, spinnerDelayComplete)
+            })
+          : null,
+        inner
+      ]
+    })
+  });
+};
+
+export let renderWithLoader =
+  <Loaders extends RenderWithLoaderLoaders>(
+    loaders: Loaders,
+    opts: RenderWithLoaderOptions = {}
+  ) =>
+  (children: RenderWithLoaderChildren<Loaders>) =>
+    React.createElement(RenderWithLoaderInner, { loaders, opts, children: children as any });
 
 export let renderWithPagination =
   <
@@ -119,6 +290,7 @@ export let renderWithPagination =
       refetch: () => void;
     }) => React.ReactNode
   ) => {
+    let boundary = useInitialLoadBoundaryState();
     let initialLoadRef = useRef(true);
     let directionRef = useRef<'next' | 'previous' | null>(null);
     let [, setSearchParams] = useSearchParams();
@@ -133,29 +305,18 @@ export let renderWithPagination =
 
     if (!loader.isLoading && initialLoadRef.current) initialLoadRef.current = false;
 
-    if (loader.isLoading && initialLoadRef.current) {
-      return React.createElement(Fragment, {
-        children: [
-          opts.spaceTop
-            ? React.createElement('div', { style: { height: opts.spaceTop } })
-            : null,
-          opts.loading ? opts.loading() : React.createElement(CenteredSpinner),
-          opts.spaceBottom
-            ? React.createElement('div', { style: { height: opts.spaceBottom } })
-            : null
-        ].map((el, i) => React.createElement(Fragment, { key: `l-${i}`, children: el }))
-      });
+    let isInitialLoading = loader.isLoading && initialLoadRef.current;
+
+    useInitialLoadRegistration(isInitialLoading);
+
+    if (isInitialLoading) {
+      if (boundary?.isAccepting()) return null;
+
+      return renderLoadingContent(opts);
     }
 
     if (loader.error) {
-      return opts.error
-        ? opts.error(loader.error)
-        : React.createElement(Error, {
-            children:
-              ('data' in loader.error ? loader.error.data.message : loader.error.message) ??
-              loader.error.message ??
-              'An error occurred'
-          });
+      return renderLoaderError(loader.error, opts);
     }
 
     let loaderWithCachedData = {

--- a/src/packages/frontend/dynamic-component/package.json
+++ b/src/packages/frontend/dynamic-component/package.json
@@ -9,6 +9,7 @@
     "lint": "prettier src/**/*.ts --check"
   },
   "dependencies": {
+    "@metorial/data-hooks": "^1.0.0",
     "@metorial/ui": "^1.0.0",
     "p-queue": "^8.1.0"
   },

--- a/src/packages/frontend/dynamic-component/src/dynamicComponent.test.tsx
+++ b/src/packages/frontend/dynamic-component/src/dynamicComponent.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { InitialLoadBoundary } from '@metorial/data-hooks';
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dynamicPage } from './dynamicComponent';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+let getByTestId = (container: HTMLElement, testId: string) =>
+  container.querySelector(`[data-testid="${testId}"]`);
+
+let expectLoaderVisible = (container: HTMLElement, testId: string) => {
+  let loader = getByTestId(container, testId);
+  expect(loader).not.toBeNull();
+  expect((loader!.parentElement as HTMLElement).style.visibility).toBe('visible');
+};
+
+let expectLoaderInactive = (container: HTMLElement, testId: string) => {
+  let loader = getByTestId(container, testId);
+  expect(loader).not.toBeNull();
+  expect((loader!.parentElement as HTMLElement).style.display).toBe('none');
+};
+
+let advance = async (ms: number) => {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+  });
+};
+
+describe('dynamicPage', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it('registers chunk loading with InitialLoadBoundary', async () => {
+    let resolvePage!: (component: () => React.ReactNode) => void;
+    let Page = dynamicPage(
+      () =>
+        new Promise<() => React.ReactNode>(resolve => {
+          resolvePage = resolve;
+        })
+    );
+
+    await act(async () => {
+      root.render(
+        <InitialLoadBoundary
+          loading={() => <div data-testid="boundary-loading">Boundary loading</div>}
+        >
+          <Page />
+        </InitialLoadBoundary>
+      );
+    });
+
+    expectLoaderVisible(container, 'boundary-loading');
+    expect(getByTestId(container, 'page')).toBeNull();
+
+    await advance(100);
+    expectLoaderVisible(container, 'boundary-loading');
+
+    await act(async () => {
+      resolvePage(() => <div data-testid="page">Page</div>);
+    });
+    await advance(30);
+
+    expectLoaderInactive(container, 'boundary-loading');
+    expect(getByTestId(container, 'page')).not.toBeNull();
+  });
+});

--- a/src/packages/frontend/dynamic-component/src/dynamicComponent.tsx
+++ b/src/packages/frontend/dynamic-component/src/dynamicComponent.tsx
@@ -1,6 +1,7 @@
+import { useInitialLoadRegistration } from '@metorial/data-hooks';
 import { Error } from '@metorial/ui';
 import PQueue from 'p-queue';
-import React, { ReactNode, useEffect, useRef, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 
 let queue = new PQueue({ concurrency: 10 });
 
@@ -33,9 +34,9 @@ export let dynamicPage = <Params extends any[]>(
 
   return (props: Params[0] extends undefined ? {} : Params[0]) => {
     let [Component, setComponent] = useState<((p: any) => ReactNode) | null>(null);
-    let [spinner, setSpinner] = useState(false);
     let [error, setError] = useState(false);
-    let completedRef = useRef(false);
+
+    useInitialLoadRegistration(!Component && !error);
 
     useEffect(() => {
       if (loadPromise == null) {
@@ -45,7 +46,6 @@ export let dynamicPage = <Params extends any[]>(
       loadPromise!
         .then(c => {
           setComponent(() => c);
-          completedRef.current = true;
         })
         .catch(() => {
           setError(true);
@@ -57,26 +57,10 @@ export let dynamicPage = <Params extends any[]>(
           current.searchParams.set('_cmp_ref', Date.now().toString());
           window.location.href = current.toString();
         });
-
-      setTimeout(() => {
-        if (!completedRef.current) setSpinner(true);
-      }, 500);
     }, []);
 
     // if (!Component && error) return <Error>Unable to load page</Error>;
     if (!Component && error) return React.createElement(Error, null, 'Unable to load page');
-
-    // if (!Component && spinner) {
-    //   return React.createElement(
-    //     'div',
-    //     {
-    //       style: {
-    //         marginTop: 20
-    //       }
-    //     },
-    //     React.createElement(CenteredSpinner, null)
-    //   );
-    // }
 
     if (Component) return React.createElement(Component as any, props as any);
 

--- a/src/packages/frontend/ui/src/combobox/index.tsx
+++ b/src/packages/frontend/ui/src/combobox/index.tsx
@@ -227,6 +227,10 @@ let ItemDescription = styled('div')`
   font-size: 12px;
   color: ${theme.colors.gray700};
   line-height: 1.35;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 let EmptyState = styled(BaseCombobox.Empty)`

--- a/src/packages/frontend/ui/src/input/index.tsx
+++ b/src/packages/frontend/ui/src/input/index.tsx
@@ -30,6 +30,33 @@ export let InputDescription = styled('p')`
   user-select: none;
 `;
 
+let LabelRow = styled('div')`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+  margin-bottom: 5px;
+
+  ${InputLabel} {
+    display: block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 0;
+  }
+`;
+
+let LabelHelp = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
 let InputWrapper = styled('div')`
   outline: 1px solid transparent;
   background: ${theme.colors.gray300};
@@ -108,6 +135,7 @@ export let Input = ({
   size = '3',
   label,
   description,
+  help,
   hideLabel,
   error,
   as = 'input',
@@ -121,6 +149,7 @@ export let Input = ({
   size?: ButtonSize;
   label: React.ReactNode;
   description?: React.ReactNode;
+  help?: React.ReactNode;
   hideLabel?: boolean;
   error?: any;
   as?: 'textarea' | 'input';
@@ -138,7 +167,10 @@ export let Input = ({
           <InputLabel htmlFor={id}>{label}</InputLabel>
         </VisuallyHidden>
       ) : (
-        <InputLabel htmlFor={id}>{label}</InputLabel>
+        <LabelRow>
+          <InputLabel htmlFor={id}>{label}</InputLabel>
+          {help && <LabelHelp>{help}</LabelHelp>}
+        </LabelRow>
       )}
 
       {description && <InputDescription>{description}</InputDescription>}

--- a/src/systems/ares/service/frontend/auth/src/components/layout.tsx
+++ b/src/systems/ares/service/frontend/auth/src/components/layout.tsx
@@ -1,10 +1,11 @@
-import { Logo, Text, theme, Title } from '@metorial-io/ui';
+import { Logo, Spacer, Text, theme, Title } from '@metorial-io/ui';
 import React from 'react';
 import { styled } from 'styled-components';
 
 let Wrapper = styled.div`
   min-height: 100dvh;
   padding: 20px;
+  box-sizing: border-box;
   background: white;
   display: flex;
   flex-direction: column;
@@ -15,6 +16,10 @@ let Wrapper = styled.div`
   @media (max-width: 800px) {
     padding: 20px 16px;
   }
+`;
+
+let BrandSlot = styled.div`
+  min-height: 30px;
 `;
 
 let Brand = styled.div`
@@ -32,232 +37,22 @@ let BrandText = styled.p`
 `;
 
 let Box = styled.div`
-  --box-width: 1100px;
-  --box-height: 680px;
-  --border-color: #ccc;
-  --dash-length: 10px;
-  --dash-gap: 8px;
-
-  position: relative;
-  width: min(var(--box-width), calc(100dvw - 40px));
-  min-height: min(var(--box-height), calc(100dvh - 40px));
-  background: white;
-
-  /* important: Box should not be the scroll container */
-  overflow: visible;
-
+  width: min(460px, 100%);
   display: flex;
-  flex-direction: column;
-
-  @media (max-width: 800px) {
-    width: min(var(--box-width), calc(100dvw - 32px));
-    min-height: 0;
-  }
-`;
-
-let BorderOverlay = styled.div`
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 2;
-  background-image:
-    repeating-linear-gradient(
-      to right,
-      var(--border-color) 0,
-      var(--border-color) var(--dash-length),
-      transparent var(--dash-length),
-      transparent calc(var(--dash-length) + var(--dash-gap))
-    ),
-    repeating-linear-gradient(
-      to right,
-      var(--border-color) 0,
-      var(--border-color) var(--dash-length),
-      transparent var(--dash-length),
-      transparent calc(var(--dash-length) + var(--dash-gap))
-    ),
-    repeating-linear-gradient(
-      to bottom,
-      var(--border-color) 0,
-      var(--border-color) var(--dash-length),
-      transparent var(--dash-length),
-      transparent calc(var(--dash-length) + var(--dash-gap))
-    ),
-    repeating-linear-gradient(
-      to bottom,
-      var(--border-color) 0,
-      var(--border-color) var(--dash-length),
-      transparent var(--dash-length),
-      transparent calc(var(--dash-length) + var(--dash-gap))
-    );
-  background-size:
-    100% 1px,
-    100% 1px,
-    1px 100%,
-    1px 100%;
-  background-position:
-    top left,
-    bottom left,
-    top left,
-    top right;
-  background-repeat: no-repeat;
-`;
-
-let Inner = styled.div`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 1px minmax(0, 1fr);
-  flex: 1;
-  position: relative;
-  z-index: 1;
-  width: 100%;
-
-  /* critical for overflow inside flex children */
-  height: 100%;
-  min-height: 0;
-  min-width: 0;
-
-  @media (max-width: 800px) {
-    grid-template-columns: 1fr;
-    height: auto;
-  }
-`;
-
-let Side = styled.section`
-  display: flex;
-  flex-direction: column;
-  padding: 50px;
-
-  overflow: auto;
-  min-height: 0;
-  min-width: 0;
-
-  -webkit-overflow-scrolling: touch;
-
-  @media (max-width: 800px) {
-    padding: 40px 24px;
-  }
-`;
-
-let IntroSide = styled(Side)`
-  background: #fafafa;
-  justify-content: center;
-  gap: 28px;
-
-  @media (max-width: 800px) {
-    display: none;
-  }
-`;
-
-let IntroBlock = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-`;
-
-let Eyebrow = styled.p`
-  margin: 0;
-  font-size: 12px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #666;
-  font-weight: 600;
-`;
-
-let IntroTitle = styled.h1`
-  margin: 0;
-  font-size: clamp(30px, 4vw, 38px);
-  line-height: 0.95;
-  font-weight: 700;
-  color: black;
-  max-width: 420px;
-`;
-
-let IntroText = styled.p`
-  margin: 0;
-  font-size: 15px;
-  line-height: 1.6;
-  color: #777;
-  max-width: 430px;
-  font-weight: 500;
-`;
-
-let FeatureList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-`;
-
-let FeatureRow = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-`;
-
-let FeatureMark = styled.span`
-  width: 6px;
-  height: 6px;
-  border-radius: 999px;
-  background: #aaa;
-  flex-shrink: 0;
-`;
-
-let FeatureText = styled.p`
-  margin: 0;
-  font-size: 14px;
-  line-height: 1.4;
-  color: #333;
-`;
-
-let IntegrationGroup = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  max-width: 420px;
-`;
-
-let IntegrationPill = styled.div`
-  padding: 8px 12px;
-  font-size: 13px;
-  line-height: 1;
-  color: #333;
-  border: 1px solid #e5e5e5;
-  border-radius: 999px;
-  background: white;
-`;
-
-let Divider = styled.div`
-  align-self: stretch;
-  background-image: repeating-linear-gradient(
-    to bottom,
-    var(--border-color) 0,
-    var(--border-color) var(--dash-length),
-    transparent var(--dash-length),
-    transparent calc(var(--dash-length) + var(--dash-gap))
-  );
-  background-repeat: no-repeat;
-  background-size: 1px 100%;
-  background-position: center;
-
-  @media (max-width: 800px) {
-    display: none;
-  }
-`;
-
-let ContentRail = styled.div`
-  display: flex;
-  flex: 1;
-  min-height: 100%;
   flex-direction: column;
 `;
 
 let Content = styled.div`
-  margin: auto 0; /* vertical centering when content is small */
+  width: 100%;
+  min-width: 0;
 `;
 
-let Main = styled.div`
+let Inner = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-bottom: 32px;
+  justify-content: center;
+  width: 100%;
+  min-width: 0;
 `;
 
 let Footer = styled.footer`
@@ -294,86 +89,48 @@ export let AuthLayout = ({
 }) => {
   return (
     <Wrapper>
-      <Brand>
-        <Logo size={28} color="black" />
-        <BrandText>Metorial</BrandText>
-      </Brand>
+      <BrandSlot>
+        <Brand>
+          <Logo size={30} color="black" />
+          <BrandText>Metorial</BrandText>
+        </Brand>
+      </BrandSlot>
 
       <Box>
-        <BorderOverlay />
-        <Inner>
-          <IntroSide>
-            <IntroBlock>
-              <Eyebrow>Connect to 1000+ verified integrations</Eyebrow>
-              <IntroTitle>Agentic infrastructure to power AI-native companies.</IntroTitle>
-              <IntroText>
-                Deploy MCP servers with build-in observability and enterprise-grade isolation
-                from day one.
-              </IntroText>
-            </IntroBlock>
+        <Content>
+          <Inner>
+            {main && (
+              <>
+                <Title as="h1" weight="bold" size="5">
+                  {main.title}
+                </Title>
 
-            <FeatureList>
-              <FeatureRow>
-                <FeatureMark />
-                <FeatureText>Available via API, MCP & CLI</FeatureText>
-              </FeatureRow>
-
-              <FeatureRow>
-                <FeatureMark />
-                <FeatureText>AI Native Access Control</FeatureText>
-              </FeatureRow>
-
-              <FeatureRow>
-                <FeatureMark />
-                <FeatureText>RBAC, SAML SSO & IAM</FeatureText>
-              </FeatureRow>
-            </FeatureList>
-
-            <IntegrationGroup>
-              <IntegrationPill>Slack</IntegrationPill>
-              <IntegrationPill>Notion</IntegrationPill>
-              <IntegrationPill>Linear</IntegrationPill>
-              <IntegrationPill>Stripe</IntegrationPill>
-              <IntegrationPill>Google Drive</IntegrationPill>
-              <IntegrationPill>Sentry</IntegrationPill>
-              <IntegrationPill>GitHub</IntegrationPill>
-              <IntegrationPill>Jira</IntegrationPill>
-              <IntegrationPill>Salesforce</IntegrationPill>
-            </IntegrationGroup>
-          </IntroSide>
-          <Divider />
-          <Side>
-            <ContentRail>
-              <Content>
-                {main && (
-                  <Main>
-                    <Title as="h1" weight="bold" size="4">
-                      {main.title}
-                    </Title>
-
-                    {main.description && (
-                      <Text color="gray600" weight="medium" size="2">
-                        {main.description}
-                      </Text>
-                    )}
-                  </Main>
+                {main.description && (
+                  <>
+                    <Spacer size={5} />
+                    <Text color="gray700" weight="medium" size="3">
+                      {main.description}
+                    </Text>
+                  </>
                 )}
 
-                {children}
-              </Content>
+                <Spacer size={25} />
+              </>
+            )}
 
-              <Footer>
-                <p>
-                  By signing up for, logging in to and/or using a{' '}
-                  <a href="https://metorial.com">Metorial</a> service, you agree to
-                  Metorial&apos;s{' '}
-                  <a href="https://metorial.com/legal/terms-of-service">terms of service</a>{' '}
-                  and <a href="https://metorial.com/legal/privacy-policy">privacy policy</a>.
-                </p>
-              </Footer>
-            </ContentRail>
-          </Side>
-        </Inner>
+            {children}
+          </Inner>
+
+          <Footer>
+            <p>
+              By signing up for, logging in to and/or using a{' '}
+              <a href="https://metorial.com">Metorial</a> service, you agree to
+              Metorial&apos;s{' '}
+              <a href="https://metorial.com/legal/terms-of-service">terms of service</a>{' '}
+              and <a href="https://metorial.com/legal/privacy-policy">privacy policy</a>.
+            </p>
+          </Footer>
+        </Content>
       </Box>
     </Wrapper>
   );

--- a/src/systems/ares/service/frontend/auth/src/scenes/authHome.tsx
+++ b/src/systems/ares/service/frontend/auth/src/scenes/authHome.tsx
@@ -215,7 +215,7 @@ export let AuthHomeScene = ({
           <>
             <Spacer height={10} />
 
-            <Text align="center" color="gray600" weight="medium" size="1">
+            <Text color="gray600" weight="medium" size="1">
               {type == 'login' ? (
                 <Link
                   to={`/signup?client_id=${encodeURIComponent(clientId)}&nextUrl=${encodeURIComponent(nextUrl)}`}

--- a/src/systems/ares/service/frontend/auth/src/scenes/authIntent.tsx
+++ b/src/systems/ares/service/frontend/auth/src/scenes/authIntent.tsx
@@ -8,18 +8,25 @@ import {
   Input,
   LinkButton,
   Spacer,
-  Switch,
-  Text
+  Switch
 } from '@metorial-io/ui';
 import { differenceInMinutes } from 'date-fns';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
+import { styled } from 'styled-components';
 import { CodeInput } from '../components/codeInput';
 import { AuthLayout } from '../components/layout';
 import { useNonNullable } from '../hooks/useNonNullable';
 import { authIntentState } from '../state/authIntent';
 import type { IAuthIntent } from '../state/client';
+
+let FullSpinner = styled.div`
+  height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
 
 let CreateUserStep = ({
   authIntent,
@@ -224,9 +231,9 @@ let AuthIntentStep = ({
   }
 
   return (
-    <AuthLayout>
+    <FullSpinner>
       <CenteredSpinner />
-    </AuthLayout>
+    </FullSpinner>
   );
 };
 
@@ -272,9 +279,9 @@ export let AuthIntentScene = (p: {
   if (authIntent.error) {
     if (authIntent.error.data.status == 404) {
       return (
-        <AuthLayout>
+        <FullSpinner>
           <CenteredSpinner />
-        </AuthLayout>
+        </FullSpinner>
       );
     }
 

--- a/src/systems/slates/apps/hub/package.json
+++ b/src/systems/slates/apps/hub/package.json
@@ -92,7 +92,7 @@
     "@remixicon/react": "^4.0.0",
     "@sentry/bun": "^10.36.0",
     "@sentry/cli": "^3.2.0",
-    "@slates/proto": "^1.0.0-rc.10",
+    "@slates/proto": "^1.0.0-rc.11",
     "@types/semver": "^7.7.1",
     "@types/unzipper": "^0.10.11",
     "date-fns": "^4.1.0",

--- a/src/systems/slates/apps/hub/package.json
+++ b/src/systems/slates/apps/hub/package.json
@@ -92,7 +92,7 @@
     "@remixicon/react": "^4.0.0",
     "@sentry/bun": "^10.36.0",
     "@sentry/cli": "^3.2.0",
-    "@slates/proto": "^1.0.0-rc.8",
+    "@slates/proto": "^1.0.0-rc.10",
     "@types/semver": "^7.7.1",
     "@types/unzipper": "^0.10.11",
     "date-fns": "^4.1.0",

--- a/src/systems/slates/apps/hub/prisma/schema/slate.prisma
+++ b/src/systems/slates/apps/hub/prisma/schema/slate.prisma
@@ -171,6 +171,9 @@ model SlateConfigSchema {
   /// [SlateConfigSchema]
   schema Json
 
+  /// [SlateDocReferences]
+  docs Json @default("[]")
+
   slateOid BigInt
   slate    Slate  @relation(fields: [slateOid], references: [oid])
 
@@ -263,8 +266,14 @@ model SlateSpecification {
   /// [SlateProviderInfo]
   providerInfo Json
 
+  /// [SlateDocReferences]
+  providerDocs Json @default("[]")
+
   /// [SlateConfigSchema]
   configSchema Json
+
+  /// [SlateDocReferences]
+  configSchemaDocs Json @default("[]")
 
   /// [SlateAuthMethods]
   authMethods Json

--- a/src/systems/slates/apps/hub/src/db.ts
+++ b/src/systems/slates/apps/hub/src/db.ts
@@ -71,6 +71,13 @@ declare global {
 
     type SlateConfigSchema = any;
 
+    type SlateDocReference = {
+      type?: string;
+      name: string;
+      url: string;
+    };
+    type SlateDocReferences = SlateDocReference[];
+
     type SlateAuthMethod = SlateAuthenticationMethod;
     type SlateAction = ProtoSlatesAction;
 

--- a/src/systems/slates/apps/hub/src/lib/specificationHash.ts
+++ b/src/systems/slates/apps/hub/src/lib/specificationHash.ts
@@ -2,6 +2,8 @@ import { canonicalize } from '@lowerdeck/canonicalize';
 import { Hash } from '@lowerdeck/hash';
 import type { SlateAuthenticationMethod, SlatesAction } from '@slates/proto';
 
+type SlateDocReference = PrismaJson.SlateDocReference;
+
 export let dedupeDiscoveredItems = <T extends { id: string }>(
   items: T[],
   d: {
@@ -40,10 +42,13 @@ export let dedupeDiscoveredItems = <T extends { id: string }>(
 export let hashDiscoveredProviderInfo = async (d: {
   protocol: string;
   provider: Record<string, any>;
+  docs: SlateDocReference[];
 }) => await Hash.sha256(canonicalize(d));
 
-export let hashDiscoveredConfigSchema = async (schema: Record<string, any>) =>
-  await Hash.sha256(canonicalize(schema));
+export let hashDiscoveredConfigSchema = async (d: {
+  schema: Record<string, any>;
+  docs: SlateDocReference[];
+}) => await Hash.sha256(canonicalize(d));
 
 export let hashDiscoveredAuthMethod = async (method: SlateAuthenticationMethod) =>
   await Hash.sha256(canonicalize(method));
@@ -55,8 +60,12 @@ export let buildDiscoveredSpecificationHashes = async (d: {
   providerInfo: {
     protocol: string;
     provider: Record<string, any>;
+    docs: SlateDocReference[];
   };
-  configSchema: Record<string, any>;
+  configSchema: {
+    schema: Record<string, any>;
+    docs: SlateDocReference[];
+  };
   authMethods: SlateAuthenticationMethod[];
   actions: SlatesAction[];
 }) => {

--- a/src/systems/slates/apps/hub/src/presenters/slateAction.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateAction.ts
@@ -23,6 +23,7 @@ export let slateActionPresenter = (
   constraints: method.spec.constraints,
   description: method.spec.description,
   instructions: method.spec.instructions,
+  docs: method.spec.docs ?? [],
   metadata: method.spec.metadata,
   tags: method.spec.tags,
   scopes: method.spec.scopes,

--- a/src/systems/slates/apps/hub/src/presenters/slateAuthMethod.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateAuthMethod.ts
@@ -20,6 +20,7 @@ export let slateAuthMethodPresenter = (
   inputSchema: method.spec.inputSchema,
   outputSchema: method.spec.outputSchema,
   scopes: method.spec.scopes,
+  docs: method.spec.docs ?? [],
 
   createdAt: method.createdAt
 });

--- a/src/systems/slates/apps/hub/src/presenters/slateSpecification.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateSpecification.ts
@@ -29,7 +29,9 @@ export let slateSpecificationPresenter = (
   protocolVersion: spec.protocolVersion,
 
   providerInfo: spec.providerInfo,
+  providerDocs: spec.providerDocs,
   configSchema: spec.configSchema,
+  configSchemaDocs: spec.configSchemaDocs,
 
   authMethods: spec.slateAuthMethods.map(sam =>
     slateAuthMethodPresenter({ ...sam.authMethod, slate: spec.slate })

--- a/src/systems/slates/apps/hub/src/queues/discovery/discover.ts
+++ b/src/systems/slates/apps/hub/src/queues/discovery/discover.ts
@@ -17,6 +17,24 @@ import { slateInvocationService } from '../../services';
 
 let Sentry = getSentry();
 
+let normalizeDiscoveredDocs = (docs: unknown): PrismaJson.SlateDocReferences => {
+  if (!Array.isArray(docs)) return [];
+
+  return docs
+    .filter(
+      (doc): doc is { name: string; url: string; type?: string } =>
+        !!doc &&
+        typeof doc === 'object' &&
+        typeof (doc as any).name === 'string' &&
+        typeof (doc as any).url === 'string'
+    )
+    .map(doc => ({
+      ...(typeof doc.type === 'string' ? { type: doc.type } : {}),
+      name: doc.name,
+      url: doc.url
+    }));
+};
+
 let syncSpecificationActions = async (d: {
   specificationOid: bigint;
   actions: Array<{ oid: bigint }>;
@@ -304,14 +322,19 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         getKey: action => `${action.type}:${action.id}`
       });
 
-      // authMethods.authenticationMethods[0]?.docs
+      let providerDocs = normalizeDiscoveredDocs(providerInfo.docs);
+      let configSchemaDocs = normalizeDiscoveredDocs(configSchema.docs);
 
       let discoveryHashes = await buildDiscoveredSpecificationHashes({
         providerInfo: {
           protocol: providerInfo.protocol,
-          provider: providerInfo.provider
+          provider: providerInfo.provider,
+          docs: providerDocs
         },
-        configSchema: configSchema.schema,
+        configSchema: {
+          schema: configSchema.schema,
+          docs: configSchemaDocs
+        },
         authMethods: discoveredAuthMethods,
         actions: discoveredActions
       });
@@ -324,7 +347,9 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         protocolVersion: providerInfo.protocol,
 
         providerInfo: providerInfo.provider,
+        providerDocs,
         configSchema: configSchema.schema,
+        configSchemaDocs,
         authMethods: discoveredAuthMethods,
         actions: discoveredActions
       };
@@ -409,10 +434,12 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
           hash: discoveryHashes.configSchemaHash,
           identifier: configIdentifier,
 
-          schema: configSchema.schema
+          schema: configSchema.schema,
+          docs: configSchemaDocs
         },
         update: {
-          schema: configSchema.schema
+          schema: configSchema.schema,
+          docs: configSchemaDocs
         }
       });
 

--- a/src/systems/slates/apps/hub/src/queues/discovery/discover.ts
+++ b/src/systems/slates/apps/hub/src/queues/discovery/discover.ts
@@ -304,6 +304,8 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         getKey: action => `${action.type}:${action.id}`
       });
 
+      // authMethods.authenticationMethods[0]?.docs
+
       let discoveryHashes = await buildDiscoveredSpecificationHashes({
         providerInfo: {
           protocol: providerInfo.protocol,

--- a/src/systems/subspace/db/prisma/schema/listing/listing.prisma
+++ b/src/systems/subspace/db/prisma/schema/listing/listing.prisma
@@ -29,6 +29,9 @@ model ProviderListing {
   description String?
   readme      String?
 
+  /// [ProviderListingDocs]
+  docs Json?
+
   rank Int @default(0)
 
   skills String[]

--- a/src/systems/subspace/db/src/db.ts
+++ b/src/systems/subspace/db/src/db.ts
@@ -172,6 +172,29 @@ declare global {
       config?: CustomProviderConfig;
     };
 
+    type ProviderListingDocReference = {
+      type?: string;
+      name: string;
+      url: string;
+    };
+
+    type ProviderListingDocs = {
+      provider: ProviderListingDocReference[];
+      config: ProviderListingDocReference[];
+      authMethods: {
+        key: string;
+        name: string;
+        type: string;
+        docs: ProviderListingDocReference[];
+      }[];
+      actions: {
+        key: string;
+        name: string;
+        type: 'tool' | 'trigger';
+        docs: ProviderListingDocReference[];
+      }[];
+    };
+
     type ProviderTypeAttributes = {
       provider: 'metorial-slates' | 'metorial-shuttle' | 'metorial-native';
       backend: 'slates' | 'mcp.container' | 'mcp.function' | 'mcp.remote' | 'native';

--- a/src/systems/subspace/modules/provider-internal/src/services/provider.ts
+++ b/src/systems/subspace/modules/provider-internal/src/services/provider.ts
@@ -6,6 +6,7 @@ import {
   db,
   type EntityImage,
   getId,
+  Prisma,
   type Provider,
   type ProviderVariant,
   type Publisher,
@@ -99,6 +100,7 @@ class providerInternalServiceImpl {
       image?: EntityImage | null;
       skills?: string[];
       readme?: string;
+      docs?: PrismaJson.ProviderListingDocs | null;
       categories?: string[];
     };
 
@@ -283,6 +285,7 @@ class providerInternalServiceImpl {
             image: d.info.image ?? { type: 'default' as const },
 
             readme: d.info.readme,
+            docs: d.info.docs ?? Prisma.DbNull,
 
             skills: d.info.skills || [],
 

--- a/src/systems/subspace/packages/presenters/src/providerListing.ts
+++ b/src/systems/subspace/packages/presenters/src/providerListing.ts
@@ -66,6 +66,7 @@ export let providerListingPresenter = async (
   aliases: providerListing.aliases,
 
   readme: providerListing.readme ?? null,
+  docs: providerListing.docs ?? null,
   skills: providerListing.skills,
 
   rank: providerListing.rank,

--- a/src/systems/subspace/provider-backends/provider-slates/src/queues/sync/syncSlateVersion.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/queues/sync/syncSlateVersion.ts
@@ -61,6 +61,61 @@ let metorialDomains = [
   'localhost'
 ];
 
+let normalizeDocs = (docs: unknown): PrismaJson.ProviderListingDocReference[] => {
+  if (!Array.isArray(docs)) return [];
+
+  return docs
+    .filter(
+      (doc): doc is { name: string; url: string; type?: string } =>
+        !!doc &&
+        typeof doc === 'object' &&
+        typeof (doc as any).name === 'string' &&
+        typeof (doc as any).url === 'string'
+    )
+    .map(doc => ({
+      ...(typeof doc.type === 'string' ? { type: doc.type } : {}),
+      name: doc.name,
+      url: doc.url
+    }));
+};
+
+let buildProviderListingDocs = (spec: any): PrismaJson.ProviderListingDocs | undefined => {
+  if (!spec) return undefined;
+
+  let providerDocs = normalizeDocs(spec.providerDocs);
+  let configDocs = normalizeDocs(spec.configSchemaDocs);
+  let authMethods = (spec.authMethods ?? [])
+    .map((authMethod: any) => ({
+      key: authMethod.key,
+      name: authMethod.name,
+      type: authMethod.type,
+      docs: normalizeDocs(authMethod.docs)
+    }))
+    .filter((authMethod: any) => authMethod.docs.length > 0);
+  let actions = [...(spec.tools ?? []), ...(spec.triggers ?? [])]
+    .map((action: any) => ({
+      key: action.key,
+      name: action.name,
+      type: action.type,
+      docs: normalizeDocs(action.docs)
+    }))
+    .filter((action: any) => action.docs.length > 0);
+
+  let hasDocs =
+    providerDocs.length > 0 ||
+    configDocs.length > 0 ||
+    authMethods.length > 0 ||
+    actions.length > 0;
+  if (!hasDocs) return undefined;
+
+  return {
+    provider: providerDocs,
+    config: configDocs,
+    authMethods,
+    actions
+  };
+};
+
 export let syncSlateVersionQueueProcessor = syncSlateVersionQueue.process(async data => {
   let version = await slates.slateVersion.get({
     slateId: data.slateId,
@@ -145,6 +200,7 @@ export let syncSlateVersionQueueProcessor = syncSlateVersionQueue.process(async 
   let hasAuthConfig = !!(spec && spec.authMethods.length > 0);
   let hasOAuth = spec?.authMethods.some(am => am.type === 'oauth');
   let hasTriggers = !!(spec ? spec.triggers.length > 0 : false);
+  let docs = buildProviderListingDocs(spec);
 
   let type = {
     name: 'Slates',
@@ -209,6 +265,7 @@ export let syncSlateVersionQueueProcessor = syncSlateVersionQueue.process(async 
         image: registryRecord.logoUrl ? { type: 'url', url: registryRecord.logoUrl } : null,
         skills: registryRecord.skills,
         readme: readme,
+        docs,
         categories: registryRecord.categories?.map((c: any) => c.identifier) ?? [],
         globalIdentifier
       };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches OAuth redirect validation and new global OAuth application lifecycle (revokes auths on archive); widespread layout loading changes could affect perceived navigation behavior across many routes.
> 
> **Overview**
> This PR coordinates **smarter loading UX** across the dashboard by wrapping many detail-route layouts in `InitialLoadBoundary` from `@metorial/data-hooks`, so nested outlets can register pending work and show a unified loading state instead of flashing partial UI.
> 
> **API and filtering:** List endpoints for consumers, portal consumer invites/profiles, and portals gain optional **`email`** (string or array) and **`search`** where missing; backend services normalize emails and apply DB filters. **Provider listings** now expose a structured **`docs`** payload (provider, config, auth methods, actions) through the dashboard presenter and generated client types.
> 
> **OAuth / machine access:** Redirect URI validation allows **HTTP on loopback** hosts for local dev; new **global user-facing OAuth application** CRUD/list flows (no org) with tests. **Provider deployment** navigation drops separate config-vaults, auth-methods, and auth-credentials routes in favor of consolidated pages.
> 
> **Dashboard product UX:** Provider **documentation links** from listing `docs`; scope picker field wrapper and links on auth credential settings; JSON schema helpers infer **defaults** so auto-empty config creation works when required fields are satisfiable by defaults; consumer overview **profiles** table restored with portal avatars; table row actions support **`hidden`**; developer page title becomes “API Keys”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e22a843d560d1de217931c14382a9d7a0a10864c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->