### PR TITLE
Harden consumer sync

### DIFF
--- a/src/backend/modules/consumer/src/queues/syncOrgMember.ts
+++ b/src/backend/modules/consumer/src/queues/syncOrgMember.ts
@@ -17,7 +17,8 @@ export let syncOrgMemberQueueProcessor = syncOrgMemberQueue.process(async data =
   syncOrgMemberLock.usingLock(data.memberId, async () => {
     let member = await db.organizationMember.findUnique({
       where: {
-        id: data.memberId
+        id: data.memberId,
+        actor: { type: 'member' }
       },
       include: {
         organization: true,
@@ -115,6 +116,8 @@ export let createOrgMemberConsumerForInstanceQueueProcessor =
       }
     });
     if (!member || !instance) throw new QueueRetryError();
+
+    if (!member.actor.email || member.actor.type !== 'member') return;
 
     await consumerService.upsertConsumer({
       organization: member.organization,

--- a/src/backend/modules/consumer/src/services/consumers/consumer.ts
+++ b/src/backend/modules/consumer/src/services/consumers/consumer.ts
@@ -115,6 +115,20 @@ class ConsumerServiceImpl {
           where: {
             AND: [
               {
+                OR: [
+                  {
+                    consumer: { organizationMember: null }
+                  },
+                  {
+                    consumer: {
+                      organizationMember: {
+                        actor: { type: 'member' }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
                 instanceOid: d.instance.oid,
                 isPending: false
               },

--- a/src/systems/ares/service/src/apis/sso/templates/index.ts
+++ b/src/systems/ares/service/src/apis/sso/templates/index.ts
@@ -521,12 +521,12 @@ You've successfully configured your SAML application. You can now assign users t
 export let templates = [
   { id: 'auth0', name: 'Auth0', md: auth0Md, type: 'saml' as const },
   { id: 'entra', name: 'Microsoft Entra ID', md: entraMd, type: 'saml' as const },
-  {
-    id: 'generic-oidc',
-    name: 'Generic OIDC Provider',
-    md: genericOidcMd,
-    type: 'oidc' as const
-  },
+  // {
+  //   id: 'generic-oidc',
+  //   name: 'Generic OIDC Provider',
+  //   md: genericOidcMd,
+  //   type: 'oidc' as const
+  // },
   {
     id: 'generic-saml',
     name: 'Generic SAML Provider',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Sync and list behavior changes for org-linked consumers may stop creating or surfacing consumers for non-`member` actors; verify no legitimate actor types rely on the old paths.
> 
> **Overview**
> **Consumer sync and listing** now treat only organization actors with `type: 'member'` as valid member-backed consumers.
> 
> The main **sync org member** queue loads members only when `actor.type` is `'member'`, so non-member actors no longer enter the fan-out path. **Create consumer for instance** exits early when the actor has no email or is not a `'member'` actor, avoiding upserts for incomplete or non-human member records.
> 
> **List consumers** adds a filter so results include consumers with no linked org member, or whose linked member’s actor is `'member'`—excluding instance consumers tied to other actor types from API listings.
> 
> Separately, the **Generic OIDC Provider** SSO setup template is commented out of the exported `templates` list (OIDC generic docs remain in the file but are not offered in the UI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a539b73a939480d25776c58c0b0ab2a03cfd8473. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->