### PR TITLE
Harden org redirect

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/index/pages/organizationRedirect.tsx
+++ b/src/frontend/apps/dashboard/src/slices/index/pages/organizationRedirect.tsx
@@ -10,6 +10,10 @@ export let OrganizationRedirect = () => {
   let [search] = useSearchParams();
   let path = search.get('path');
 
+  let nonPathQuery = new URLSearchParams(search);
+  nonPathQuery.delete('path');
+  let nonPathQueryObj = Object.fromEntries(nonPathQuery.entries());
+
   let navigatedRef = useRef(false);
   useLayoutEffect(() => {
     if (!org.data || navigatedRef.current) return;
@@ -19,7 +23,9 @@ export let OrganizationRedirect = () => {
     let instance = orgInstances[0];
 
     if (instance) {
-      navigate(Paths.instance(org.data, instance.project, instance, path), { replace: true });
+      navigate(Paths.instance(org.data, instance.project, instance, path, nonPathQueryObj), {
+        replace: true
+      });
     } else {
       createProject({ organizationId: org.data.id, name: 'Default Project' });
     }

--- a/src/frontend/apps/dashboard/src/slices/index/pages/projectRedirect.tsx
+++ b/src/frontend/apps/dashboard/src/slices/index/pages/projectRedirect.tsx
@@ -10,6 +10,10 @@ export let ProjectRedirect = () => {
   let [search] = useSearchParams();
   let path = search.get('path');
 
+  let nonPathQuery = new URLSearchParams(search);
+  nonPathQuery.delete('path');
+  let nonPathQueryObj = Object.fromEntries(nonPathQuery.entries());
+
   let navigatedRef = useRef(false);
   useLayoutEffect(() => {
     if (!project.data || navigatedRef.current) return;
@@ -20,9 +24,18 @@ export let ProjectRedirect = () => {
     if (!instance) instance = project.data.instances[0];
     if (!instance) return navigate('/');
 
-    navigate(Paths.instance(project.data.organization, instance.project, instance, path), {
-      replace: true
-    });
+    navigate(
+      Paths.instance(
+        project.data.organization,
+        instance.project,
+        instance,
+        path,
+        nonPathQueryObj
+      ),
+      {
+        replace: true
+      }
+    );
   }, [project.data]);
 
   return null;

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/components/scopePicker.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/components/scopePicker.tsx
@@ -263,7 +263,7 @@ export let ScopePicker = ({
 export let ScopePickerField = ({
   label = 'Scopes',
   help,
-  maxHeight = 260,
+  maxHeight = 410,
   ...props
 }: {
   label?: ReactNode;

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/modal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/modal.tsx
@@ -42,7 +42,8 @@ export let ProviderAuthCredentialsForm = ({
   onBack,
   onCreate,
   embedded = false,
-  hideProviderContext = false
+  hideProviderContext = false,
+  showScopePicker = false
 }: {
   instanceId: string;
   providerId: string;
@@ -54,6 +55,7 @@ export let ProviderAuthCredentialsForm = ({
   ) => void;
   embedded?: boolean;
   hideProviderContext?: boolean;
+  showScopePicker?: boolean;
 }) => {
   let effectiveHideProviderContext = hideProviderContext || !!deploymentId;
   let dismissSecondaryLabel = effectiveHideProviderContext ? 'Close' : 'Back';
@@ -190,8 +192,6 @@ export let ProviderAuthCredentialsForm = ({
           <Dialog.Description>
             Enter your {oauthMethodName} app credentials for {providerName}.
           </Dialog.Description>
-
-          <Spacer size={15} />
         </>
       )}
 
@@ -258,7 +258,7 @@ export let ProviderAuthCredentialsForm = ({
         />
         <form.RenderError field="clientSecret" />
 
-        {availableScopes.length > 0 && (
+        {showScopePicker && availableScopes.length > 0 && (
           <>
             <Spacer size={10} />
             <ScopePickerField

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/panelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/panelFlow.tsx
@@ -69,6 +69,7 @@ export let ProviderAuthCredentialsPanelFlow = (p: {
               onBack={() => setStep(0)}
               embedded
               hideProviderContext
+              showScopePicker
               onCreate={credentials => {
                 if (!organization.data || !project.data || !instance.data) return;
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerContextCard.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerContextCard.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 let Card = styled.div`
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 10px;
   padding: 10px 12px;
   border: 1px solid ${theme.colors.gray300};

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/index.tsx
@@ -15,7 +15,7 @@ import { Button, Flex, Text } from '@metorial/ui';
 import { sortBy } from 'lodash';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Stepper } from '../../../../../components/stepper';
-import { getConfigDoc, getProviderDoc, getScopeDoc } from '../../../lib/providerDocs';
+import { getConfigDoc, getProviderDoc } from '../../../lib/providerDocs';
 import { getProviderOAuthAutoRegistrationEnabled } from '../../../lib/providerOAuthAutoRegistration';
 import {
   ConnectStep,
@@ -113,8 +113,7 @@ export let ProviderSetupSessionEmbed = ({
       selectedCredentialId: fixedCredentialId ?? '',
       newCredName: '',
       newCredClientId: '',
-      newCredClientSecret: '',
-      newCredScopes: [] as string[]
+      newCredClientSecret: ''
     },
     onSubmit: async () => {
       let providerAuthCredentialsId = await resolveSelectedCredentialId();
@@ -205,11 +204,6 @@ export let ProviderSetupSessionEmbed = ({
     () => (authMethods.data?.items ?? []).find(method => method.id === selectedMethodId),
     [authMethods.data?.items, selectedMethodId]
   );
-  let selectedMethodScopes = useMemo(
-    () => selectedMethod?.scopes?.map(scope => scope.scope) ?? [],
-    [selectedMethod?.scopes]
-  );
-  let selectedMethodScopeKey = selectedMethodScopes.join('\n');
 
   let providerName = deployment.data?.name ?? provider.data?.name ?? providerId;
   let oauthMethodName = selectedMethod?.name ?? 'OAuth';
@@ -221,7 +215,6 @@ export let ProviderSetupSessionEmbed = ({
   let providerImageUrl = provider.data?.publisher.imageUrl;
   let providerDoc = getProviderDoc(providerListing.data);
   let configDoc = getConfigDoc(providerListing.data);
-  let scopeDoc = getScopeDoc(providerListing.data, selectedMethod);
 
   let visibleAuthCredentials = sortBy(authCredentials.data?.items ?? [], [
     credential => Number(!credential.isManaged),
@@ -372,10 +365,6 @@ export let ProviderSetupSessionEmbed = ({
   };
 
   useEffect(() => {
-    void credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
-  }, [selectedMethod?.id, selectedMethodScopeKey]);
-
-  useEffect(() => {
     if (!collectAuthConfigDetails || !onAuthConfigDetailsChange) return;
 
     onAuthConfigDetailsChange({
@@ -500,8 +489,7 @@ export let ProviderSetupSessionEmbed = ({
   ]);
 
   let handleCreateCredentials = async (): Promise<string | null> => {
-    let { newCredClientId, newCredClientSecret, newCredName, newCredScopes } =
-      credentialsForm.values;
+    let { newCredClientId, newCredClientSecret, newCredName } = credentialsForm.values;
     if (!newCredName || !newCredClientId || !newCredClientSecret || !selectedMethod) return null;
 
     setError(null);
@@ -514,7 +502,7 @@ export let ProviderSetupSessionEmbed = ({
         type: 'oauth',
         clientId: newCredClientId,
         clientSecret: newCredClientSecret,
-        scopes: newCredScopes
+        scopes: selectedMethod.scopes?.map(scope => scope.scope) ?? []
       }
     });
 
@@ -531,7 +519,6 @@ export let ProviderSetupSessionEmbed = ({
     await credentialsForm.setFieldValue('newCredName', '');
     await credentialsForm.setFieldValue('newCredClientId', '');
     await credentialsForm.setFieldValue('newCredClientSecret', '');
-    await credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
 
     return result.id;
   };
@@ -547,7 +534,6 @@ export let ProviderSetupSessionEmbed = ({
     if (value === '__create_new__') {
       void credentialsForm.setFieldValue('credentialMode', 'new');
       void credentialsForm.setFieldValue('selectedCredentialId', '');
-      void credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
       return;
     }
 
@@ -896,10 +882,8 @@ export let ProviderSetupSessionEmbed = ({
     isManagedSelected,
     error,
     createCredentials,
-    selectedMethod,
     providerDoc,
     configDoc,
-    scopeDoc,
     showHiddenMethodStep,
     includeMethodStep,
     skipMethodStep,
@@ -922,10 +906,8 @@ export let ProviderSetupSessionEmbed = ({
     hasManagedVisibleCredentials,
     createCredentials,
     createSetupSession,
-    selectedMethod,
     providerDoc,
     configDoc,
-    scopeDoc,
     error,
     setupSession,
     setupWindowBlocked,

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/stepContent.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/stepContent.tsx
@@ -12,7 +12,6 @@ import {
 } from '@metorial/ui';
 import type { ReactNode } from 'react';
 import { ProviderDocsLink, type ProviderDocReference } from '../../../lib/providerDocs';
-import { ScopePickerField } from '../../../pages/(deployments)/provider-auth-credential/components/scopePicker';
 import { AuthMethodPicker } from '../../providerAuthConfigs/authMethodPicker';
 import {
   FlatConnectForm,
@@ -34,7 +33,7 @@ import {
   SummaryFieldMeta,
   SummaryFieldValue
 } from './styled';
-import type { AuthMethod, SetupSessionState } from './types';
+import type { SetupSessionState } from './types';
 
 type AnyForm = any;
 
@@ -155,15 +154,9 @@ let RedirectUriField = (p: {
 
 let NewCredentialsFields = (p: {
   credentialsForm: AnyForm;
-  selectedMethod?: AuthMethod;
   providerDoc?: ProviderDocReference | null;
-  scopeDoc?: ProviderDocReference | null;
   disabled?: boolean;
 }) => {
-  let availableScopes = p.selectedMethod?.scopes ?? [];
-  let selectedScopes =
-    p.credentialsForm.values.newCredScopes ?? availableScopes.map(scope => scope.scope);
-
   return (
     <>
       <Spacer size={12} />
@@ -200,21 +193,6 @@ let NewCredentialsFields = (p: {
         type="password"
       />
       <p.credentialsForm.RenderError field="newCredClientSecret" />
-
-      {availableScopes.length > 0 && (
-        <>
-          <Spacer size={8} />
-          <ScopePickerField
-            scopes={availableScopes}
-            selectedScopes={selectedScopes}
-            onSelectedScopesChange={scopes =>
-              p.credentialsForm.setFieldValue('newCredScopes', scopes)
-            }
-            help={<ProviderDocsLink doc={p.scopeDoc}>Scope docs</ProviderDocsLink>}
-            disabled={p.disabled}
-          />
-        </>
-      )}
     </>
   );
 };
@@ -227,10 +205,8 @@ let CredentialsSelector = (p: {
   hasManagedVisibleCredentials: boolean;
   isCreatingCredentials: boolean;
   redirectUri?: string;
-  selectedMethod?: AuthMethod;
   providerDoc?: ProviderDocReference | null;
   configDoc?: ProviderDocReference | null;
-  scopeDoc?: ProviderDocReference | null;
   isCustomSelected: boolean;
   disableCredentialSelection?: boolean;
   disabled?: boolean;
@@ -278,9 +254,7 @@ let CredentialsSelector = (p: {
       {p.isCreatingCredentials && !p.disableCredentialSelection && (
         <NewCredentialsFields
           credentialsForm={p.credentialsForm}
-          selectedMethod={p.selectedMethod}
           providerDoc={p.providerDoc}
-          scopeDoc={p.scopeDoc}
           disabled={p.disabled}
         />
       )}
@@ -485,10 +459,8 @@ export let CredentialsSelectionStep = (p: {
   handleCredentialSelectionChange: (value: string) => void;
   hasManagedVisibleCredentials: boolean;
   redirectUri?: string;
-  selectedMethod?: AuthMethod;
   providerDoc?: ProviderDocReference | null;
   configDoc?: ProviderDocReference | null;
-  scopeDoc?: ProviderDocReference | null;
   isCustomSelected: boolean;
   isCreatingCredentials: boolean;
   disableCredentialSelection?: boolean;
@@ -535,10 +507,8 @@ export let CredentialsSelectionStep = (p: {
                 hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
                 isCreatingCredentials={p.isCreatingCredentials}
                 redirectUri={p.redirectUri}
-                selectedMethod={p.selectedMethod}
                 providerDoc={p.providerDoc}
                 configDoc={p.configDoc}
-                scopeDoc={p.scopeDoc}
                 isCustomSelected={p.isCustomSelected}
                 disableCredentialSelection={p.disableCredentialSelection}
               />
@@ -564,10 +534,8 @@ export let CredentialsSelectionStep = (p: {
             hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
             isCreatingCredentials={p.isCreatingCredentials}
             redirectUri={p.redirectUri}
-            selectedMethod={p.selectedMethod}
             providerDoc={p.providerDoc}
             configDoc={p.configDoc}
-            scopeDoc={p.scopeDoc}
             isCustomSelected={p.isCustomSelected}
             disableCredentialSelection={p.disableCredentialSelection}
           />
@@ -638,10 +606,8 @@ export let FlatOAuthConnectStep = (p: {
   hasManagedVisibleCredentials: boolean;
   createCredentials: { isPending: boolean; RenderError: () => ReactNode };
   createSetupSession: { isPending: boolean; RenderError: () => ReactNode };
-  selectedMethod?: AuthMethod;
   providerDoc?: ProviderDocReference | null;
   configDoc?: ProviderDocReference | null;
-  scopeDoc?: ProviderDocReference | null;
   error: string | null;
   setupSession: SetupSessionState | null;
   setupWindowBlocked: boolean;
@@ -694,10 +660,8 @@ export let FlatOAuthConnectStep = (p: {
                 handleCredentialSelectionChange={p.handleCredentialSelectionChange}
                 hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
                 redirectUri={p.redirectUri}
-                selectedMethod={p.selectedMethod}
                 providerDoc={p.providerDoc}
                 configDoc={p.configDoc}
-                scopeDoc={p.scopeDoc}
                 isCreatingCredentials={p.isCreatingCredentials}
                 isCustomSelected={p.isCustomSelected}
                 disableCredentialSelection={p.disableCredentialSelection}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Redirect query forwarding can change landing URLs and behavior for bookmarked links; setup-time credential creation no longer lets users trim OAuth scopes, which may grant broader permissions than before.
> 
> **Overview**
> **Org/project redirects** now forward every query parameter except `path` when resolving to an instance URL, so deep links and other search params survive the hop through `OrganizationRedirect` and `ProjectRedirect`.
> 
> **OAuth credentials UX** splits scope selection by surface: the dedicated **Create Auth Credentials** panel flow turns on `showScopePicker` on `ProviderAuthCredentialsForm`, while the standalone modal and the provider **setup session embed** no longer expose the scope picker. In the embed, new credentials are created with the auth method’s full default scope list instead of user-edited `newCredScopes`. `ScopePickerField` default scroll height increases to **410px**, and `ProviderContextCard` vertically centers its content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4665990f3052be440169df6738daa262abb88d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->