### PR TITLE
Add provider docs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2563,7 +2563,7 @@
         "@remixicon/react": "^4.0.0",
         "@sentry/bun": "^10.36.0",
         "@sentry/cli": "^3.2.0",
-        "@slates/proto": "^1.0.0-rc.10",
+        "@slates/proto": "^1.0.0-rc.11",
         "@types/semver": "^7.7.1",
         "@types/unzipper": "^0.10.11",
         "date-fns": "^4.1.0",
@@ -5258,7 +5258,7 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
-    "@slates/proto": ["@slates/proto@1.0.0-rc.10", "", { "dependencies": { "@lowerdeck/emitter": "^1.0.4", "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-d2ZzchGaF8zzCd/5AvtdeUIi9hkNwIOFj3T38Dh67z/z2R8Evl5/SgkYMhMHZ7C+JqcwSdf1Zz5XAHwkhYpPzA=="],
+    "@slates/proto": ["@slates/proto@1.0.0-rc.11", "", { "dependencies": { "@lowerdeck/emitter": "^1.0.4", "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-g/MMRAciX5D0UmEiwBy9656qEaade2ZMysIRMYoL64PzwfLC2rorOuTfE+kfBhNfH1IeA9UgmfVT8+8vGbQv3Q=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q=="],
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-listings/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-listings/get.ts
@@ -86,6 +86,22 @@ export type DashboardInstanceProviderListingsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  docs: {
+    provider: { type?: string | undefined; name: string; url: string }[];
+    config: { type?: string | undefined; name: string; url: string }[];
+    authMethods: {
+      key: string;
+      name: string;
+      type: string;
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+    actions: {
+      key: string;
+      name: string;
+      type: 'tool' | 'trigger';
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+  } | null;
   provider: {
     object: 'provider';
     id: string;
@@ -423,7 +439,72 @@ export let mapDashboardInstanceProviderListingsGetOutput = mtMap.union([
         )
       ),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      docs: mtMap.objectField(
+        'docs',
+        mtMap.object({
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          authMethods: mtMap.objectField(
+            'auth_methods',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          ),
+          actions: mtMap.objectField(
+            'actions',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          )
+        })
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-listings/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-listings/list.ts
@@ -87,6 +87,22 @@ export type DashboardInstanceProviderListingsListOutput = {
     createdAt: Date;
     updatedAt: Date;
   } & {
+    docs: {
+      provider: { type?: string | undefined; name: string; url: string }[];
+      config: { type?: string | undefined; name: string; url: string }[];
+      authMethods: {
+        key: string;
+        name: string;
+        type: string;
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+      actions: {
+        key: string;
+        name: string;
+        type: 'tool' | 'trigger';
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+    } | null;
     provider: {
       object: 'provider';
       id: string;
@@ -507,7 +523,84 @@ export let mapDashboardInstanceProviderListingsListOutput =
                 )
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              docs: mtMap.objectField(
+                'docs',
+                mtMap.object({
+                  provider: mtMap.objectField(
+                    'provider',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  authMethods: mtMap.objectField(
+                    'auth_methods',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  ),
+                  actions: mtMap.objectField(
+                    'actions',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  )
+                })
+              )
             })
           )
         ])

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-listings/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-listings/get.ts
@@ -86,6 +86,22 @@ export type ManagementInstanceProviderListingsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  docs: {
+    provider: { type?: string | undefined; name: string; url: string }[];
+    config: { type?: string | undefined; name: string; url: string }[];
+    authMethods: {
+      key: string;
+      name: string;
+      type: string;
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+    actions: {
+      key: string;
+      name: string;
+      type: 'tool' | 'trigger';
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+  } | null;
   provider: {
     object: 'provider';
     id: string;
@@ -423,7 +439,72 @@ export let mapManagementInstanceProviderListingsGetOutput = mtMap.union([
         )
       ),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      docs: mtMap.objectField(
+        'docs',
+        mtMap.object({
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          authMethods: mtMap.objectField(
+            'auth_methods',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          ),
+          actions: mtMap.objectField(
+            'actions',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          )
+        })
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-listings/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-listings/list.ts
@@ -87,6 +87,22 @@ export type ManagementInstanceProviderListingsListOutput = {
     createdAt: Date;
     updatedAt: Date;
   } & {
+    docs: {
+      provider: { type?: string | undefined; name: string; url: string }[];
+      config: { type?: string | undefined; name: string; url: string }[];
+      authMethods: {
+        key: string;
+        name: string;
+        type: string;
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+      actions: {
+        key: string;
+        name: string;
+        type: 'tool' | 'trigger';
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+    } | null;
     provider: {
       object: 'provider';
       id: string;
@@ -507,7 +523,84 @@ export let mapManagementInstanceProviderListingsListOutput =
                 )
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              docs: mtMap.objectField(
+                'docs',
+                mtMap.object({
+                  provider: mtMap.objectField(
+                    'provider',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  authMethods: mtMap.objectField(
+                    'auth_methods',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  ),
+                  actions: mtMap.objectField(
+                    'actions',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  )
+                })
+              )
             })
           )
         ])

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-listings/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-listings/get.ts
@@ -86,6 +86,22 @@ export type ProviderListingsGetOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  docs: {
+    provider: { type?: string | undefined; name: string; url: string }[];
+    config: { type?: string | undefined; name: string; url: string }[];
+    authMethods: {
+      key: string;
+      name: string;
+      type: string;
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+    actions: {
+      key: string;
+      name: string;
+      type: 'tool' | 'trigger';
+      docs: { type?: string | undefined; name: string; url: string }[];
+    }[];
+  } | null;
   provider: {
     object: 'provider';
     id: string;
@@ -423,7 +439,72 @@ export let mapProviderListingsGetOutput = mtMap.union([
         )
       ),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      docs: mtMap.objectField(
+        'docs',
+        mtMap.object({
+          provider: mtMap.objectField(
+            'provider',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          config: mtMap.objectField(
+            'config',
+            mtMap.array(
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough())
+              })
+            )
+          ),
+          authMethods: mtMap.objectField(
+            'auth_methods',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          ),
+          actions: mtMap.objectField(
+            'actions',
+            mtMap.array(
+              mtMap.object({
+                key: mtMap.objectField('key', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                docs: mtMap.objectField(
+                  'docs',
+                  mtMap.array(
+                    mtMap.object({
+                      type: mtMap.objectField('type', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      url: mtMap.objectField('url', mtMap.passthrough())
+                    })
+                  )
+                )
+              })
+            )
+          )
+        })
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-listings/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/provider-listings/list.ts
@@ -87,6 +87,22 @@ export type ProviderListingsListOutput = {
     createdAt: Date;
     updatedAt: Date;
   } & {
+    docs: {
+      provider: { type?: string | undefined; name: string; url: string }[];
+      config: { type?: string | undefined; name: string; url: string }[];
+      authMethods: {
+        key: string;
+        name: string;
+        type: string;
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+      actions: {
+        key: string;
+        name: string;
+        type: 'tool' | 'trigger';
+        docs: { type?: string | undefined; name: string; url: string }[];
+      }[];
+    } | null;
     provider: {
       object: 'provider';
       id: string;
@@ -507,7 +523,84 @@ export let mapProviderListingsListOutput =
                 )
               ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              docs: mtMap.objectField(
+                'docs',
+                mtMap.object({
+                  provider: mtMap.objectField(
+                    'provider',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  config: mtMap.objectField(
+                    'config',
+                    mtMap.array(
+                      mtMap.object({
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        url: mtMap.objectField('url', mtMap.passthrough())
+                      })
+                    )
+                  ),
+                  authMethods: mtMap.objectField(
+                    'auth_methods',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  ),
+                  actions: mtMap.objectField(
+                    'actions',
+                    mtMap.array(
+                      mtMap.object({
+                        key: mtMap.objectField('key', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        type: mtMap.objectField('type', mtMap.passthrough()),
+                        docs: mtMap.objectField(
+                          'docs',
+                          mtMap.array(
+                            mtMap.object({
+                              type: mtMap.objectField(
+                                'type',
+                                mtMap.passthrough()
+                              ),
+                              name: mtMap.objectField(
+                                'name',
+                                mtMap.passthrough()
+                              ),
+                              url: mtMap.objectField('url', mtMap.passthrough())
+                            })
+                          )
+                        )
+                      })
+                    )
+                  )
+                })
+              )
             })
           )
         ])

--- a/src/backend/apis/core/src/presenters/implementation/provider/provider/providerListing.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/provider/providerListing.ts
@@ -7,6 +7,56 @@ import { v1ProviderListingCollectionPresenter } from './collection';
 import { v1ProviderListingGroupPresenter } from './group';
 import { dashboardProviderPresenter, v1ProviderPresenter } from './provider';
 
+let providerListingDocReferenceSchema = v.object({
+  type: v.optional(v.string({ description: 'The protocol-specific documentation type.' })),
+  name: v.string({ description: 'The display name for this documentation reference.' }),
+  url: v.string({ description: 'The documentation URL.' })
+});
+
+let providerListingDocsSchema = v.nullable(
+  v.object({
+    provider: v.array(providerListingDocReferenceSchema),
+    config: v.array(providerListingDocReferenceSchema),
+    auth_methods: v.array(
+      v.object({
+        key: v.string(),
+        name: v.string(),
+        type: v.string(),
+        docs: v.array(providerListingDocReferenceSchema)
+      })
+    ),
+    actions: v.array(
+      v.object({
+        key: v.string(),
+        name: v.string(),
+        type: v.enumOf(['tool', 'trigger']),
+        docs: v.array(providerListingDocReferenceSchema)
+      })
+    )
+  })
+);
+
+let presentProviderListingDocs = (docs: any) => {
+  if (!docs) return null;
+
+  return {
+    provider: docs.provider ?? [],
+    config: docs.config ?? [],
+    auth_methods: (docs.authMethods ?? []).map((authMethod: any) => ({
+      key: authMethod.key,
+      name: authMethod.name,
+      type: authMethod.type,
+      docs: authMethod.docs ?? []
+    })),
+    actions: (docs.actions ?? []).map((action: any) => ({
+      key: action.key,
+      name: action.name,
+      type: action.type,
+      docs: action.docs ?? []
+    }))
+  };
+};
+
 export let v1ProviderListingPresenter = Presenter.create(providerListingType)
   .presenter(async ({ providerListing }, opts) => {
     return {
@@ -153,6 +203,7 @@ export let dashboardProviderListingPresenter = Presenter.create(providerListingT
 
     return {
       ...inner,
+      docs: presentProviderListingDocs((input.providerListing as any).docs),
       provider: await dashboardProviderPresenter
         .present({ provider: input.providerListing.provider }, opts)
         .run()
@@ -162,6 +213,7 @@ export let dashboardProviderListingPresenter = Presenter.create(providerListingT
     v.intersection([
       v1ProviderListingPresenter.schema,
       v.object({
+        docs: providerListingDocsSchema,
         provider: dashboardProviderPresenter.schema
       })
     ])

--- a/src/frontend/apps/dashboard/src/slices/product/lib/providerDocs.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/lib/providerDocs.tsx
@@ -1,0 +1,105 @@
+import { theme } from '@metorial/ui';
+import React from 'react';
+import styled from 'styled-components';
+
+export type ProviderDocReference = {
+  type?: string | null;
+  name: string;
+  url: string;
+};
+
+type ProviderListingDocs = {
+  provider?: ProviderDocReference[] | null;
+  config?: ProviderDocReference[] | null;
+  auth_methods?:
+    | {
+        key?: string | null;
+        name?: string | null;
+        type?: string | null;
+        docs?: ProviderDocReference[] | null;
+      }[]
+    | null;
+};
+
+type AuthMethodDocTarget = {
+  key?: string | null;
+  name?: string | null;
+  type?: string | null;
+};
+
+let DocsLink = styled.a`
+  display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
+  color: ${theme.colors.gray600};
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.2;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  white-space: nowrap;
+
+  &:hover {
+    color: ${theme.colors.gray900};
+  }
+`;
+
+let getDocs = (providerListing: unknown): ProviderListingDocs | null => {
+  let docs = (providerListing as any)?.docs;
+  if (!docs || typeof docs !== 'object') return null;
+  return docs as ProviderListingDocs;
+};
+
+let getFirstDoc = (docs: ProviderDocReference[] | null | undefined) =>
+  (docs ?? []).find(doc => !!doc?.url) ?? null;
+
+let matchesAuthMethod = (
+  docMethod: AuthMethodDocTarget,
+  authMethod?: AuthMethodDocTarget | null
+) => {
+  if (!authMethod) return false;
+
+  if (docMethod.key && authMethod.key && docMethod.key === authMethod.key) return true;
+  if (docMethod.name && authMethod.name && docMethod.name === authMethod.name) return true;
+  if (docMethod.type && authMethod.type && docMethod.type === authMethod.type) return true;
+
+  return false;
+};
+
+export let getProviderDoc = (providerListing: unknown) =>
+  getFirstDoc(getDocs(providerListing)?.provider);
+
+export let getConfigDoc = (providerListing: unknown) =>
+  getFirstDoc(getDocs(providerListing)?.config);
+
+export let getAuthMethodDoc = (
+  providerListing: unknown,
+  authMethod?: AuthMethodDocTarget | null
+) => {
+  let docs = getDocs(providerListing);
+  let authMethodDocs = docs?.auth_methods ?? [];
+  let exactMatch = authMethodDocs.find(docMethod => matchesAuthMethod(docMethod, authMethod));
+
+  return (
+    getFirstDoc(exactMatch?.docs) ?? getFirstDoc(authMethodDocs.flatMap(m => m.docs ?? []))
+  );
+};
+
+export let getScopeDoc = (providerListing: unknown, authMethod?: AuthMethodDocTarget | null) =>
+  getAuthMethodDoc(providerListing, authMethod) ?? getProviderDoc(providerListing);
+
+export let ProviderDocsLink = ({
+  doc,
+  children
+}: {
+  doc?: ProviderDocReference | null;
+  children?: React.ReactNode;
+}) => {
+  if (!doc?.url) return null;
+
+  return (
+    <DocsLink href={doc.url} target="_blank" rel="noopener noreferrer">
+      {children ?? doc.name}
+    </DocsLink>
+  );
+};

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/components/scopePicker.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/components/scopePicker.tsx
@@ -1,5 +1,7 @@
-import { Checkbox, Flex, OptionToggle, Text, theme } from '@metorial/ui';
+import { Checkbox, Flex, InputLabel, OptionToggle, Text, theme } from '@metorial/ui';
+import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
+import styled from 'styled-components';
 
 type ScopePermissionMode = 'allow' | 'reject' | 'mixed';
 type ScopeSectionId = 'read' | 'write' | 'dangerous';
@@ -10,6 +12,39 @@ export type ScopePickerScope = {
   name?: string | null;
   description?: string | null;
 };
+
+let ScopeFieldHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+  margin-bottom: 5px;
+
+  ${InputLabel} {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 0;
+  }
+`;
+
+let ScopeFieldHelp = styled.div`
+  min-width: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+let ScopeFieldBox = styled.div`
+  width: 100%;
+  min-width: 0;
+  overflow: auto;
+  border: 1px solid ${theme.colors.gray300};
+  border-radius: 10px;
+  padding: 10px 12px;
+`;
 
 let dangerousScopeKeywords = [
   'admin',
@@ -56,12 +91,14 @@ export let ScopePicker = ({
   scopes,
   selectedScopes,
   onSelectedScopesChange,
-  disabled
+  disabled,
+  flushScrollPadding = true
 }: {
   scopes: ScopePickerScope[];
   selectedScopes: string[];
   onSelectedScopesChange: (scopes: string[]) => void;
   disabled?: boolean;
+  flushScrollPadding?: boolean;
 }) => {
   let [sectionModeOverrides, setSectionModeOverrides] = useState<
     Partial<Record<ScopeSectionId, ScopePermissionMode>>
@@ -145,8 +182,8 @@ export let ScopePicker = ({
   return (
     <div
       style={{
-        marginRight: -20,
-        paddingRight: 20
+        marginRight: flushScrollPadding ? -20 : 0,
+        paddingRight: flushScrollPadding ? 20 : 0
       }}
     >
       <Flex direction="column" gap={12}>
@@ -219,6 +256,31 @@ export let ScopePicker = ({
             </div>
           ))}
       </Flex>
+    </div>
+  );
+};
+
+export let ScopePickerField = ({
+  label = 'Scopes',
+  help,
+  maxHeight = 260,
+  ...props
+}: {
+  label?: ReactNode;
+  help?: ReactNode;
+  maxHeight?: number | string;
+} & Omit<Parameters<typeof ScopePicker>[0], 'flushScrollPadding'>) => {
+  if (props.scopes.length === 0) return null;
+
+  return (
+    <div>
+      <ScopeFieldHeader>
+        <InputLabel>{label}</InputLabel>
+        {help && <ScopeFieldHelp>{help}</ScopeFieldHelp>}
+      </ScopeFieldHeader>
+      <ScopeFieldBox style={{ maxHeight }}>
+        <ScopePicker {...props} flushScrollPadding={false} />
+      </ScopeFieldBox>
     </div>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/settings.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/settings.tsx
@@ -4,12 +4,14 @@ import {
   useCurrentInstance,
   useProvider,
   useProviderAuthCredential,
-  useProviderAuthMethods
+  useProviderAuthMethods,
+  useProviderListing
 } from '@metorial/state';
 import { Button, Callout, Input, Spacer } from '@metorial/ui';
 import { Box } from '@metorial/ui-product';
 import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { getScopeDoc, ProviderDocsLink } from '../../../lib/providerDocs';
 import { DeleteResourceDangerZone } from '../../../scenes/deleteResourceDangerZone';
 import { ScopePicker } from './components/scopePicker';
 
@@ -20,16 +22,19 @@ export let ProviderAuthCredentialSettingsPage = () => {
   let { providerAuthCredentialsId } = useParams();
   let credential = useProviderAuthCredential(instance.data?.id, providerAuthCredentialsId);
   let provider = useProvider(instance.data?.id, credential.data?.providerId);
+  let providerListing = useProviderListing(instance.data?.id, credential.data?.providerId);
   let versionId = provider.data?.currentVersion?.id;
   let authMethods = useProviderAuthMethods(
     instance.data?.id,
     versionId ? { providerVersionId: versionId } : null
   );
 
-  let availableScopes = useMemo(() => {
-    let oauthMethod = (authMethods.data?.items ?? []).find(m => m.type === 'oauth');
-    return oauthMethod?.scopes ?? [];
-  }, [authMethods.data?.items]);
+  let oauthMethod = useMemo(
+    () => (authMethods.data?.items ?? []).find(m => m.type === 'oauth'),
+    [authMethods.data?.items]
+  );
+  let availableScopes = oauthMethod?.scopes ?? [];
+  let scopeDoc = getScopeDoc(providerListing.data, oauthMethod);
 
   let [selectedScopes, setSelectedScopes] = useState<string[] | null>(null);
 
@@ -103,6 +108,7 @@ export let ProviderAuthCredentialSettingsPage = () => {
           <Box
             title="Scopes"
             description="Select which OAuth scopes this credential should request."
+            rightActions={<ProviderDocsLink doc={scopeDoc}>Scope docs</ProviderDocsLink>}
           >
             <ScopePicker
               scopes={availableScopes}

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/auth-methods.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/auth-methods.tsx
@@ -33,19 +33,6 @@ export let ProviderAuthMethodsPage = () => {
                 <Text size="2" weight="strong">
                   {method.name}
                 </Text>
-                <Text
-                  size="2"
-                  color="gray600"
-                  style={{
-                    display: 'block',
-                    maxWidth: '100%',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis'
-                  }}
-                >
-                  {description}
-                </Text>
               </Flex>,
               <Flex gap={6} style={{ alignItems: 'center', flexWrap: 'wrap' }}>
                 <Badge color={getProviderAuthMethodTypeColor(method.type)} size="1">

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/index.tsx
@@ -111,19 +111,6 @@ export let ProviderToolsPage = () => {
                 <Text size="2" weight="strong">
                   {tool.name}
                 </Text>
-                <Text
-                  size="2"
-                  color="gray600"
-                  style={{
-                    display: 'block',
-                    maxWidth: '100%',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis'
-                  }}
-                >
-                  {description}
-                </Text>
               </Flex>,
               <Flex gap={6} style={{ alignItems: 'center', flexWrap: 'wrap' }}>
                 {modeBadges.length > 0 ? (

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/triggers.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/triggers.tsx
@@ -131,19 +131,6 @@ export let ProviderTriggersPage = () => {
                 <Text size="2" weight="strong">
                   {trigger.name}
                 </Text>
-                <Text
-                  size="2"
-                  color="gray600"
-                  style={{
-                    display: 'block',
-                    maxWidth: '100%',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis'
-                  }}
-                >
-                  {description}
-                </Text>
               </Flex>,
               <Badge color={invocationBadge.color} size="1">
                 {invocationBadge.label}

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/index.tsx
@@ -35,7 +35,8 @@ export let ProviderOverviewPage = () => {
     {
       providerId,
       status: ['active'],
-      limit: 3
+      limit: 15,
+      order: 'desc'
     }
   );
   let magicMcpServers = useMagicMcpServers(
@@ -43,7 +44,8 @@ export let ProviderOverviewPage = () => {
     {
       providerId,
       status: ['active'],
-      limit: 3
+      limit: 15,
+      order: 'desc'
     }
   );
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
@@ -682,7 +682,7 @@ let IntegrationProviderSetupStep = (p: {
         !isConfigSelectionComplete(values.selectedConfiguration)
       ) {
         form.setFieldTouched('selectedConfiguration', true, false);
-        form.setFieldError('selectedConfiguration', 'Select a config or config vault');
+        form.setFieldError('selectedConfiguration', 'Select a config');
         return;
       }
 
@@ -1236,7 +1236,7 @@ let IntegrationInstanceProviderPanel = (p: {
         !isConfigSelectionComplete(values.selectedConfiguration)
       ) {
         form.setFieldTouched('selectedConfiguration', true, false);
-        form.setFieldError('selectedConfiguration', 'Select a config or config vault');
+        form.setFieldError('selectedConfiguration', 'Select a config');
         return;
       }
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/modal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/modal.tsx
@@ -7,7 +7,8 @@ import {
   useCreateProviderAuthCredentials,
   useProvider,
   useProviderAuthMethods,
-  useProviderDeployment
+  useProviderDeployment,
+  useProviderListing
 } from '@metorial/state';
 import {
   Button,
@@ -16,12 +17,19 @@ import {
   Copy,
   Dialog,
   Input,
+  showModal,
   Spacer,
-  Text,
-  showModal
+  Text
 } from '@metorial/ui';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useProviderAuthCreationCapabilities } from '../../lib/providerCreationCapabilities';
+import {
+  getConfigDoc,
+  getProviderDoc,
+  getScopeDoc,
+  ProviderDocsLink
+} from '../../lib/providerDocs';
+import { ScopePickerField } from '../../pages/(deployments)/provider-auth-credential/components/scopePicker';
 import { ProviderContextCard } from '../providerContextCard';
 
 type AuthMethod = DashboardInstanceProvidersAuthMethodsListOutput['items'][number];
@@ -65,6 +73,17 @@ export let ProviderAuthCredentialsForm = ({
   let providerName = deployment.data?.name ?? provider.data?.name ?? providerId;
   let oauthMethodName = oauthMethod?.name ?? 'OAuth';
   let authCreation = useProviderAuthCreationCapabilities(instanceId, deploymentId, providerId);
+  let providerListing = useProviderListing(instanceId, providerId);
+  let providerDoc = getProviderDoc(providerListing.data);
+  let configDoc = getConfigDoc(providerListing.data);
+  let scopeDoc = getScopeDoc(providerListing.data, oauthMethod);
+  let availableScopes = oauthMethod?.scopes ?? [];
+  let defaultScopes = useMemo(
+    () => availableScopes.map(scope => scope.scope),
+    [availableScopes]
+  );
+  let [selectedScopes, setSelectedScopes] = useState<string[] | null>(null);
+  let effectiveScopes = selectedScopes ?? defaultScopes;
 
   let createCredentials = useCreateProviderAuthCredentials();
 
@@ -83,7 +102,7 @@ export let ProviderAuthCredentialsForm = ({
           type: 'oauth',
           clientId: values.clientId,
           clientSecret: values.clientSecret,
-          scopes: oauthMethod?.scopes?.map(scope => scope.scope) ?? []
+          scopes: effectiveScopes
         }
       });
 
@@ -99,6 +118,10 @@ export let ProviderAuthCredentialsForm = ({
         clientSecret: yup.string().required('Client Secret is required')
       })
   });
+
+  useEffect(() => {
+    setSelectedScopes(null);
+  }, [oauthMethod?.id]);
 
   if (authCreation.isLoading) {
     return (
@@ -194,6 +217,11 @@ export let ProviderAuthCredentialsForm = ({
             </Text>
             <Text size="1" color="gray600" style={{ marginBottom: 5 }}>
               You must configure this redirect URI in your OAuth app.
+              {configDoc ? (
+                <>
+                  <ProviderDocsLink doc={configDoc}>View config docs</ProviderDocsLink>
+                </>
+              ) : null}
             </Text>
             <Copy value={redirectUri} />
             <Spacer size={10} />
@@ -213,6 +241,7 @@ export let ProviderAuthCredentialsForm = ({
         <Input
           label="Client ID"
           placeholder="Enter client ID from provider"
+          help={<ProviderDocsLink doc={providerDoc}>Provider docs</ProviderDocsLink>}
           required
           {...form.getFieldProps('clientId')}
         />
@@ -228,6 +257,18 @@ export let ProviderAuthCredentialsForm = ({
           {...form.getFieldProps('clientSecret')}
         />
         <form.RenderError field="clientSecret" />
+
+        {availableScopes.length > 0 && (
+          <>
+            <Spacer size={10} />
+            <ScopePickerField
+              scopes={availableScopes}
+              selectedScopes={effectiveScopes}
+              onSelectedScopesChange={setSelectedScopes}
+              help={<ProviderDocsLink doc={scopeDoc}>Scope docs</ProviderDocsLink>}
+            />
+          </>
+        )}
 
         <createCredentials.RenderError />
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/index.tsx
@@ -8,12 +8,14 @@ import {
   useProvider,
   useProviderAuthCredentials,
   useProviderAuthMethods,
-  useProviderDeployment
+  useProviderDeployment,
+  useProviderListing
 } from '@metorial/state';
 import { Button, Flex, Text } from '@metorial/ui';
 import { sortBy } from 'lodash';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Stepper } from '../../../../../components/stepper';
+import { getConfigDoc, getProviderDoc, getScopeDoc } from '../../../lib/providerDocs';
 import { getProviderOAuthAutoRegistrationEnabled } from '../../../lib/providerOAuthAutoRegistration';
 import {
   ConnectStep,
@@ -59,6 +61,7 @@ export let ProviderSetupSessionEmbed = ({
   let deployment = useProviderDeployment(instanceId, deploymentId);
   let lockedVersionId = deployment.data?.lockedVersion?.id;
   let provider = useProvider(instanceId, providerId);
+  let providerListing = useProviderListing(instanceId, providerId);
   let project = useCurrentProject();
   let projectBrand = useProjectBrand(project.data?.organization.id, project.data?.id);
   let effectiveVersionId = lockedVersionId ?? provider.data?.currentVersion?.id;
@@ -110,7 +113,8 @@ export let ProviderSetupSessionEmbed = ({
       selectedCredentialId: fixedCredentialId ?? '',
       newCredName: '',
       newCredClientId: '',
-      newCredClientSecret: ''
+      newCredClientSecret: '',
+      newCredScopes: [] as string[]
     },
     onSubmit: async () => {
       let providerAuthCredentialsId = await resolveSelectedCredentialId();
@@ -201,6 +205,11 @@ export let ProviderSetupSessionEmbed = ({
     () => (authMethods.data?.items ?? []).find(method => method.id === selectedMethodId),
     [authMethods.data?.items, selectedMethodId]
   );
+  let selectedMethodScopes = useMemo(
+    () => selectedMethod?.scopes?.map(scope => scope.scope) ?? [],
+    [selectedMethod?.scopes]
+  );
+  let selectedMethodScopeKey = selectedMethodScopes.join('\n');
 
   let providerName = deployment.data?.name ?? provider.data?.name ?? providerId;
   let oauthMethodName = selectedMethod?.name ?? 'OAuth';
@@ -210,6 +219,9 @@ export let ProviderSetupSessionEmbed = ({
   let projectBrandImageUrl = projectBrand.data?.imageUrl;
   let projectBrandName = projectBrand.data?.name ?? project.data?.name ?? 'Metorial';
   let providerImageUrl = provider.data?.publisher.imageUrl;
+  let providerDoc = getProviderDoc(providerListing.data);
+  let configDoc = getConfigDoc(providerListing.data);
+  let scopeDoc = getScopeDoc(providerListing.data, selectedMethod);
 
   let visibleAuthCredentials = sortBy(authCredentials.data?.items ?? [], [
     credential => Number(!credential.isManaged),
@@ -360,6 +372,10 @@ export let ProviderSetupSessionEmbed = ({
   };
 
   useEffect(() => {
+    void credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
+  }, [selectedMethod?.id, selectedMethodScopeKey]);
+
+  useEffect(() => {
     if (!collectAuthConfigDetails || !onAuthConfigDetailsChange) return;
 
     onAuthConfigDetailsChange({
@@ -484,7 +500,8 @@ export let ProviderSetupSessionEmbed = ({
   ]);
 
   let handleCreateCredentials = async (): Promise<string | null> => {
-    let { newCredClientId, newCredClientSecret, newCredName } = credentialsForm.values;
+    let { newCredClientId, newCredClientSecret, newCredName, newCredScopes } =
+      credentialsForm.values;
     if (!newCredName || !newCredClientId || !newCredClientSecret || !selectedMethod) return null;
 
     setError(null);
@@ -497,7 +514,7 @@ export let ProviderSetupSessionEmbed = ({
         type: 'oauth',
         clientId: newCredClientId,
         clientSecret: newCredClientSecret,
-        scopes: selectedMethod.scopes?.map(scope => scope.scope) ?? []
+        scopes: newCredScopes
       }
     });
 
@@ -514,6 +531,7 @@ export let ProviderSetupSessionEmbed = ({
     await credentialsForm.setFieldValue('newCredName', '');
     await credentialsForm.setFieldValue('newCredClientId', '');
     await credentialsForm.setFieldValue('newCredClientSecret', '');
+    await credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
 
     return result.id;
   };
@@ -529,6 +547,7 @@ export let ProviderSetupSessionEmbed = ({
     if (value === '__create_new__') {
       void credentialsForm.setFieldValue('credentialMode', 'new');
       void credentialsForm.setFieldValue('selectedCredentialId', '');
+      void credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
       return;
     }
 
@@ -877,6 +896,10 @@ export let ProviderSetupSessionEmbed = ({
     isManagedSelected,
     error,
     createCredentials,
+    selectedMethod,
+    providerDoc,
+    configDoc,
+    scopeDoc,
     showHiddenMethodStep,
     includeMethodStep,
     skipMethodStep,
@@ -899,6 +922,10 @@ export let ProviderSetupSessionEmbed = ({
     hasManagedVisibleCredentials,
     createCredentials,
     createSetupSession,
+    selectedMethod,
+    providerDoc,
+    configDoc,
+    scopeDoc,
     error,
     setupSession,
     setupWindowBlocked,

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/stepContent.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/stepContent.tsx
@@ -11,6 +11,8 @@ import {
   Text
 } from '@metorial/ui';
 import type { ReactNode } from 'react';
+import { ProviderDocsLink, type ProviderDocReference } from '../../../lib/providerDocs';
+import { ScopePickerField } from '../../../pages/(deployments)/provider-auth-credential/components/scopePicker';
 import { AuthMethodPicker } from '../../providerAuthConfigs/authMethodPicker';
 import {
   FlatConnectForm,
@@ -32,7 +34,7 @@ import {
   SummaryFieldMeta,
   SummaryFieldValue
 } from './styled';
-import type { SetupSessionState } from './types';
+import type { AuthMethod, SetupSessionState } from './types';
 
 type AnyForm = any;
 
@@ -127,7 +129,10 @@ export let AuthConfigDetailsFields = (p: {
   );
 };
 
-let RedirectUriField = (p: { redirectUri: string }) => {
+let RedirectUriField = (p: {
+  redirectUri: string;
+  configDoc?: ProviderDocReference | null;
+}) => {
   return (
     <>
       <Spacer size={12} />
@@ -136,13 +141,29 @@ let RedirectUriField = (p: { redirectUri: string }) => {
       </Text>
       <Text size="1" color="gray600" style={{ marginBottom: 5 }}>
         You must configure this redirect URI in your OAuth app.
+        {p.configDoc ? (
+          <>
+            {' '}
+            <ProviderDocsLink doc={p.configDoc}>View config docs</ProviderDocsLink>
+          </>
+        ) : null}
       </Text>
       <Copy value={p.redirectUri} />
     </>
   );
 };
 
-let NewCredentialsFields = (p: { credentialsForm: AnyForm; disabled?: boolean }) => {
+let NewCredentialsFields = (p: {
+  credentialsForm: AnyForm;
+  selectedMethod?: AuthMethod;
+  providerDoc?: ProviderDocReference | null;
+  scopeDoc?: ProviderDocReference | null;
+  disabled?: boolean;
+}) => {
+  let availableScopes = p.selectedMethod?.scopes ?? [];
+  let selectedScopes =
+    p.credentialsForm.values.newCredScopes ?? availableScopes.map(scope => scope.scope);
+
   return (
     <>
       <Spacer size={12} />
@@ -164,6 +185,7 @@ let NewCredentialsFields = (p: { credentialsForm: AnyForm; disabled?: boolean })
         disabled={p.disabled}
         onChange={e => p.credentialsForm.setFieldValue('newCredClientId', e.target.value)}
         placeholder="Enter client ID from provider"
+        help={<ProviderDocsLink doc={p.providerDoc}>Provider docs</ProviderDocsLink>}
       />
       <p.credentialsForm.RenderError field="newCredClientId" />
 
@@ -178,6 +200,21 @@ let NewCredentialsFields = (p: { credentialsForm: AnyForm; disabled?: boolean })
         type="password"
       />
       <p.credentialsForm.RenderError field="newCredClientSecret" />
+
+      {availableScopes.length > 0 && (
+        <>
+          <Spacer size={8} />
+          <ScopePickerField
+            scopes={availableScopes}
+            selectedScopes={selectedScopes}
+            onSelectedScopesChange={scopes =>
+              p.credentialsForm.setFieldValue('newCredScopes', scopes)
+            }
+            help={<ProviderDocsLink doc={p.scopeDoc}>Scope docs</ProviderDocsLink>}
+            disabled={p.disabled}
+          />
+        </>
+      )}
     </>
   );
 };
@@ -190,6 +227,10 @@ let CredentialsSelector = (p: {
   hasManagedVisibleCredentials: boolean;
   isCreatingCredentials: boolean;
   redirectUri?: string;
+  selectedMethod?: AuthMethod;
+  providerDoc?: ProviderDocReference | null;
+  configDoc?: ProviderDocReference | null;
+  scopeDoc?: ProviderDocReference | null;
   isCustomSelected: boolean;
   disableCredentialSelection?: boolean;
   disabled?: boolean;
@@ -231,11 +272,17 @@ let CredentialsSelector = (p: {
       )}
 
       {shouldShowRedirectUri && p.redirectUri && (
-        <RedirectUriField redirectUri={p.redirectUri} />
+        <RedirectUriField redirectUri={p.redirectUri} configDoc={p.configDoc} />
       )}
 
       {p.isCreatingCredentials && !p.disableCredentialSelection && (
-        <NewCredentialsFields credentialsForm={p.credentialsForm} disabled={p.disabled} />
+        <NewCredentialsFields
+          credentialsForm={p.credentialsForm}
+          selectedMethod={p.selectedMethod}
+          providerDoc={p.providerDoc}
+          scopeDoc={p.scopeDoc}
+          disabled={p.disabled}
+        />
       )}
     </>
   );
@@ -438,6 +485,10 @@ export let CredentialsSelectionStep = (p: {
   handleCredentialSelectionChange: (value: string) => void;
   hasManagedVisibleCredentials: boolean;
   redirectUri?: string;
+  selectedMethod?: AuthMethod;
+  providerDoc?: ProviderDocReference | null;
+  configDoc?: ProviderDocReference | null;
+  scopeDoc?: ProviderDocReference | null;
   isCustomSelected: boolean;
   isCreatingCredentials: boolean;
   disableCredentialSelection?: boolean;
@@ -484,6 +535,10 @@ export let CredentialsSelectionStep = (p: {
                 hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
                 isCreatingCredentials={p.isCreatingCredentials}
                 redirectUri={p.redirectUri}
+                selectedMethod={p.selectedMethod}
+                providerDoc={p.providerDoc}
+                configDoc={p.configDoc}
+                scopeDoc={p.scopeDoc}
                 isCustomSelected={p.isCustomSelected}
                 disableCredentialSelection={p.disableCredentialSelection}
               />
@@ -509,6 +564,10 @@ export let CredentialsSelectionStep = (p: {
             hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
             isCreatingCredentials={p.isCreatingCredentials}
             redirectUri={p.redirectUri}
+            selectedMethod={p.selectedMethod}
+            providerDoc={p.providerDoc}
+            configDoc={p.configDoc}
+            scopeDoc={p.scopeDoc}
             isCustomSelected={p.isCustomSelected}
             disableCredentialSelection={p.disableCredentialSelection}
           />
@@ -579,6 +638,10 @@ export let FlatOAuthConnectStep = (p: {
   hasManagedVisibleCredentials: boolean;
   createCredentials: { isPending: boolean; RenderError: () => ReactNode };
   createSetupSession: { isPending: boolean; RenderError: () => ReactNode };
+  selectedMethod?: AuthMethod;
+  providerDoc?: ProviderDocReference | null;
+  configDoc?: ProviderDocReference | null;
+  scopeDoc?: ProviderDocReference | null;
   error: string | null;
   setupSession: SetupSessionState | null;
   setupWindowBlocked: boolean;
@@ -631,6 +694,10 @@ export let FlatOAuthConnectStep = (p: {
                 handleCredentialSelectionChange={p.handleCredentialSelectionChange}
                 hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
                 redirectUri={p.redirectUri}
+                selectedMethod={p.selectedMethod}
+                providerDoc={p.providerDoc}
+                configDoc={p.configDoc}
+                scopeDoc={p.scopeDoc}
                 isCreatingCredentials={p.isCreatingCredentials}
                 isCustomSelected={p.isCustomSelected}
                 disableCredentialSelection={p.disableCredentialSelection}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
@@ -999,7 +999,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
       <ConfigureSectionCard
         key="config"
         title="Config"
-        description="Choose the provider configuration or vault this setup should use."
+        description="Choose the provider configuration this setup should use."
         requirement={configRequirement}
         completed={isConfigCompleted}
       >
@@ -1011,7 +1011,6 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
             value={p.selectedConfiguration}
             onChange={p.onSelectedConfigurationChange}
             label="Config"
-            includeVaults
             createConfigButtonLabel="Create Config"
             showExistingOptions={showExistingConfigOptions}
             filterAvailableResources={filterAvailableResources}
@@ -1617,7 +1616,7 @@ let ConfigureStep = (p: {
       p.form.values.selectedConfiguration.kind === 'none'
     ) {
       p.form.setFieldTouched('selectedConfiguration', true, false);
-      p.form.setFieldError('selectedConfiguration', 'Select a config or config vault');
+      p.form.setFieldError('selectedConfiguration', 'Select a config');
       isValid = false;
     }
 

--- a/src/packages/backend/fabric/src/types.ts
+++ b/src/packages/backend/fabric/src/types.ts
@@ -78,23 +78,29 @@ export type MachineAccessInput =
     };
 
 export type OAuthApplicationCreateInput = {
+  status?: 'active' | 'archived';
   type: 'user_facing' | 'server_side' | 'cli_auth';
   accessLevel: 'organization' | 'global';
+  allowClientSecretlessTokenExchange?: boolean;
   name: string;
   description?: string;
   websiteUrl?: string;
   privacyPolicyUrl?: string;
   termsOfServiceUrl?: string;
+  redirectUris?: string[];
   scopes: string[];
   image?: PrismaJson.EntityImage;
 };
 
 export type OAuthApplicationUpdateInput = {
+  accessLevel?: 'organization' | 'global';
+  allowClientSecretlessTokenExchange?: boolean;
   name?: string;
   description?: string | null;
   websiteUrl?: string | null;
   privacyPolicyUrl?: string | null;
   termsOfServiceUrl?: string | null;
+  redirectUris?: string[];
   scopes?: string[];
   image?: PrismaJson.EntityImage;
 };
@@ -285,8 +291,8 @@ export interface FabricEvents {
   'machine_access.oauth_application.created:after': { organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; input: OAuthApplicationCreateInput; serverSideMachineAccess: MachineAccess | null; oauthApplication: OAuthApplication; };
   'machine_access.oauth_application.updated:before': { oauthApplication: OAuthApplication; organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; input: OAuthApplicationUpdateInput; };
   'machine_access.oauth_application.updated:after': { oauthApplication: OAuthApplication; organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; input: OAuthApplicationUpdateInput; };
-  'machine_access.oauth_application.archived:before': { oauthApplication: OAuthApplication; organization: Organization; performedBy: OrganizationActor; context: Context; };
-  'machine_access.oauth_application.archived:after': { oauthApplication: OAuthApplication; organization: Organization; performedBy: OrganizationActor; context: Context; };
+  'machine_access.oauth_application.archived:before': { oauthApplication: OAuthApplication; organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; };
+  'machine_access.oauth_application.archived:after': { oauthApplication: OAuthApplication; organization: Organization | null; performedBy: OrganizationActor | null; context: Context | null; };
   'machine_access.oauth_application.client_secret.create:after': { oauthApplication: OAuthApplication; };
   'machine_access.oauth_application.client_secret.revoked:after': { oauthApplication: OAuthApplication; };
 

--- a/src/packages/frontend/ui/src/input/index.tsx
+++ b/src/packages/frontend/ui/src/input/index.tsx
@@ -30,6 +30,33 @@ export let InputDescription = styled('p')`
   user-select: none;
 `;
 
+let LabelRow = styled('div')`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+  margin-bottom: 5px;
+
+  ${InputLabel} {
+    display: block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 0;
+  }
+`;
+
+let LabelHelp = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
 let InputWrapper = styled('div')`
   outline: 1px solid transparent;
   background: ${theme.colors.gray300};
@@ -108,6 +135,7 @@ export let Input = ({
   size = '3',
   label,
   description,
+  help,
   hideLabel,
   error,
   as = 'input',
@@ -121,6 +149,7 @@ export let Input = ({
   size?: ButtonSize;
   label: React.ReactNode;
   description?: React.ReactNode;
+  help?: React.ReactNode;
   hideLabel?: boolean;
   error?: any;
   as?: 'textarea' | 'input';
@@ -138,7 +167,10 @@ export let Input = ({
           <InputLabel htmlFor={id}>{label}</InputLabel>
         </VisuallyHidden>
       ) : (
-        <InputLabel htmlFor={id}>{label}</InputLabel>
+        <LabelRow>
+          <InputLabel htmlFor={id}>{label}</InputLabel>
+          {help && <LabelHelp>{help}</LabelHelp>}
+        </LabelRow>
       )}
 
       {description && <InputDescription>{description}</InputDescription>}

--- a/src/systems/ares/service/frontend/auth/src/scenes/authHome.tsx
+++ b/src/systems/ares/service/frontend/auth/src/scenes/authHome.tsx
@@ -215,7 +215,7 @@ export let AuthHomeScene = ({
           <>
             <Spacer height={10} />
 
-            <Text align="center" color="gray600" weight="medium" size="1">
+            <Text color="gray600" weight="medium" size="1">
               {type == 'login' ? (
                 <Link
                   to={`/signup?client_id=${encodeURIComponent(clientId)}&nextUrl=${encodeURIComponent(nextUrl)}`}

--- a/src/systems/ares/service/frontend/auth/src/scenes/authIntent.tsx
+++ b/src/systems/ares/service/frontend/auth/src/scenes/authIntent.tsx
@@ -8,18 +8,25 @@ import {
   Input,
   LinkButton,
   Spacer,
-  Switch,
-  Text
+  Switch
 } from '@metorial-io/ui';
 import { differenceInMinutes } from 'date-fns';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
+import { styled } from 'styled-components';
 import { CodeInput } from '../components/codeInput';
 import { AuthLayout } from '../components/layout';
 import { useNonNullable } from '../hooks/useNonNullable';
 import { authIntentState } from '../state/authIntent';
 import type { IAuthIntent } from '../state/client';
+
+let FullSpinner = styled.div`
+  height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
 
 let CreateUserStep = ({
   authIntent,
@@ -224,9 +231,9 @@ let AuthIntentStep = ({
   }
 
   return (
-    <AuthLayout>
+    <FullSpinner>
       <CenteredSpinner />
-    </AuthLayout>
+    </FullSpinner>
   );
 };
 
@@ -272,9 +279,9 @@ export let AuthIntentScene = (p: {
   if (authIntent.error) {
     if (authIntent.error.data.status == 404) {
       return (
-        <AuthLayout>
+        <FullSpinner>
           <CenteredSpinner />
-        </AuthLayout>
+        </FullSpinner>
       );
     }
 

--- a/src/systems/slates/apps/hub/package.json
+++ b/src/systems/slates/apps/hub/package.json
@@ -92,7 +92,7 @@
     "@remixicon/react": "^4.0.0",
     "@sentry/bun": "^10.36.0",
     "@sentry/cli": "^3.2.0",
-    "@slates/proto": "^1.0.0-rc.10",
+    "@slates/proto": "^1.0.0-rc.11",
     "@types/semver": "^7.7.1",
     "@types/unzipper": "^0.10.11",
     "date-fns": "^4.1.0",

--- a/src/systems/slates/apps/hub/prisma/schema/slate.prisma
+++ b/src/systems/slates/apps/hub/prisma/schema/slate.prisma
@@ -171,6 +171,9 @@ model SlateConfigSchema {
   /// [SlateConfigSchema]
   schema Json
 
+  /// [SlateDocReferences]
+  docs Json @default("[]")
+
   slateOid BigInt
   slate    Slate  @relation(fields: [slateOid], references: [oid])
 
@@ -263,8 +266,14 @@ model SlateSpecification {
   /// [SlateProviderInfo]
   providerInfo Json
 
+  /// [SlateDocReferences]
+  providerDocs Json @default("[]")
+
   /// [SlateConfigSchema]
   configSchema Json
+
+  /// [SlateDocReferences]
+  configSchemaDocs Json @default("[]")
 
   /// [SlateAuthMethods]
   authMethods Json

--- a/src/systems/slates/apps/hub/src/db.ts
+++ b/src/systems/slates/apps/hub/src/db.ts
@@ -71,6 +71,13 @@ declare global {
 
     type SlateConfigSchema = any;
 
+    type SlateDocReference = {
+      type?: string;
+      name: string;
+      url: string;
+    };
+    type SlateDocReferences = SlateDocReference[];
+
     type SlateAuthMethod = SlateAuthenticationMethod;
     type SlateAction = ProtoSlatesAction;
 

--- a/src/systems/slates/apps/hub/src/lib/specificationHash.ts
+++ b/src/systems/slates/apps/hub/src/lib/specificationHash.ts
@@ -2,6 +2,8 @@ import { canonicalize } from '@lowerdeck/canonicalize';
 import { Hash } from '@lowerdeck/hash';
 import type { SlateAuthenticationMethod, SlatesAction } from '@slates/proto';
 
+type SlateDocReference = PrismaJson.SlateDocReference;
+
 export let dedupeDiscoveredItems = <T extends { id: string }>(
   items: T[],
   d: {
@@ -40,10 +42,13 @@ export let dedupeDiscoveredItems = <T extends { id: string }>(
 export let hashDiscoveredProviderInfo = async (d: {
   protocol: string;
   provider: Record<string, any>;
+  docs: SlateDocReference[];
 }) => await Hash.sha256(canonicalize(d));
 
-export let hashDiscoveredConfigSchema = async (schema: Record<string, any>) =>
-  await Hash.sha256(canonicalize(schema));
+export let hashDiscoveredConfigSchema = async (d: {
+  schema: Record<string, any>;
+  docs: SlateDocReference[];
+}) => await Hash.sha256(canonicalize(d));
 
 export let hashDiscoveredAuthMethod = async (method: SlateAuthenticationMethod) =>
   await Hash.sha256(canonicalize(method));
@@ -55,8 +60,12 @@ export let buildDiscoveredSpecificationHashes = async (d: {
   providerInfo: {
     protocol: string;
     provider: Record<string, any>;
+    docs: SlateDocReference[];
   };
-  configSchema: Record<string, any>;
+  configSchema: {
+    schema: Record<string, any>;
+    docs: SlateDocReference[];
+  };
   authMethods: SlateAuthenticationMethod[];
   actions: SlatesAction[];
 }) => {

--- a/src/systems/slates/apps/hub/src/presenters/slateAction.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateAction.ts
@@ -23,6 +23,7 @@ export let slateActionPresenter = (
   constraints: method.spec.constraints,
   description: method.spec.description,
   instructions: method.spec.instructions,
+  docs: method.spec.docs ?? [],
   metadata: method.spec.metadata,
   tags: method.spec.tags,
   scopes: method.spec.scopes,

--- a/src/systems/slates/apps/hub/src/presenters/slateAuthMethod.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateAuthMethod.ts
@@ -20,6 +20,7 @@ export let slateAuthMethodPresenter = (
   inputSchema: method.spec.inputSchema,
   outputSchema: method.spec.outputSchema,
   scopes: method.spec.scopes,
+  docs: method.spec.docs ?? [],
 
   createdAt: method.createdAt
 });

--- a/src/systems/slates/apps/hub/src/presenters/slateSpecification.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateSpecification.ts
@@ -29,7 +29,9 @@ export let slateSpecificationPresenter = (
   protocolVersion: spec.protocolVersion,
 
   providerInfo: spec.providerInfo,
+  providerDocs: spec.providerDocs,
   configSchema: spec.configSchema,
+  configSchemaDocs: spec.configSchemaDocs,
 
   authMethods: spec.slateAuthMethods.map(sam =>
     slateAuthMethodPresenter({ ...sam.authMethod, slate: spec.slate })

--- a/src/systems/slates/apps/hub/src/queues/discovery/discover.ts
+++ b/src/systems/slates/apps/hub/src/queues/discovery/discover.ts
@@ -17,6 +17,24 @@ import { slateInvocationService } from '../../services';
 
 let Sentry = getSentry();
 
+let normalizeDiscoveredDocs = (docs: unknown): PrismaJson.SlateDocReferences => {
+  if (!Array.isArray(docs)) return [];
+
+  return docs
+    .filter(
+      (doc): doc is { name: string; url: string; type?: string } =>
+        !!doc &&
+        typeof doc === 'object' &&
+        typeof (doc as any).name === 'string' &&
+        typeof (doc as any).url === 'string'
+    )
+    .map(doc => ({
+      ...(typeof doc.type === 'string' ? { type: doc.type } : {}),
+      name: doc.name,
+      url: doc.url
+    }));
+};
+
 let syncSpecificationActions = async (d: {
   specificationOid: bigint;
   actions: Array<{ oid: bigint }>;
@@ -304,14 +322,19 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         getKey: action => `${action.type}:${action.id}`
       });
 
-      // authMethods.authenticationMethods[0]?.docs
+      let providerDocs = normalizeDiscoveredDocs(providerInfo.docs);
+      let configSchemaDocs = normalizeDiscoveredDocs(configSchema.docs);
 
       let discoveryHashes = await buildDiscoveredSpecificationHashes({
         providerInfo: {
           protocol: providerInfo.protocol,
-          provider: providerInfo.provider
+          provider: providerInfo.provider,
+          docs: providerDocs
         },
-        configSchema: configSchema.schema,
+        configSchema: {
+          schema: configSchema.schema,
+          docs: configSchemaDocs
+        },
         authMethods: discoveredAuthMethods,
         actions: discoveredActions
       });
@@ -324,7 +347,9 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         protocolVersion: providerInfo.protocol,
 
         providerInfo: providerInfo.provider,
+        providerDocs,
         configSchema: configSchema.schema,
+        configSchemaDocs,
         authMethods: discoveredAuthMethods,
         actions: discoveredActions
       };
@@ -409,10 +434,12 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
           hash: discoveryHashes.configSchemaHash,
           identifier: configIdentifier,
 
-          schema: configSchema.schema
+          schema: configSchema.schema,
+          docs: configSchemaDocs
         },
         update: {
-          schema: configSchema.schema
+          schema: configSchema.schema,
+          docs: configSchemaDocs
         }
       });
 

--- a/src/systems/subspace/db/prisma/schema/listing/listing.prisma
+++ b/src/systems/subspace/db/prisma/schema/listing/listing.prisma
@@ -29,6 +29,9 @@ model ProviderListing {
   description String?
   readme      String?
 
+  /// [ProviderListingDocs]
+  docs Json?
+
   rank Int @default(0)
 
   skills String[]

--- a/src/systems/subspace/db/src/db.ts
+++ b/src/systems/subspace/db/src/db.ts
@@ -172,6 +172,29 @@ declare global {
       config?: CustomProviderConfig;
     };
 
+    type ProviderListingDocReference = {
+      type?: string;
+      name: string;
+      url: string;
+    };
+
+    type ProviderListingDocs = {
+      provider: ProviderListingDocReference[];
+      config: ProviderListingDocReference[];
+      authMethods: {
+        key: string;
+        name: string;
+        type: string;
+        docs: ProviderListingDocReference[];
+      }[];
+      actions: {
+        key: string;
+        name: string;
+        type: 'tool' | 'trigger';
+        docs: ProviderListingDocReference[];
+      }[];
+    };
+
     type ProviderTypeAttributes = {
       provider: 'metorial-slates' | 'metorial-shuttle' | 'metorial-native';
       backend: 'slates' | 'mcp.container' | 'mcp.function' | 'mcp.remote' | 'native';

--- a/src/systems/subspace/modules/provider-internal/src/services/provider.ts
+++ b/src/systems/subspace/modules/provider-internal/src/services/provider.ts
@@ -6,6 +6,7 @@ import {
   db,
   type EntityImage,
   getId,
+  Prisma,
   type Provider,
   type ProviderVariant,
   type Publisher,
@@ -99,6 +100,7 @@ class providerInternalServiceImpl {
       image?: EntityImage | null;
       skills?: string[];
       readme?: string;
+      docs?: PrismaJson.ProviderListingDocs | null;
       categories?: string[];
     };
 
@@ -283,6 +285,7 @@ class providerInternalServiceImpl {
             image: d.info.image ?? { type: 'default' as const },
 
             readme: d.info.readme,
+            docs: d.info.docs ?? Prisma.DbNull,
 
             skills: d.info.skills || [],
 

--- a/src/systems/subspace/packages/presenters/src/providerListing.ts
+++ b/src/systems/subspace/packages/presenters/src/providerListing.ts
@@ -66,6 +66,7 @@ export let providerListingPresenter = async (
   aliases: providerListing.aliases,
 
   readme: providerListing.readme ?? null,
+  docs: providerListing.docs ?? null,
   skills: providerListing.skills,
 
   rank: providerListing.rank,

--- a/src/systems/subspace/provider-backends/provider-slates/src/queues/sync/syncSlateVersion.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/queues/sync/syncSlateVersion.ts
@@ -61,6 +61,61 @@ let metorialDomains = [
   'localhost'
 ];
 
+let normalizeDocs = (docs: unknown): PrismaJson.ProviderListingDocReference[] => {
+  if (!Array.isArray(docs)) return [];
+
+  return docs
+    .filter(
+      (doc): doc is { name: string; url: string; type?: string } =>
+        !!doc &&
+        typeof doc === 'object' &&
+        typeof (doc as any).name === 'string' &&
+        typeof (doc as any).url === 'string'
+    )
+    .map(doc => ({
+      ...(typeof doc.type === 'string' ? { type: doc.type } : {}),
+      name: doc.name,
+      url: doc.url
+    }));
+};
+
+let buildProviderListingDocs = (spec: any): PrismaJson.ProviderListingDocs | undefined => {
+  if (!spec) return undefined;
+
+  let providerDocs = normalizeDocs(spec.providerDocs);
+  let configDocs = normalizeDocs(spec.configSchemaDocs);
+  let authMethods = (spec.authMethods ?? [])
+    .map((authMethod: any) => ({
+      key: authMethod.key,
+      name: authMethod.name,
+      type: authMethod.type,
+      docs: normalizeDocs(authMethod.docs)
+    }))
+    .filter((authMethod: any) => authMethod.docs.length > 0);
+  let actions = [...(spec.tools ?? []), ...(spec.triggers ?? [])]
+    .map((action: any) => ({
+      key: action.key,
+      name: action.name,
+      type: action.type,
+      docs: normalizeDocs(action.docs)
+    }))
+    .filter((action: any) => action.docs.length > 0);
+
+  let hasDocs =
+    providerDocs.length > 0 ||
+    configDocs.length > 0 ||
+    authMethods.length > 0 ||
+    actions.length > 0;
+  if (!hasDocs) return undefined;
+
+  return {
+    provider: providerDocs,
+    config: configDocs,
+    authMethods,
+    actions
+  };
+};
+
 export let syncSlateVersionQueueProcessor = syncSlateVersionQueue.process(async data => {
   let version = await slates.slateVersion.get({
     slateId: data.slateId,
@@ -145,6 +200,7 @@ export let syncSlateVersionQueueProcessor = syncSlateVersionQueue.process(async 
   let hasAuthConfig = !!(spec && spec.authMethods.length > 0);
   let hasOAuth = spec?.authMethods.some(am => am.type === 'oauth');
   let hasTriggers = !!(spec ? spec.triggers.length > 0 : false);
+  let docs = buildProviderListingDocs(spec);
 
   let type = {
     name: 'Slates',
@@ -209,6 +265,7 @@ export let syncSlateVersionQueueProcessor = syncSlateVersionQueue.process(async 
         image: registryRecord.logoUrl ? { type: 'url', url: registryRecord.logoUrl } : null,
         skills: registryRecord.skills,
         readme: readme,
+        docs,
         categories: registryRecord.categories?.map((c: any) => c.identifier) ?? [],
         globalIdentifier
       };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> OAuth credential create/update now sends user-selected scopes instead of always using all defaults, which can change requested permissions; the new docs sync path spans Slates, subspace DB, and API presenters but is mostly additive.
> 
> **Overview**
> Adds **structured documentation links** on provider listings (provider, config, per–auth-method, and per-action) and surfaces them in the dashboard during OAuth setup.
> 
> **Pipeline:** Slates discovery now normalizes and persists doc references on specifications and config schemas (included in content hashes), bumps `@slates/proto` to `1.0.0-rc.11`, and subspace sync maps that into a new `docs` field on provider listings. The dashboard API presenter and generated client types/mappers expose `docs` on provider listing get/list responses.
> 
> **Dashboard UX:** New `providerDocs` helpers and `ProviderDocsLink` wire links into auth credential create/settings, setup-session embeds (redirect URI, client ID, scopes), and `Input` gains an optional `help` slot beside the label. OAuth credential creation and embedded setup now use a **selectable scope picker** (persisting chosen scopes) instead of always submitting all default scopes. `ScopePickerField` wraps the scope UI with label/help styling.
> 
> **Smaller changes:** Provider setup flows drop config-vault wording/options in a few places; capability list tables no longer show truncated descriptions; provider overview fetches more integrations/MCP servers (limit 15, desc order); fabric OAuth application create/update types and archive event payloads are broadened; minor auth loading/layout tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 245c4c5ad35a2a0c299fd28bfef3333bd91560fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->