### PR TITLE
Harden oauth apps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2563,7 +2563,7 @@
         "@remixicon/react": "^4.0.0",
         "@sentry/bun": "^10.36.0",
         "@sentry/cli": "^3.2.0",
-        "@slates/proto": "^1.0.0-rc.10",
+        "@slates/proto": "^1.0.0-rc.11",
         "@types/semver": "^7.7.1",
         "@types/unzipper": "^0.10.11",
         "date-fns": "^4.1.0",
@@ -5258,7 +5258,7 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
-    "@slates/proto": ["@slates/proto@1.0.0-rc.10", "", { "dependencies": { "@lowerdeck/emitter": "^1.0.4", "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-d2ZzchGaF8zzCd/5AvtdeUIi9hkNwIOFj3T38Dh67z/z2R8Evl5/SgkYMhMHZ7C+JqcwSdf1Zz5XAHwkhYpPzA=="],
+    "@slates/proto": ["@slates/proto@1.0.0-rc.11", "", { "dependencies": { "@lowerdeck/emitter": "^1.0.4", "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-g/MMRAciX5D0UmEiwBy9656qEaade2ZMysIRMYoL64PzwfLC2rorOuTfE+kfBhNfH1IeA9UgmfVT8+8vGbQv3Q=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q=="],
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-listings/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-listings/get.ts
@@ -86,6 +86,22 @@ export type DashboardInstanceProviderListingsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  docs: {
+    provider: { type?: string | undefined; name: string; url: string }[];
+    config: { type?: string | undefined; name: string; url: string }[];
+    authMethods: {
+      key: string;
+      name: string;
+      type: string;
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+    actions: {
+      key: string;
+      name: string;
+      type: 'tool' | 'trigger';
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+  } | null;
   provider: {
     object: 'provider';
     id: string;
@@ -423,7 +439,72 @@ export let mapDashboardInstanceProviderListingsGetOutput = mtMap.union([
         )
       ),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      docs: mtMap.objectField(
+        'docs',
+        mtMap.object({
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          authMethods: mtMap.objectField(
+            'auth_methods',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          ),
+          actions: mtMap.objectField(
+            'actions',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          )
+        })
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-listings/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-listings/list.ts
@@ -87,6 +87,22 @@ export type DashboardInstanceProviderListingsListOutput = {
     createdAt: Date;
     updatedAt: Date;
   } & {
+    docs: {
+      provider: { type?: string | undefined; name: string; url: string }[];
+      config: { type?: string | undefined; name: string; url: string }[];
+      authMethods: {
+        key: string;
+        name: string;
+        type: string;
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+      actions: {
+        key: string;
+        name: string;
+        type: 'tool' | 'trigger';
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+    } | null;
     provider: {
       object: 'provider';
       id: string;
@@ -507,7 +523,84 @@ export let mapDashboardInstanceProviderListingsListOutput =
                 )
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              docs: mtMap.objectField(
+                'docs',
+                mtMap.object({
+                  provider: mtMap.objectField(
+                    'provider',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  authMethods: mtMap.objectField(
+                    'auth_methods',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  ),
+                  actions: mtMap.objectField(
+                    'actions',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  )
+                })
+              )
             })
           )
         ])

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-listings/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-listings/get.ts
@@ -86,6 +86,22 @@ export type ManagementInstanceProviderListingsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  docs: {
+    provider: { type?: string | undefined; name: string; url: string }[];
+    config: { type?: string | undefined; name: string; url: string }[];
+    authMethods: {
+      key: string;
+      name: string;
+      type: string;
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+    actions: {
+      key: string;
+      name: string;
+      type: 'tool' | 'trigger';
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+  } | null;
   provider: {
     object: 'provider';
     id: string;
@@ -423,7 +439,72 @@ export let mapManagementInstanceProviderListingsGetOutput = mtMap.union([
         )
       ),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      docs: mtMap.objectField(
+        'docs',
+        mtMap.object({
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          authMethods: mtMap.objectField(
+            'auth_methods',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          ),
+          actions: mtMap.objectField(
+            'actions',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          )
+        })
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-listings/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-listings/list.ts
@@ -87,6 +87,22 @@ export type ManagementInstanceProviderListingsListOutput = {
     createdAt: Date;
     updatedAt: Date;
   } & {
+    docs: {
+      provider: { type?: string | undefined; name: string; url: string }[];
+      config: { type?: string | undefined; name: string; url: string }[];
+      authMethods: {
+        key: string;
+        name: string;
+        type: string;
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+      actions: {
+        key: string;
+        name: string;
+        type: 'tool' | 'trigger';
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+    } | null;
     provider: {
       object: 'provider';
       id: string;
@@ -507,7 +523,84 @@ export let mapManagementInstanceProviderListingsListOutput =
                 )
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              docs: mtMap.objectField(
+                'docs',
+                mtMap.object({
+                  provider: mtMap.objectField(
+                    'provider',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  authMethods: mtMap.objectField(
+                    'auth_methods',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  ),
+                  actions: mtMap.objectField(
+                    'actions',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  )
+                })
+              )
             })
           )
         ])

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-listings/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-listings/get.ts
@@ -86,6 +86,22 @@ export type ProviderListingsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  docs: {
+    provider: { type?: string | undefined; name: string; url: string }[];
+    config: { type?: string | undefined; name: string; url: string }[];
+    authMethods: {
+      key: string;
+      name: string;
+      type: string;
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+    actions: {
+      key: string;
+      name: string;
+      type: 'tool' | 'trigger';
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+  } | null;
   provider: {
     object: 'provider';
     id: string;
@@ -423,7 +439,72 @@ export let mapProviderListingsGetOutput = mtMap.union([
         )
       ),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      docs: mtMap.objectField(
+        'docs',
+        mtMap.object({
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          authMethods: mtMap.objectField(
+            'auth_methods',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          ),
+          actions: mtMap.objectField(
+            'actions',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          )
+        })
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-listings/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-listings/list.ts
@@ -87,6 +87,22 @@ export type ProviderListingsListOutput = {
     createdAt: Date;
     updatedAt: Date;
   } & {
+    docs: {
+      provider: { type?: string | undefined; name: string; url: string }[];
+      config: { type?: string | undefined; name: string; url: string }[];
+      authMethods: {
+        key: string;
+        name: string;
+        type: string;
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+      actions: {
+        key: string;
+        name: string;
+        type: 'tool' | 'trigger';
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+    } | null;
     provider: {
       object: 'provider';
       id: string;
@@ -507,7 +523,84 @@ export let mapProviderListingsListOutput =
                 )
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              docs: mtMap.objectField(
+                'docs',
+                mtMap.object({
+                  provider: mtMap.objectField(
+                    'provider',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  authMethods: mtMap.objectField(
+                    'auth_methods',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  ),
+                  actions: mtMap.objectField(
+                    'actions',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  )
+                })
+              )
             })
           )
         ])

--- a/src/backend/apis/core/src/presenters/implementation/provider/provider/providerListing.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/provider/providerListing.ts
@@ -7,6 +7,56 @@ import { v1ProviderListingCollectionPresenter } from './collection';
 import { v1ProviderListingGroupPresenter } from './group';
 import { dashboardProviderPresenter, v1ProviderPresenter } from './provider';
 
+let providerListingDocReferenceSchema = v.object({
+  type: v.optional(v.string({ description: 'The protocol-specific documentation type.' })),
+  name: v.string({ description: 'The display name for this documentation reference.' }),
+  url: v.string({ description: 'The documentation URL.' })
+});
+
+let providerListingDocsSchema = v.nullable(
+  v.object({
+    provider: v.array(providerListingDocReferenceSchema),
+    config: v.array(providerListingDocReferenceSchema),
+    auth_methods: v.array(
+      v.object({
+        key: v.string(),
+        name: v.string(),
+        type: v.string(),
+        docs: v.array(providerListingDocReferenceSchema)
+      })
+    ),
+    actions: v.array(
+      v.object({
+        key: v.string(),
+        name: v.string(),
+        type: v.enumOf(['tool', 'trigger']),
+        docs: v.array(providerListingDocReferenceSchema)
+      })
+    )
+  })
+);
+
+let presentProviderListingDocs = (docs: any) => {
+  if (!docs) return null;
+
+  return {
+    provider: docs.provider ?? [],
+    config: docs.config ?? [],
+    auth_methods: (docs.authMethods ?? []).map((authMethod: any) => ({
+      key: authMethod.key,
+      name: authMethod.name,
+      type: authMethod.type,
+      docs: authMethod.docs ?? []
+    })),
+    actions: (docs.actions ?? []).map((action: any) => ({
+      key: action.key,
+      name: action.name,
+      type: action.type,
+      docs: action.docs ?? []
+    }))
+  };
+};
+
 export let v1ProviderListingPresenter = Presenter.create(providerListingType)
   .presenter(async ({ providerListing }, opts) => {
     return {
@@ -153,6 +203,7 @@ export let dashboardProviderListingPresenter = Presenter.create(providerListingT
 
     return {
       ...inner,
+      docs: presentProviderListingDocs((input.providerListing as any).docs),
       provider: await dashboardProviderPresenter
         .present({ provider: input.providerListing.provider }, opts)
         .run()
@@ -162,6 +213,7 @@ export let dashboardProviderListingPresenter = Presenter.create(providerListingT
     v.intersection([
       v1ProviderListingPresenter.schema,
       v.object({
+        docs: providerListingDocsSchema,
         provider: dashboardProviderPresenter.schema
       })
     ])

--- a/src/backend/modules/machine-access/src/services/oauthApplication.ts
+++ b/src/backend/modules/machine-access/src/services/oauthApplication.ts
@@ -123,6 +123,22 @@ class OAuthApplicationService {
     }
   }
 
+  private assertGlobalUserFacingApplication(oauthApplication: OAuthApplication) {
+    if (
+      oauthApplication.type == 'user_facing' &&
+      oauthApplication.accessLevel == 'global' &&
+      oauthApplication.organizationOid == null
+    ) {
+      return;
+    }
+
+    throw new ServiceError(
+      forbiddenError({
+        message: 'Only global user-facing oauth applications are supported by this action'
+      })
+    );
+  }
+
   private assertAllowedAccessLevel(d: {
     type: Exclude<OAuthApplicationType, 'cli_auth'>;
     accessLevel: OAuthAuthorizationAccessLevel;
@@ -446,6 +462,207 @@ class OAuthApplicationService {
     });
   }
 
+  async createGlobalUserFacingOAuthApplication(d: {
+    input: {
+      allowClientSecretlessTokenExchange?: boolean;
+      name: string;
+      description?: string;
+      websiteUrl?: string;
+      privacyPolicyUrl?: string;
+      termsOfServiceUrl?: string;
+      redirectUris?: string[];
+      scopes: string[];
+      image?: PrismaJson.EntityImage;
+    };
+  }) {
+    let scopes = validateOAuthScopes(d.input.scopes);
+    let redirectUris = (d.input.redirectUris ?? []).map(uri => {
+      validateUri(uri);
+      return uri;
+    });
+
+    let input = {
+      status: 'active' as const,
+      type: 'user_facing' as const,
+      accessLevel: 'global' as const,
+      allowClientSecretlessTokenExchange: d.input.allowClientSecretlessTokenExchange ?? false,
+      name: d.input.name,
+      description: d.input.description,
+      websiteUrl: d.input.websiteUrl,
+      privacyPolicyUrl: d.input.privacyPolicyUrl,
+      termsOfServiceUrl: d.input.termsOfServiceUrl,
+      redirectUris,
+      scopes,
+      image: d.input.image ?? { type: 'default' as const }
+    };
+
+    return await withTransaction(async db => {
+      await Fabric.fire('machine_access.oauth_application.created:before', {
+        organization: null,
+        performedBy: null,
+        context: null,
+        input,
+        serverSideMachineAccess: null
+      });
+
+      let oauthApplication = await db.oAuthApplication.create({
+        data: {
+          id: await ID.generateId('oauthApplication'),
+          clientId: generateCustomId('mt_oauth_', 32),
+          ...input,
+          organizationOid: null,
+          serverSideMachineAccessOid: null,
+          scopedInstallationOid: null
+        },
+        include
+      });
+
+      addAfterTransactionHook(() =>
+        Fabric.fire('machine_access.oauth_application.created:after', {
+          organization: null,
+          performedBy: null,
+          context: null,
+          input,
+          serverSideMachineAccess: null,
+          oauthApplication
+        })
+      );
+
+      return oauthApplication;
+    });
+  }
+
+  async updateGlobalUserFacingOAuthApplication(d: {
+    oauthApplication: OAuthApplication;
+    input: {
+      allowClientSecretlessTokenExchange?: boolean;
+      name?: string;
+      description?: string | null;
+      websiteUrl?: string | null;
+      privacyPolicyUrl?: string | null;
+      termsOfServiceUrl?: string | null;
+      redirectUris?: string[];
+      scopes?: string[];
+      image?: PrismaJson.EntityImage;
+    };
+  }) {
+    await this.assertApplicationActive(d.oauthApplication);
+    this.assertApplicationOwnedLocally(d.oauthApplication);
+    this.assertGlobalUserFacingApplication(d.oauthApplication);
+
+    let scopes = d.input.scopes ? validateOAuthScopes(d.input.scopes) : undefined;
+    let redirectUris = d.input.redirectUris
+      ? d.input.redirectUris.map(uri => {
+          validateUri(uri);
+          return uri;
+        })
+      : undefined;
+
+    return await withTransaction(async db => {
+      await Fabric.fire('machine_access.oauth_application.updated:before', {
+        oauthApplication: d.oauthApplication,
+        organization: null,
+        performedBy: null,
+        context: null,
+        input: {
+          ...d.input,
+          scopes,
+          redirectUris
+        }
+      });
+
+      let oauthApplication = await db.oAuthApplication.update({
+        where: { oid: d.oauthApplication.oid },
+        data: {
+          allowClientSecretlessTokenExchange: d.input.allowClientSecretlessTokenExchange,
+          name: d.input.name,
+          description: d.input.description,
+          websiteUrl: d.input.websiteUrl,
+          privacyPolicyUrl: d.input.privacyPolicyUrl,
+          termsOfServiceUrl: d.input.termsOfServiceUrl,
+          redirectUris,
+          scopes,
+          image: d.input.image
+        },
+        include
+      });
+
+      addAfterTransactionHook(() =>
+        Fabric.fire('machine_access.oauth_application.updated:after', {
+          oauthApplication,
+          organization: null,
+          performedBy: null,
+          context: null,
+          input: {
+            ...d.input,
+            scopes,
+            redirectUris
+          }
+        })
+      );
+
+      return oauthApplication;
+    });
+  }
+
+  async archiveGlobalUserFacingOAuthApplication(d: { oauthApplication: OAuthApplication }) {
+    await this.assertApplicationActive(d.oauthApplication);
+    this.assertApplicationOwnedLocally(d.oauthApplication);
+    this.assertGlobalUserFacingApplication(d.oauthApplication);
+
+    let now = new Date();
+
+    return await withTransaction(async db => {
+      await Fabric.fire('machine_access.oauth_application.archived:before', {
+        oauthApplication: d.oauthApplication,
+        organization: null,
+        performedBy: null,
+        context: null
+      });
+
+      await db.oAuthAuthorization.updateMany({
+        where: {
+          oauthApplicationOid: d.oauthApplication.oid,
+          status: 'active'
+        },
+        data: {
+          status: 'revoked',
+          revokedAt: now
+        }
+      });
+
+      await db.oAuthInstallation.updateMany({
+        where: {
+          oauthApplicationOid: d.oauthApplication.oid,
+          status: 'active'
+        },
+        data: {
+          status: 'revoked',
+          revokedAt: now
+        }
+      });
+
+      let oauthApplication = await db.oAuthApplication.update({
+        where: { oid: d.oauthApplication.oid },
+        data: {
+          status: 'archived'
+        },
+        include
+      });
+
+      addAfterTransactionHook(() =>
+        Fabric.fire('machine_access.oauth_application.archived:after', {
+          oauthApplication,
+          organization: null,
+          performedBy: null,
+          context: null
+        })
+      );
+
+      return oauthApplication;
+    });
+  }
+
   async getOAuthApplicationById(d: {
     organization: Organization;
     oauthApplicationId: string;
@@ -457,6 +674,23 @@ class OAuthApplicationService {
         type: {
           in: ['user_facing', 'server_side']
         }
+      },
+      include
+    });
+    if (!oauthApplication) {
+      throw new ServiceError(notFoundError('oauth_application', d.oauthApplicationId));
+    }
+
+    return oauthApplication;
+  }
+
+  async getGlobalUserFacingOAuthApplicationById(d: { oauthApplicationId: string }) {
+    let oauthApplication = await db.oAuthApplication.findFirst({
+      where: {
+        id: d.oauthApplicationId,
+        organizationOid: null,
+        type: 'user_facing',
+        accessLevel: 'global'
       },
       include
     });
@@ -482,6 +716,37 @@ class OAuthApplicationService {
               type: {
                 in: ['user_facing']
               }
+            },
+            include
+          })
+      )
+    );
+  }
+
+  async listGlobalUserFacingOAuthApplications(d: {
+    statuses?: OAuthApplicationStatus[];
+    search?: string;
+  }) {
+    let search = d.search?.trim();
+
+    return Paginator.create(({ prisma }) =>
+      prisma(
+        async opts =>
+          await db.oAuthApplication.findMany({
+            ...opts,
+            where: {
+              organizationOid: null,
+              accessLevel: 'global',
+              status: d.statuses ? { in: d.statuses } : 'active',
+              type: 'user_facing',
+              OR: search
+                ? [
+                    { id: { contains: search, mode: 'insensitive' } },
+                    { clientId: { contains: search, mode: 'insensitive' } },
+                    { name: { contains: search, mode: 'insensitive' } },
+                    { description: { contains: search, mode: 'insensitive' } }
+                  ]
+                : undefined
             },
             include
           })

--- a/src/backend/modules/machine-access/test/oauthApplication.test.ts
+++ b/src/backend/modules/machine-access/test/oauthApplication.test.ts
@@ -225,6 +225,40 @@ describe('oauthApplicationService', () => {
     expect(mockDb.oAuthApplication.create).not.toHaveBeenCalled();
   });
 
+  it('creates a global user-facing oauth app without an organization or scoped installation', async () => {
+    mockDb.oAuthApplication.create.mockImplementationOnce(async ({ data }: any) => ({
+      oid: 'oauth-app-oid',
+      ...data,
+      clientSecrets: [],
+      organization: null,
+      serverSideMachineAccess: null,
+      scopedInstallation: null
+    }));
+
+    let result = await oauthApplicationService.createGlobalUserFacingOAuthApplication({
+      input: {
+        name: 'Global App',
+        redirectUris: ['https://example.com/callback'],
+        scopes: ['organization:read']
+      }
+    });
+
+    expect(machineAccessCreateMock).not.toHaveBeenCalled();
+    expect(mockDb.oAuthInstallation.create).not.toHaveBeenCalled();
+    expect(mockDb.oAuthApplication.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: 'user_facing',
+          accessLevel: 'global',
+          organizationOid: null,
+          scopedInstallationOid: null,
+          serverSideMachineAccessOid: null
+        })
+      })
+    );
+    expect(result.accessLevel).toBe('global');
+  });
+
   it('updates server-side scopes and syncs them to installation and machine access', async () => {
     await oauthApplicationService.updateOAuthApplication({
       oauthApplication: {
@@ -317,6 +351,68 @@ describe('oauthApplicationService', () => {
     expect(mockDb.oAuthApplication.update).not.toHaveBeenCalled();
   });
 
+  it('updates a global user-facing oauth app', async () => {
+    mockDb.oAuthApplication.update.mockImplementationOnce(async ({ data }: any) => ({
+      oid: 'oauth-app-oid',
+      id: 'oauth-app-id',
+      status: 'active',
+      type: 'user_facing',
+      accessLevel: 'global',
+      organization: null,
+      serverSideMachineAccess: null,
+      scopedInstallation: null,
+      clientSecrets: [],
+      ...data
+    }));
+
+    let result = await oauthApplicationService.updateGlobalUserFacingOAuthApplication({
+      oauthApplication: {
+        oid: 'oauth-app-oid',
+        type: 'user_facing',
+        status: 'active',
+        accessLevel: 'global',
+        isImportedFromOtherInstance: false
+      } as any,
+      input: {
+        name: 'Global App 2',
+        redirectUris: ['https://example.com/callback'],
+        scopes: ['organization:write']
+      }
+    });
+
+    expect(machineAccessUpdateMock).not.toHaveBeenCalled();
+    expect(mockDb.oAuthInstallation.update).not.toHaveBeenCalled();
+    expect(mockDb.oAuthApplication.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: 'Global App 2',
+          redirectUris: ['https://example.com/callback'],
+          scopes: ['organization:write']
+        })
+      })
+    );
+    expect(result.name).toBe('Global App 2');
+  });
+
+  it('rejects updating an imported global oauth app', async () => {
+    await expect(
+      oauthApplicationService.updateGlobalUserFacingOAuthApplication({
+        oauthApplication: {
+          oid: 'oauth-app-oid',
+          type: 'user_facing',
+          status: 'active',
+          accessLevel: 'global',
+          isImportedFromOtherInstance: true
+        } as any,
+        input: {
+          name: 'Imported App'
+        }
+      })
+    ).rejects.toThrow(ServiceError);
+
+    expect(mockDb.oAuthApplication.update).not.toHaveBeenCalled();
+  });
+
   it('archives app by revoking authorizations and installations', async () => {
     let result = await oauthApplicationService.archiveOAuthApplication({
       oauthApplication: {
@@ -330,6 +426,29 @@ describe('oauthApplicationService', () => {
     });
 
     expect(mockDb.oAuthAuthorization.updateMany).toHaveBeenCalled();
+    expect(mockDb.oAuthInstallation.updateMany).toHaveBeenCalled();
+    expect(result.status).toBe('archived');
+  });
+
+  it('archives a global user-facing oauth app', async () => {
+    let result = await oauthApplicationService.archiveGlobalUserFacingOAuthApplication({
+      oauthApplication: {
+        oid: 'oauth-app-oid',
+        type: 'user_facing',
+        status: 'active',
+        accessLevel: 'global',
+        isImportedFromOtherInstance: false
+      } as any
+    });
+
+    expect(mockDb.oAuthAuthorization.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          oauthApplicationOid: 'oauth-app-oid',
+          status: 'active'
+        })
+      })
+    );
     expect(mockDb.oAuthInstallation.updateMany).toHaveBeenCalled();
     expect(result.status).toBe('archived');
   });

--- a/src/frontend/apps/dashboard/src/slices/product/lib/jsonSchema.ts
+++ b/src/frontend/apps/dashboard/src/slices/product/lib/jsonSchema.ts
@@ -1,4 +1,4 @@
-import { JSONSchema7 } from 'json-schema';
+import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 
 export type JsonSchemaEnvelope = {
   type: 'json_schema';
@@ -38,6 +38,98 @@ export let getJsonSchemaObject = (
   if (!schema || typeof schema !== 'object') return null;
   if (schema.type && schema.type !== 'object') return null;
   return schema as JsonSchemaObject;
+};
+
+let isJsonSchemaObjectDefinition = (
+  value: JSONSchema7Definition
+): value is JSONSchema7 => typeof value === 'object' && value !== null;
+
+let cloneJsonSchemaDefault = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(cloneJsonSchemaDefault);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, cloneJsonSchemaDefault(entry)])
+    );
+  }
+
+  return value;
+};
+
+let inferJsonSchemaDefault = (
+  schema: JSONSchema7,
+  forceObjectPresence = false
+): { hasValue: boolean; value: unknown } => {
+  if (schema.default !== undefined) {
+    return { hasValue: true, value: cloneJsonSchemaDefault(schema.default) };
+  }
+
+  if (schema.type !== 'object' && !schema.properties) {
+    return { hasValue: false, value: undefined };
+  }
+
+  let required = schema.required ?? [];
+  let value: Record<string, unknown> = {};
+
+  for (let [key, property] of Object.entries(schema.properties ?? {})) {
+    if (!isJsonSchemaObjectDefinition(property)) continue;
+
+    let inferred = inferJsonSchemaDefault(property, required.includes(key));
+    if (inferred.hasValue) value[key] = inferred.value;
+  }
+
+  if (Object.keys(value).length === 0 && !forceObjectPresence) {
+    return { hasValue: false, value: undefined };
+  }
+
+  return { hasValue: true, value };
+};
+
+let areJsonSchemaRequiredFieldsDefaultSatisfied = (schema: JSONSchema7): boolean => {
+  if (schema.default !== undefined) return true;
+  if (schema.type !== 'object' && !schema.properties) return false;
+
+  let properties = schema.properties ?? {};
+
+  for (let requiredKey of schema.required ?? []) {
+    let property = properties[requiredKey];
+    if (!property || !isJsonSchemaObjectDefinition(property)) return false;
+    if (property.default !== undefined) continue;
+
+    if (
+      (property.type === 'object' || property.properties) &&
+      areJsonSchemaRequiredFieldsDefaultSatisfied(property)
+    ) {
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
+};
+
+export let getJsonSchemaDefaultObject = (
+  value: JsonSchemaEnvelope | Record<string, unknown> | null | undefined
+): Record<string, unknown> => {
+  let schema = getJsonSchemaObject(value);
+  if (!schema) return {};
+
+  let inferred = inferJsonSchemaDefault(schema, true);
+
+  if (inferred.value && typeof inferred.value === 'object' && !Array.isArray(inferred.value)) {
+    return inferred.value as Record<string, unknown>;
+  }
+
+  return {};
+};
+
+export let areJsonSchemaRequiredFieldsDefaulted = (
+  value: JsonSchemaEnvelope | Record<string, unknown> | null | undefined
+) => {
+  let schema = getJsonSchemaObject(value);
+  if (!schema) return true;
+
+  return areJsonSchemaRequiredFieldsDefaultSatisfied(schema);
 };
 
 export let hasJsonSchemaProperties = (

--- a/src/frontend/apps/dashboard/src/slices/product/lib/providerCreationCapabilities.ts
+++ b/src/frontend/apps/dashboard/src/slices/product/lib/providerCreationCapabilities.ts
@@ -5,7 +5,13 @@ import {
   useProviderDeployment,
   useProviderDeploymentConfigSchema
 } from '@metorial/state';
-import { getJsonSchemaObject, hasJsonSchemaProperties, hasRequiredJsonSchemaFields } from './jsonSchema';
+import {
+  areJsonSchemaRequiredFieldsDefaulted,
+  getJsonSchemaDefaultObject,
+  getJsonSchemaObject,
+  hasJsonSchemaProperties,
+  hasRequiredJsonSchemaFields
+} from './jsonSchema';
 import { getProviderOAuthAutoRegistrationEnabled } from './providerOAuthAutoRegistration';
 
 let getAuthMethodOrderRank = (type: string | null | undefined) => {
@@ -58,12 +64,14 @@ export let getProviderConfigSchemaCapabilities = (d: {
   let hasSchemaObject = !!schemaObject;
   let hasSchemaFields = hasJsonSchemaProperties(d.schemaValue);
   let hasRequiredFields = hasRequiredJsonSchemaFields(d.schemaValue);
+  let requiredFieldsHaveDefaults = areJsonSchemaRequiredFieldsDefaulted(d.schemaValue);
+  let defaultConfigValue = getJsonSchemaDefaultObject(d.schemaValue);
   let hasExplicitEmptySchema = Boolean(
     schemaObject && !hasSchemaFields && schemaObject.additionalProperties === false
   );
   let canCreateConfig = hasSchemaFields || hasExplicitEmptySchema || d.hasVaults;
   let canCreateConfigVault = hasSchemaFields || hasExplicitEmptySchema;
-  let canAutoCreateEmptyConfig = !hasRequiredFields;
+  let canAutoCreateEmptyConfig = !hasRequiredFields || requiredFieldsHaveDefaults;
   let isLoading = !!d.isLoading;
   let configDisabledReason = isLoading
     ? 'Loading configuration options...'
@@ -81,6 +89,8 @@ export let getProviderConfigSchemaCapabilities = (d: {
     hasSchemaObject,
     hasSchemaFields,
     hasRequiredFields,
+    requiredFieldsHaveDefaults,
+    defaultConfigValue,
     hasExplicitEmptySchema,
     hasVaults: d.hasVaults,
     isLoading,

--- a/src/frontend/apps/dashboard/src/slices/product/lib/providerDocs.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/lib/providerDocs.tsx
@@ -1,0 +1,105 @@
+import { theme } from '@metorial/ui';
+import React from 'react';
+import styled from 'styled-components';
+
+export type ProviderDocReference = {
+  type?: string | null;
+  name: string;
+  url: string;
+};
+
+type ProviderListingDocs = {
+  provider?: ProviderDocReference[] | null;
+  config?: ProviderDocReference[] | null;
+  auth_methods?:
+    | {
+        key?: string | null;
+        name?: string | null;
+        type?: string | null;
+        docs?: ProviderDocReference[] | null;
+      }[]
+    | null;
+};
+
+type AuthMethodDocTarget = {
+  key?: string | null;
+  name?: string | null;
+  type?: string | null;
+};
+
+let DocsLink = styled.a`
+  display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
+  color: ${theme.colors.gray600};
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.2;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  white-space: nowrap;
+
+  &:hover {
+    color: ${theme.colors.gray900};
+  }
+`;
+
+let getDocs = (providerListing: unknown): ProviderListingDocs | null => {
+  let docs = (providerListing as any)?.docs;
+  if (!docs || typeof docs !== 'object') return null;
+  return docs as ProviderListingDocs;
+};
+
+let getFirstDoc = (docs: ProviderDocReference[] | null | undefined) =>
+  (docs ?? []).find(doc => !!doc?.url) ?? null;
+
+let matchesAuthMethod = (
+  docMethod: AuthMethodDocTarget,
+  authMethod?: AuthMethodDocTarget | null
+) => {
+  if (!authMethod) return false;
+
+  if (docMethod.key && authMethod.key && docMethod.key === authMethod.key) return true;
+  if (docMethod.name && authMethod.name && docMethod.name === authMethod.name) return true;
+  if (docMethod.type && authMethod.type && docMethod.type === authMethod.type) return true;
+
+  return false;
+};
+
+export let getProviderDoc = (providerListing: unknown) =>
+  getFirstDoc(getDocs(providerListing)?.provider);
+
+export let getConfigDoc = (providerListing: unknown) =>
+  getFirstDoc(getDocs(providerListing)?.config);
+
+export let getAuthMethodDoc = (
+  providerListing: unknown,
+  authMethod?: AuthMethodDocTarget | null
+) => {
+  let docs = getDocs(providerListing);
+  let authMethodDocs = docs?.auth_methods ?? [];
+  let exactMatch = authMethodDocs.find(docMethod => matchesAuthMethod(docMethod, authMethod));
+
+  return (
+    getFirstDoc(exactMatch?.docs) ?? getFirstDoc(authMethodDocs.flatMap(m => m.docs ?? []))
+  );
+};
+
+export let getScopeDoc = (providerListing: unknown, authMethod?: AuthMethodDocTarget | null) =>
+  getAuthMethodDoc(providerListing, authMethod) ?? getProviderDoc(providerListing);
+
+export let ProviderDocsLink = ({
+  doc,
+  children
+}: {
+  doc?: ProviderDocReference | null;
+  children?: React.ReactNode;
+}) => {
+  if (!doc?.url) return null;
+
+  return (
+    <DocsLink href={doc.url} target="_blank" rel="noopener noreferrer">
+      {children ?? doc.name}
+    </DocsLink>
+  );
+};

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/components/scopePicker.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/components/scopePicker.tsx
@@ -1,5 +1,7 @@
-import { Checkbox, Flex, OptionToggle, Text, theme } from '@metorial/ui';
+import { Checkbox, Flex, InputLabel, OptionToggle, Text, theme } from '@metorial/ui';
+import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
+import styled from 'styled-components';
 
 type ScopePermissionMode = 'allow' | 'reject' | 'mixed';
 type ScopeSectionId = 'read' | 'write' | 'dangerous';
@@ -10,6 +12,39 @@ export type ScopePickerScope = {
   name?: string | null;
   description?: string | null;
 };
+
+let ScopeFieldHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+  margin-bottom: 5px;
+
+  ${InputLabel} {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 0;
+  }
+`;
+
+let ScopeFieldHelp = styled.div`
+  min-width: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+let ScopeFieldBox = styled.div`
+  width: 100%;
+  min-width: 0;
+  overflow: auto;
+  border: 1px solid ${theme.colors.gray300};
+  border-radius: 10px;
+  padding: 10px 12px;
+`;
 
 let dangerousScopeKeywords = [
   'admin',
@@ -56,12 +91,14 @@ export let ScopePicker = ({
   scopes,
   selectedScopes,
   onSelectedScopesChange,
-  disabled
+  disabled,
+  flushScrollPadding = true
 }: {
   scopes: ScopePickerScope[];
   selectedScopes: string[];
   onSelectedScopesChange: (scopes: string[]) => void;
   disabled?: boolean;
+  flushScrollPadding?: boolean;
 }) => {
   let [sectionModeOverrides, setSectionModeOverrides] = useState<
     Partial<Record<ScopeSectionId, ScopePermissionMode>>
@@ -145,8 +182,8 @@ export let ScopePicker = ({
   return (
     <div
       style={{
-        marginRight: -20,
-        paddingRight: 20
+        marginRight: flushScrollPadding ? -20 : 0,
+        paddingRight: flushScrollPadding ? 20 : 0
       }}
     >
       <Flex direction="column" gap={12}>
@@ -219,6 +256,31 @@ export let ScopePicker = ({
             </div>
           ))}
       </Flex>
+    </div>
+  );
+};
+
+export let ScopePickerField = ({
+  label = 'Scopes',
+  help,
+  maxHeight = 260,
+  ...props
+}: {
+  label?: ReactNode;
+  help?: ReactNode;
+  maxHeight?: number | string;
+} & Omit<Parameters<typeof ScopePicker>[0], 'flushScrollPadding'>) => {
+  if (props.scopes.length === 0) return null;
+
+  return (
+    <div>
+      <ScopeFieldHeader>
+        <InputLabel>{label}</InputLabel>
+        {help && <ScopeFieldHelp>{help}</ScopeFieldHelp>}
+      </ScopeFieldHeader>
+      <ScopeFieldBox style={{ maxHeight }}>
+        <ScopePicker {...props} flushScrollPadding={false} />
+      </ScopeFieldBox>
     </div>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/settings.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/settings.tsx
@@ -4,12 +4,14 @@ import {
   useCurrentInstance,
   useProvider,
   useProviderAuthCredential,
-  useProviderAuthMethods
+  useProviderAuthMethods,
+  useProviderListing
 } from '@metorial/state';
 import { Button, Callout, Input, Spacer } from '@metorial/ui';
 import { Box } from '@metorial/ui-product';
 import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { getScopeDoc, ProviderDocsLink } from '../../../lib/providerDocs';
 import { DeleteResourceDangerZone } from '../../../scenes/deleteResourceDangerZone';
 import { ScopePicker } from './components/scopePicker';
 
@@ -20,16 +22,19 @@ export let ProviderAuthCredentialSettingsPage = () => {
   let { providerAuthCredentialsId } = useParams();
   let credential = useProviderAuthCredential(instance.data?.id, providerAuthCredentialsId);
   let provider = useProvider(instance.data?.id, credential.data?.providerId);
+  let providerListing = useProviderListing(instance.data?.id, credential.data?.providerId);
   let versionId = provider.data?.currentVersion?.id;
   let authMethods = useProviderAuthMethods(
     instance.data?.id,
     versionId ? { providerVersionId: versionId } : null
   );
 
-  let availableScopes = useMemo(() => {
-    let oauthMethod = (authMethods.data?.items ?? []).find(m => m.type === 'oauth');
-    return oauthMethod?.scopes ?? [];
-  }, [authMethods.data?.items]);
+  let oauthMethod = useMemo(
+    () => (authMethods.data?.items ?? []).find(m => m.type === 'oauth'),
+    [authMethods.data?.items]
+  );
+  let availableScopes = oauthMethod?.scopes ?? [];
+  let scopeDoc = getScopeDoc(providerListing.data, oauthMethod);
 
   let [selectedScopes, setSelectedScopes] = useState<string[] | null>(null);
 
@@ -103,6 +108,7 @@ export let ProviderAuthCredentialSettingsPage = () => {
           <Box
             title="Scopes"
             description="Select which OAuth scopes this credential should request."
+            rightActions={<ProviderDocsLink doc={scopeDoc}>Scope docs</ProviderDocsLink>}
           >
             <ScopePicker
               scopes={availableScopes}

--- a/src/frontend/apps/dashboard/src/slices/product/pages/explorer/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/explorer/index.tsx
@@ -7,10 +7,12 @@ import { renderWithLoader } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
 import {
   useCreateProviderDeployment,
+  useCreateProviderConfig,
   useCreateSession,
   useCurrentInstance,
   useProvider,
   useProviderConfigs,
+  useProviderConfigSchemaTarget,
   useProviderConfigVaults,
   useProviderDeployment,
   useProviderDeployments,
@@ -39,6 +41,7 @@ import {
   emptyConfigurationSelection,
   type ConfigurationSelection
 } from '../../lib/configSelection';
+import { getProviderConfigSchemaCapabilities } from '../../lib/providerCreationCapabilities';
 import { ProviderSearch } from '../../scenes/providers/search';
 import { ProviderSetupSections } from '../../scenes/sessionTemplates/addProviderPanelFlow';
 import { SessionTracingScene } from '../../scenes/sessionTracing';
@@ -182,6 +185,7 @@ export let ExplorerPage = () => {
 
   let instance = useCurrentInstance();
   let createSession = useCreateSession(instance.data?.id);
+  let createProviderConfig = useCreateProviderConfig();
 
   useEffect(() => {
     if (sessionIdParam) setSessionId(sessionIdParam);
@@ -354,6 +358,20 @@ export let ExplorerPage = () => {
   let providerConfigVaults = useProviderConfigVaults(instance.data?.id, {
     providerDeploymentId: providerDeploymentId ?? undefined
   });
+  let providerSupportsConfig = activeProvider.data?.type.config.status == 'enabled';
+  let providerConfigSchema = useProviderConfigSchemaTarget(
+    instance.data?.id,
+    providerDeploymentId
+      ? { providerDeploymentId }
+      : activeProviderId
+        ? { providerId: activeProviderId }
+        : null
+  );
+  let configCapabilities = getProviderConfigSchemaCapabilities({
+    schemaValue: providerConfigSchema.data?.schema,
+    hasVaults: (providerConfigVaults.data?.items ?? []).length > 0,
+    isLoading: providerSupportsConfig ? providerConfigSchema.isLoading : false
+  });
   let createMutation = useCreateProviderDeployment();
 
   useEffect(() => {
@@ -482,7 +500,16 @@ export let ExplorerPage = () => {
     setSearch
   ]);
 
-  let requiresProviderConfig = activeProvider.data?.type.config.status == 'enabled';
+  let canAutoCreateProviderConfig =
+    !!providerSupportsConfig &&
+    !configCapabilities.isLoading &&
+    configCapabilities.canAutoCreateEmptyConfig;
+  let showConfigSection =
+    !!providerSupportsConfig &&
+    (configCapabilities.hasSchemaFields || !canAutoCreateProviderConfig);
+  let configRequirement: 'required' | 'optional' =
+    providerSupportsConfig && !canAutoCreateProviderConfig ? 'required' : 'optional';
+  let requiresProviderConfig = providerSupportsConfig && !canAutoCreateProviderConfig;
   let requiresAuthConfig = activeProvider.data?.type.auth.status == 'enabled';
   let isResolvingProviderDeployment =
     !!providerIdToResolve &&
@@ -493,6 +520,57 @@ export let ExplorerPage = () => {
       createMutation.isPending ||
       resolvingProviderIdRef.current === providerIdToResolve);
 
+  let createSessionWithSelectedSetup = useCallback(
+    async (deploymentId: string, options?: { name?: string }) => {
+      let providerConfigId =
+        selectedConfiguration.kind === 'config' ? selectedConfiguration.id : undefined;
+      let providerConfigVaultId =
+        selectedConfiguration.kind === 'vault' ? selectedConfiguration.id : undefined;
+
+      if (
+        !providerConfigId &&
+        !providerConfigVaultId &&
+        canAutoCreateProviderConfig &&
+        activeProviderId &&
+        instance.data
+      ) {
+        setIsCreatingSession(true);
+        let [config] = await createProviderConfig.mutate({
+          instanceId: instance.data.id,
+          providerId: activeProviderId,
+          providerDeploymentId: deploymentId,
+          name: `${activeProvider.data?.name ?? provider.data?.name ?? 'Provider'} Config`,
+          value: configCapabilities.defaultConfigValue
+        });
+
+        providerConfigId = config?.id;
+        if (!providerConfigId) {
+          setIsCreatingSession(false);
+          return;
+        }
+      }
+
+      await createSessionForDeployment(deploymentId, {
+        name: options?.name,
+        providerConfigId,
+        providerConfigVaultId,
+        providerAuthConfigId: selectedAuthConfigId || undefined
+      });
+    },
+    [
+      activeProvider.data?.name,
+      activeProviderId,
+      canAutoCreateProviderConfig,
+      configCapabilities.defaultConfigValue,
+      createProviderConfig,
+      createSessionForDeployment,
+      instance.data,
+      provider.data?.name,
+      selectedAuthConfigId,
+      selectedConfiguration
+    ]
+  );
+
   useEffect(() => {
     if (
       providerDeploymentId &&
@@ -500,10 +578,10 @@ export let ExplorerPage = () => {
       !isCreatingSession &&
       !!activeProvider.data &&
       !activeProvider.isLoading &&
-      !requiresProviderConfig &&
+      !showConfigSection &&
       !requiresAuthConfig
     ) {
-      createSessionForDeployment(providerDeploymentId, {
+      createSessionWithSelectedSetup(providerDeploymentId, {
         name: `Explorer Session - ${new Date().toLocaleString()}`
       });
     }
@@ -513,9 +591,9 @@ export let ExplorerPage = () => {
     isCreatingSession,
     activeProvider.data,
     activeProvider.isLoading,
-    requiresProviderConfig,
+    showConfigSection,
     requiresAuthConfig,
-    createSessionForDeployment
+    createSessionWithSelectedSetup
   ]);
 
   let renderSetupPanel = () => {
@@ -570,6 +648,8 @@ export let ExplorerPage = () => {
             selectedAuthConfigId={selectedAuthConfigId}
             onSelectedAuthConfigIdChange={setSelectedAuthConfigId}
             showToolFilters={false}
+            showConfigSection={showConfigSection}
+            configRequirement={configRequirement}
             configError={
               providerConfigs.error || providerConfigVaults.error ? (
                 <Text size="2" color="red500">
@@ -580,9 +660,14 @@ export let ExplorerPage = () => {
               ) : null
             }
             emptyState={null}
-            supplementaryContent={<createSession.RenderError />}
+            supplementaryContent={
+              <>
+                <createProviderConfig.RenderError />
+                <createSession.RenderError />
+              </>
+            }
             footer={
-              (requiresProviderConfig || requiresAuthConfig) && (
+              (showConfigSection || requiresAuthConfig) && (
                 <Flex gap={10}>
                   <Button
                     type="button"
@@ -590,18 +675,8 @@ export let ExplorerPage = () => {
                     onClick={() => {
                       if (!canOpenExplorer) return;
 
-                      createSessionForDeployment(providerDeploymentId, {
-                        name: `Explorer Session - ${new Date().toLocaleString()}`,
-
-                        providerConfigId:
-                          selectedConfiguration.kind === 'config'
-                            ? selectedConfiguration.id
-                            : undefined,
-                        providerConfigVaultId:
-                          selectedConfiguration.kind === 'vault'
-                            ? selectedConfiguration.id
-                            : undefined,
-                        providerAuthConfigId: selectedAuthConfigId || undefined
+                      createSessionWithSelectedSetup(providerDeploymentId, {
+                        name: `Explorer Session - ${new Date().toLocaleString()}`
                       });
                     }}
                     loading={isCreatingSession}

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/auth-methods.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/auth-methods.tsx
@@ -33,19 +33,6 @@ export let ProviderAuthMethodsPage = () => {
                 <Text size="2" weight="strong">
                   {method.name}
                 </Text>
-                <Text
-                  size="2"
-                  color="gray600"
-                  style={{
-                    display: 'block',
-                    maxWidth: '100%',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis'
-                  }}
-                >
-                  {description}
-                </Text>
               </Flex>,
               <Flex gap={6} style={{ alignItems: 'center', flexWrap: 'wrap' }}>
                 <Badge color={getProviderAuthMethodTypeColor(method.type)} size="1">

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/index.tsx
@@ -111,19 +111,6 @@ export let ProviderToolsPage = () => {
                 <Text size="2" weight="strong">
                   {tool.name}
                 </Text>
-                <Text
-                  size="2"
-                  color="gray600"
-                  style={{
-                    display: 'block',
-                    maxWidth: '100%',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis'
-                  }}
-                >
-                  {description}
-                </Text>
               </Flex>,
               <Flex gap={6} style={{ alignItems: 'center', flexWrap: 'wrap' }}>
                 {modeBadges.length > 0 ? (

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/triggers.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/triggers.tsx
@@ -131,19 +131,6 @@ export let ProviderTriggersPage = () => {
                 <Text size="2" weight="strong">
                   {trigger.name}
                 </Text>
-                <Text
-                  size="2"
-                  color="gray600"
-                  style={{
-                    display: 'block',
-                    maxWidth: '100%',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis'
-                  }}
-                >
-                  {description}
-                </Text>
               </Flex>,
               <Badge color={invocationBadge.color} size="1">
                 {invocationBadge.label}

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/index.tsx
@@ -35,7 +35,8 @@ export let ProviderOverviewPage = () => {
     {
       providerId,
       status: ['active'],
-      limit: 3
+      limit: 15,
+      order: 'desc'
     }
   );
   let magicMcpServers = useMagicMcpServers(
@@ -43,7 +44,8 @@ export let ProviderOverviewPage = () => {
     {
       providerId,
       status: ['active'],
-      limit: 3
+      limit: 15,
+      order: 'desc'
     }
   );
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
@@ -682,7 +682,7 @@ let IntegrationProviderSetupStep = (p: {
         !isConfigSelectionComplete(values.selectedConfiguration)
       ) {
         form.setFieldTouched('selectedConfiguration', true, false);
-        form.setFieldError('selectedConfiguration', 'Select a config or config vault');
+        form.setFieldError('selectedConfiguration', 'Select a config');
         return;
       }
 
@@ -1236,7 +1236,7 @@ let IntegrationInstanceProviderPanel = (p: {
         !isConfigSelectionComplete(values.selectedConfiguration)
       ) {
         form.setFieldTouched('selectedConfiguration', true, false);
-        form.setFieldError('selectedConfiguration', 'Select a config or config vault');
+        form.setFieldError('selectedConfiguration', 'Select a config');
         return;
       }
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
@@ -39,6 +39,7 @@ import {
   emptyConfigurationSelection
 } from '../../lib/configSelection';
 import { getProviderConfigSchemaCapabilities } from '../../lib/providerCreationCapabilities';
+import { getProviderOAuthAutoRegistrationEnabled } from '../../lib/providerOAuthAutoRegistration';
 import { AuthMethodPicker } from '../providerAuthConfigs/authMethodPicker';
 import { showProviderAuthCredentialsFormModal } from '../providerAuthCredentials/modal';
 import {
@@ -123,7 +124,8 @@ let useProviderSetupVisibility = (p: {
   if (p.respectIntegrationToolFilterPolicy === false) allowToolFilters = true;
   let providerSupportsAuth = provider.data?.type.auth.status === 'enabled';
   let requiresProviderConfig =
-    providerSupportsConfig && configCapabilities.hasRequiredFields;
+    providerSupportsConfig && !configCapabilities.canAutoCreateEmptyConfig;
+  let hasEditableConfigFields = configCapabilities.hasSchemaFields;
   let isInstanceProviderPanel =
     p.inheritedConfigId !== undefined || p.instanceConfigId !== undefined;
   let satisfiedConfigId = isInstanceProviderPanel
@@ -148,7 +150,9 @@ let useProviderSetupVisibility = (p: {
   let showConfig = p.isUpdate
     ? allowCustomConfigs
     : mustRequestInstanceConfig ||
-      (allowCustomConfigs && providerSupportsConfig && !shouldAutoCreateEmptyConfig);
+      (allowCustomConfigs &&
+        providerSupportsConfig &&
+        (hasEditableConfigFields || !shouldAutoCreateEmptyConfig));
   let configRequirement: 'required' | 'optional' = isInstanceProviderPanel
     ? mustRequestInstanceConfig
       ? 'required'
@@ -164,6 +168,7 @@ let useProviderSetupVisibility = (p: {
     showAuth: (p.allowAuthConfig ?? true) && providerSupportsAuth,
     showToolFilters: allowToolFilters,
     shouldAutoCreateEmptyConfig,
+    defaultConfigValue: configCapabilities.defaultConfigValue,
     configRequirement,
     mustRequestInstanceConfig,
     providerName: getProviderName(provider.data, p.providerId ?? undefined),
@@ -362,10 +367,13 @@ let IntegrationProviderAuthSection = (p: {
   selectedAuthCredentialsId: string;
   selectedAuthCredentialsLabel?: string;
   onSelectedAuthCredentialsIdChange: (value: string) => void;
+  oauthAutoRegistrationEnabled?: boolean;
   authMethodError?: React.ReactNode;
   authCredentialsError?: React.ReactNode;
 }) => {
   let authMethodItems = p.authMethods.data?.items ?? [];
+  let showAuthCredentials =
+    p.selectedAuthMethod?.type === 'oauth' && !p.oauthAutoRegistrationEnabled;
 
   return (
     <Flex direction="column" gap={12}>
@@ -394,11 +402,16 @@ let IntegrationProviderAuthSection = (p: {
                 }))}
               />
               {p.authMethodError}
+              {p.selectedAuthMethod?.type === 'oauth' && p.oauthAutoRegistrationEnabled ? (
+                <Callout color="gray">
+                  OAuth credentials will be registered automatically for this provider.
+                </Callout>
+              ) : null}
             </Flex>
           </ConfigureSectionCard>
 
           <AnimatePresence initial={false}>
-            {p.selectedAuthMethod?.type === 'oauth' ? (
+            {showAuthCredentials ? (
               <motion.div
                 key="oauth-auth-credentials"
                 initial={{ opacity: 0, y: -8, height: 0 }}
@@ -532,6 +545,9 @@ let IntegrationProviderSetupStep = (p: {
   let effectiveShowAuth =
     visibility.showAuth &&
     (!isUpdate || (!authMethods.isLoading && (authMethods.data?.items.length ?? 0) > 0));
+  let oauthAutoRegistrationEnabled = getProviderOAuthAutoRegistrationEnabled(
+    visibility.provider.data
+  );
 
   let submitProviderSetup = async (values: IntegrationProviderFormValues) => {
     if (!instance.data) return false;
@@ -550,13 +566,16 @@ let IntegrationProviderSetupStep = (p: {
         instanceId: instance.data.id,
         providerId: p.providerId,
         name: `${visibility.providerName} Config`,
-        value: {}
+        value: visibility.defaultConfigValue
       });
       providerConfigId = config?.id;
     }
 
     let providerAuthMethodId = values.selectedAuthMethodId || undefined;
-    let providerAuthCredentialsId = values.selectedAuthCredentialsId || undefined;
+    let providerAuthCredentialsId =
+      selectedAuthMethod?.type === 'oauth' && !oauthAutoRegistrationEnabled
+        ? values.selectedAuthCredentialsId || undefined
+        : undefined;
 
     let toolFilters = getToolFilters(values);
 
@@ -647,7 +666,11 @@ let IntegrationProviderSetupStep = (p: {
           return;
         }
 
-        if (selectedAuthMethod?.type === 'oauth' && !values.selectedAuthCredentialsId) {
+        if (
+          selectedAuthMethod?.type === 'oauth' &&
+          !oauthAutoRegistrationEnabled &&
+          !values.selectedAuthCredentialsId
+        ) {
           form.setFieldTouched('selectedAuthCredentialsId', true, false);
           form.setFieldError('selectedAuthCredentialsId', 'Select auth credentials');
           return;
@@ -678,9 +701,11 @@ let IntegrationProviderSetupStep = (p: {
   let selectedAuthMethod = authMethods.data?.items.find(
     method => method.id === form.values.selectedAuthMethodId
   );
+  let requiresAuthCredentials =
+    selectedAuthMethod?.type === 'oauth' && !oauthAutoRegistrationEnabled;
   let authCredentials = useProviderAuthCredentials(
     instance.data?.id,
-    effectiveShowAuth
+    effectiveShowAuth && requiresAuthCredentials
       ? {
           providerId: p.providerId,
           ...(form.values.selectedAuthMethodId
@@ -711,13 +736,18 @@ let IntegrationProviderSetupStep = (p: {
 
   useEffect(() => {
     if (authMethods.isLoading) return;
-    if (selectedAuthMethod?.type === 'oauth') return;
+    if (selectedAuthMethod?.type === 'oauth' && !oauthAutoRegistrationEnabled) return;
     if (!form.values.selectedAuthCredentialsId) return;
 
     form.setFieldValue('selectedAuthCredentialsId', '');
     form.setFieldTouched('selectedAuthCredentialsId', false, false);
     form.setFieldError('selectedAuthCredentialsId', undefined);
-  }, [authMethods.isLoading, selectedAuthMethod?.type, form.values.selectedAuthCredentialsId]);
+  }, [
+    authMethods.isLoading,
+    oauthAutoRegistrationEnabled,
+    selectedAuthMethod?.type,
+    form.values.selectedAuthCredentialsId
+  ]);
 
   useEffect(() => {
     if (!effectiveShowAuth) return;
@@ -747,7 +777,7 @@ let IntegrationProviderSetupStep = (p: {
       isConfigSelectionComplete(form.values.selectedConfiguration)) &&
     (!effectiveShowAuth ||
       (Boolean(form.values.selectedAuthMethodId) &&
-        (selectedAuthMethod?.type !== 'oauth' || Boolean(form.values.selectedAuthCredentialsId))));
+        (!requiresAuthCredentials || Boolean(form.values.selectedAuthCredentialsId))));
   let isSaving =
     createDeployment.isPending ||
     createConfig.isLoading ||
@@ -835,6 +865,7 @@ let IntegrationProviderSetupStep = (p: {
               form.setFieldTouched('selectedAuthCredentialsId', false, false);
               form.setFieldError('selectedAuthCredentialsId', undefined);
             }}
+            oauthAutoRegistrationEnabled={oauthAutoRegistrationEnabled}
             authMethodError={<form.RenderError field="selectedAuthMethodId" />}
             authCredentialsError={<form.RenderError field="selectedAuthCredentialsId" />}
           />
@@ -1158,7 +1189,7 @@ let IntegrationInstanceProviderPanel = (p: {
         instanceId: instance.data.id,
         providerId,
         name: `${visibility.providerName} Config`,
-        value: {}
+        value: visibility.defaultConfigValue
       });
       providerConfigId = config?.id;
     }

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createManualModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createManualModal.tsx
@@ -6,10 +6,12 @@ export let ProviderAuthConfigManualCreateContent = (p: {
   providerDeploymentId?: string;
   providerId?: string;
   initialAuthMethodId: string;
+  defaultAuthConfigName?: string;
   close: () => void;
-  onCreate?: (authConfig: { id: string }) => void;
+  onCreate?: (authConfig: { id: string; name?: string | null }) => void;
   onBack?: () => void;
   embedded?: boolean;
+  hideDetailsInputs?: boolean;
 }) => {
   let useFlatLayout = true;
 
@@ -33,10 +35,12 @@ export let ProviderAuthConfigManualCreateContent = (p: {
         hideAuthMethodStep
         flattenCreateStep={useFlatLayout}
         hideProviderContext={useFlatLayout}
+        defaultName={p.defaultAuthConfigName}
+        hideDetailsInputs={p.hideDetailsInputs}
         close={p.close}
         onBack={p.onBack}
         onCreate={authConfig => {
-          p.onCreate?.({ id: authConfig.id });
+          p.onCreate?.({ id: authConfig.id, name: authConfig.name });
         }}
       />
     </>

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createModal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/createModal.tsx
@@ -17,6 +17,7 @@ export type ProviderAuthConfigCreateModalProps = {
   autoStartManagedCredentialSetup?: boolean;
   onCreate?: (authConfig: { id: string; name?: string | null }) => void;
   onBack?: () => void;
+  hideDetailsInputs?: boolean;
 };
 
 let ProviderAuthConfigCreateModalContent = (
@@ -183,10 +184,12 @@ export let ProviderAuthConfigCreateFlowContent = (
           providerDeploymentId={p.providerDeploymentId}
           providerId={providerId}
           initialAuthMethodId={method.id}
+          defaultAuthConfigName={p.defaultAuthConfigName}
           close={p.close}
           onBack={p.onBack}
           onCreate={p.onCreate}
           embedded={p.embedded}
+          hideDetailsInputs={p.hideDetailsInputs}
         />
       );
     }

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/form.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthConfigs/form.tsx
@@ -74,6 +74,8 @@ export type ProviderAuthConfigFormProps =
       showAuthMethodStepInStepper?: boolean;
       flattenCreateStep?: boolean;
       hideProviderContext?: boolean;
+      defaultName?: string;
+      hideDetailsInputs?: boolean;
     }
   | {
       type: 'update';
@@ -129,7 +131,7 @@ export let ProviderAuthConfigForm = (
 
   let form = useForm({
     initialValues: {
-      name: '',
+      name: props.type === 'create' ? (props.defaultName ?? '') : '',
       description: '',
       authMethodId: props.type === 'create' ? (props.initialAuthMethodId ?? '') : '',
       credentialsDataJson: '{}',
@@ -142,12 +144,9 @@ export let ProviderAuthConfigForm = (
       if (!values.authMethodId) return;
 
       if (props.type === 'create' && props.flattenCreateStep && skipAuthMethodStep) {
-        form.setFieldTouched('name', true, false);
-        await form.validateField('name');
         let credentialsValid = await validateCredentialsForContinuation();
-        let nameValid = !!values.name.trim();
 
-        if (!credentialsValid || !nameValid) return;
+        if (!credentialsValid) return;
       }
 
       let parsedCredentials: Record<string, unknown> = {};
@@ -169,13 +168,16 @@ export let ProviderAuthConfigForm = (
 
       if (props.type !== 'create' || !instanceId) return;
 
+      let name = values.name.trim() || props.defaultName?.trim();
+      let description = props.hideDetailsInputs ? undefined : values.description || undefined;
+
       let [result] = await createMutation.mutate({
         instanceId,
         ...(props.providerDeploymentId
           ? { providerDeploymentId: props.providerDeploymentId }
           : {}),
-        name: values.name.trim(),
-        description: values.description || undefined,
+        ...(name ? { name } : {}),
+        ...(description ? { description } : {}),
         providerAuthMethodId: values.authMethodId,
         value: parsedCredentials
       });
@@ -188,7 +190,7 @@ export let ProviderAuthConfigForm = (
     schemaDependencies: [authMethods.data?.items, oauthAutoRegistrationEnabled],
     schema: yup =>
       yup.object({
-        name: yup.string().trim().required('Name is required'),
+        name: yup.string().trim(),
         description: yup.string().ensure(),
         authMethodId: yup.string().required('Authentication method is required'),
         credentialsData: yup.mixed<Record<string, unknown>>().defined(),
@@ -402,6 +404,7 @@ export let ProviderAuthConfigForm = (
   if (props.type === 'create') {
     let credentialsStepIndex = includeAuthMethodStep ? 1 : 0;
     let detailsStepIndex = includeAuthMethodStep ? 2 : 1;
+    let hideDetailsInputs = !!props.hideDetailsInputs;
 
     let goToCredentialsStep = async () => {
       form.setFieldTouched('authMethodId', true, false);
@@ -425,28 +428,32 @@ export let ProviderAuthConfigForm = (
 
           <form noValidate onSubmit={form.handleSubmit}>
             <FlatCreateSections>
-              <Input
-                label="Auth Config Name"
-                {...form.getFieldProps('name')}
-                description="Name this auth config so your team can identify it quickly."
-                placeholder={
-                  useOAuthAuthConfigNameHints
-                    ? 'e.g. John Doe'
-                    : 'e.g. CRM Production Connection'
-                }
-              />
-              <form.RenderError field="name" />
+              {!hideDetailsInputs ? (
+                <>
+                  <Input
+                    label="Auth Config Name"
+                    {...form.getFieldProps('name')}
+                    description="Name this auth config so your team can identify it quickly."
+                    placeholder={
+                      useOAuthAuthConfigNameHints
+                        ? 'e.g. John Doe'
+                        : 'e.g. CRM Production Connection'
+                    }
+                  />
+                  <form.RenderError field="name" />
 
-              <Spacer size={10} />
+                  <Spacer size={10} />
 
-              <Input
-                label="Auth Config Description"
-                {...authConfigDescriptionInputHints}
-                {...form.getFieldProps('description')}
-              />
-              <form.RenderError field="description" />
+                  <Input
+                    label="Auth Config Description"
+                    {...authConfigDescriptionInputHints}
+                    {...form.getFieldProps('description')}
+                  />
+                  <form.RenderError field="description" />
 
-              <Spacer size={15} />
+                  <Spacer size={15} />
+                </>
+              ) : null}
 
               <FlatCreateSectionGroup>
                 <InputLabel>Credentials</InputLabel>

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/modal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/modal.tsx
@@ -7,7 +7,8 @@ import {
   useCreateProviderAuthCredentials,
   useProvider,
   useProviderAuthMethods,
-  useProviderDeployment
+  useProviderDeployment,
+  useProviderListing
 } from '@metorial/state';
 import {
   Button,
@@ -16,12 +17,19 @@ import {
   Copy,
   Dialog,
   Input,
+  showModal,
   Spacer,
-  Text,
-  showModal
+  Text
 } from '@metorial/ui';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useProviderAuthCreationCapabilities } from '../../lib/providerCreationCapabilities';
+import {
+  getConfigDoc,
+  getProviderDoc,
+  getScopeDoc,
+  ProviderDocsLink
+} from '../../lib/providerDocs';
+import { ScopePickerField } from '../../pages/(deployments)/provider-auth-credential/components/scopePicker';
 import { ProviderContextCard } from '../providerContextCard';
 
 type AuthMethod = DashboardInstanceProvidersAuthMethodsListOutput['items'][number];
@@ -65,6 +73,17 @@ export let ProviderAuthCredentialsForm = ({
   let providerName = deployment.data?.name ?? provider.data?.name ?? providerId;
   let oauthMethodName = oauthMethod?.name ?? 'OAuth';
   let authCreation = useProviderAuthCreationCapabilities(instanceId, deploymentId, providerId);
+  let providerListing = useProviderListing(instanceId, providerId);
+  let providerDoc = getProviderDoc(providerListing.data);
+  let configDoc = getConfigDoc(providerListing.data);
+  let scopeDoc = getScopeDoc(providerListing.data, oauthMethod);
+  let availableScopes = oauthMethod?.scopes ?? [];
+  let defaultScopes = useMemo(
+    () => availableScopes.map(scope => scope.scope),
+    [availableScopes]
+  );
+  let [selectedScopes, setSelectedScopes] = useState<string[] | null>(null);
+  let effectiveScopes = selectedScopes ?? defaultScopes;
 
   let createCredentials = useCreateProviderAuthCredentials();
 
@@ -83,7 +102,7 @@ export let ProviderAuthCredentialsForm = ({
           type: 'oauth',
           clientId: values.clientId,
           clientSecret: values.clientSecret,
-          scopes: oauthMethod?.scopes?.map(scope => scope.scope) ?? []
+          scopes: effectiveScopes
         }
       });
 
@@ -99,6 +118,10 @@ export let ProviderAuthCredentialsForm = ({
         clientSecret: yup.string().required('Client Secret is required')
       })
   });
+
+  useEffect(() => {
+    setSelectedScopes(null);
+  }, [oauthMethod?.id]);
 
   if (authCreation.isLoading) {
     return (
@@ -194,6 +217,11 @@ export let ProviderAuthCredentialsForm = ({
             </Text>
             <Text size="1" color="gray600" style={{ marginBottom: 5 }}>
               You must configure this redirect URI in your OAuth app.
+              {configDoc ? (
+                <>
+                  <ProviderDocsLink doc={configDoc}>View config docs</ProviderDocsLink>
+                </>
+              ) : null}
             </Text>
             <Copy value={redirectUri} />
             <Spacer size={10} />
@@ -213,6 +241,7 @@ export let ProviderAuthCredentialsForm = ({
         <Input
           label="Client ID"
           placeholder="Enter client ID from provider"
+          help={<ProviderDocsLink doc={providerDoc}>Provider docs</ProviderDocsLink>}
           required
           {...form.getFieldProps('clientId')}
         />
@@ -228,6 +257,18 @@ export let ProviderAuthCredentialsForm = ({
           {...form.getFieldProps('clientSecret')}
         />
         <form.RenderError field="clientSecret" />
+
+        {availableScopes.length > 0 && (
+          <>
+            <Spacer size={10} />
+            <ScopePickerField
+              scopes={availableScopes}
+              selectedScopes={effectiveScopes}
+              onSelectedScopesChange={setSelectedScopes}
+              help={<ProviderDocsLink doc={scopeDoc}>Scope docs</ProviderDocsLink>}
+            />
+          </>
+        )}
 
         <createCredentials.RenderError />
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerConfigs/form.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerConfigs/form.tsx
@@ -42,6 +42,8 @@ export type ProviderConfigFormProps = {
   providerDeploymentId?: string;
   instanceId?: string;
   embedded?: boolean;
+  defaultName?: string;
+  hideDetailsInputs?: boolean;
 };
 
 export let ProviderConfigForm = (
@@ -100,11 +102,14 @@ export let ProviderConfigForm = (
       return;
     }
 
+    let name = values.name.trim() || props.defaultName?.trim();
+    let description = props.hideDetailsInputs ? undefined : values.description || undefined;
+
     if (values.sourceMode === 'vault') {
       let [result] = await createMutation.mutate({
         instanceId,
-        name: values.name.trim(),
-        description: values.description || undefined,
+        ...(name ? { name } : {}),
+        ...(description ? { description } : {}),
         providerId,
         ...(props.providerDeploymentId
           ? { providerDeploymentId: props.providerDeploymentId }
@@ -121,8 +126,8 @@ export let ProviderConfigForm = (
 
     let [result] = await createMutation.mutate({
       instanceId,
-      name: values.name.trim(),
-      description: values.description || undefined,
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
       providerId,
       ...(props.providerDeploymentId
         ? { providerDeploymentId: props.providerDeploymentId }
@@ -138,17 +143,17 @@ export let ProviderConfigForm = (
 
   let form = useForm({
     initialValues: {
-      name: '',
+      name: props.defaultName ?? '',
       description: '',
       sourceMode: '' as ConfigSourceMode,
       providerConfigVaultId: '',
-      configData: {} as Record<string, unknown>
+      configData: schemaCapabilities.defaultConfigValue
     },
     onSubmit: async () => undefined,
     schemaDependencies: [canCreateFromVault, schemaCapabilities.hasSchemaFields],
     schema: yup =>
       yup.object({
-        name: yup.string().trim().required('Name is required'),
+        name: yup.string().trim(),
         description: yup.string(),
         sourceMode: yup
           .string()
@@ -189,6 +194,18 @@ export let ProviderConfigForm = (
     }
   }, [canCreateFromVault, canCreateManualConfig, form, form.values.sourceMode]);
 
+  let defaultConfigValueKey = JSON.stringify(schemaCapabilities.defaultConfigValue);
+
+  useEffect(() => {
+    if (!canCreateManualConfig) return;
+    if (Object.keys(form.values.configData).length > 0) return;
+
+    let defaultConfigValue = schemaCapabilities.defaultConfigValue;
+    if (Object.keys(defaultConfigValue).length === 0) return;
+
+    form.setFieldValue('configData', defaultConfigValue);
+  }, [canCreateManualConfig, defaultConfigValueKey, form, form.values.configData]);
+
   if (props.providerDeploymentId && deployment.isLoading) {
     return <CenteredSpinner />;
   }
@@ -227,10 +244,6 @@ export let ProviderConfigForm = (
   let closeAction = props.onBack ?? props.close;
 
   let createConfig = async () => {
-    form.setFieldTouched('name', true, false);
-    await form.validateField('name');
-    if (form.getFieldMeta('name').error || !form.values.name.trim()) return;
-
     form.setFieldTouched('sourceMode', true, false);
     await form.validateField('sourceMode');
     if (form.getFieldMeta('sourceMode').error || !form.values.sourceMode) return;
@@ -250,6 +263,7 @@ export let ProviderConfigForm = (
     ...(canCreateFromVault ? [{ id: 'vault', label: 'Use config vault' }] : [])
   ];
   let hideSourceSelectInFlatCreate = canCreateManualConfig && !canCreateFromVault;
+  let hideDetailsInputs = !!props.hideDetailsInputs;
 
   return (
     <>
@@ -260,15 +274,19 @@ export let ProviderConfigForm = (
             void createConfig();
           }}
         >
-          <Input label="Name" {...form.getFieldProps('name')} />
-          <form.RenderError field="name" />
+          {!hideDetailsInputs ? (
+            <>
+              <Input label="Name" {...form.getFieldProps('name')} />
+              <form.RenderError field="name" />
 
-          <Spacer size={8} />
+              <Spacer size={8} />
 
-          <Input label="Description" {...form.getFieldProps('description')} />
-          <form.RenderError field="description" />
+              <Input label="Description" {...form.getFieldProps('description')} />
+              <form.RenderError field="description" />
 
-          <Spacer size={10} />
+              <Spacer size={10} />
+            </>
+          ) : null}
 
           {!hideSourceSelectInFlatCreate ? (
             <>
@@ -342,7 +360,6 @@ export let ProviderConfigForm = (
               loading={createMutation.isLoading}
               disabled={
                 !form.values.sourceMode ||
-                !form.values.name.trim() ||
                 (form.values.sourceMode === 'vault' && !form.values.providerConfigVaultId)
               }
             >

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerConfigs/selection.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerConfigs/selection.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../lib/configSelection';
 import { getProviderConfigSchemaCapabilities } from '../../lib/providerCreationCapabilities';
 import { showProviderConfigVaultFormModal } from '../providerConfigVaults/modal';
+import { ProviderConfigForm } from './form';
 import { showProviderConfigFormModal } from './modal';
 
 type ConfigItem = DashboardInstanceProviderDeploymentsConfigsListOutput['items'][number];
@@ -40,7 +41,10 @@ export let ProviderConfigurationSelection = ({
   createConfigButtonLabel,
   showExistingOptions = true,
   filterAvailableResources = false,
-  disabled = false
+  disabled = false,
+  inlineCreateConfig = false,
+  defaultConfigName,
+  hideCreateConfigDetails = false
 }: {
   instanceId: string;
   providerDeploymentId?: string;
@@ -53,6 +57,9 @@ export let ProviderConfigurationSelection = ({
   showExistingOptions?: boolean;
   filterAvailableResources?: boolean;
   disabled?: boolean;
+  inlineCreateConfig?: boolean;
+  defaultConfigName?: string;
+  hideCreateConfigDetails?: boolean;
 }) => {
   let query = filterAvailableResources
     ? {
@@ -95,9 +102,11 @@ export let ProviderConfigurationSelection = ({
   let scopeKey = providerDeploymentId ?? providerId ?? '__none__';
   let handledAutoSelectionRef = useRef<string | null>(null);
   let [createdSelection, setCreatedSelection] = useState<CreatedSelectionState | null>(null);
+  let [isCreatingInlineConfig, setIsCreatingInlineConfig] = useState(false);
 
   useEffect(() => {
     handledAutoSelectionRef.current = null;
+    setIsCreatingInlineConfig(false);
   }, [scopeKey]);
 
   useEffect(() => {
@@ -136,6 +145,14 @@ export let ProviderConfigurationSelection = ({
       : effectiveValue.kind === 'vault'
         ? (selectedVault.data?.name ?? selectedVault.data?.id)
         : undefined);
+  let handleConfigCreated = async (config: { id: string; name?: string | null }) => {
+    let label = config.name ?? config.id;
+    onChange({ kind: 'config', id: config.id });
+    setCreatedSelection({ kind: 'config', id: config.id, label });
+    setIsCreatingInlineConfig(false);
+    await Promise.resolve(configs.refetch?.());
+    onChange({ kind: 'config', id: config.id });
+  };
 
   return (
     <Flex direction="column" gap={8}>
@@ -156,6 +173,17 @@ export let ProviderConfigurationSelection = ({
             </Button>
           </Flex>
         </Callout>
+      ) : isCreatingInlineConfig ? (
+        <ProviderConfigForm
+          type="create"
+          instanceId={instanceId}
+          providerDeploymentId={providerDeploymentId}
+          providerId={providerId}
+          defaultName={defaultConfigName}
+          hideDetailsInputs={hideCreateConfigDetails}
+          close={() => setIsCreatingInlineConfig(false)}
+          onCreate={handleConfigCreated}
+        />
       ) : (
         <Flex gap={8} align="end">
           {showExistingOptions ? (
@@ -224,21 +252,20 @@ export let ProviderConfigurationSelection = ({
                 size="3"
                 iconLeft={<RiAddLine />}
                 disabled={disabled || !configCreation.canCreateConfig}
-                onClick={() =>
+                onClick={() => {
+                  if (inlineCreateConfig) {
+                    setIsCreatingInlineConfig(true);
+                    return;
+                  }
+
                   showProviderConfigFormModal({
                     type: 'create',
                     instanceId,
                     ...(providerDeploymentId ? { providerDeploymentId } : {}),
                     ...(providerId ? { providerId } : {}),
-                    onCreate: async config => {
-                      let label = config.name ?? config.id;
-                      onChange({ kind: 'config', id: config.id });
-                      setCreatedSelection({ kind: 'config', id: config.id, label });
-                      await Promise.resolve(configs.refetch?.());
-                      onChange({ kind: 'config', id: config.id });
-                    }
-                  })
-                }
+                    onCreate: handleConfigCreated
+                  });
+                }}
               >
                 {createConfigButtonLabel}
               </Button>

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/index.tsx
@@ -8,12 +8,14 @@ import {
   useProvider,
   useProviderAuthCredentials,
   useProviderAuthMethods,
-  useProviderDeployment
+  useProviderDeployment,
+  useProviderListing
 } from '@metorial/state';
 import { Button, Flex, Text } from '@metorial/ui';
 import { sortBy } from 'lodash';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Stepper } from '../../../../../components/stepper';
+import { getConfigDoc, getProviderDoc, getScopeDoc } from '../../../lib/providerDocs';
 import { getProviderOAuthAutoRegistrationEnabled } from '../../../lib/providerOAuthAutoRegistration';
 import {
   ConnectStep,
@@ -59,6 +61,7 @@ export let ProviderSetupSessionEmbed = ({
   let deployment = useProviderDeployment(instanceId, deploymentId);
   let lockedVersionId = deployment.data?.lockedVersion?.id;
   let provider = useProvider(instanceId, providerId);
+  let providerListing = useProviderListing(instanceId, providerId);
   let project = useCurrentProject();
   let projectBrand = useProjectBrand(project.data?.organization.id, project.data?.id);
   let effectiveVersionId = lockedVersionId ?? provider.data?.currentVersion?.id;
@@ -110,7 +113,8 @@ export let ProviderSetupSessionEmbed = ({
       selectedCredentialId: fixedCredentialId ?? '',
       newCredName: '',
       newCredClientId: '',
-      newCredClientSecret: ''
+      newCredClientSecret: '',
+      newCredScopes: [] as string[]
     },
     onSubmit: async () => {
       let providerAuthCredentialsId = await resolveSelectedCredentialId();
@@ -201,6 +205,11 @@ export let ProviderSetupSessionEmbed = ({
     () => (authMethods.data?.items ?? []).find(method => method.id === selectedMethodId),
     [authMethods.data?.items, selectedMethodId]
   );
+  let selectedMethodScopes = useMemo(
+    () => selectedMethod?.scopes?.map(scope => scope.scope) ?? [],
+    [selectedMethod?.scopes]
+  );
+  let selectedMethodScopeKey = selectedMethodScopes.join('\n');
 
   let providerName = deployment.data?.name ?? provider.data?.name ?? providerId;
   let oauthMethodName = selectedMethod?.name ?? 'OAuth';
@@ -210,6 +219,9 @@ export let ProviderSetupSessionEmbed = ({
   let projectBrandImageUrl = projectBrand.data?.imageUrl;
   let projectBrandName = projectBrand.data?.name ?? project.data?.name ?? 'Metorial';
   let providerImageUrl = provider.data?.publisher.imageUrl;
+  let providerDoc = getProviderDoc(providerListing.data);
+  let configDoc = getConfigDoc(providerListing.data);
+  let scopeDoc = getScopeDoc(providerListing.data, selectedMethod);
 
   let visibleAuthCredentials = sortBy(authCredentials.data?.items ?? [], [
     credential => Number(!credential.isManaged),
@@ -360,6 +372,10 @@ export let ProviderSetupSessionEmbed = ({
   };
 
   useEffect(() => {
+    void credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
+  }, [selectedMethod?.id, selectedMethodScopeKey]);
+
+  useEffect(() => {
     if (!collectAuthConfigDetails || !onAuthConfigDetailsChange) return;
 
     onAuthConfigDetailsChange({
@@ -484,7 +500,8 @@ export let ProviderSetupSessionEmbed = ({
   ]);
 
   let handleCreateCredentials = async (): Promise<string | null> => {
-    let { newCredClientId, newCredClientSecret, newCredName } = credentialsForm.values;
+    let { newCredClientId, newCredClientSecret, newCredName, newCredScopes } =
+      credentialsForm.values;
     if (!newCredName || !newCredClientId || !newCredClientSecret || !selectedMethod) return null;
 
     setError(null);
@@ -497,7 +514,7 @@ export let ProviderSetupSessionEmbed = ({
         type: 'oauth',
         clientId: newCredClientId,
         clientSecret: newCredClientSecret,
-        scopes: selectedMethod.scopes?.map(scope => scope.scope) ?? []
+        scopes: newCredScopes
       }
     });
 
@@ -514,6 +531,7 @@ export let ProviderSetupSessionEmbed = ({
     await credentialsForm.setFieldValue('newCredName', '');
     await credentialsForm.setFieldValue('newCredClientId', '');
     await credentialsForm.setFieldValue('newCredClientSecret', '');
+    await credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
 
     return result.id;
   };
@@ -529,6 +547,7 @@ export let ProviderSetupSessionEmbed = ({
     if (value === '__create_new__') {
       void credentialsForm.setFieldValue('credentialMode', 'new');
       void credentialsForm.setFieldValue('selectedCredentialId', '');
+      void credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
       return;
     }
 
@@ -877,6 +896,10 @@ export let ProviderSetupSessionEmbed = ({
     isManagedSelected,
     error,
     createCredentials,
+    selectedMethod,
+    providerDoc,
+    configDoc,
+    scopeDoc,
     showHiddenMethodStep,
     includeMethodStep,
     skipMethodStep,
@@ -899,6 +922,10 @@ export let ProviderSetupSessionEmbed = ({
     hasManagedVisibleCredentials,
     createCredentials,
     createSetupSession,
+    selectedMethod,
+    providerDoc,
+    configDoc,
+    scopeDoc,
     error,
     setupSession,
     setupWindowBlocked,

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/stepContent.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/stepContent.tsx
@@ -11,6 +11,8 @@ import {
   Text
 } from '@metorial/ui';
 import type { ReactNode } from 'react';
+import { ProviderDocsLink, type ProviderDocReference } from '../../../lib/providerDocs';
+import { ScopePickerField } from '../../../pages/(deployments)/provider-auth-credential/components/scopePicker';
 import { AuthMethodPicker } from '../../providerAuthConfigs/authMethodPicker';
 import {
   FlatConnectForm,
@@ -32,7 +34,7 @@ import {
   SummaryFieldMeta,
   SummaryFieldValue
 } from './styled';
-import type { SetupSessionState } from './types';
+import type { AuthMethod, SetupSessionState } from './types';
 
 type AnyForm = any;
 
@@ -127,7 +129,10 @@ export let AuthConfigDetailsFields = (p: {
   );
 };
 
-let RedirectUriField = (p: { redirectUri: string }) => {
+let RedirectUriField = (p: {
+  redirectUri: string;
+  configDoc?: ProviderDocReference | null;
+}) => {
   return (
     <>
       <Spacer size={12} />
@@ -136,13 +141,29 @@ let RedirectUriField = (p: { redirectUri: string }) => {
       </Text>
       <Text size="1" color="gray600" style={{ marginBottom: 5 }}>
         You must configure this redirect URI in your OAuth app.
+        {p.configDoc ? (
+          <>
+            {' '}
+            <ProviderDocsLink doc={p.configDoc}>View config docs</ProviderDocsLink>
+          </>
+        ) : null}
       </Text>
       <Copy value={p.redirectUri} />
     </>
   );
 };
 
-let NewCredentialsFields = (p: { credentialsForm: AnyForm; disabled?: boolean }) => {
+let NewCredentialsFields = (p: {
+  credentialsForm: AnyForm;
+  selectedMethod?: AuthMethod;
+  providerDoc?: ProviderDocReference | null;
+  scopeDoc?: ProviderDocReference | null;
+  disabled?: boolean;
+}) => {
+  let availableScopes = p.selectedMethod?.scopes ?? [];
+  let selectedScopes =
+    p.credentialsForm.values.newCredScopes ?? availableScopes.map(scope => scope.scope);
+
   return (
     <>
       <Spacer size={12} />
@@ -164,6 +185,7 @@ let NewCredentialsFields = (p: { credentialsForm: AnyForm; disabled?: boolean })
         disabled={p.disabled}
         onChange={e => p.credentialsForm.setFieldValue('newCredClientId', e.target.value)}
         placeholder="Enter client ID from provider"
+        help={<ProviderDocsLink doc={p.providerDoc}>Provider docs</ProviderDocsLink>}
       />
       <p.credentialsForm.RenderError field="newCredClientId" />
 
@@ -178,6 +200,21 @@ let NewCredentialsFields = (p: { credentialsForm: AnyForm; disabled?: boolean })
         type="password"
       />
       <p.credentialsForm.RenderError field="newCredClientSecret" />
+
+      {availableScopes.length > 0 && (
+        <>
+          <Spacer size={8} />
+          <ScopePickerField
+            scopes={availableScopes}
+            selectedScopes={selectedScopes}
+            onSelectedScopesChange={scopes =>
+              p.credentialsForm.setFieldValue('newCredScopes', scopes)
+            }
+            help={<ProviderDocsLink doc={p.scopeDoc}>Scope docs</ProviderDocsLink>}
+            disabled={p.disabled}
+          />
+        </>
+      )}
     </>
   );
 };
@@ -190,6 +227,10 @@ let CredentialsSelector = (p: {
   hasManagedVisibleCredentials: boolean;
   isCreatingCredentials: boolean;
   redirectUri?: string;
+  selectedMethod?: AuthMethod;
+  providerDoc?: ProviderDocReference | null;
+  configDoc?: ProviderDocReference | null;
+  scopeDoc?: ProviderDocReference | null;
   isCustomSelected: boolean;
   disableCredentialSelection?: boolean;
   disabled?: boolean;
@@ -231,11 +272,17 @@ let CredentialsSelector = (p: {
       )}
 
       {shouldShowRedirectUri && p.redirectUri && (
-        <RedirectUriField redirectUri={p.redirectUri} />
+        <RedirectUriField redirectUri={p.redirectUri} configDoc={p.configDoc} />
       )}
 
       {p.isCreatingCredentials && !p.disableCredentialSelection && (
-        <NewCredentialsFields credentialsForm={p.credentialsForm} disabled={p.disabled} />
+        <NewCredentialsFields
+          credentialsForm={p.credentialsForm}
+          selectedMethod={p.selectedMethod}
+          providerDoc={p.providerDoc}
+          scopeDoc={p.scopeDoc}
+          disabled={p.disabled}
+        />
       )}
     </>
   );
@@ -438,6 +485,10 @@ export let CredentialsSelectionStep = (p: {
   handleCredentialSelectionChange: (value: string) => void;
   hasManagedVisibleCredentials: boolean;
   redirectUri?: string;
+  selectedMethod?: AuthMethod;
+  providerDoc?: ProviderDocReference | null;
+  configDoc?: ProviderDocReference | null;
+  scopeDoc?: ProviderDocReference | null;
   isCustomSelected: boolean;
   isCreatingCredentials: boolean;
   disableCredentialSelection?: boolean;
@@ -484,6 +535,10 @@ export let CredentialsSelectionStep = (p: {
                 hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
                 isCreatingCredentials={p.isCreatingCredentials}
                 redirectUri={p.redirectUri}
+                selectedMethod={p.selectedMethod}
+                providerDoc={p.providerDoc}
+                configDoc={p.configDoc}
+                scopeDoc={p.scopeDoc}
                 isCustomSelected={p.isCustomSelected}
                 disableCredentialSelection={p.disableCredentialSelection}
               />
@@ -509,6 +564,10 @@ export let CredentialsSelectionStep = (p: {
             hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
             isCreatingCredentials={p.isCreatingCredentials}
             redirectUri={p.redirectUri}
+            selectedMethod={p.selectedMethod}
+            providerDoc={p.providerDoc}
+            configDoc={p.configDoc}
+            scopeDoc={p.scopeDoc}
             isCustomSelected={p.isCustomSelected}
             disableCredentialSelection={p.disableCredentialSelection}
           />
@@ -579,6 +638,10 @@ export let FlatOAuthConnectStep = (p: {
   hasManagedVisibleCredentials: boolean;
   createCredentials: { isPending: boolean; RenderError: () => ReactNode };
   createSetupSession: { isPending: boolean; RenderError: () => ReactNode };
+  selectedMethod?: AuthMethod;
+  providerDoc?: ProviderDocReference | null;
+  configDoc?: ProviderDocReference | null;
+  scopeDoc?: ProviderDocReference | null;
   error: string | null;
   setupSession: SetupSessionState | null;
   setupWindowBlocked: boolean;
@@ -631,6 +694,10 @@ export let FlatOAuthConnectStep = (p: {
                 handleCredentialSelectionChange={p.handleCredentialSelectionChange}
                 hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
                 redirectUri={p.redirectUri}
+                selectedMethod={p.selectedMethod}
+                providerDoc={p.providerDoc}
+                configDoc={p.configDoc}
+                scopeDoc={p.scopeDoc}
                 isCreatingCredentials={p.isCreatingCredentials}
                 isCustomSelected={p.isCustomSelected}
                 disableCredentialSelection={p.disableCredentialSelection}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
@@ -6,6 +6,7 @@ import {
   useProvider,
   useProviderAuthConfig,
   useProviderAuthConfigs,
+  useProviderConfigSchemaTarget,
   useProviderListing,
   useProviderTools
 } from '@metorial/state';
@@ -20,8 +21,11 @@ import {
   Dialog,
   Entity,
   Flex,
+  Menu,
   OptionToggle,
   Text,
+  Tooltip,
+  type ButtonSize,
   theme
 } from '@metorial/ui';
 import { RiAddLine, RiArrowDownSLine, RiCheckLine } from '@remixicon/react';
@@ -32,7 +36,18 @@ import {
   emptyConfigurationSelection,
   type ConfigurationSelection
 } from '../../lib/configSelection';
-import { ProviderAuthConfigCreateButton } from '../providerAuthConfigs/modal';
+import {
+  getProviderConfigSchemaCapabilities,
+  useProviderAuthCreationCapabilities
+} from '../../lib/providerCreationCapabilities';
+import {
+  ProviderAuthConfigCreateFlowContent,
+  showProviderAuthConfigCreateModal
+} from '../providerAuthConfigs/createModal';
+import {
+  getCreateMethodDescription,
+  isSetupFlowAuthMethod
+} from '../providerAuthConfigs/modalHelpers';
 import { ProviderConfigurationSelection } from '../providerConfigs/selection';
 import {
   ProviderCreationPanelShell,
@@ -113,6 +128,13 @@ type AddProviderPanelFlowProps = {
   onComplete: () => void;
 };
 
+let getProviderSetupGeneratedName = (providerName: string | null | undefined) => {
+  let normalizedProviderName = providerName?.trim() || 'Provider';
+  let date = new Date().toISOString().slice(0, 10);
+
+  return `${normalizedProviderName} - ${date}`;
+};
+
 export let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
   let createConfigMutation = useCreateProviderConfig();
   let createMutation = useCreateSessionTemplateProvider();
@@ -162,18 +184,19 @@ export let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
       setSubmitError(null);
       let fallbackProviderConfigId: string | undefined;
       let needsFallbackConfig =
-        !values.selectedDeploymentId &&
+        canAutoCreateEmptyConfig &&
         values.selectedConfiguration.kind === 'none' &&
-        !values.selectedAuthConfigId;
+        values.selectedProviderId;
 
       if (needsFallbackConfig) {
-        let fallbackConfigName = `${values.selectedProviderName || 'Provider'} Config`;
         let [config, configError] = await createConfigMutation.mutate({
           instanceId: p.instanceId,
           providerId: values.selectedProviderId,
-          name: fallbackConfigName,
-          description: 'Automatically created for session template provider setup.',
-          value: {}
+          ...(values.selectedDeploymentId
+            ? { providerDeploymentId: values.selectedDeploymentId }
+            : {}),
+          name: getProviderSetupGeneratedName(values.selectedProviderName),
+          value: selectedConfigCapabilities.defaultConfigValue
         });
 
         if (!config || configError) {
@@ -285,6 +308,30 @@ export let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
         selectedToolKeys: yup.array().of(yup.string().required()).defined()
       })
   });
+
+  let configuredProvider = useProvider(
+    p.instanceId,
+    form.values.selectedProviderId || p.providerId || null
+  );
+  let configuredProviderRequiresConfig =
+    configuredProvider.data?.type.config.status == 'enabled';
+  let selectedConfigSchema = useProviderConfigSchemaTarget(
+    p.instanceId,
+    form.values.selectedDeploymentId
+      ? { providerDeploymentId: form.values.selectedDeploymentId }
+      : form.values.selectedProviderId
+        ? { providerId: form.values.selectedProviderId }
+        : null
+  );
+  let selectedConfigCapabilities = getProviderConfigSchemaCapabilities({
+    schemaValue: selectedConfigSchema.data?.schema,
+    hasVaults: false,
+    isLoading: selectedConfigSchema.isLoading
+  });
+  let canAutoCreateEmptyConfig =
+    !!configuredProviderRequiresConfig &&
+    !selectedConfigSchema.isLoading &&
+    selectedConfigCapabilities.canAutoCreateEmptyConfig;
 
   useEffect(() => {
     if (!p.providerId) return;
@@ -426,30 +473,29 @@ export let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
       title: 'Configure',
       render: () =>
         form.values.selectedProviderId ? (
-          <form onSubmit={form.handleSubmit}>
-            <ConfigureStep
-              form={form}
-              instanceId={p.instanceId}
-              providerId={form.values.selectedProviderId}
-              providerName={form.values.selectedProviderName}
-              saving={
-                createConfigMutation.isLoading ||
-                isSubmitting ||
-                createMutation.isPending ||
-                deleteMutation.isPending
-              }
-              mutationError={
-                <>
-                  <createConfigMutation.RenderError />
-                  <createMutation.RenderError />
-                  <deleteMutation.RenderError />
-                </>
-              }
-              submitLabel={p.action || 'Add Provider'}
-              filterAvailableResources={p.filterAvailableResources}
-              onBack={p.hideProviderStep ? p.close : () => setStep(0)}
-            />
-          </form>
+          <ConfigureStep
+            form={form}
+            instanceId={p.instanceId}
+            providerId={form.values.selectedProviderId}
+            providerName={form.values.selectedProviderName}
+            canAutoCreateEmptyConfig={canAutoCreateEmptyConfig}
+            saving={
+              createConfigMutation.isLoading ||
+              isSubmitting ||
+              createMutation.isPending ||
+              deleteMutation.isPending
+            }
+            mutationError={
+              <>
+                <createConfigMutation.RenderError />
+                <createMutation.RenderError />
+                <deleteMutation.RenderError />
+              </>
+            }
+            submitLabel={p.action || 'Add Provider'}
+            filterAvailableResources={p.filterAvailableResources}
+            onBack={p.hideProviderStep ? p.close : () => setStep(0)}
+          />
         ) : (
           <CenteredSpinner />
         )
@@ -484,6 +530,7 @@ export let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
     submitError,
     createMutation.isPending,
     deleteMutation.isPending,
+    canAutoCreateEmptyConfig,
     form.handleSubmit,
     p.action,
     p.hideProviderStep,
@@ -753,6 +800,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
     id: string;
     label: string;
   } | null>(null);
+  let [inlineAuthMethodId, setInlineAuthMethodId] = useState<string | null>(null);
   let scrollContainerRef = useRef<HTMLDivElement | null>(null);
   let [scrollIndicators, setScrollIndicators] = useState({
     canScrollUp: false,
@@ -850,6 +898,10 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
   }, [createdAuthConfigSelection, p.selectedAuthConfigId]);
 
   useEffect(() => {
+    setInlineAuthMethodId(null);
+  }, [p.providerId, p.providerDeploymentId, p.fixedAuthMethodId]);
+
+  useEffect(() => {
     if (!showToolFilters || toolItems.length === 0) return;
     if (!p.onSelectedToolKeysChange || !p.onToolFilterModeChange) return;
     if (toolFilterMode !== 'all') return;
@@ -916,6 +968,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
     ? 'Create Auth Config'
     : `Log in with ${providerDisplayName}`;
   let providerImageUrl = providerListing.data?.imageUrl;
+  let generatedResourceName = getProviderSetupGeneratedName(providerDisplayName);
 
   if (showProviderSummary) {
     sectionItems.push(
@@ -962,6 +1015,9 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
             createConfigButtonLabel="Create Config"
             showExistingOptions={showExistingConfigOptions}
             filterAvailableResources={filterAvailableResources}
+            inlineCreateConfig
+            defaultConfigName={generatedResourceName}
+            hideCreateConfigDetails
             disabled={p.disabled}
           />
           {p.configError}
@@ -995,6 +1051,29 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
                 Choose another
               </Button>
             </Flex>
+          ) : inlineAuthMethodId ? (
+            <ProviderAuthConfigCreateFlowContent
+              instanceId={p.instanceId}
+              providerDeploymentId={p.providerDeploymentId ?? undefined}
+              providerId={p.providerId}
+              initialAuthMethodId={inlineAuthMethodId}
+              fixedAuthCredentialsId={p.fixedAuthCredentialsId}
+              defaultAuthConfigName={generatedResourceName}
+              autoStartManagedCredentialSetup={autoStartManagedCredentialSetup}
+              close={() => setInlineAuthMethodId(null)}
+              onBack={() => setInlineAuthMethodId(null)}
+              embedded
+              hideDetailsInputs
+              onCreate={authConfig => {
+                pendingCreatedAuthConfigIdRef.current = authConfig.id;
+                setCreatedAuthConfigSelection({
+                  id: authConfig.id,
+                  label: authConfig.name ?? generatedResourceName
+                });
+                setInlineAuthMethodId(null);
+                p.onSelectedAuthConfigIdChange(authConfig.id);
+              }}
+            />
           ) : (
             <Flex gap={8} align="end">
               {showExistingAuthOptions ? (
@@ -1040,7 +1119,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
                 </div>
               ) : null}
 
-              <ProviderAuthConfigCreateButton
+              <ProviderAuthConfigCreateAction
                 instanceId={p.instanceId}
                 providerDeploymentId={p.providerDeploymentId ?? undefined}
                 providerId={p.providerId}
@@ -1048,6 +1127,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
                 fixedAuthCredentialsId={p.fixedAuthCredentialsId}
                 defaultAuthConfigName={p.defaultAuthConfigName}
                 autoStartManagedCredentialSetup={autoStartManagedCredentialSetup}
+                onInlineCreate={authMethodId => setInlineAuthMethodId(authMethodId)}
                 onCreate={async authConfig => {
                   pendingCreatedAuthConfigIdRef.current = authConfig.id;
                   setCreatedAuthConfigSelection({
@@ -1062,7 +1142,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
                 disabled={p.disabled}
               >
                 {createAuthConfigLabel}
-              </ProviderAuthConfigCreateButton>
+              </ProviderAuthConfigCreateAction>
             </Flex>
           )}
 
@@ -1325,6 +1405,137 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
   );
 };
 
+let ProviderAuthConfigCreateAction = (p: {
+  instanceId: string;
+  providerDeploymentId?: string;
+  providerId?: string;
+  fixedAuthMethodId?: string;
+  fixedAuthCredentialsId?: string;
+  defaultAuthConfigName?: string;
+  autoStartManagedCredentialSetup?: boolean;
+  onInlineCreate: (authMethodId: string) => void;
+  onCreate?: (authConfig: { id: string; name?: string | null }) => void;
+  onBack?: () => void;
+  size?: ButtonSize;
+  iconLeft?: ReactNode;
+  children: ReactNode;
+  ariaLabel?: string;
+  disabled?: boolean;
+}) => {
+  let authCreation = useProviderAuthCreationCapabilities(
+    p.instanceId,
+    p.providerDeploymentId,
+    p.providerId
+  );
+
+  let openCreateFlow = (authMethodId: string) => {
+    let method = authCreation.authMethodItems.find(method => method.id === authMethodId);
+
+    if (method && !isSetupFlowAuthMethod(method)) {
+      p.onInlineCreate(authMethodId);
+      return;
+    }
+
+    showProviderAuthConfigCreateModal({
+      instanceId: p.instanceId,
+      providerDeploymentId: p.providerDeploymentId,
+      providerId: p.providerId,
+      initialAuthMethodId: authMethodId,
+      fixedAuthCredentialsId: p.fixedAuthCredentialsId,
+      defaultAuthConfigName: p.defaultAuthConfigName,
+      autoStartManagedCredentialSetup: p.autoStartManagedCredentialSetup,
+      onCreate: p.onCreate,
+      onBack: p.onBack
+    });
+  };
+
+  let disabledReason = authCreation.isLoading
+    ? 'Loading authentication options...'
+    : authCreation.authConfigDisabledReason;
+  let isDisabled = p.disabled || authCreation.isLoading || !authCreation.canCreateAuthConfig;
+
+  if (p.fixedAuthMethodId) {
+    return (
+      <Tooltip content={disabledReason ?? ''} enabled={!p.disabled && isDisabled}>
+        <div style={{ display: 'inline-flex' }}>
+          <Button
+            type="button"
+            size={p.size}
+            iconLeft={p.iconLeft}
+            aria-label={p.ariaLabel}
+            disabled={isDisabled}
+            onClick={() => openCreateFlow(p.fixedAuthMethodId!)}
+          >
+            {p.children}
+          </Button>
+        </div>
+      </Tooltip>
+    );
+  }
+
+  if (isDisabled) {
+    return (
+      <Tooltip
+        content={disabledReason ?? ''}
+        enabled={!p.disabled && !authCreation.canCreateAuthConfig}
+        delayDuration={0}
+      >
+        <div style={{ display: 'inline-flex' }}>
+          <Button
+            type="button"
+            size={p.size}
+            iconLeft={p.iconLeft}
+            aria-label={p.ariaLabel}
+            disabled
+          >
+            {p.children}
+          </Button>
+        </div>
+      </Tooltip>
+    );
+  }
+
+  if (authCreation.authMethodItems.length <= 1) {
+    let method = authCreation.authMethodItems[0];
+
+    return (
+      <Button
+        type="button"
+        size={p.size}
+        iconLeft={p.iconLeft}
+        aria-label={p.ariaLabel}
+        disabled={p.disabled || !method}
+        onClick={() => method && openCreateFlow(method.id)}
+      >
+        {p.children}
+      </Button>
+    );
+  }
+
+  return (
+    <Menu
+      label={typeof p.children === 'string' ? p.children : p.ariaLabel}
+      title="Choose authentication method"
+      items={authCreation.authMethodItems.map(method => ({
+        id: method.id,
+        label: method.name,
+        description: getCreateMethodDescription(method)
+      }))}
+      onItemClick={authMethodId => openCreateFlow(authMethodId)}
+    >
+      <Button
+        type="button"
+        size={p.size}
+        iconLeft={p.iconLeft}
+        aria-label={p.ariaLabel}
+        disabled={p.disabled}
+      >
+        {p.children}
+      </Button>
+    </Menu>
+  );
+};
+
 let PickProviderStep = (p: {
   instanceId: string;
   excludeProviderIds?: string[];
@@ -1384,6 +1595,7 @@ let ConfigureStep = (p: {
   instanceId: string;
   providerId: string;
   providerName: string;
+  canAutoCreateEmptyConfig: boolean;
   saving: boolean;
   mutationError: ReactNode;
   submitLabel: string;
@@ -1393,10 +1605,17 @@ let ConfigureStep = (p: {
   let provider = useProvider(p.instanceId, p.providerId);
   let requiresProviderConfig = provider.data?.type.config.status == 'enabled';
   let requiresAuthConfig = provider.data?.type.auth.status == 'enabled';
+  let configRequirement: 'required' | 'optional' = p.canAutoCreateEmptyConfig
+    ? 'optional'
+    : 'required';
   let validateRequiredSelections = () => {
     let isValid = true;
 
-    if (requiresProviderConfig && p.form.values.selectedConfiguration.kind === 'none') {
+    if (
+      requiresProviderConfig &&
+      !p.canAutoCreateEmptyConfig &&
+      p.form.values.selectedConfiguration.kind === 'none'
+    ) {
       p.form.setFieldTouched('selectedConfiguration', true, false);
       p.form.setFieldError('selectedConfiguration', 'Select a config or config vault');
       isValid = false;
@@ -1412,7 +1631,9 @@ let ConfigureStep = (p: {
   };
 
   let canSubmit =
-    (!requiresProviderConfig || p.form.values.selectedConfiguration.kind !== 'none') &&
+    (!requiresProviderConfig ||
+      p.canAutoCreateEmptyConfig ||
+      p.form.values.selectedConfiguration.kind !== 'none') &&
     (!requiresAuthConfig || Boolean(p.form.values.selectedAuthConfigId));
 
   let handleSubmitClick = async () => {
@@ -1429,6 +1650,7 @@ let ConfigureStep = (p: {
       providerName={p.providerName}
       providerDeploymentId={p.form.values.selectedDeploymentId || undefined}
       filterAvailableResources={p.filterAvailableResources}
+      configRequirement={configRequirement}
       selectedConfiguration={p.form.values.selectedConfiguration}
       onSelectedConfigurationChange={value => {
         p.form.setFieldValue('selectedConfiguration', value);

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
@@ -999,7 +999,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
       <ConfigureSectionCard
         key="config"
         title="Config"
-        description="Choose the provider configuration or vault this setup should use."
+        description="Choose the provider configuration this setup should use."
         requirement={configRequirement}
         completed={isConfigCompleted}
       >
@@ -1011,7 +1011,6 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
             value={p.selectedConfiguration}
             onChange={p.onSelectedConfigurationChange}
             label="Config"
-            includeVaults
             createConfigButtonLabel="Create Config"
             showExistingOptions={showExistingConfigOptions}
             filterAvailableResources={filterAvailableResources}
@@ -1617,7 +1616,7 @@ let ConfigureStep = (p: {
       p.form.values.selectedConfiguration.kind === 'none'
     ) {
       p.form.setFieldTouched('selectedConfiguration', true, false);
-      p.form.setFieldError('selectedConfiguration', 'Select a config or config vault');
+      p.form.setFieldError('selectedConfiguration', 'Select a config');
       isValid = false;
     }
 

--- a/src/packages/backend/fabric/src/types.ts
+++ b/src/packages/backend/fabric/src/types.ts
@@ -78,23 +78,29 @@ export type MachineAccessInput =
     };
 
 export type OAuthApplicationCreateInput = {
+  status?: 'active' | 'archived';
   type: 'user_facing' | 'server_side' | 'cli_auth';
   accessLevel: 'organization' | 'global';
+  allowClientSecretlessTokenExchange?: boolean;
   name: string;
   description?: string;
   websiteUrl?: string;
   privacyPolicyUrl?: string;
   termsOfServiceUrl?: string;
+  redirectUris?: string[];
   scopes: string[];
   image?: PrismaJson.EntityImage;
 };
 
 export type OAuthApplicationUpdateInput = {
+  accessLevel?: 'organization' | 'global';
+  allowClientSecretlessTokenExchange?: boolean;
   name?: string;
   description?: string | null;
   websiteUrl?: string | null;
   privacyPolicyUrl?: string | null;
   termsOfServiceUrl?: string | null;
+  redirectUris?: string[];
   scopes?: string[];
   image?: PrismaJson.EntityImage;
 };
@@ -285,8 +291,8 @@ export interface FabricEvents {
   'machine_access.oauth_application.created:after': { organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; input: OAuthApplicationCreateInput; serverSideMachineAccess: MachineAccess | null; oauthApplication: OAuthApplication; };
   'machine_access.oauth_application.updated:before': { oauthApplication: OAuthApplication; organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; input: OAuthApplicationUpdateInput; };
   'machine_access.oauth_application.updated:after': { oauthApplication: OAuthApplication; organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; input: OAuthApplicationUpdateInput; };
-  'machine_access.oauth_application.archived:before': { oauthApplication: OAuthApplication; organization: Organization; performedBy: OrganizationActor; context: Context; };
-  'machine_access.oauth_application.archived:after': { oauthApplication: OAuthApplication; organization: Organization; performedBy: OrganizationActor; context: Context; };
+  'machine_access.oauth_application.archived:before': { oauthApplication: OAuthApplication; organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; };
+  'machine_access.oauth_application.archived:after': { oauthApplication: OAuthApplication; organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; };
   'machine_access.oauth_application.client_secret.create:after': { oauthApplication: OAuthApplication; };
   'machine_access.oauth_application.client_secret.revoked:after': { oauthApplication: OAuthApplication; };
 

--- a/src/packages/frontend/ui/src/combobox/index.tsx
+++ b/src/packages/frontend/ui/src/combobox/index.tsx
@@ -227,6 +227,10 @@ let ItemDescription = styled('div')`
   font-size: 12px;
   color: ${theme.colors.gray700};
   line-height: 1.35;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 let EmptyState = styled(BaseCombobox.Empty)`

--- a/src/packages/frontend/ui/src/input/index.tsx
+++ b/src/packages/frontend/ui/src/input/index.tsx
@@ -30,6 +30,33 @@ export let InputDescription = styled('p')`
   user-select: none;
 `;
 
+let LabelRow = styled('div')`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+  margin-bottom: 5px;
+
+  ${InputLabel} {
+    display: block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 0;
+  }
+`;
+
+let LabelHelp = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
 let InputWrapper = styled('div')`
   outline: 1px solid transparent;
   background: ${theme.colors.gray300};
@@ -108,6 +135,7 @@ export let Input = ({
   size = '3',
   label,
   description,
+  help,
   hideLabel,
   error,
   as = 'input',
@@ -121,6 +149,7 @@ export let Input = ({
   size?: ButtonSize;
   label: React.ReactNode;
   description?: React.ReactNode;
+  help?: React.ReactNode;
   hideLabel?: boolean;
   error?: any;
   as?: 'textarea' | 'input';
@@ -138,7 +167,10 @@ export let Input = ({
           <InputLabel htmlFor={id}>{label}</InputLabel>
         </VisuallyHidden>
       ) : (
-        <InputLabel htmlFor={id}>{label}</InputLabel>
+        <LabelRow>
+          <InputLabel htmlFor={id}>{label}</InputLabel>
+          {help && <LabelHelp>{help}</LabelHelp>}
+        </LabelRow>
       )}
 
       {description && <InputDescription>{description}</InputDescription>}

--- a/src/systems/ares/service/frontend/auth/src/scenes/authHome.tsx
+++ b/src/systems/ares/service/frontend/auth/src/scenes/authHome.tsx
@@ -215,7 +215,7 @@ export let AuthHomeScene = ({
           <>
             <Spacer height={10} />
 
-            <Text align="center" color="gray600" weight="medium" size="1">
+            <Text color="gray600" weight="medium" size="1">
               {type == 'login' ? (
                 <Link
                   to={`/signup?client_id=${encodeURIComponent(clientId)}&nextUrl=${encodeURIComponent(nextUrl)}`}

--- a/src/systems/ares/service/frontend/auth/src/scenes/authIntent.tsx
+++ b/src/systems/ares/service/frontend/auth/src/scenes/authIntent.tsx
@@ -8,18 +8,25 @@ import {
   Input,
   LinkButton,
   Spacer,
-  Switch,
-  Text
+  Switch
 } from '@metorial-io/ui';
 import { differenceInMinutes } from 'date-fns';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
+import { styled } from 'styled-components';
 import { CodeInput } from '../components/codeInput';
 import { AuthLayout } from '../components/layout';
 import { useNonNullable } from '../hooks/useNonNullable';
 import { authIntentState } from '../state/authIntent';
 import type { IAuthIntent } from '../state/client';
+
+let FullSpinner = styled.div`
+  height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
 
 let CreateUserStep = ({
   authIntent,
@@ -224,9 +231,9 @@ let AuthIntentStep = ({
   }
 
   return (
-    <AuthLayout>
+    <FullSpinner>
       <CenteredSpinner />
-    </AuthLayout>
+    </FullSpinner>
   );
 };
 
@@ -272,9 +279,9 @@ export let AuthIntentScene = (p: {
   if (authIntent.error) {
     if (authIntent.error.data.status == 404) {
       return (
-        <AuthLayout>
+        <FullSpinner>
           <CenteredSpinner />
-        </AuthLayout>
+        </FullSpinner>
       );
     }
 

--- a/src/systems/slates/apps/hub/package.json
+++ b/src/systems/slates/apps/hub/package.json
@@ -92,7 +92,7 @@
     "@remixicon/react": "^4.0.0",
     "@sentry/bun": "^10.36.0",
     "@sentry/cli": "^3.2.0",
-    "@slates/proto": "^1.0.0-rc.10",
+    "@slates/proto": "^1.0.0-rc.11",
     "@types/semver": "^7.7.1",
     "@types/unzipper": "^0.10.11",
     "date-fns": "^4.1.0",

--- a/src/systems/slates/apps/hub/prisma/schema/slate.prisma
+++ b/src/systems/slates/apps/hub/prisma/schema/slate.prisma
@@ -171,6 +171,9 @@ model SlateConfigSchema {
   /// [SlateConfigSchema]
   schema Json
 
+  /// [SlateDocReferences]
+  docs Json @default("[]")
+
   slateOid BigInt
   slate    Slate  @relation(fields: [slateOid], references: [oid])
 
@@ -263,8 +266,14 @@ model SlateSpecification {
   /// [SlateProviderInfo]
   providerInfo Json
 
+  /// [SlateDocReferences]
+  providerDocs Json @default("[]")
+
   /// [SlateConfigSchema]
   configSchema Json
+
+  /// [SlateDocReferences]
+  configSchemaDocs Json @default("[]")
 
   /// [SlateAuthMethods]
   authMethods Json

--- a/src/systems/slates/apps/hub/src/db.ts
+++ b/src/systems/slates/apps/hub/src/db.ts
@@ -71,6 +71,13 @@ declare global {
 
     type SlateConfigSchema = any;
 
+    type SlateDocReference = {
+      type?: string;
+      name: string;
+      url: string;
+    };
+    type SlateDocReferences = SlateDocReference[];
+
     type SlateAuthMethod = SlateAuthenticationMethod;
     type SlateAction = ProtoSlatesAction;
 

--- a/src/systems/slates/apps/hub/src/lib/specificationHash.ts
+++ b/src/systems/slates/apps/hub/src/lib/specificationHash.ts
@@ -2,6 +2,8 @@ import { canonicalize } from '@lowerdeck/canonicalize';
 import { Hash } from '@lowerdeck/hash';
 import type { SlateAuthenticationMethod, SlatesAction } from '@slates/proto';
 
+type SlateDocReference = PrismaJson.SlateDocReference;
+
 export let dedupeDiscoveredItems = <T extends { id: string }>(
   items: T[],
   d: {
@@ -40,10 +42,13 @@ export let dedupeDiscoveredItems = <T extends { id: string }>(
 export let hashDiscoveredProviderInfo = async (d: {
   protocol: string;
   provider: Record<string, any>;
+  docs: SlateDocReference[];
 }) => await Hash.sha256(canonicalize(d));
 
-export let hashDiscoveredConfigSchema = async (schema: Record<string, any>) =>
-  await Hash.sha256(canonicalize(schema));
+export let hashDiscoveredConfigSchema = async (d: {
+  schema: Record<string, any>;
+  docs: SlateDocReference[];
+}) => await Hash.sha256(canonicalize(d));
 
 export let hashDiscoveredAuthMethod = async (method: SlateAuthenticationMethod) =>
   await Hash.sha256(canonicalize(method));
@@ -55,8 +60,12 @@ export let buildDiscoveredSpecificationHashes = async (d: {
   providerInfo: {
     protocol: string;
     provider: Record<string, any>;
+    docs: SlateDocReference[];
   };
-  configSchema: Record<string, any>;
+  configSchema: {
+    schema: Record<string, any>;
+    docs: SlateDocReference[];
+  };
   authMethods: SlateAuthenticationMethod[];
   actions: SlatesAction[];
 }) => {

--- a/src/systems/slates/apps/hub/src/presenters/slateAction.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateAction.ts
@@ -23,6 +23,7 @@ export let slateActionPresenter = (
   constraints: method.spec.constraints,
   description: method.spec.description,
   instructions: method.spec.instructions,
+  docs: method.spec.docs ?? [],
   metadata: method.spec.metadata,
   tags: method.spec.tags,
   scopes: method.spec.scopes,

--- a/src/systems/slates/apps/hub/src/presenters/slateAuthMethod.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateAuthMethod.ts
@@ -20,6 +20,7 @@ export let slateAuthMethodPresenter = (
   inputSchema: method.spec.inputSchema,
   outputSchema: method.spec.outputSchema,
   scopes: method.spec.scopes,
+  docs: method.spec.docs ?? [],
 
   createdAt: method.createdAt
 });

--- a/src/systems/slates/apps/hub/src/presenters/slateSpecification.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateSpecification.ts
@@ -29,7 +29,9 @@ export let slateSpecificationPresenter = (
   protocolVersion: spec.protocolVersion,
 
   providerInfo: spec.providerInfo,
+  providerDocs: spec.providerDocs,
   configSchema: spec.configSchema,
+  configSchemaDocs: spec.configSchemaDocs,
 
   authMethods: spec.slateAuthMethods.map(sam =>
     slateAuthMethodPresenter({ ...sam.authMethod, slate: spec.slate })

--- a/src/systems/slates/apps/hub/src/queues/discovery/discover.ts
+++ b/src/systems/slates/apps/hub/src/queues/discovery/discover.ts
@@ -17,6 +17,24 @@ import { slateInvocationService } from '../../services';
 
 let Sentry = getSentry();
 
+let normalizeDiscoveredDocs = (docs: unknown): PrismaJson.SlateDocReferences => {
+  if (!Array.isArray(docs)) return [];
+
+  return docs
+    .filter(
+      (doc): doc is { name: string; url: string; type?: string } =>
+        !!doc &&
+        typeof doc === 'object' &&
+        typeof (doc as any).name === 'string' &&
+        typeof (doc as any).url === 'string'
+    )
+    .map(doc => ({
+      ...(typeof doc.type === 'string' ? { type: doc.type } : {}),
+      name: doc.name,
+      url: doc.url
+    }));
+};
+
 let syncSpecificationActions = async (d: {
   specificationOid: bigint;
   actions: Array<{ oid: bigint }>;
@@ -304,14 +322,19 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         getKey: action => `${action.type}:${action.id}`
       });
 
-      // authMethods.authenticationMethods[0]?.docs
+      let providerDocs = normalizeDiscoveredDocs(providerInfo.docs);
+      let configSchemaDocs = normalizeDiscoveredDocs(configSchema.docs);
 
       let discoveryHashes = await buildDiscoveredSpecificationHashes({
         providerInfo: {
           protocol: providerInfo.protocol,
-          provider: providerInfo.provider
+          provider: providerInfo.provider,
+          docs: providerDocs
         },
-        configSchema: configSchema.schema,
+        configSchema: {
+          schema: configSchema.schema,
+          docs: configSchemaDocs
+        },
         authMethods: discoveredAuthMethods,
         actions: discoveredActions
       });
@@ -324,7 +347,9 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         protocolVersion: providerInfo.protocol,
 
         providerInfo: providerInfo.provider,
+        providerDocs,
         configSchema: configSchema.schema,
+        configSchemaDocs,
         authMethods: discoveredAuthMethods,
         actions: discoveredActions
       };
@@ -409,10 +434,12 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
           hash: discoveryHashes.configSchemaHash,
           identifier: configIdentifier,
 
-          schema: configSchema.schema
+          schema: configSchema.schema,
+          docs: configSchemaDocs
         },
         update: {
-          schema: configSchema.schema
+          schema: configSchema.schema,
+          docs: configSchemaDocs
         }
       });
 

--- a/src/systems/subspace/db/prisma/schema/listing/listing.prisma
+++ b/src/systems/subspace/db/prisma/schema/listing/listing.prisma
@@ -29,6 +29,9 @@ model ProviderListing {
   description String?
   readme      String?
 
+  /// [ProviderListingDocs]
+  docs Json?
+
   rank Int @default(0)
 
   skills String[]

--- a/src/systems/subspace/db/src/db.ts
+++ b/src/systems/subspace/db/src/db.ts
@@ -172,6 +172,29 @@ declare global {
       config?: CustomProviderConfig;
     };
 
+    type ProviderListingDocReference = {
+      type?: string;
+      name: string;
+      url: string;
+    };
+
+    type ProviderListingDocs = {
+      provider: ProviderListingDocReference[];
+      config: ProviderListingDocReference[];
+      authMethods: {
+        key: string;
+        name: string;
+        type: string;
+        docs: ProviderListingDocReference[];
+      }[];
+      actions: {
+        key: string;
+        name: string;
+        type: 'tool' | 'trigger';
+        docs: ProviderListingDocReference[];
+      }[];
+    };
+
     type ProviderTypeAttributes = {
       provider: 'metorial-slates' | 'metorial-shuttle' | 'metorial-native';
       backend: 'slates' | 'mcp.container' | 'mcp.function' | 'mcp.remote' | 'native';

--- a/src/systems/subspace/modules/provider-internal/src/services/provider.ts
+++ b/src/systems/subspace/modules/provider-internal/src/services/provider.ts
@@ -6,6 +6,7 @@ import {
   db,
   type EntityImage,
   getId,
+  Prisma,
   type Provider,
   type ProviderVariant,
   type Publisher,
@@ -99,6 +100,7 @@ class providerInternalServiceImpl {
       image?: EntityImage | null;
       skills?: string[];
       readme?: string;
+      docs?: PrismaJson.ProviderListingDocs | null;
       categories?: string[];
     };
 
@@ -283,6 +285,7 @@ class providerInternalServiceImpl {
             image: d.info.image ?? { type: 'default' as const },
 
             readme: d.info.readme,
+            docs: d.info.docs ?? Prisma.DbNull,
 
             skills: d.info.skills || [],
 

--- a/src/systems/subspace/packages/presenters/src/providerListing.ts
+++ b/src/systems/subspace/packages/presenters/src/providerListing.ts
@@ -66,6 +66,7 @@ export let providerListingPresenter = async (
   aliases: providerListing.aliases,
 
   readme: providerListing.readme ?? null,
+  docs: providerListing.docs ?? null,
   skills: providerListing.skills,
 
   rank: providerListing.rank,

--- a/src/systems/subspace/provider-backends/provider-slates/src/queues/sync/syncSlateVersion.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/queues/sync/syncSlateVersion.ts
@@ -61,6 +61,61 @@ let metorialDomains = [
   'localhost'
 ];
 
+let normalizeDocs = (docs: unknown): PrismaJson.ProviderListingDocReference[] => {
+  if (!Array.isArray(docs)) return [];
+
+  return docs
+    .filter(
+      (doc): doc is { name: string; url: string; type?: string } =>
+        !!doc &&
+        typeof doc === 'object' &&
+        typeof (doc as any).name === 'string' &&
+        typeof (doc as any).url === 'string'
+    )
+    .map(doc => ({
+      ...(typeof doc.type === 'string' ? { type: doc.type } : {}),
+      name: doc.name,
+      url: doc.url
+    }));
+};
+
+let buildProviderListingDocs = (spec: any): PrismaJson.ProviderListingDocs | undefined => {
+  if (!spec) return undefined;
+
+  let providerDocs = normalizeDocs(spec.providerDocs);
+  let configDocs = normalizeDocs(spec.configSchemaDocs);
+  let authMethods = (spec.authMethods ?? [])
+    .map((authMethod: any) => ({
+      key: authMethod.key,
+      name: authMethod.name,
+      type: authMethod.type,
+      docs: normalizeDocs(authMethod.docs)
+    }))
+    .filter((authMethod: any) => authMethod.docs.length > 0);
+  let actions = [...(spec.tools ?? []), ...(spec.triggers ?? [])]
+    .map((action: any) => ({
+      key: action.key,
+      name: action.name,
+      type: action.type,
+      docs: normalizeDocs(action.docs)
+    }))
+    .filter((action: any) => action.docs.length > 0);
+
+  let hasDocs =
+    providerDocs.length > 0 ||
+    configDocs.length > 0 ||
+    authMethods.length > 0 ||
+    actions.length > 0;
+  if (!hasDocs) return undefined;
+
+  return {
+    provider: providerDocs,
+    config: configDocs,
+    authMethods,
+    actions
+  };
+};
+
 export let syncSlateVersionQueueProcessor = syncSlateVersionQueue.process(async data => {
   let version = await slates.slateVersion.get({
     slateId: data.slateId,
@@ -145,6 +200,7 @@ export let syncSlateVersionQueueProcessor = syncSlateVersionQueue.process(async 
   let hasAuthConfig = !!(spec && spec.authMethods.length > 0);
   let hasOAuth = spec?.authMethods.some(am => am.type === 'oauth');
   let hasTriggers = !!(spec ? spec.triggers.length > 0 : false);
+  let docs = buildProviderListingDocs(spec);
 
   let type = {
     name: 'Slates',
@@ -209,6 +265,7 @@ export let syncSlateVersionQueueProcessor = syncSlateVersionQueue.process(async 
         image: registryRecord.logoUrl ? { type: 'url', url: registryRecord.logoUrl } : null,
         skills: registryRecord.skills,
         readme: readme,
+        docs,
         categories: registryRecord.categories?.map((c: any) => c.identifier) ?? [],
         globalIdentifier
       };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches OAuth application lifecycle (including revoking authorizations on archive) and widespread dashboard provider/OAuth setup paths; incorrect guards or auto-config defaults could block integrations or create wrong configs.
> 
> **Overview**
> Adds **organization-less global user-facing OAuth applications** with dedicated create, update, archive, list, and get paths, strict guards that only `user_facing` + `global` + no-org apps are eligible, and Fabric event payloads that allow null organization/actor on those lifecycle hooks.
> 
> **Provider documentation** is threaded end-to-end: Slates discovery persists doc references on specs, config schemas, and auth/actions; sync into provider listings stores structured `docs`; the dashboard API presenter exposes them; generated clients and new `providerDocs` UI surface links during OAuth credential setup, scope selection, and auth config flows (including a reusable `ScopePickerField` and optional `Input` **help** slot).
> 
> **Provider setup UX** is streamlined: JSON Schema **default inference** enables auto-creating configs when required fields have defaults; Explorer and integration/session flows skip mandatory config UI when auto-create applies, prefill default config values, support inline config/auth creation with optional hidden name fields, and respect OAuth auto-registration by not requiring manual credential selection when enabled.
> 
> Also bumps **`@slates/proto`** to `1.0.0-rc.11`, extends Slates hub Prisma models for docs fields, and includes minor auth UI loading/layout tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 725c1bce57a3fa034c01c436106911560260d2e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->