### PR TITLE
Harden remote tool discovery

### DIFF
--- a/src/systems/shuttle/service/src/queues/discovery/server.test.ts
+++ b/src/systems/shuttle/service/src/queues/discovery/server.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let queues: Record<string, any> = {};
+
+let serverDiscoveryFindFirst = vi.fn();
+let serverDiscoveryUpdate = vi.fn();
+let serverSpecificationUpsert = vi.fn();
+let serverVersionUpdate = vi.fn();
+let createServerConnection = vi.fn();
+let createEmbeddedConnection = vi.fn();
+let client: any;
+
+let db = {
+  serverDiscovery: {
+    findFirst: serverDiscoveryFindFirst,
+    update: serverDiscoveryUpdate
+  },
+  serverSpecification: {
+    upsert: serverSpecificationUpsert
+  },
+  serverVersion: {
+    update: serverVersionUpdate
+  }
+};
+
+vi.mock('@lowerdeck/delay', () => ({
+  delay: () => new Promise(() => {})
+}));
+
+vi.mock('@lowerdeck/queue', () => ({
+  QueueRetryError: class QueueRetryError extends Error {},
+  createQueue: (opts: { name: string }) => {
+    let queue = {
+      add: vi.fn(),
+      process: vi.fn((processor: unknown) => {
+        queue.processor = processor;
+        return { name: opts.name };
+      }),
+      processor: undefined as unknown
+    };
+    queues[opts.name] = queue;
+    return queue;
+  }
+}));
+
+vi.mock('@lowerdeck/sentry', () => ({
+  getSentry: () => ({ captureException: vi.fn() })
+}));
+
+vi.mock('../../db', () => ({ db }));
+
+vi.mock('../../env', () => ({
+  env: { service: { REDIS_URL: 'redis://localhost:6379' } }
+}));
+
+vi.mock('../../id', () => ({
+  getId: (model: string) => ({ oid: 100n, id: `${model}_id` })
+}));
+
+vi.mock('../../mcp/connection/embedded', () => ({
+  EmbeddedConnection: {
+    create: createEmbeddedConnection
+  },
+  EmbeddedConnectionError: class EmbeddedConnectionError extends Error {
+    code = 'connection_error';
+  }
+}));
+
+vi.mock('../../mcp/utils/paginate', () => ({
+  autoPaginateMcp: async (fn: (cursor?: string) => Promise<unknown>) => [await fn(undefined)]
+}));
+
+vi.mock('../../services', () => ({
+  serverConnectionService: {
+    createServerConnection
+  }
+}));
+
+let discovery = {
+  oid: 1n,
+  id: 'server_discovery_1',
+  tenant: { oid: 2n, id: 'tenant_1' },
+  serverConfig: { oid: 3n },
+  serverAuthConfig: null,
+  serverVersion: {
+    oid: 4n,
+    id: 'server_version_1',
+    serverOid: 5n,
+    remoteProtocolAutoSwitchStatus: 'none',
+    remoteProtocol: 'streamable_http',
+    originalRemoteProtocol: null,
+    server: {
+      oid: 5n,
+      type: 'container'
+    }
+  }
+};
+
+describe('discoverServerQueueProcessor', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    queues = {};
+
+    serverDiscoveryFindFirst.mockReset();
+    serverDiscoveryUpdate.mockReset();
+    serverSpecificationUpsert.mockReset();
+    serverVersionUpdate.mockReset();
+    createServerConnection.mockReset();
+    createEmbeddedConnection.mockReset();
+
+    client = {
+      getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
+      getServerVersion: vi.fn().mockResolvedValue({ name: 'remote', version: '1.0.0' }),
+      getInstructions: vi.fn().mockResolvedValue(undefined),
+      listTools: vi.fn(),
+      terminate: vi.fn()
+    };
+
+    serverDiscoveryFindFirst.mockResolvedValue(discovery);
+    createServerConnection.mockResolvedValue({ oid: 6n });
+    createEmbeddedConnection.mockResolvedValue(client);
+    serverSpecificationUpsert.mockResolvedValue({ oid: 7n });
+  });
+
+  it('fails discovery when an advertised tools/list call fails', async () => {
+    await import('./server');
+    client.listTools.mockRejectedValue(new Error('MCP error -32601: method does not exist'));
+
+    await queues['shut/server/discover'].processor({
+      serverDiscoveryId: discovery.id
+    });
+
+    expect(serverSpecificationUpsert).not.toHaveBeenCalled();
+    expect(serverDiscoveryUpdate).toHaveBeenCalledWith({
+      where: { oid: discovery.oid },
+      data: expect.objectContaining({
+        status: 'failed',
+        warnings: [
+          expect.objectContaining({
+            code: 'invalid_response'
+          })
+        ]
+      })
+    });
+  });
+
+  it('succeeds discovery when an advertised tools/list call returns an empty list', async () => {
+    await import('./server');
+    client.listTools.mockResolvedValue({ tools: [] });
+
+    await queues['shut/server/discover'].processor({
+      serverDiscoveryId: discovery.id
+    });
+
+    expect(serverSpecificationUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          value: expect.objectContaining({
+            tools: []
+          })
+        })
+      })
+    );
+    expect(serverDiscoveryUpdate).toHaveBeenCalledWith({
+      where: { oid: discovery.oid },
+      data: expect.objectContaining({
+        status: 'succeeded',
+        specificationOid: 7n,
+        warnings: []
+      })
+    });
+  });
+});

