### PR TITLE
Add auth method an tool filtering

### DIFF
--- a/src/systems/slates/apps/hub/src/presenters/slateAction.ts
+++ b/src/systems/slates/apps/hub/src/presenters/slateAction.ts
@@ -27,6 +27,7 @@ export let slateActionPresenter = (
   metadata: method.spec.metadata,
   tags: method.spec.tags,
   scopes: method.spec.scopes,
+  authMethods: method.spec.authMethods,
 
   createdAt: method.createdAt
 });

--- a/src/systems/slates/apps/hub/src/queues/instance/processAuth.test.ts
+++ b/src/systems/slates/apps/hub/src/queues/instance/processAuth.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let queues: Record<string, any> = {};
+
+let slateAuthConfigFindFirst = vi.fn();
+let slateAuthConfigUpdateMany = vi.fn();
+let slateVersionFindUnique = vi.fn();
+let decryptSecret = vi.fn();
+let updateSecret = vi.fn();
+let createInvocation = vi.fn();
+let getAuthOutput = vi.fn();
+let sendUpdatedAuthInput = vi.fn();
+let updateProfileQueueAdd = vi.fn();
+
+let db = {
+  slateAuthConfig: {
+    findFirst: slateAuthConfigFindFirst,
+    updateMany: slateAuthConfigUpdateMany
+  },
+  slateVersion: {
+    findUnique: slateVersionFindUnique
+  }
+};
+
+vi.mock('@lowerdeck/queue', () => ({
+  QueueRetryError: class QueueRetryError extends Error {},
+  createQueue: (opts: { name: string }) => {
+    let queue = {
+      add: vi.fn(),
+      process: vi.fn((processor: unknown) => {
+        queue.processor = processor;
+        return { name: opts.name };
+      }),
+      processor: undefined as unknown
+    };
+    queues[opts.name] = queue;
+    return queue;
+  }
+}));
+
+vi.mock('../../db', () => ({
+  db
+}));
+
+vi.mock('../../env', () => ({
+  env: { service: { REDIS_URL: 'redis://localhost:6379' } }
+}));
+
+vi.mock('../../services', () => ({
+  secretService: {
+    DANGEROUSLY_decryptSecret: decryptSecret,
+    DANGEROUSLY_updateSecret: updateSecret
+  },
+  slateErrorService: {
+    recordSlateError: vi.fn()
+  },
+  slateInvocationService: {
+    createInvocation,
+    getAuthOutput,
+    sendUpdatedAuthInput
+  }
+}));
+
+vi.mock('./updateProfile', () => ({
+  updateProfileQueue: {
+    add: updateProfileQueueAdd
+  }
+}));
+
+describe('processAuthQueueProcessor', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    queues = {};
+    slateAuthConfigFindFirst.mockReset();
+    slateAuthConfigUpdateMany.mockReset();
+    slateVersionFindUnique.mockReset();
+    decryptSecret.mockReset();
+    updateSecret.mockReset();
+    createInvocation.mockReset();
+    getAuthOutput.mockReset();
+    sendUpdatedAuthInput.mockReset();
+    updateProfileQueueAdd.mockReset();
+  });
+
+  it('stores non-empty getOutput scopes as granted scopes', async () => {
+    await import('./processAuth');
+
+    slateAuthConfigFindFirst.mockResolvedValue({
+      oid: 1n,
+      id: 'slateAuthConfig_1',
+      secretOid: 2n,
+      tokenExpiresAt: undefined,
+      authMethod: {
+        key: 'token_auth',
+        spec: {
+          capabilities: {
+            handleChangedInput: { enabled: false },
+            getProfile: { enabled: false }
+          }
+        }
+      },
+      oauthCredentials: null,
+      instance: null,
+      slate: {
+        oid: 3n,
+        currentVersionOid: 4n
+      },
+      tenant: {
+        oid: 5n
+      }
+    });
+    slateVersionFindUnique.mockResolvedValue({ oid: 4n });
+    decryptSecret.mockResolvedValue({
+      input: {
+        token: 'token'
+      }
+    });
+    createInvocation.mockResolvedValue({ id: 'stack' });
+    getAuthOutput.mockResolvedValue({
+      status: 'success',
+      data: {
+        output: {
+          token: 'token'
+        },
+        scopes: ['scope:read']
+      }
+    });
+
+    await queues['shub/soat/procAuth'].processor({ configId: 'slateAuthConfig_1' });
+
+    expect(updateSecret).toHaveBeenCalledWith(
+      expect.objectContaining({
+        secretData: {
+          input: {
+            token: 'token'
+          },
+          output: {
+            token: 'token'
+          }
+        }
+      })
+    );
+    expect(slateAuthConfigUpdateMany).toHaveBeenLastCalledWith({
+      where: { oid: 1n },
+      data: {
+        isProcessing: false,
+        errorCode: null,
+        errorMessage: null,
+        errorInvocationId: null,
+        grantedScopes: ['scope:read']
+      }
+    });
+  });
+});

