### PR TITLE
Harden credentials form

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/index/pages/organizationRedirect.tsx
+++ b/src/frontend/apps/dashboard/src/slices/index/pages/organizationRedirect.tsx
@@ -10,6 +10,10 @@ export let OrganizationRedirect = () => {
   let [search] = useSearchParams();
   let path = search.get('path');
 
+  let nonPathQuery = new URLSearchParams(search);
+  nonPathQuery.delete('path');
+  let nonPathQueryObj = Object.fromEntries(nonPathQuery.entries());
+
   let navigatedRef = useRef(false);
   useLayoutEffect(() => {
     if (!org.data || navigatedRef.current) return;
@@ -19,7 +23,9 @@ export let OrganizationRedirect = () => {
     let instance = orgInstances[0];
 
     if (instance) {
-      navigate(Paths.instance(org.data, instance.project, instance, path), { replace: true });
+      navigate(Paths.instance(org.data, instance.project, instance, path, nonPathQueryObj), {
+        replace: true
+      });
     } else {
       createProject({ organizationId: org.data.id, name: 'Default Project' });
     }

--- a/src/frontend/apps/dashboard/src/slices/index/pages/projectRedirect.tsx
+++ b/src/frontend/apps/dashboard/src/slices/index/pages/projectRedirect.tsx
@@ -10,6 +10,10 @@ export let ProjectRedirect = () => {
   let [search] = useSearchParams();
   let path = search.get('path');
 
+  let nonPathQuery = new URLSearchParams(search);
+  nonPathQuery.delete('path');
+  let nonPathQueryObj = Object.fromEntries(nonPathQuery.entries());
+
   let navigatedRef = useRef(false);
   useLayoutEffect(() => {
     if (!project.data || navigatedRef.current) return;
@@ -20,9 +24,18 @@ export let ProjectRedirect = () => {
     if (!instance) instance = project.data.instances[0];
     if (!instance) return navigate('/');
 
-    navigate(Paths.instance(project.data.organization, instance.project, instance, path), {
-      replace: true
-    });
+    navigate(
+      Paths.instance(
+        project.data.organization,
+        instance.project,
+        instance,
+        path,
+        nonPathQueryObj
+      ),
+      {
+        replace: true
+      }
+    );
   }, [project.data]);
 
   return null;

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/code.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/code.tsx
@@ -8,20 +8,30 @@ import {
   useCustomProviderCodeEditorToken,
   useCustomProviderEnv
 } from '@metorial/state';
-import { Button, Dialog, Flex, Input, showModal, Spacer, Text, theme, toast } from '@metorial/ui';
+import {
+  Button,
+  Dialog,
+  Flex,
+  Input,
+  showModal,
+  Spacer,
+  Text,
+  theme,
+  toast
+} from '@metorial/ui';
 import { SideBox } from '@metorial/ui-product';
 import { RiArrowRightSLine, RiExpandDiagonal2Line, RiUpload2Line } from '@remixicon/react';
 import { motion } from 'framer-motion';
 import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import { SelectRepo } from '../../../scenes/customProvider/selectRepo';
 import {
   getCustomProviderLinkedRepo,
   getFunctionProviderVersionFrom,
   normalizeEnvRecord,
   normalizeRepoPath
 } from '../../../scenes/customProvider/utils';
-import { SelectRepo } from '../../../scenes/customProvider/selectRepo';
 
 let Wrapper = styled.div`
   &[data-expanded='true'] {
@@ -273,7 +283,7 @@ export let CustomProviderCodePage = () => {
           >
             <Button
               size="1"
-              variant="outline"
+              variant="soft"
               iconLeft={<RiUpload2Line />}
               disabled={!canPublish}
               loading={customProviderEnv.isLoading || createVersion.isLoading}
@@ -284,7 +294,7 @@ export let CustomProviderCodePage = () => {
 
             <Button
               size="1"
-              variant="outline"
+              variant="soft"
               iconLeft={<RiExpandDiagonal2Line />}
               onClick={() => setIsExpanded(expanded => !expanded)}
             >

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/components/scopePicker.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/components/scopePicker.tsx
@@ -263,7 +263,7 @@ export let ScopePicker = ({
 export let ScopePickerField = ({
   label = 'Scopes',
   help,
-  maxHeight = 260,
+  maxHeight = 410,
   ...props
 }: {
   label?: ReactNode;

--- a/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/group/overview.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/group/overview.tsx
@@ -118,7 +118,7 @@ export let MagicMcpGroupOverviewPage = () => {
   return renderWithLoader({ group })(({ group }) => (
     <>
       <Attributes
-        itemWidth="250px"
+        itemWidth="300px"
         attributes={[
           {
             label: 'Name',

--- a/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/overview.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/overview.tsx
@@ -97,18 +97,11 @@ export let MagicMcpServerOverviewPage = () => {
       streamableHttpUrl && activeTokenSecret
         ? `${streamableHttpUrl}?key=${activeTokenSecret}`
         : null;
-    let hasRelatedActiveToken = tokens.data.items.length > 0;
-    let detailsPathParams = [
-      instance.data?.organization,
-      instance.data?.project,
-      instance.data,
-      server.data.id
-    ] as const;
 
     return (
       <Flex direction="column" gap={16}>
         <Attributes
-          itemWidth="280px"
+          itemWidth="300px"
           attributes={[
             {
               label: 'ID',

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
@@ -366,7 +366,10 @@ let IntegrationProviderAuthSection = (p: {
   onSelectedAuthMethodIdChange: (value: string) => void;
   selectedAuthCredentialsId: string;
   selectedAuthCredentialsLabel?: string;
-  onSelectedAuthCredentialsIdChange: (value: string) => void;
+  onSelectedAuthCredentialsIdChange: (
+    value: string,
+    credentials?: { id: string; name?: string | null }
+  ) => void;
   oauthAutoRegistrationEnabled?: boolean;
   authMethodError?: React.ReactNode;
   authCredentialsError?: React.ReactNode;
@@ -479,7 +482,7 @@ let IntegrationProviderAuthSection = (p: {
                               providerId: p.providerId,
                               deploymentId: p.providerDeploymentId,
                               onCreate: credentials => {
-                                p.onSelectedAuthCredentialsIdChange(credentials.id);
+                                p.onSelectedAuthCredentialsIdChange(credentials.id, credentials);
                               }
                             })
                           }
@@ -522,6 +525,10 @@ let IntegrationProviderSetupStep = (p: {
   let createIntegrationProvider = useCreateIntegrationProvider();
   let updateIntegrationProvider = useUpdateIntegrationProvider();
   let autoSubmitAttemptedRef = useRef(false);
+  let [createdAuthCredentialsSelection, setCreatedAuthCredentialsSelection] = useState<{
+    id: string;
+    label: string;
+  } | null>(null);
   let isUpdate = !!p.integrationProvider;
   let visibility = useProviderSetupVisibility({
     instanceId: instance.data?.id,
@@ -742,6 +749,7 @@ let IntegrationProviderSetupStep = (p: {
     form.setFieldValue('selectedAuthCredentialsId', '');
     form.setFieldTouched('selectedAuthCredentialsId', false, false);
     form.setFieldError('selectedAuthCredentialsId', undefined);
+    setCreatedAuthCredentialsSelection(null);
   }, [
     authMethods.isLoading,
     oauthAutoRegistrationEnabled,
@@ -753,20 +761,26 @@ let IntegrationProviderSetupStep = (p: {
     if (!effectiveShowAuth) return;
     if (!form.values.selectedAuthCredentialsId) return;
     if (authCredentials.isLoading) return;
+    if (selectedAuthCredential.isLoading) return;
 
     let credentialExists = (authCredentials.data?.items ?? []).some(
       credential => credential.id === form.values.selectedAuthCredentialsId
     );
+    let selectedCredentialExists =
+      selectedAuthCredential.data?.id === form.values.selectedAuthCredentialsId;
 
-    if (!credentialExists) {
+    if (!credentialExists && !selectedCredentialExists) {
       form.setFieldValue('selectedAuthCredentialsId', '');
       form.setFieldTouched('selectedAuthCredentialsId', false, false);
       form.setFieldError('selectedAuthCredentialsId', undefined);
+      setCreatedAuthCredentialsSelection(null);
     }
   }, [
     effectiveShowAuth,
     authCredentials.isLoading,
     authCredentials.data?.items,
+    selectedAuthCredential.isLoading,
+    selectedAuthCredential.data?.id,
     form.values.selectedAuthCredentialsId
   ]);
 
@@ -855,15 +869,30 @@ let IntegrationProviderSetupStep = (p: {
             selectedAuthCredentialsLabel={
               selectedAuthCredential.data?.name ??
               selectedAuthCredential.data?.id ??
+              (createdAuthCredentialsSelection?.id === form.values.selectedAuthCredentialsId
+                ? createdAuthCredentialsSelection.label
+                : undefined) ??
               authCredentials.data?.items.find(
                 credential => credential.id === form.values.selectedAuthCredentialsId
               )?.name ??
               form.values.selectedAuthCredentialsId
             }
-            onSelectedAuthCredentialsIdChange={value => {
+            onSelectedAuthCredentialsIdChange={(value, credentials) => {
               form.setFieldValue('selectedAuthCredentialsId', value);
               form.setFieldTouched('selectedAuthCredentialsId', false, false);
               form.setFieldError('selectedAuthCredentialsId', undefined);
+
+              if (credentials && value) {
+                setCreatedAuthCredentialsSelection({
+                  id: credentials.id,
+                  label: credentials.name ?? credentials.id
+                });
+                return;
+              }
+
+              if (!value || createdAuthCredentialsSelection?.id !== value) {
+                setCreatedAuthCredentialsSelection(null);
+              }
             }}
             oauthAutoRegistrationEnabled={oauthAutoRegistrationEnabled}
             authMethodError={<form.RenderError field="selectedAuthMethodId" />}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providersManager.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providersManager.tsx
@@ -74,12 +74,13 @@ let useIntegrationProvidersTableState = (
     hasMoreBefore: providers.data?.pagination.hasMoreBefore ?? false,
     items: providers.data?.items ?? [],
     loadNext: providers.next,
-    loadPrevious: providers.previous
+    loadPrevious: providers.previous,
+    providers
   };
 };
 
 let useIntegrationProvidersTableHookState = (
-  _: ReturnType<typeof useIntegrationProvidersTableState>,
+  tableState: ReturnType<typeof useIntegrationProvidersTableState>,
   props: IntegrationProvidersManagerProps
 ) => {
   let deleteProvider = useDeleteIntegrationProvider();
@@ -87,6 +88,7 @@ let useIntegrationProvidersTableHookState = (
 
   return {
     deleteProvider,
+    providers: tableState.providers,
     instanceId: props.instanceId,
     integration: props.integration,
     onComplete: props.onComplete,
@@ -106,6 +108,7 @@ let deleteIntegrationProviderImmediately = async (
       instanceId: state.instanceId,
       integrationProviderId: provider.id
     });
+    await state.providers.refetch();
     state.onComplete?.();
   } finally {
     state.setLoadingIds(current => current.filter(id => id !== provider.id));

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/modal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/modal.tsx
@@ -42,7 +42,8 @@ export let ProviderAuthCredentialsForm = ({
   onBack,
   onCreate,
   embedded = false,
-  hideProviderContext = false
+  hideProviderContext = false,
+  showScopePicker = false
 }: {
   instanceId: string;
   providerId: string;
@@ -54,6 +55,7 @@ export let ProviderAuthCredentialsForm = ({
   ) => void;
   embedded?: boolean;
   hideProviderContext?: boolean;
+  showScopePicker?: boolean;
 }) => {
   let effectiveHideProviderContext = hideProviderContext || !!deploymentId;
   let dismissSecondaryLabel = effectiveHideProviderContext ? 'Close' : 'Back';
@@ -190,8 +192,6 @@ export let ProviderAuthCredentialsForm = ({
           <Dialog.Description>
             Enter your {oauthMethodName} app credentials for {providerName}.
           </Dialog.Description>
-
-          <Spacer size={15} />
         </>
       )}
 
@@ -258,7 +258,7 @@ export let ProviderAuthCredentialsForm = ({
         />
         <form.RenderError field="clientSecret" />
 
-        {availableScopes.length > 0 && (
+        {showScopePicker && availableScopes.length > 0 && (
           <>
             <Spacer size={10} />
             <ScopePickerField

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/panelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/panelFlow.tsx
@@ -69,6 +69,7 @@ export let ProviderAuthCredentialsPanelFlow = (p: {
               onBack={() => setStep(0)}
               embedded
               hideProviderContext
+              showScopePicker
               onCreate={credentials => {
                 if (!organization.data || !project.data || !instance.data) return;
 

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerContextCard.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerContextCard.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 let Card = styled.div`
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 10px;
   padding: 10px 12px;
   border: 1px solid ${theme.colors.gray300};

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/index.tsx
@@ -15,7 +15,7 @@ import { Button, Flex, Text } from '@metorial/ui';
 import { sortBy } from 'lodash';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Stepper } from '../../../../../components/stepper';
-import { getConfigDoc, getProviderDoc, getScopeDoc } from '../../../lib/providerDocs';
+import { getConfigDoc, getProviderDoc } from '../../../lib/providerDocs';
 import { getProviderOAuthAutoRegistrationEnabled } from '../../../lib/providerOAuthAutoRegistration';
 import {
   ConnectStep,
@@ -113,8 +113,7 @@ export let ProviderSetupSessionEmbed = ({
       selectedCredentialId: fixedCredentialId ?? '',
       newCredName: '',
       newCredClientId: '',
-      newCredClientSecret: '',
-      newCredScopes: [] as string[]
+      newCredClientSecret: ''
     },
     onSubmit: async () => {
       let providerAuthCredentialsId = await resolveSelectedCredentialId();
@@ -205,11 +204,6 @@ export let ProviderSetupSessionEmbed = ({
     () => (authMethods.data?.items ?? []).find(method => method.id === selectedMethodId),
     [authMethods.data?.items, selectedMethodId]
   );
-  let selectedMethodScopes = useMemo(
-    () => selectedMethod?.scopes?.map(scope => scope.scope) ?? [],
-    [selectedMethod?.scopes]
-  );
-  let selectedMethodScopeKey = selectedMethodScopes.join('\n');
 
   let providerName = deployment.data?.name ?? provider.data?.name ?? providerId;
   let oauthMethodName = selectedMethod?.name ?? 'OAuth';
@@ -221,7 +215,6 @@ export let ProviderSetupSessionEmbed = ({
   let providerImageUrl = provider.data?.publisher.imageUrl;
   let providerDoc = getProviderDoc(providerListing.data);
   let configDoc = getConfigDoc(providerListing.data);
-  let scopeDoc = getScopeDoc(providerListing.data, selectedMethod);
 
   let visibleAuthCredentials = sortBy(authCredentials.data?.items ?? [], [
     credential => Number(!credential.isManaged),
@@ -372,10 +365,6 @@ export let ProviderSetupSessionEmbed = ({
   };
 
   useEffect(() => {
-    void credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
-  }, [selectedMethod?.id, selectedMethodScopeKey]);
-
-  useEffect(() => {
     if (!collectAuthConfigDetails || !onAuthConfigDetailsChange) return;
 
     onAuthConfigDetailsChange({
@@ -500,8 +489,7 @@ export let ProviderSetupSessionEmbed = ({
   ]);
 
   let handleCreateCredentials = async (): Promise<string | null> => {
-    let { newCredClientId, newCredClientSecret, newCredName, newCredScopes } =
-      credentialsForm.values;
+    let { newCredClientId, newCredClientSecret, newCredName } = credentialsForm.values;
     if (!newCredName || !newCredClientId || !newCredClientSecret || !selectedMethod) return null;
 
     setError(null);
@@ -514,7 +502,7 @@ export let ProviderSetupSessionEmbed = ({
         type: 'oauth',
         clientId: newCredClientId,
         clientSecret: newCredClientSecret,
-        scopes: newCredScopes
+        scopes: selectedMethod.scopes?.map(scope => scope.scope) ?? []
       }
     });
 
@@ -531,7 +519,6 @@ export let ProviderSetupSessionEmbed = ({
     await credentialsForm.setFieldValue('newCredName', '');
     await credentialsForm.setFieldValue('newCredClientId', '');
     await credentialsForm.setFieldValue('newCredClientSecret', '');
-    await credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
 
     return result.id;
   };
@@ -547,7 +534,6 @@ export let ProviderSetupSessionEmbed = ({
     if (value === '__create_new__') {
       void credentialsForm.setFieldValue('credentialMode', 'new');
       void credentialsForm.setFieldValue('selectedCredentialId', '');
-      void credentialsForm.setFieldValue('newCredScopes', selectedMethodScopes);
       return;
     }
 
@@ -896,10 +882,8 @@ export let ProviderSetupSessionEmbed = ({
     isManagedSelected,
     error,
     createCredentials,
-    selectedMethod,
     providerDoc,
     configDoc,
-    scopeDoc,
     showHiddenMethodStep,
     includeMethodStep,
     skipMethodStep,
@@ -922,10 +906,8 @@ export let ProviderSetupSessionEmbed = ({
     hasManagedVisibleCredentials,
     createCredentials,
     createSetupSession,
-    selectedMethod,
     providerDoc,
     configDoc,
-    scopeDoc,
     error,
     setupSession,
     setupWindowBlocked,

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/stepContent.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/stepContent.tsx
@@ -12,7 +12,6 @@ import {
 } from '@metorial/ui';
 import type { ReactNode } from 'react';
 import { ProviderDocsLink, type ProviderDocReference } from '../../../lib/providerDocs';
-import { ScopePickerField } from '../../../pages/(deployments)/provider-auth-credential/components/scopePicker';
 import { AuthMethodPicker } from '../../providerAuthConfigs/authMethodPicker';
 import {
   FlatConnectForm,
@@ -34,7 +33,7 @@ import {
   SummaryFieldMeta,
   SummaryFieldValue
 } from './styled';
-import type { AuthMethod, SetupSessionState } from './types';
+import type { SetupSessionState } from './types';
 
 type AnyForm = any;
 
@@ -155,15 +154,9 @@ let RedirectUriField = (p: {
 
 let NewCredentialsFields = (p: {
   credentialsForm: AnyForm;
-  selectedMethod?: AuthMethod;
   providerDoc?: ProviderDocReference | null;
-  scopeDoc?: ProviderDocReference | null;
   disabled?: boolean;
 }) => {
-  let availableScopes = p.selectedMethod?.scopes ?? [];
-  let selectedScopes =
-    p.credentialsForm.values.newCredScopes ?? availableScopes.map(scope => scope.scope);
-
   return (
     <>
       <Spacer size={12} />
@@ -200,21 +193,6 @@ let NewCredentialsFields = (p: {
         type="password"
       />
       <p.credentialsForm.RenderError field="newCredClientSecret" />
-
-      {availableScopes.length > 0 && (
-        <>
-          <Spacer size={8} />
-          <ScopePickerField
-            scopes={availableScopes}
-            selectedScopes={selectedScopes}
-            onSelectedScopesChange={scopes =>
-              p.credentialsForm.setFieldValue('newCredScopes', scopes)
-            }
-            help={<ProviderDocsLink doc={p.scopeDoc}>Scope docs</ProviderDocsLink>}
-            disabled={p.disabled}
-          />
-        </>
-      )}
     </>
   );
 };
@@ -227,10 +205,8 @@ let CredentialsSelector = (p: {
   hasManagedVisibleCredentials: boolean;
   isCreatingCredentials: boolean;
   redirectUri?: string;
-  selectedMethod?: AuthMethod;
   providerDoc?: ProviderDocReference | null;
   configDoc?: ProviderDocReference | null;
-  scopeDoc?: ProviderDocReference | null;
   isCustomSelected: boolean;
   disableCredentialSelection?: boolean;
   disabled?: boolean;
@@ -278,9 +254,7 @@ let CredentialsSelector = (p: {
       {p.isCreatingCredentials && !p.disableCredentialSelection && (
         <NewCredentialsFields
           credentialsForm={p.credentialsForm}
-          selectedMethod={p.selectedMethod}
           providerDoc={p.providerDoc}
-          scopeDoc={p.scopeDoc}
           disabled={p.disabled}
         />
       )}
@@ -485,10 +459,8 @@ export let CredentialsSelectionStep = (p: {
   handleCredentialSelectionChange: (value: string) => void;
   hasManagedVisibleCredentials: boolean;
   redirectUri?: string;
-  selectedMethod?: AuthMethod;
   providerDoc?: ProviderDocReference | null;
   configDoc?: ProviderDocReference | null;
-  scopeDoc?: ProviderDocReference | null;
   isCustomSelected: boolean;
   isCreatingCredentials: boolean;
   disableCredentialSelection?: boolean;
@@ -535,10 +507,8 @@ export let CredentialsSelectionStep = (p: {
                 hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
                 isCreatingCredentials={p.isCreatingCredentials}
                 redirectUri={p.redirectUri}
-                selectedMethod={p.selectedMethod}
                 providerDoc={p.providerDoc}
                 configDoc={p.configDoc}
-                scopeDoc={p.scopeDoc}
                 isCustomSelected={p.isCustomSelected}
                 disableCredentialSelection={p.disableCredentialSelection}
               />
@@ -564,10 +534,8 @@ export let CredentialsSelectionStep = (p: {
             hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
             isCreatingCredentials={p.isCreatingCredentials}
             redirectUri={p.redirectUri}
-            selectedMethod={p.selectedMethod}
             providerDoc={p.providerDoc}
             configDoc={p.configDoc}
-            scopeDoc={p.scopeDoc}
             isCustomSelected={p.isCustomSelected}
             disableCredentialSelection={p.disableCredentialSelection}
           />
@@ -638,10 +606,8 @@ export let FlatOAuthConnectStep = (p: {
   hasManagedVisibleCredentials: boolean;
   createCredentials: { isPending: boolean; RenderError: () => ReactNode };
   createSetupSession: { isPending: boolean; RenderError: () => ReactNode };
-  selectedMethod?: AuthMethod;
   providerDoc?: ProviderDocReference | null;
   configDoc?: ProviderDocReference | null;
-  scopeDoc?: ProviderDocReference | null;
   error: string | null;
   setupSession: SetupSessionState | null;
   setupWindowBlocked: boolean;
@@ -694,10 +660,8 @@ export let FlatOAuthConnectStep = (p: {
                 handleCredentialSelectionChange={p.handleCredentialSelectionChange}
                 hasManagedVisibleCredentials={p.hasManagedVisibleCredentials}
                 redirectUri={p.redirectUri}
-                selectedMethod={p.selectedMethod}
                 providerDoc={p.providerDoc}
                 configDoc={p.configDoc}
-                scopeDoc={p.scopeDoc}
                 isCreatingCredentials={p.isCreatingCredentials}
                 isCustomSelected={p.isCustomSelected}
                 disableCredentialSelection={p.disableCredentialSelection}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/useProviderButton.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/useProviderButton.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react';
 import { Paths } from '@metorial/frontend-config';
 import {
   useCurrentInstance,
@@ -6,6 +5,7 @@ import {
   useCurrentProject
 } from '@metorial/state';
 import { Button, Menu } from '@metorial/ui';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { showCreateIntegrationProviderFirstFlow } from '../integrations/providerPanelFlow';
 import { showMagicMcpServerCreateFlow } from '../providerDeployments/magicMcpForm';
@@ -33,7 +33,7 @@ export let UseProviderButton = (p: UseProviderButtonProps) => {
         {
           id: 'magic-mcp-server',
           label: 'Magic MCP Server',
-          description: 'Create a server from this provider.'
+          description: 'Create a connectable MCP server.'
         },
         {
           id: 'integration',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dashboard-only UX and list refresh around OAuth credential picking and provider deletion; no auth or API contract changes.
> 
> **Overview**
> Hardens the integration provider **auth credentials** combobox so a credential created in-modal stays selected and shows the right label before the paginated list catches up.
> 
> The credentials change handler now accepts optional `{ id, name }` metadata; local `createdAuthCredentialsSelection` state drives the combobox label after create. Validation no longer clears the selection when the ID is missing from the list query but still resolves via `useProviderAuthCredential`, and that local state is reset when the auth method changes or the credential is invalid.
> 
> **Integration providers table:** after removing a provider, the list query is **refetched** so the UI matches the server.
> 
> Minor copy tweak on the provider **Use** menu (“connectable MCP server”); import order only in `useProviderButton`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66d181a8eb7187093033348b31fd2c87e543545a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->