--- a/src/systems/shuttle/service/src/queues/discovery/server.ts
+++ b/src/systems/shuttle/service/src/queues/discovery/server.ts
@@ -56,6 +56,21 @@ let doWithCheck = async <T>(
   }
 };
 
+let doWithRequiredCheck = async <T>(
+  warnings: PrismaJson.ServerDiscoveryWarning[],
+  fn: () => Promise<T>
+) => {
+  try {
+    await fn();
+  } catch (e) {
+    console.warn('Required step failed during server discovery:', e);
+    let warning = checkInnerError(e);
+    console.warn('Required step failed during server discovery:', warning);
+    passWarning(warnings, warning);
+    throw e;
+  }
+};
+
 class TimeoutError extends Error {}
 
 export let discoverServerQueue = createQueue<{
@@ -138,7 +153,7 @@ export let discoverServerQueueProcessor = discoverServerQueue.process(async data
 
         state.step = 'discovery:tools';
 
-        await doWithCheck(state.warnings, async () => {
+        await doWithRequiredCheck(state.warnings, async () => {
           let toolsRaw = capabilities?.tools
             ? await autoPaginateMcp(cursor => state.client!.listTools({ cursor }))
             : [];

--- a/src/systems/slates/apps/hub/src/endpoints.ts
+++ b/src/systems/slates/apps/hub/src/endpoints.ts
@@ -7,12 +7,14 @@ import { db } from './db';
 
 Bun.serve({
   fetch: hubApp.fetch,
-  port: 52045
+  port: 52045,
+  idleTimeout: 250
 });
 
 Bun.serve({
   fetch: slatesHubApi,
-  port: 52046
+  port: 52046,
+  idleTimeout: 250
 });
 
 Bun.serve({

--- a/src/systems/subspace/modules/connection/src/sender/manager.ts
+++ b/src/systems/subspace/modules/connection/src/sender/manager.ts
@@ -63,6 +63,7 @@ import { createMessage, type CreateMessageProps } from '../shared/createMessage'
 import { createWarning } from '../shared/createWarning';
 import { extractToolCallOperation } from '../shared/toolCallOperation';
 import { upsertParticipant } from '../shared/upsertParticipant';
+import { resolveProviderToolListingSpecificationOid } from './toolSpecification';
 
 let Sentry = getSentry();
 
@@ -473,7 +474,10 @@ export class SenderManager {
         }
       }
 
-      if (pair.version.specificationDiscoveryStatus == 'failed') {
+      if (
+        pair.version.specificationDiscoveryStatus == 'failed' &&
+        !pair.version.specificationOid
+      ) {
         await createError({
           session: this.session,
           connection: this.connection,
@@ -553,17 +557,15 @@ export class SenderManager {
 
     if (res.status === 'discovery_failed') return res;
 
-    let tools = await db.providerTool.findMany({
-      where: {
-        specification: {
-          providerVersions: {
-            some: {
-              oid: res.instance.pairVersion.versionOid
-            }
-          }
-        }
-      }
+    let specificationOid = await resolveProviderToolListingSpecificationOid({
+      pairVersion: res.instance.pairVersion
     });
+
+    let tools = specificationOid
+      ? await db.providerTool.findMany({
+          where: { specificationOid }
+        })
+      : [];
 
     let grantedScopes = resolveGrantedScopes({
       authConfig: provider.authConfig,

--- a/src/systems/subspace/modules/connection/src/sender/toolSpecification.test.ts
+++ b/src/systems/subspace/modules/connection/src/sender/toolSpecification.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let providerVersionFindFirst = vi.fn();
+
+vi.mock('@metorial-subspace/db', () => ({
+  db: {
+    providerVersion: {
+      findFirst: providerVersionFindFirst
+    }
+  }
+}));
+
+describe('resolveProviderToolListingSpecificationOid', () => {
+  beforeEach(() => {
+    providerVersionFindFirst.mockReset();
+  });
+
+  it('uses the pair version specification when available', async () => {
+    let { resolveProviderToolListingSpecificationOid } = await import('./toolSpecification');
+
+    let specificationOid = await resolveProviderToolListingSpecificationOid({
+      pairVersion: {
+        specificationOid: 10n,
+        versionOid: 20n
+      }
+    });
+
+    expect(specificationOid).toBe(10n);
+    expect(providerVersionFindFirst).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the provider version specification while pair discovery is pending', async () => {
+    let { resolveProviderToolListingSpecificationOid } = await import('./toolSpecification');
+    providerVersionFindFirst.mockResolvedValue({ specificationOid: 30n });
+
+    let specificationOid = await resolveProviderToolListingSpecificationOid({
+      pairVersion: {
+        specificationOid: null,
+        versionOid: 20n
+      }
+    });
+
+    expect(specificationOid).toBe(30n);
+    expect(providerVersionFindFirst).toHaveBeenCalledWith({
+      where: { oid: 20n },
+      select: { specificationOid: true }
+    });
+  });
+});

--- a/src/systems/subspace/modules/connection/src/sender/toolSpecification.ts
+++ b/src/systems/subspace/modules/connection/src/sender/toolSpecification.ts
@@ -1,0 +1,17 @@
+import { db } from '@metorial-subspace/db';
+
+export let resolveProviderToolListingSpecificationOid = async (d: {
+  pairVersion: {
+    specificationOid: bigint | null;
+    versionOid: bigint;
+  };
+}) => {
+  if (d.pairVersion.specificationOid) return d.pairVersion.specificationOid;
+
+  let version = await db.providerVersion.findFirst({
+    where: { oid: d.pairVersion.versionOid },
+    select: { specificationOid: true }
+  });
+
+  return version?.specificationOid ?? null;
+};

--- a/src/systems/subspace/modules/provider-internal/src/queues/deploymentConfigPair/setSpec.test.ts
+++ b/src/systems/subspace/modules/provider-internal/src/queues/deploymentConfigPair/setSpec.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let queues: Record<string, any> = {};
+
+let pairFindFirst = vi.fn();
+let providerVersionFindFirst = vi.fn();
+let pairVersionFindUnique = vi.fn();
+let pairVersionUpsert = vi.fn();
+let providerSpecificationFindFirst = vi.fn();
+let providerVersionUpdate = vi.fn();
+
+let db = {
+  providerDeploymentConfigPair: {
+    findFirst: pairFindFirst
+  },
+  providerVersion: {
+    findFirst: providerVersionFindFirst,
+    update: providerVersionUpdate
+  },
+  providerDeploymentConfigPairProviderVersion: {
+    findUnique: pairVersionFindUnique,
+    upsert: pairVersionUpsert,
+    update: vi.fn()
+  },
+  providerSpecification: {
+    findFirst: providerSpecificationFindFirst
+  },
+  providerDeploymentConfigPairSpecificationChange: {
+    create: vi.fn()
+  },
+  providerSpecificationChangeNotification: {
+    create: vi.fn()
+  }
+};
+
+vi.mock('@lowerdeck/queue', () => ({
+  QueueRetryError: class QueueRetryError extends Error {},
+  createQueue: (opts: { name: string }) => {
+    let queue = {
+      add: vi.fn(),
+      process: vi.fn((processor: unknown) => {
+        queue.processor = processor;
+        return { name: opts.name };
+      }),
+      processor: undefined as unknown
+    };
+    queues[opts.name] = queue;
+    return queue;
+  }
+}));
+
+vi.mock('@metorial-subspace/db', () => ({
+  db,
+  getId: (model: string) => ({ oid: 100n, id: `${model}_id` }),
+  withTransaction: async (fn: (tx: typeof db) => Promise<unknown>) => await fn(db)
+}));
+
+vi.mock('@metorial-subspace/module-monitor/src/queues/schemaChange', () => ({
+  schemaChangeNotificationAlertIngestQueue: { add: vi.fn() }
+}));
+
+vi.mock('../../env', () => ({
+  env: { service: { REDIS_URL: 'redis://localhost:6379' } }
+}));
+
+describe('providerDeploymentConfigPairSetSpecificationQueue', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    queues = {};
+    pairFindFirst.mockReset();
+    providerVersionFindFirst.mockReset();
+    pairVersionFindUnique.mockReset();
+    pairVersionUpsert.mockReset();
+    providerSpecificationFindFirst.mockReset();
+    providerVersionUpdate.mockReset();
+  });
+
+  it('preserves an existing pair specification when a refresh fails', async () => {
+    await import('./setSpec');
+
+    let pair = {
+      oid: 1n,
+      providerDeploymentVersion: {
+        deployment: {
+          providerVariantOid: 2n,
+          tenantOid: 3n,
+          environmentOid: 4n,
+          solutionOid: 5
+        }
+      }
+    };
+    let version = {
+      oid: 6n,
+      providerVariantOid: 2n,
+      previousVersionOid: null,
+      specificationOid: 7n
+    };
+    let existingPairVersion = {
+      oid: 8n,
+      specificationOid: 9n,
+      previousPairVersion: null
+    };
+
+    pairFindFirst.mockResolvedValue(pair);
+    providerVersionFindFirst.mockResolvedValue(version);
+    pairVersionFindUnique.mockResolvedValue(existingPairVersion);
+    providerSpecificationFindFirst.mockResolvedValue({ oid: 7n, type: 'full' });
+    pairVersionUpsert.mockImplementation(async ({ update }) => ({
+      ...existingPairVersion,
+      ...update,
+      specification: { oid: existingPairVersion.specificationOid, type: 'full' }
+    }));
+
+    await queues['sub/pint/pdep/spec/set'].processor({
+      providerDeploymentConfigPairOid: pair.oid,
+      versionOid: version.oid,
+      result: { status: 'failure', discoveryRecordOid: 10n }
+    });
+
+    expect(pairVersionUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          specificationDiscoveryStatus: 'failed',
+          specificationOid: existingPairVersion.specificationOid,
+          latestDiscoveryRecordOid: 10n
+        })
+      })
+    );
+    expect(providerVersionUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/systems/subspace/modules/provider-internal/src/queues/deploymentConfigPair/setSpec.ts
+++ b/src/systems/subspace/modules/provider-internal/src/queues/deploymentConfigPair/setSpec.ts
@@ -86,7 +86,7 @@ export let providerDeploymentConfigPairSetSpecificationQueueProcessor =
     } else {
       result = {
         specificationDiscoveryStatus: 'failed',
-        specificationOid: null
+        specificationOid: existingPairVersion?.specificationOid ?? null
       };
     }
 

--- a/src/systems/subspace/modules/provider-internal/src/queues/deploymentConfigPair/syncSpec.test.ts
+++ b/src/systems/subspace/modules/provider-internal/src/queues/deploymentConfigPair/syncSpec.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let queues: Record<string, any> = {};
+
+let pairFindFirst = vi.fn();
+let providerVersionFindFirstOrThrow = vi.fn();
+let pairVersionFindUnique = vi.fn();
+let providerToolCount = vi.fn();
+let discoveryCreate = vi.fn();
+let getBackend = vi.fn();
+let ensureProviderSpecification = vi.fn();
+let pairSetSpecificationAdd = vi.fn();
+
+let db = {
+  providerDeploymentConfigPair: {
+    findFirst: pairFindFirst
+  },
+  providerVersion: {
+    findFirstOrThrow: providerVersionFindFirstOrThrow
+  },
+  providerDeploymentConfigPairProviderVersion: {
+    findUnique: pairVersionFindUnique
+  },
+  providerTool: {
+    count: providerToolCount
+  },
+  providerDeploymentConfigPairDiscovery: {
+    create: discoveryCreate
+  }
+};
+
+vi.mock('@lowerdeck/queue', () => ({
+  QueueRetryError: class QueueRetryError extends Error {},
+  createQueue: (opts: { name: string }) => {
+    let queue = {
+      add: vi.fn(),
+      process: vi.fn((processor: unknown) => {
+        queue.processor = processor;
+        return { name: opts.name };
+      }),
+      processor: undefined as unknown
+    };
+    queues[opts.name] = queue;
+    return queue;
+  }
+}));
+
+vi.mock('@metorial-subspace/db', () => ({
+  db,
+  getId: (model: string) => ({ oid: 100n, id: `${model}_id` })
+}));
+
+vi.mock('@metorial-subspace/provider', () => ({
+  getBackend
+}));
+
+vi.mock('../../services/providerSpecification', () => ({
+  providerSpecificationInternalService: {
+    ensureProviderSpecification
+  }
+}));
+
+vi.mock('./setSpec', () => ({
+  providerDeploymentConfigPairSetSpecificationQueue: {
+    add: pairSetSpecificationAdd
+  }
+}));
+
+vi.mock('../../env', () => ({
+  env: { service: { REDIS_URL: 'redis://localhost:6379' } }
+}));
+
+describe('providerDeploymentConfigPairSyncSpecificationQueue', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    queues = {};
+    pairFindFirst.mockReset();
+    providerVersionFindFirstOrThrow.mockReset();
+    pairVersionFindUnique.mockReset();
+    providerToolCount.mockReset();
+    discoveryCreate.mockReset();
+    getBackend.mockReset();
+    ensureProviderSpecification.mockReset();
+    pairSetSpecificationAdd.mockReset();
+  });
+
+  it('does not promote an empty remote discovery over an existing non-empty pair spec', async () => {
+    await import('./syncSpec');
+
+    let pair = {
+      oid: 1n,
+      id: 'pair_1',
+      tenant: { oid: 2n },
+      providerConfigVersion: { oid: 3n },
+      providerAuthConfigVersion: null,
+      providerDeploymentVersion: {
+        oid: 4n,
+        deployment: {
+          provider: { id: 'provider_1' },
+          providerVariant: { id: 'provider_variant_1' }
+        }
+      }
+    };
+    let version = {
+      oid: 5n,
+      id: 'provider_version_1',
+      specification: { oid: 6n, type: 'full' },
+      shuttleServer: { type: 'remote' }
+    };
+    let existingPairVersion = {
+      oid: 7n,
+      specificationOid: 8n
+    };
+    let backend = {
+      capabilities: {
+        getSpecificationForProviderPair: vi.fn().mockResolvedValue({
+          status: 'success',
+          type: 'full',
+          specification: { specId: 'empty', key: 'remote', name: 'Remote' },
+          authMethods: [],
+          features: { supportsAuthMethod: false, configContainsAuth: true },
+          tools: [],
+          triggers: []
+        })
+      }
+    };
+
+    pairFindFirst.mockResolvedValue(pair);
+    providerVersionFindFirstOrThrow.mockResolvedValue(version);
+    pairVersionFindUnique.mockResolvedValue(existingPairVersion);
+    providerToolCount.mockResolvedValue(1);
+    discoveryCreate.mockResolvedValue({ oid: 9n });
+    getBackend.mockResolvedValue(backend);
+
+    await queues['sub/pint/pdep/spec/sync'].processor({
+      providerDeploymentConfigPairId: pair.id,
+      versionId: version.id
+    });
+
+    expect(ensureProviderSpecification).not.toHaveBeenCalled();
+    expect(discoveryCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        status: 'succeeded_with_warnings',
+        warnings: [
+          expect.objectContaining({
+            code: 'empty_tools_discovery_result'
+          })
+        ]
+      })
+    });
+    expect(pairSetSpecificationAdd).toHaveBeenCalledWith({
+      providerDeploymentConfigPairOid: pair.oid,
+      versionOid: version.oid,
+      result: { status: 'failure', discoveryRecordOid: 9n }
+    });
+  });
+});

--- a/src/systems/subspace/modules/provider-internal/src/queues/deploymentConfigPair/syncSpec.ts
+++ b/src/systems/subspace/modules/provider-internal/src/queues/deploymentConfigPair/syncSpec.ts
@@ -6,6 +6,11 @@ import { env } from '../../env';
 import { providerSpecificationInternalService } from '../../services/providerSpecification';
 import { providerDeploymentConfigPairSetSpecificationQueue } from './setSpec';
 
+let hasProviderTools = async (specificationOid: bigint) =>
+  (await db.providerTool.count({
+    where: { specificationOid }
+  })) > 0;
+
 export let providerDeploymentConfigPairSyncSpecificationQueue = createQueue<{
   providerDeploymentConfigPairId: string;
   versionId: string;
@@ -41,7 +46,16 @@ export let providerDeploymentConfigPairSyncSpecificationQueueProcessor =
 
     let version = await db.providerVersion.findFirstOrThrow({
       where: { id: data.versionId },
-      include: { specification: true }
+      include: { specification: true, shuttleServer: true }
+    });
+
+    let existingPairVersion = await db.providerDeploymentConfigPairProviderVersion.findUnique({
+      where: {
+        pairOid_versionOid: {
+          pairOid: pair.oid,
+          versionOid: version.oid
+        }
+      }
     });
 
     try {
@@ -88,15 +102,36 @@ export let providerDeploymentConfigPairSyncSpecificationQueueProcessor =
         console.error('Error discovering capabilities:', e);
       }
 
+      let warnings = [...(capabilities?.warnings ?? [])];
+      let shouldPreserveExistingSpec =
+        capabilities?.status === 'success' &&
+        version.shuttleServer?.type === 'remote' &&
+        existingPairVersion?.specificationOid &&
+        capabilities.tools.length === 0 &&
+        (await hasProviderTools(existingPairVersion.specificationOid));
+
+      if (shouldPreserveExistingSpec) {
+        warnings.push({
+          code: 'empty_tools_discovery_result',
+          message:
+            'Remote provider discovery returned no tools after a previous non-empty specification; keeping the existing specification.',
+          data: {
+            providerDeploymentConfigPairId: pair.id,
+            providerVersionId: version.id,
+            existingSpecificationOid: existingPairVersion!.specificationOid!.toString()
+          }
+        });
+      }
+
       let record =
-        capabilities?.warnings?.length || capabilities?.status == 'failure'
+        warnings.length || capabilities?.status == 'failure'
           ? await db.providerDeploymentConfigPairDiscovery.create({
               data: {
                 ...getId('providerDeploymentConfigPairDiscovery'),
                 status:
-                  capabilities.status === 'success' ? 'succeeded_with_warnings' : 'failed',
-                error: capabilities.status === 'failure' ? capabilities.error : null,
-                warnings: capabilities.warnings,
+                  capabilities?.status === 'success' ? 'succeeded_with_warnings' : 'failed',
+                error: capabilities?.status === 'failure' ? capabilities.error : null,
+                warnings,
                 pairOid: pair.oid,
                 versionOid: version.oid
               }
@@ -105,6 +140,15 @@ export let providerDeploymentConfigPairSyncSpecificationQueueProcessor =
 
       // Some backends might need a config to be able to discover specifications
       if (!capabilities || capabilities.status == 'failure') {
+        await providerDeploymentConfigPairSetSpecificationQueue.add({
+          providerDeploymentConfigPairOid: pair.oid,
+          versionOid: version.oid,
+          result: { status: 'failure', discoveryRecordOid: record?.oid }
+        });
+        return;
+      }
+
+      if (shouldPreserveExistingSpec) {
         await providerDeploymentConfigPairSetSpecificationQueue.add({
           providerDeploymentConfigPairOid: pair.oid,
           versionOid: version.oid,

--- a/src/systems/subspace/modules/provider-internal/src/queues/version/setSpec.test.ts
+++ b/src/systems/subspace/modules/provider-internal/src/queues/version/setSpec.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let queues: Record<string, any> = {};
+
+let providerVersionFindFirst = vi.fn();
+let providerVersionUpdate = vi.fn();
+let providerAuthConfigUpdateMany = vi.fn();
+let providerAuthCredentialsUpdateMany = vi.fn();
+
+let db = {
+  providerVersion: {
+    findFirst: providerVersionFindFirst,
+    update: providerVersionUpdate
+  },
+  providerAuthConfig: {
+    updateMany: providerAuthConfigUpdateMany
+  },
+  providerAuthCredentials: {
+    updateMany: providerAuthCredentialsUpdateMany
+  },
+  providerVersionSpecificationChange: {
+    create: vi.fn()
+  },
+  providerSpecificationChangeNotification: {
+    create: vi.fn()
+  }
+};
+
+vi.mock('@lowerdeck/queue', () => ({
+  QueueRetryError: class QueueRetryError extends Error {},
+  createQueue: (opts: { name: string }) => {
+    let queue = {
+      add: vi.fn(),
+      process: vi.fn((processor: unknown) => {
+        queue.processor = processor;
+        return { name: opts.name };
+      }),
+      processor: undefined as unknown
+    };
+    queues[opts.name] = queue;
+    return queue;
+  }
+}));
+
+vi.mock('@metorial-subspace/db', () => ({
+  db,
+  getId: (model: string) => ({ oid: 100n, id: `${model}_id` })
+}));
+
+vi.mock('@metorial-subspace/module-monitor/src/queues/schemaChange', () => ({
+  schemaChangeNotificationAlertIngestQueue: { add: vi.fn() }
+}));
+
+vi.mock('../../env', () => ({
+  env: { service: { REDIS_URL: 'redis://localhost:6379' } }
+}));
+
+describe('providerVersionSetSpecificationQueue', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    queues = {};
+    providerVersionFindFirst.mockReset();
+    providerVersionUpdate.mockReset();
+    providerAuthConfigUpdateMany.mockReset();
+    providerAuthCredentialsUpdateMany.mockReset();
+  });
+
+  for (let status of ['not_discoverable', 'waiting_for_pair'] as const) {
+    it(`preserves the existing specification when status becomes ${status}`, async () => {
+      await import('./setSpec');
+
+      let version = {
+        oid: 1n,
+        id: 'provider_version_1',
+        providerOid: 2n,
+        specificationOid: 3n,
+        previousVersionOid: null
+      };
+      providerVersionFindFirst.mockResolvedValue(version);
+      providerVersionUpdate.mockImplementation(async ({ data }) => ({ ...version, ...data }));
+
+      await queues['sub/pint/pver/spec/set'].processor({
+        versionOid: version.oid,
+        result: { status }
+      });
+
+      expect(providerVersionUpdate).toHaveBeenCalledWith({
+        where: { oid: version.oid },
+        data: {
+          specificationDiscoveryStatus: status,
+          specificationOid: version.specificationOid
+        }
+      });
+      expect(providerAuthConfigUpdateMany).not.toHaveBeenCalled();
+      expect(providerAuthCredentialsUpdateMany).not.toHaveBeenCalled();
+    });
+  }
+});

--- a/src/systems/subspace/modules/provider-internal/src/queues/version/setSpec.ts
+++ b/src/systems/subspace/modules/provider-internal/src/queues/version/setSpec.ts
@@ -47,7 +47,7 @@ export let providerVersionSetSpecificationQueueProcessor =
     } else {
       result = {
         specificationDiscoveryStatus: data.result.status,
-        specificationOid: null
+        specificationOid: version.specificationOid
       };
     }
 

--- a/src/systems/subspace/modules/provider-internal/src/queues/version/syncSpec.test.ts
+++ b/src/systems/subspace/modules/provider-internal/src/queues/version/syncSpec.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let queues: Record<string, any> = {};
+
+let providerVersionFindFirst = vi.fn();
+let providerToolCount = vi.fn();
+let getBackend = vi.fn();
+let ensureProviderSpecification = vi.fn();
+let providerVersionSetSpecificationAdd = vi.fn();
+
+let db = {
+  providerVersion: {
+    findFirst: providerVersionFindFirst
+  },
+  providerTool: {
+    count: providerToolCount
+  }
+};
+
+vi.mock('@lowerdeck/queue', () => ({
+  QueueRetryError: class QueueRetryError extends Error {},
+  createQueue: (opts: { name: string }) => {
+    let queue = {
+      add: vi.fn(),
+      process: vi.fn((processor: unknown) => {
+        queue.processor = processor;
+        return { name: opts.name };
+      }),
+      processor: undefined as unknown
+    };
+    queues[opts.name] = queue;
+    return queue;
+  }
+}));
+
+vi.mock('@metorial-subspace/db', () => ({
+  db
+}));
+
+vi.mock('@metorial-subspace/provider', () => ({
+  getBackend
+}));
+
+vi.mock('../../services/providerSpecification', () => ({
+  providerSpecificationInternalService: {
+    ensureProviderSpecification
+  }
+}));
+
+vi.mock('./setSpec', () => ({
+  providerVersionSetSpecificationQueue: {
+    add: providerVersionSetSpecificationAdd
+  }
+}));
+
+vi.mock('../../env', () => ({
+  env: { service: { REDIS_URL: 'redis://localhost:6379' } }
+}));
+
+describe('providerVersionSyncSpecificationQueue', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    queues = {};
+    providerVersionFindFirst.mockReset();
+    providerToolCount.mockReset();
+    getBackend.mockReset();
+    ensureProviderSpecification.mockReset();
+    providerVersionSetSpecificationAdd.mockReset();
+  });
+
+  it('does not replace an existing full spec with a preliminary version spec', async () => {
+    await import('./syncSpec');
+
+    let version = {
+      oid: 1n,
+      id: 'provider_version_1',
+      specificationOid: 2n,
+      specification: { oid: 2n, type: 'full' },
+      provider: {
+        id: 'provider_1',
+        ownerTenant: null
+      },
+      providerVariant: { id: 'provider_variant_1' },
+      shuttleServer: { type: 'remote' }
+    };
+    let backend = {
+      capabilities: {
+        getSpecificationBehavior: vi.fn().mockResolvedValue({
+          supportsVersionSpecification: true,
+          supportsDeploymentSpecification: true
+        }),
+        getSpecificationForProviderVersion: vi.fn().mockResolvedValue({
+          status: 'success',
+          type: 'preliminary',
+          specification: { specId: 'preliminary', key: 'remote', name: 'Remote' },
+          authMethods: [],
+          features: { supportsAuthMethod: false, configContainsAuth: true },
+          tools: [],
+          triggers: []
+        })
+      }
+    };
+
+    providerVersionFindFirst.mockResolvedValue(version);
+    getBackend.mockResolvedValue(backend);
+
+    await queues['sub/pint/pver/spec/sync'].processor({
+      providerVersionId: version.id
+    });
+
+    expect(ensureProviderSpecification).not.toHaveBeenCalled();
+    expect(providerVersionSetSpecificationAdd).not.toHaveBeenCalled();
+  });
+});

--- a/src/systems/subspace/modules/provider-internal/src/queues/version/syncSpec.ts
+++ b/src/systems/subspace/modules/provider-internal/src/queues/version/syncSpec.ts
@@ -6,6 +6,11 @@ import { env } from '../../env';
 import { providerSpecificationInternalService } from '../../services/providerSpecification';
 import { providerVersionSetSpecificationQueue } from './setSpec';
 
+let hasProviderTools = async (specificationOid: bigint) =>
+  (await db.providerTool.count({
+    where: { specificationOid }
+  })) > 0;
+
 export let providerVersionSyncSpecificationQueue = createQueue<{ providerVersionId: string }>({
   name: 'sub/pint/pver/spec/sync',
   redisUrl: env.service.REDIS_URL,
@@ -22,7 +27,12 @@ export let providerVersionSyncSpecificationQueueProcessor =
   providerVersionSyncSpecificationQueue.process(async data => {
     let version = await db.providerVersion.findFirst({
       where: { id: data.providerVersionId },
-      include: { provider: { include: { ownerTenant: true } }, providerVariant: true }
+      include: {
+        provider: { include: { ownerTenant: true } },
+        providerVariant: true,
+        specification: true,
+        shuttleServer: true
+      }
     });
     if (!version) throw new QueueRetryError();
 
@@ -61,6 +71,36 @@ export let providerVersionSyncSpecificationQueueProcessor =
           versionOid: version.oid,
           result: { status: 'not_discoverable' }
         });
+        return;
+      }
+
+      if (version.specification?.type === 'full' && capabilities.type === 'preliminary') {
+        console.warn(
+          'Skipping preliminary provider version specification over existing full spec',
+          {
+            providerVersionId: version.id,
+            providerId: version.provider.id,
+            existingSpecificationOid: version.specificationOid?.toString()
+          }
+        );
+        return;
+      }
+
+      if (
+        version.shuttleServer?.type === 'remote' &&
+        version.specificationOid &&
+        capabilities.tools.length === 0 &&
+        (await hasProviderTools(version.specificationOid))
+      ) {
+        console.warn(
+          'Skipping empty remote provider version specification over existing tools',
+          {
+            providerVersionId: version.id,
+            providerId: version.provider.id,
+            existingSpecificationOid: version.specificationOid.toString(),
+            newSpecificationType: capabilities.type
+          }
+        );
         return;
       }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes discovery failure semantics and which specification OIDs sessions use for tool lists; incorrect guards could hide real spec updates or leave stale tools, but behavior is heavily covered by new queue tests.
> 
> **Overview**
> Hardens **remote MCP tool discovery** so flaky or empty rediscoveries do not wipe usable tool specs, and makes shuttle **tools/list** a required step when the server advertises tool support.
> 
> **Shuttle discovery** treats advertised `tools/list` as mandatory via `doWithRequiredCheck` (fail discovery on MCP “method does not exist”; still allow an empty tool list). **Provider spec sync** skips replacing a **full** spec with a **preliminary** one, and for **remote** servers refuses to apply discovery that returns **zero tools** when the stored spec still has tools—recording `empty_tools_discovery_result` and routing through a failure path that **keeps the prior specification**. **Set-spec** queues on failure now retain the existing `specificationOid` instead of clearing it (pair and provider version).
> 
> **Sessions** only surface `provider_discovery_failed` when discovery failed **and** there is no specification to fall back to; tool listing resolves specs through `resolveProviderToolListingSpecificationOid` (pair version first, then provider version while pair discovery is pending). Slates hub public/internal servers get a short **idleTimeout** on `Bun.serve`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31a5e840edf67d2ba37d286750c632a04b0818f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->