### PR TITLE
Harden custom provider build and discovery

### DIFF
--- a/src/systems/forge/service/src/providers/aws-codebuild/index.ts
+++ b/src/systems/forge/service/src/providers/aws-codebuild/index.ts
@@ -227,6 +227,8 @@ export class AwsCodeBuildAdapter extends ForgeBuildAdapter {
             }
           }
         } else if (data.buildStarted && !data.buildEnded && data.currentStepOid) {
+          if (!message) continue;
+
           let string = collectedMessages.get(data.currentStepOid) || '';
           string += JSON.stringify([event.timestamp || 0, message]) + '\n';
           collectedMessages.set(data.currentStepOid, string);

--- a/src/systems/forge/service/src/services/workflowRun.ts
+++ b/src/systems/forge/service/src/services/workflowRun.ts
@@ -166,10 +166,25 @@ class workflowRunServiceImpl {
     );
   }
 
+  private trimBlankLogEdges(
+    logs: {
+      timestamp: number;
+      message: string;
+    }[]
+  ) {
+    let start = 0;
+    let end = logs.length;
+
+    while (start < end && !logs[start]!.message.trim()) start++;
+    while (end > start && !logs[end - 1]!.message.trim()) end--;
+
+    return logs.slice(start, end);
+  }
+
   private presentOutput(lines: string | string[]) {
     let array = (Array.isArray(lines) ? lines : lines.split('\n')).filter(Boolean);
 
-    return array
+    let logs = array
       .map(line => {
         if (!line.startsWith('[')) return undefined!;
         try {
@@ -180,6 +195,8 @@ class workflowRunServiceImpl {
         }
       })
       .filter(Boolean);
+
+    return this.trimBlankLogEdges(logs);
   }
 
   async getWorkflowRunOutput(d: { run: WorkflowRun }) {

--- a/src/systems/function-bay/packages/nodejs/package.json
+++ b/src/systems/function-bay/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@function-bay/nodejs",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "publishConfig": {
     "access": "public"
   },

--- a/src/systems/function-bay/service/src/providers/_lib.test.ts
+++ b/src/systems/function-bay/service/src/providers/_lib.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { parseInvocationPayload } from './_lib';
+
+vi.mock('@lowerdeck/sentry', () => ({
+  getSentry: () => ({
+    captureException: vi.fn(),
+    captureMessage: vi.fn()
+  })
+}));
+
+describe('parseInvocationPayload', () => {
+  it('treats Lambda ReferenceError payloads as function errors', () => {
+    let res = parseInvocationPayload({
+      payload: JSON.stringify({
+        errorType: 'ReferenceError',
+        errorMessage: 'require is not defined in ES module scope',
+        trace: ['ReferenceError: require is not defined in ES module scope']
+      }),
+      outputs: {
+        logs: [],
+        computeTimeMs: 10,
+        billedTimeMs: 10
+      }
+    });
+
+    expect(res.type).toBe('error');
+    if (res.type !== 'error') throw new Error('Expected parser to return an error');
+
+    expect(res.error.code).toBe('function_bay.function_error');
+    expect(res.error.message).toContain('ReferenceError require is not defined');
+  });
+});

--- a/src/systems/function-bay/service/src/providers/_lib.ts
+++ b/src/systems/function-bay/service/src/providers/_lib.ts
@@ -180,7 +180,10 @@ export let parseInvocationPayload = (d: {
     }
 
     let errorBody = body as any;
-    if (errorBody?.errorType == 'Error' && typeof errorBody?.errorMessage == 'string') {
+    if (
+      typeof errorBody?.errorType == 'string' &&
+      typeof errorBody?.errorMessage == 'string'
+    ) {
       let traceArr = errorBody?.trace && Array.isArray(errorBody.trace) ? errorBody.trace : [];
       let trace = traceArr.join('\n');
 
@@ -188,7 +191,7 @@ export let parseInvocationPayload = (d: {
         type: 'error',
         error: {
           code: 'function_bay.function_error',
-          message: `Function invocation resulted in an error:\nError ${errorBody.errorMessage}\n\n${trace}`
+          message: `Function invocation resulted in an error:\n${errorBody.errorType} ${errorBody.errorMessage}\n\n${trace}`
         },
         internalError: d.internalError,
         ...d.outputs

--- a/src/systems/shuttle/service/prisma/schema/function.prisma
+++ b/src/systems/shuttle/service/prisma/schema/function.prisma
@@ -80,6 +80,8 @@ model FunctionServerInvocation {
   isError Boolean
 
   functionBayInvocationId String
+  errorCode               String?
+  errorMessage            String?
 
   connectionOid BigInt?
   connection    ServerConnection? @relation(fields: [connectionOid], references: [oid])

--- a/src/systems/shuttle/service/src/lib/function/getFs.test.ts
+++ b/src/systems/shuttle/service/src/lib/function/getFs.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { getFunctionFs } from './getFs';
+
+let getFile = (
+  res: Extract<ReturnType<typeof getFunctionFs>, { ok: true }>,
+  filename: string
+) => res.files.find(file => file.filename === filename);
+
+let payload = (
+  files: PrismaJson.UpcomingFunctionServerPayload['files']
+): PrismaJson.UpcomingFunctionServerPayload => ({
+  runtime: { identifier: 'nodejs', version: '24.x' },
+  env: {},
+  files
+});
+
+describe('getFunctionFs', () => {
+  it('removes module package type while preserving main entrypoint detection', () => {
+    let res = getFunctionFs({
+      payload: payload([
+        {
+          filename: 'package.json',
+          content: JSON.stringify({
+            name: 'custom-provider',
+            type: 'module',
+            main: 'src/index.ts'
+          })
+        },
+        {
+          filename: 'src/index.ts',
+          content: 'export default {};'
+        }
+      ])
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('Expected function fs to be valid');
+
+    expect(getFile(res, 'shuttle_entry_point.js')?.content).toContain(
+      "from './src/index.ts'"
+    );
+
+    let packageJson = JSON.parse(getFile(res, 'package.json')!.content);
+    expect(packageJson.type).toBeUndefined();
+    expect(packageJson.main).toBe('src/index.ts');
+  });
+
+  it('normalizes base64 encoded package files', () => {
+    let encodedPackageJson = Buffer.from(
+      JSON.stringify({
+        name: 'custom-provider',
+        type: 'module',
+        main: 'index.ts'
+      }),
+      'utf-8'
+    ).toString('base64');
+
+    let res = getFunctionFs({
+      payload: payload([
+        {
+          filename: 'package.json',
+          content: encodedPackageJson,
+          encoding: 'base64'
+        },
+        {
+          filename: 'index.ts',
+          content: 'export default {};'
+        }
+      ])
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('Expected function fs to be valid');
+
+    let packageFile = getFile(res, 'package.json')!;
+    expect(packageFile.encoding).toBe('base64');
+
+    let packageJson = JSON.parse(
+      Buffer.from(packageFile.content, 'base64').toString('utf-8')
+    );
+    expect(packageJson.type).toBeUndefined();
+    expect(packageJson.main).toBe('index.ts');
+  });
+
+  it('falls back to common entrypoints without package json', () => {
+    let res = getFunctionFs({
+      payload: payload([
+        {
+          filename: 'index.js',
+          content: 'export default {};'
+        }
+      ])
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('Expected function fs to be valid');
+
+    expect(getFile(res, 'shuttle_entry_point.js')?.content).toContain("from './index.js'");
+  });
+});

--- a/src/systems/shuttle/service/src/lib/function/getFs.ts
+++ b/src/systems/shuttle/service/src/lib/function/getFs.ts
@@ -15,6 +15,16 @@ let commonEntrypoints = commonDirs.flatMap(dir =>
   commonNames.flatMap(name => extension.map(ext => dir + name + ext))
 );
 
+type FunctionFile = PrismaJson.UpcomingFunctionServerPayload['files'][number];
+
+let decodeFileContent = (file: FunctionFile) =>
+  file.encoding === 'base64'
+    ? Buffer.from(file.content, 'base64').toString('utf-8')
+    : file.content;
+
+let encodeFileContent = (file: FunctionFile, content: string) =>
+  file.encoding === 'base64' ? Buffer.from(content, 'utf-8').toString('base64') : content;
+
 export let getFunctionFs = (d: { payload: PrismaJson.UpcomingFunctionServerPayload }) => {
   let files = d.payload.files;
   let functionEntrypoint: string | undefined;
@@ -25,10 +35,7 @@ export let getFunctionFs = (d: { payload: PrismaJson.UpcomingFunctionServerPaylo
   let logs: string[] = [];
 
   if (packageJson?.content) {
-    let stringContents =
-      packageJson.encoding === 'base64'
-        ? Buffer.from(packageJson.content, 'base64').toString('utf-8')
-        : packageJson.content;
+    let stringContents = decodeFileContent(packageJson);
 
     try {
       let pkg = JSON.parse(stringContents);
@@ -89,10 +96,27 @@ export let getFunctionFs = (d: { payload: PrismaJson.UpcomingFunctionServerPaylo
     }
   ];
   let initialFilenames = new Set(initialFiles.map(f => f.filename));
+  let packagedFiles = files.map(file => {
+    if (file !== packageJson || !packageJson.content) return file;
+
+    try {
+      let pkg = JSON.parse(decodeFileContent(packageJson));
+      if (pkg.type !== 'module') return file;
+
+      delete pkg.type;
+
+      return {
+        ...file,
+        content: encodeFileContent(file, JSON.stringify(pkg, null, 2))
+      };
+    } catch {
+      return file;
+    }
+  });
 
   return {
     ok: true as const,
     logs,
-    files: [...initialFiles, ...files.filter(f => !initialFilenames.has(f.filename))]
+    files: [...initialFiles, ...packagedFiles.filter(f => !initialFilenames.has(f.filename))]
   };
 };

--- a/src/systems/shuttle/service/src/mcp/function/connection.ts
+++ b/src/systems/shuttle/service/src/mcp/function/connection.ts
@@ -11,9 +11,8 @@ import type {
   ServerInstanceConfiguration
 } from '../../../prisma/generated/client';
 import { db } from '../../db';
-import { snowflake } from '../../id';
 import { callFunction } from '../../lib/function/call';
-import { secretService } from '../../services';
+import { functionServerInvocationService, secretService } from '../../services';
 import type { McpConnectionBackendAdapter } from '../connection/adapter';
 import { ConnectionManager } from '../utils/connection';
 import { ConnectionLogger } from '../utils/logger';
@@ -148,16 +147,14 @@ export class FunctionConnection implements McpConnectionBackendAdapter {
 
       (async () => {
         if (res.functionCallId) {
-          await db.functionServerInvocation.create({
-            data: {
-              oid: snowflake.nextId(),
-              isError: res.status == 'error',
-              functionBayInvocationId: res.functionCallId,
-              connectionOid: this.connection.oid,
-              functionServerOid: this.functionServer.oid,
-              tenantOid: this.tenant.oid,
-              logs: res.logs.length > 0 ? res.logs : undefined
-            }
+          await functionServerInvocationService.ensureFunctionServerInvocation({
+            functionServer: this.functionServer,
+            tenant: this.tenant,
+            functionInvocationId: res.functionCallId,
+            isError: res.status == 'error',
+            error: res.status == 'error' ? res.error : null,
+            connection: this.connection,
+            logs: res.logs
           });
 
           for (let logEntry of res.logs) {

--- a/src/systems/shuttle/service/src/presenters/functionServerInvocation.ts
+++ b/src/systems/shuttle/service/src/presenters/functionServerInvocation.ts
@@ -9,14 +9,23 @@ export let functionServerInvocationPresenter = (
     connection: ServerConnection | null;
     functionServer: FunctionServer;
   }
-) => ({
-  object: 'shuttle#function_server.invocation',
+) => {
+  let invocationError = invocation as typeof invocation & {
+    errorCode?: string | null;
+    errorMessage?: string | null;
+  };
 
-  id: invocation.functionBayInvocationId,
-  isError: invocation.isError,
+  return {
+    object: 'shuttle#function_server.invocation',
 
-  serverConnectionId: invocation.connection?.id ?? null,
-  functionServerId: invocation.functionServer.id,
+    id: invocation.functionBayInvocationId,
+    isError: invocation.isError,
+    errorCode: invocationError.errorCode ?? null,
+    errorMessage: invocationError.errorMessage ?? null,
 
-  createdAt: invocation.createdAt
-});
+    serverConnectionId: invocation.connection?.id ?? null,
+    functionServerId: invocation.functionServer.id,
+
+    createdAt: invocation.createdAt
+  };
+};

--- a/src/systems/shuttle/service/src/queues/function/discover.ts
+++ b/src/systems/shuttle/service/src/queues/function/discover.ts
@@ -6,6 +6,7 @@ import { env } from '../../env';
 import { DeploymentManager } from '../../lib/deployment';
 import { callFunction } from '../../lib/function/call';
 import { normalizeJsonSchema } from '../../lib/jsonSchema/normalizeJsonSchema';
+import { functionServerInvocationService } from '../../services';
 import { deployServerFailedQueue } from '../deployment/failed';
 import { deployFunctionServerPublishQueue } from './publish';
 
@@ -46,7 +47,7 @@ export let deployFunctionServerDiscoverQueueProcessor =
     let failDiscovery = async (d: {
       errorCode: string;
       errorMessage: string;
-      logMessage?: string;
+      logMessage?: string | string[];
     }) => {
       await db.functionServer.update({
         where: { id: functionServer.id },
@@ -88,15 +89,40 @@ export let deployFunctionServerDiscoverQueueProcessor =
         })
       ]);
 
-      step.log(discoveryRes.logs.map(l => l.message));
+      let functionLogs = discoveryRes.logs
+        .map(l => l.message)
+        .filter(message => message.trim());
 
       if (discoveryRes.status == 'error') {
+        if (discoveryRes.functionCallId && dep.serverDeployment.tenantOid) {
+          let tenant = await db.tenant.findUnique({
+            where: { oid: dep.serverDeployment.tenantOid }
+          });
+
+          if (tenant) {
+            await functionServerInvocationService.ensureFunctionServerInvocation({
+              functionServer,
+              tenant,
+              functionInvocationId: discoveryRes.functionCallId,
+              isError: true,
+              error: discoveryRes.error,
+              logs: discoveryRes.logs
+            });
+          }
+        }
+
         await failDiscovery({
           errorCode: discoveryRes.error.code,
-          errorMessage: discoveryRes.error.message
+          errorMessage: discoveryRes.error.message,
+          logMessage: [
+            ...(functionLogs.length ? ['Function logs:', ...functionLogs] : []),
+            `Discovery failed: ${discoveryRes.error.code} - ${discoveryRes.error.message}`
+          ]
         });
         return;
       } else {
+        step.log(functionLogs);
+
         await db.functionServer.update({
           where: { id: functionServer.id },
           data: {

--- a/src/systems/shuttle/service/src/services/functionServerInvocation.ts
+++ b/src/systems/shuttle/service/src/services/functionServerInvocation.ts
@@ -16,6 +16,11 @@ let include = {
   functionServer: true
 };
 
+type FunctionServerInvocationErrorFields = {
+  errorCode?: string | null;
+  errorMessage?: string | null;
+};
+
 let parseStoredLogs = (logs: unknown): FunctionCallLog[] => {
   if (!Array.isArray(logs)) return [];
 
@@ -29,6 +34,46 @@ let parseStoredLogs = (logs: unknown): FunctionCallLog[] => {
 
     return [{ timestamp, message }];
   });
+};
+
+let getInvocationError = (invocation: FunctionServerInvocationErrorFields) => {
+  if (!invocation.errorMessage) return null;
+
+  return {
+    code: invocation.errorCode ?? 'function_bay.function_error',
+    message: invocation.errorMessage
+  };
+};
+
+let formatInvocationError = (error: { code: string; message: string }) =>
+  `Invocation failed: ${error.code} - ${error.message}`;
+
+let addInvocationErrorLog = (
+  logs: FunctionCallLog[],
+  invocation: FunctionServerInvocation & FunctionServerInvocationErrorFields
+) => {
+  let error = getInvocationError(invocation);
+  if (!error) return logs;
+  let formattedError = formatInvocationError(error);
+
+  if (
+    logs.some(log => log.message.includes(formattedError) || log.message.includes(error.code))
+  ) {
+    return logs;
+  }
+
+  let timestamp =
+    logs.length > 0
+      ? Math.max(...logs.map(log => log.timestamp)) + 1
+      : invocation.createdAt.getTime();
+
+  return [
+    ...logs,
+    {
+      timestamp,
+      message: formattedError
+    }
+  ];
 };
 
 let presentInvocationLogs = (logs: FunctionCallLog[], functionInvocationId: string) => ({
@@ -48,6 +93,10 @@ class functionServerInvocationServiceImpl {
     tenant: Tenant;
     functionInvocationId: string | null | undefined;
     isError: boolean;
+    error?: {
+      code: string;
+      message: string;
+    } | null;
     connection?: ServerConnection | null;
     logs?: FunctionCallLog[];
   }) {
@@ -59,13 +108,30 @@ class functionServerInvocationServiceImpl {
       },
       include
     });
-    if (existing) return existing;
+    if (existing) {
+      let existingWithError = existing as typeof existing &
+        FunctionServerInvocationErrorFields;
+      if (d.error && !existingWithError.errorMessage) {
+        return await db.functionServerInvocation.update({
+          where: { oid: existing.oid },
+          data: {
+            errorCode: d.error.code,
+            errorMessage: d.error.message
+          },
+          include
+        });
+      }
+
+      return existing;
+    }
 
     return await db.functionServerInvocation.create({
       data: {
         oid: snowflake.nextId(),
         isError: d.isError,
         functionBayInvocationId: d.functionInvocationId,
+        errorCode: d.error?.code ?? null,
+        errorMessage: d.error?.message ?? null,
         connectionOid: d.connection?.oid ?? null,
         functionServerOid: d.functionServer.oid,
         tenantOid: d.tenant.oid,
@@ -108,18 +174,21 @@ class functionServerInvocationServiceImpl {
     functionServerInvocation: FunctionServerInvocation & {
       functionServer: FunctionServer;
       connection: ServerConnection | null;
-    };
+    } & FunctionServerInvocationErrorFields;
   }) {
     let storedLogs = parseStoredLogs(d.functionServerInvocation.logs);
     if (storedLogs.length > 0) {
       return presentInvocationLogs(
-        storedLogs,
+        addInvocationErrorLog(storedLogs, d.functionServerInvocation),
         d.functionServerInvocation.functionBayInvocationId
       );
     }
 
     if (!d.functionServerInvocation.connection) {
-      return presentInvocationLogs([], d.functionServerInvocation.functionBayInvocationId);
+      return presentInvocationLogs(
+        addInvocationErrorLog([], d.functionServerInvocation),
+        d.functionServerInvocation.functionBayInvocationId
+      );
     }
 
     let nextInvocation = d.functionServerInvocation.connectionOid
@@ -143,9 +212,7 @@ class functionServerInvocationServiceImpl {
       .filter(log => {
         let ts = log.timestamp.getTime();
         return (
-          log.outputType === 'stdout' &&
-          ts >= invocationCreatedAt - 1000 &&
-          ts < upperBoundMs
+          log.outputType === 'stdout' && ts >= invocationCreatedAt - 1000 && ts < upperBoundMs
         );
       })
       .map(log => ({
@@ -153,7 +220,10 @@ class functionServerInvocationServiceImpl {
         message: log.message
       }));
 
-    return presentInvocationLogs(logs, d.functionServerInvocation.functionBayInvocationId);
+    return presentInvocationLogs(
+      addInvocationErrorLog(logs, d.functionServerInvocation),
+      d.functionServerInvocation.functionBayInvocationId
+    );
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Schema and invocation persistence changes affect discovery and MCP error reporting; packaging changes alter how user `package.json` is deployed at runtime.
> 
> **Overview**
> Hardens **custom provider** packaging and discovery by fixing ESM/`package.json` handling, surfacing Lambda-style runtime failures, and improving build/discovery observability.
> 
> **Shuttle function packaging** strips `"type": "module"` from uploaded `package.json` (including base64-encoded files) while keeping `main` and entrypoint detection, so custom providers that would otherwise hit ES-module/`require` issues can run behind the generated `shuttle_entry_point.js`.
> 
> **Function Bay** now treats any Lambda payload with `errorType` + `errorMessage` (not only `Error`) as a function error and includes the error type in the message (e.g. `ReferenceError`).
> 
> **Invocation tracking** adds optional `errorCode` / `errorMessage` on `FunctionServerInvocation`, centralizes persistence via `ensureFunctionServerInvocation` (including discovery failures and MCP connections), exposes those fields in the API presenter, and appends a formatted failure line when returning invocation logs.
> 
> **Forge / workflow output** skips appending CodeBuild log lines when `message` is missing, and trims leading/trailing blank log lines when presenting workflow run output.
> 
> `@function-bay/nodejs` is bumped to **1.0.15**; new tests cover payload parsing and `getFunctionFs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d3a6eebc491261d5fea6cd5967a7f88321ee22b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->