### PR TITLE
Simplify custom provider nav

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/index.tsx
@@ -557,11 +557,8 @@ let CustomProviderListingPage = dynamicPage(() =>
     c => c.CustomProviderListingPage
   )
 );
-let ManagedServersListLayout = dynamicPage(() =>
-  import('./pages/(custom-providers)/(list)/_layout').then(c => c.ManagedProvidersListLayout)
-);
-let ExternalServersListLayout = dynamicPage(() =>
-  import('./pages/(custom-providers)/(list)/_layout').then(c => c.ExternalProvidersListLayout)
+let CustomProvidersListLayout = dynamicPage(() =>
+  import('./pages/(custom-providers)/(list)/_layout').then(c => c.CustomProvidersListLayout)
 );
 let ExternalServersPage = dynamicPage(() =>
   import('./pages/(custom-providers)/(list)/external-providers').then(
@@ -1893,24 +1890,16 @@ export let productHomeSlice = createSlice([
 
           {
             path: '',
-            element: <ManagedServersListLayout />,
-
-            children: [
-              {
-                path: 'custom-providers',
-                element: <ManagedServersPage />
-              }
-            ]
-          },
-
-          {
-            path: '',
-            element: <ExternalServersListLayout />,
+            element: <CustomProvidersListLayout />,
 
             children: [
               {
                 path: 'external-providers',
                 element: <ExternalServersPage />
+              },
+              {
+                path: 'custom-providers',
+                element: <ManagedServersPage />
               }
             ]
           },

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/(list)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/(list)/_layout.tsx
@@ -1,111 +1,136 @@
 import { PaginationSearchParamsProvider } from '@metorial/data-hooks';
+import { Paths } from '@metorial/frontend-config';
 import { ContentLayout, PageHeader } from '@metorial/layout';
-import { useDashboardFlags, useUser } from '@metorial/state';
-import { Button, Menu } from '@metorial/ui';
-import { Outlet } from 'react-router-dom';
+import {
+  useCurrentInstance,
+  useCurrentOrganization,
+  useCurrentProject,
+  useDashboardFlags,
+  useUser
+} from '@metorial/state';
+import { Button, LinkTabs, Menu } from '@metorial/ui';
+import { Outlet, useLocation } from 'react-router-dom';
 import { showCustomProviderRemoteFormModal } from '../../../scenes/customProvider/modal';
 
-export let ManagedProvidersListLayout = () => {
+export let CustomProvidersListLayout = () => {
+  let instance = useCurrentInstance();
+  let organization = useCurrentOrganization();
+  let project = useCurrentProject();
   let flags = useDashboardFlags();
   let user = useUser();
-  let openManagedCreateModal = () => {
-    if (!user.data) return;
+  let pathname = useLocation().pathname;
+
+  let listPathParams = [organization.data, project.data, instance.data] as const;
+  let isRemoteList = pathname.endsWith('/external-providers');
+  let page = isRemoteList
+    ? {
+        title: 'Remote MCP Servers',
+        description: 'Connect to remote MCP servers using the Metorial platform.',
+        actionLabel: 'Link Remote MCP Server',
+        actionType: 'remote' as const
+      }
+    : {
+        title: 'Custom MCP Servers',
+        description:
+          'Build custom MCP servers powered by Metorial. Deploy them on your own infrastructure or use Metorial-managed infrastructure.',
+        actionLabel: 'Create Custom MCP Server',
+        actionType: 'managed' as const
+      };
+
+  let openCreateModal = (type: 'remote' | 'managed' | 'docker') => {
+    if (type === 'managed' && !user.data) return;
 
     showCustomProviderRemoteFormModal({
-      type: 'managed'
+      type
     });
+  };
+
+  let renderActions = () => {
+    if (isRemoteList) {
+      return (
+        !!flags.data?.flags['paid-custom-providers'] && (
+          <Button onClick={() => openCreateModal(page.actionType)} size="2">
+            {page.actionLabel}
+          </Button>
+        )
+      );
+    }
+
+    if (flags.data?.flags['paid-custom-docker-providers']) {
+      return (
+        <Menu
+          label={page.actionLabel}
+          items={[
+            {
+              id: 'docker',
+              label: 'Docker MCP Server',
+              description: 'Deploy a custom Docker image as an MCP server on Metorial.'
+            },
+            {
+              id: 'managed',
+              label: 'Custom MCP Server',
+              description:
+                'Connect a GitHub repo and deploy a custom MCP server to Metorial automatically.'
+            }
+          ]}
+          onItemClick={id => {
+            if (id === 'managed') {
+              openCreateModal(page.actionType);
+              return;
+            }
+
+            openCreateModal('docker');
+          }}
+        >
+          <Button size="2" loading={user.isLoading} disabled={!user.data && !user.isLoading}>
+            {page.actionLabel}
+          </Button>
+        </Menu>
+      );
+    }
+
+    return (
+      !!(
+        flags.data?.flags['custom-providers-enabled'] &&
+        flags.data?.flags['paid-custom-providers']
+      ) && (
+        <Button
+          onClick={() => openCreateModal(page.actionType)}
+          loading={user.isLoading}
+          disabled={!user.data && !user.isLoading}
+          size="2"
+        >
+          {page.actionLabel}
+        </Button>
+      )
+    );
   };
 
   return (
     <ContentLayout>
       <PageHeader
-        title="Custom MCP Servers"
-        description="Build custom MCP servers powered by Metorial. Deploy them on your own infrastructure or use Metorial-managed infrastructure."
-        actions={
-          !!flags.data?.flags['paid-custom-docker-providers'] ? (
-            <Menu
-              label="Create Custom MCP Server"
-              items={[
-                {
-                  id: 'docker',
-                  label: 'Docker MCP Server',
-                  description: 'Deploy a custom Docker image as an MCP server on Metorial.'
-                },
-                {
-                  id: 'managed',
-                  label: 'Custom MCP Server',
-                  description: 'Connect a GitHub repo and deploy a custom MCP server to Metorial automatically.'
-                }
-              ]}
-              onItemClick={id => {
-                if (id === 'managed') {
-                  openManagedCreateModal();
-                  return;
-                }
+        title={page.title}
+        description={page.description}
+        actions={renderActions()}
+      />
 
-                showCustomProviderRemoteFormModal({
-                  type: 'docker'
-                });
-              }}
-            >
-              <Button
-                size="2"
-                loading={user.isLoading}
-                disabled={!user.data && !user.isLoading}
-              >
-                Create Custom MCP Server
-              </Button>
-            </Menu>
-          ) : (
-            !!(
-              flags.data?.flags['custom-providers-enabled'] &&
-              flags.data?.flags['paid-custom-providers']
-            ) && (
-              <Button
-                onClick={openManagedCreateModal}
-                loading={user.isLoading}
-                disabled={!user.data && !user.isLoading}
-                size="2"
-              >
-                Create Custom MCP Server
-              </Button>
-            )
-          )
-        }
+      <LinkTabs
+        current={pathname}
+        links={[
+          {
+            label: 'Remote MCP Server',
+            to: Paths.instance.externalProviders(...listPathParams)
+          },
+          {
+            label: 'Custom MCP Server',
+            to: Paths.instance.customProviders(...listPathParams)
+          }
+        ]}
       />
 
       <PaginationSearchParamsProvider enabled={true}>
         <Outlet />
       </PaginationSearchParamsProvider>
-    </ContentLayout>
-  );
-};
-
-export let ExternalProvidersListLayout = () => {
-  let flags = useDashboardFlags();
-
-  return (
-    <ContentLayout>
-      <PageHeader
-        title="Remote MCP Servers"
-        description="Connect to remote MCP servers using the Metorial platform."
-        actions={
-          !!flags.data?.flags['paid-custom-providers'] && (
-            <Button
-              onClick={() =>
-                showCustomProviderRemoteFormModal({
-                  type: 'remote'
-                })
-              }
-              size="2"
-            >
-              Link Remote MCP Server
-            </Button>
-          )
-        }
-      />
-
-      <Outlet />
     </ContentLayout>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Frontend routing and layout refactor only; URLs and page components are unchanged, with low risk aside from verifying tab UX and pagination on the remote list.
> 
> **Overview**
> Unifies **Remote** and **Custom MCP Server** list pages under a single `CustomProvidersListLayout` instead of two separate layouts and route branches.
> 
> Routing now loads one shared layout for both `external-providers` and `custom-providers`, with **LinkTabs** to switch between them. The header title, description, and primary action (link remote vs create custom, including the docker menu when flagged) are chosen from the current pathname. Pagination search params wrap both list outlets; the remote list previously rendered without that provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae68534634293f8274b6b86e5108579f825c4687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->