--- a/src/systems/slates/apps/hub/src/queues/instance/processAuth.ts
+++ b/src/systems/slates/apps/hub/src/queues/instance/processAuth.ts
@@ -39,6 +39,7 @@ export let processAuthQueueProcessor = processAuthQueue.process(async data => {
   });
 
   let secretUpdated = false;
+  let grantedScopes: string[] | undefined;
 
   if (
     decrypted.input &&
@@ -124,6 +125,9 @@ export let processAuthQueueProcessor = processAuthQueue.process(async data => {
     }
 
     decrypted.output = res.data.output;
+    if (res.data.scopes?.length) {
+      grantedScopes = res.data.scopes;
+    }
     secretUpdated = true;
   }
 
@@ -146,7 +150,13 @@ export let processAuthQueueProcessor = processAuthQueue.process(async data => {
 
   await db.slateAuthConfig.updateMany({
     where: { oid: authConfig.oid },
-    data: { isProcessing: false, errorCode: null, errorMessage: null, errorInvocationId: null }
+    data: {
+      isProcessing: false,
+      errorCode: null,
+      errorMessage: null,
+      errorInvocationId: null,
+      ...(grantedScopes ? { grantedScopes } : {})
+    }
   });
 
   if (authConfig.authMethod.spec.capabilities.getProfile?.enabled) {

--- a/src/systems/subspace/modules/catalog/src/services/providerTool.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerTool.ts
@@ -6,12 +6,14 @@ import {
   type Environment,
   type ProviderAuthConfig,
   type ProviderAuthCredentials,
+  type ProviderAuthMethod,
   type ProviderSpecification,
   type ProviderVersion,
   type Solution,
   type Tenant
 } from '@metorial-subspace/db';
 import {
+  checkToolAuthMethodSatisfied,
   checkToolScopesSatisfied,
   resolveGrantedScopes
 } from '@metorial-subspace/module-provider-internal';
@@ -180,7 +182,7 @@ class providerToolServiceImpl {
 
     providerVersion: ProviderVersion;
 
-    providerAuthConfig?: ProviderAuthConfig | null;
+    providerAuthConfig?: (ProviderAuthConfig & { authMethod?: ProviderAuthMethod | null }) | null;
     providerAuthCredentials?: ProviderAuthCredentials | null;
   }) {
     let version = d.providerVersion?.oid
@@ -201,16 +203,31 @@ class providerToolServiceImpl {
       authConfig: d.providerAuthConfig,
       authCredentials: d.providerAuthCredentials
     });
+    let authMethod = d.providerAuthConfig
+      ? ((d.providerAuthConfig as any).authMethod ??
+        (await db.providerAuthMethod.findUnique({
+          where: { oid: d.providerAuthConfig.authMethodOid }
+        })))
+      : null;
 
-    if (grantedScopes === null) {
+    if (grantedScopes === null && !d.providerAuthConfig) {
       return Paginator.create(({ prisma }) => prisma(opts => queryTools(ctx, opts)));
     }
 
     return Paginator.create(() => async input => {
       let allTools = await queryTools(ctx);
-      let filtered = allTools.filter(
-        tool => checkToolScopesSatisfied(tool, grantedScopes).allowed
-      );
+      let filtered = allTools.filter(tool => {
+        if (
+          d.providerAuthConfig &&
+          !checkToolAuthMethodSatisfied(tool, authMethod).allowed
+        ) {
+          return false;
+        }
+
+        return grantedScopes === null
+          ? true
+          : checkToolScopesSatisfied(tool, grantedScopes).allowed;
+      });
       return paginateInMemory(filtered, input);
     });
   }

--- a/src/systems/subspace/modules/connection/src/sender/manager.ts
+++ b/src/systems/subspace/modules/connection/src/sender/manager.ts
@@ -17,6 +17,7 @@ import {
   ID,
   type ProviderAuthConfig,
   type ProviderAuthCredentials,
+  type ProviderAuthMethod,
   type ProviderDeployment,
   type Session,
   type SessionConnection,
@@ -36,6 +37,7 @@ import {
 } from '@metorial-subspace/module-agent';
 import { enclaveIngressPolicyService } from '@metorial-subspace/module-enclave';
 import {
+  checkToolAuthMethodSatisfied,
   checkToolAccess,
   checkToolScopesSatisfied,
   providerDeploymentConfigPairInternalService,
@@ -543,7 +545,10 @@ export class SenderManager {
       provider: { name: string };
       deployment: ProviderDeployment;
       authConfig?:
-        | (ProviderAuthConfig & { authCredentials?: ProviderAuthCredentials | null })
+        | (ProviderAuthConfig & {
+            authCredentials?: ProviderAuthCredentials | null;
+            authMethod?: ProviderAuthMethod | null;
+          })
         | null;
     }
   ) {
@@ -567,6 +572,10 @@ export class SenderManager {
         })
       : [];
 
+    let authMethodFilteredTools = tools.filter(
+      tool => checkToolAuthMethodSatisfied(tool, provider.authConfig?.authMethod).allowed
+    );
+
     let grantedScopes = resolveGrantedScopes({
       authConfig: provider.authConfig,
       authCredentials: provider.authConfig?.authCredentials
@@ -574,8 +583,10 @@ export class SenderManager {
 
     let scopeFilteredTools =
       grantedScopes === null
-        ? tools
-        : tools.filter(tool => checkToolScopesSatisfied(tool, grantedScopes).allowed);
+        ? authMethodFilteredTools
+        : authMethodFilteredTools.filter(
+            tool => checkToolScopesSatisfied(tool, grantedScopes).allowed
+          );
 
     return {
       status: 'ok' as const,
@@ -595,7 +606,7 @@ export class SenderManager {
         provider: true,
         deployment: true,
         config: true,
-        authConfig: { include: { authCredentials: true } }
+        authConfig: { include: { authCredentials: true, authMethod: true } }
       }
     });
 
@@ -665,7 +676,7 @@ export class SenderManager {
         provider: true,
         deployment: true,
         config: true,
-        authConfig: { include: { authCredentials: true } }
+        authConfig: { include: { authCredentials: true, authMethod: true } }
       }
     });
     if (!provider) throw new ServiceError(notFoundError('provider', d.tag));
@@ -702,7 +713,10 @@ export class SenderManager {
     provider: SessionProvider & {
       provider: { name: string };
       authConfig?:
-        | (ProviderAuthConfig & { authCredentials?: ProviderAuthCredentials | null })
+        | (ProviderAuthConfig & {
+            authCredentials?: ProviderAuthCredentials | null;
+            authMethod?: ProviderAuthMethod | null;
+          })
         | null;
     };
     originalToolName: string;
@@ -745,6 +759,13 @@ export class SenderManager {
     let { allowed } = checkToolAccess(tool, d.provider, 'call');
     if (!allowed) {
       throw new ServiceError(badRequestError({ message: 'Tool access not allowed' }));
+    }
+
+    let authMethodCheck = checkToolAuthMethodSatisfied(tool, d.provider.authConfig?.authMethod);
+    if (!authMethodCheck.allowed) {
+      throw new ServiceError(
+        badRequestError({ message: 'Tool is not available for this authentication method' })
+      );
     }
 
     let grantedScopes = resolveGrantedScopes({

--- a/src/systems/subspace/modules/provider-internal/src/index.ts
+++ b/src/systems/subspace/modules/provider-internal/src/index.ts
@@ -1,5 +1,6 @@
 export * from './services';
 
 export * from './lib/checkProviderMatch';
+export * from './lib/toolAuthMethods';
 export * from './lib/toolFilter';
 export * from './lib/toolScopes';

--- a/src/systems/subspace/modules/provider-internal/src/lib/toolAuthMethods.test.ts
+++ b/src/systems/subspace/modules/provider-internal/src/lib/toolAuthMethods.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { checkToolAuthMethodSatisfied, filterToolsByAuthMethod } from './toolAuthMethods';
+
+let createTool = (authMethods?: string[] | null) =>
+  ({
+    id: 'ptl_x',
+    value: {
+      authMethods
+    }
+  }) as any;
+
+describe('checkToolAuthMethodSatisfied', () => {
+  it('allows tools without auth method restrictions', () => {
+    expect(checkToolAuthMethodSatisfied(createTool(undefined), null)).toEqual({ allowed: true });
+    expect(checkToolAuthMethodSatisfied(createTool(null), { key: 'token_auth' })).toEqual({
+      allowed: true
+    });
+    expect(checkToolAuthMethodSatisfied(createTool([]), { key: 'token_auth' })).toEqual({
+      allowed: true
+    });
+  });
+
+  it('allows tools when the active auth method key is listed', () => {
+    expect(
+      checkToolAuthMethodSatisfied(createTool(['token_auth', 'service_account']), {
+        key: 'service_account'
+      })
+    ).toEqual({ allowed: true });
+  });
+
+  it('denies tools when the active auth method is missing or different', () => {
+    expect(checkToolAuthMethodSatisfied(createTool(['token_auth']), null)).toEqual({
+      allowed: false
+    });
+    expect(checkToolAuthMethodSatisfied(createTool(['token_auth']), { key: 'oauth' })).toEqual({
+      allowed: false
+    });
+  });
+});
+
+describe('filterToolsByAuthMethod', () => {
+  it('filters out tools unavailable for the active auth method', () => {
+    let tokenOnly = createTool(['token_auth']);
+    let oauthOnly = createTool(['oauth']);
+    let unrestricted = createTool(null);
+
+    expect(filterToolsByAuthMethod([tokenOnly, oauthOnly, unrestricted], { key: 'token_auth' }))
+      .toEqual([tokenOnly, unrestricted]);
+  });
+});

--- a/src/systems/subspace/modules/provider-internal/src/lib/toolAuthMethods.ts
+++ b/src/systems/subspace/modules/provider-internal/src/lib/toolAuthMethods.ts
@@ -1,0 +1,26 @@
+import type { ProviderAuthMethod, ProviderTool } from '@metorial-subspace/db';
+
+export type ToolAuthMethodCarrier = Pick<ProviderTool, 'value'>;
+
+export type ToolAuthMethodSource = Pick<ProviderAuthMethod, 'key'> | null | undefined;
+
+export let checkToolAuthMethodSatisfied = (
+  tool: ToolAuthMethodCarrier,
+  authMethod: ToolAuthMethodSource
+) => {
+  let toolAuthMethods = tool.value?.authMethods;
+  if (!Array.isArray(toolAuthMethods) || toolAuthMethods.length === 0) {
+    return { allowed: true as const };
+  }
+
+  if (!authMethod?.key) {
+    return { allowed: false as const };
+  }
+
+  return { allowed: toolAuthMethods.includes(authMethod.key) };
+};
+
+export let filterToolsByAuthMethod = <T extends ToolAuthMethodCarrier>(
+  tools: T[],
+  authMethod: ToolAuthMethodSource
+): T[] => tools.filter(tool => checkToolAuthMethodSatisfied(tool, authMethod).allowed);

--- a/src/systems/subspace/provider-backends/provider-slates/src/impl/capabilities.ts
+++ b/src/systems/subspace/provider-backends/provider-slates/src/impl/capabilities.ts
@@ -174,6 +174,7 @@ export class ProviderCapabilities extends IProviderCapabilities {
           type: 'tool.callable'
         },
         scopes: t.scopes ?? null,
+        authMethods: t.authMethods ?? null,
         tags: t.tags,
         metadata: {}
       }))

--- a/src/systems/subspace/provider-backends/provider-utils/src/types/specification.ts
+++ b/src/systems/subspace/provider-backends/provider-utils/src/types/specification.ts
@@ -84,6 +84,7 @@ export interface SpecificationTool {
   };
 
   scopes?: SpecificationActionScopes | null;
+  authMethods?: string[] | null;
 
   metadata: Record<string, any>;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which tools appear in catalog and MCP sessions and blocks tool calls by auth method; scope persistence on auth config affects downstream scope filtering.
> 
> **Overview**
> Adds **per-tool `authMethods`** on specifications and slate actions, and enforces that only tools allowed for the **active provider auth method** are listed or callable.
> 
> A new `checkToolAuthMethodSatisfied` helper treats empty/missing restrictions as unrestricted; otherwise the tool’s `value.authMethods` must include the auth method **key**. Catalog `listProviderTools` and session `SenderManager` apply this filter alongside existing scope checks, load `authMethod` on auth configs, and reject tool calls when the method does not match.
> 
> Slate auth processing now persists **`grantedScopes`** on `slateAuthConfig` when `getAuthOutput` returns non-empty scopes. Provider-slates capability mapping passes `authMethods` through from slate tools into the shared specification shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0691f01c390de891e5ec5caf0d13fc7d9c7f12d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->