### PR TITLE
Add integration magic mcp servers

### DIFF
--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/magic-mcp-servers/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/magic-mcp-servers/create.ts
@@ -129,6 +129,17 @@ export type DashboardInstanceMagicMcpServersCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  integrationId: string | null;
+  integrationInstanceId: string | null;
+  consumerOwners: {
+    consumerIntegrationId: string | null;
+    consumerId: string;
+    consumerProfileId: string;
+    consumerName: string;
+    consumerEmail: string;
+    consumerProfileName: string;
+    consumerProfileEmail: string;
+  }[];
   providers: ({
     object: 'magic_mcp.server.provider';
     id: string;
@@ -542,7 +553,44 @@ export let mapDashboardInstanceMagicMcpServersCreateOutput = mtMap.union([
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      consumerOwners: mtMap.objectField(
+        'consumer_owners',
+        mtMap.array(
+          mtMap.object({
+            consumerIntegrationId: mtMap.objectField(
+              'consumer_integration_id',
+              mtMap.passthrough()
+            ),
+            consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+            consumerProfileId: mtMap.objectField(
+              'consumer_profile_id',
+              mtMap.passthrough()
+            ),
+            consumerName: mtMap.objectField(
+              'consumer_name',
+              mtMap.passthrough()
+            ),
+            consumerEmail: mtMap.objectField(
+              'consumer_email',
+              mtMap.passthrough()
+            ),
+            consumerProfileName: mtMap.objectField(
+              'consumer_profile_name',
+              mtMap.passthrough()
+            ),
+            consumerProfileEmail: mtMap.objectField(
+              'consumer_profile_email',
+              mtMap.passthrough()
+            )
+          })
+        )
+      )
     })
   )
 ]);
@@ -552,6 +600,7 @@ export type DashboardInstanceMagicMcpServersCreateBody = {
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
   providerTemplateId?: string | undefined;
+  integrationInstanceId?: string | undefined;
   consumerProfileId?: string | undefined;
 };
 
@@ -562,6 +611,10 @@ export let mapDashboardInstanceMagicMcpServersCreateBody =
     metadata: mtMap.objectField('metadata', mtMap.passthrough()),
     providerTemplateId: mtMap.objectField(
       'provider_template_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
       mtMap.passthrough()
     ),
     consumerProfileId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/magic-mcp-servers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/magic-mcp-servers/delete.ts
@@ -129,6 +129,17 @@ export type DashboardInstanceMagicMcpServersDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  integrationId: string | null;
+  integrationInstanceId: string | null;
+  consumerOwners: {
+    consumerIntegrationId: string | null;
+    consumerId: string;
+    consumerProfileId: string;
+    consumerName: string;
+    consumerEmail: string;
+    consumerProfileName: string;
+    consumerProfileEmail: string;
+  }[];
   providers: ({
     object: 'magic_mcp.server.provider';
     id: string;
@@ -542,7 +553,44 @@ export let mapDashboardInstanceMagicMcpServersDeleteOutput = mtMap.union([
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      consumerOwners: mtMap.objectField(
+        'consumer_owners',
+        mtMap.array(
+          mtMap.object({
+            consumerIntegrationId: mtMap.objectField(
+              'consumer_integration_id',
+              mtMap.passthrough()
+            ),
+            consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+            consumerProfileId: mtMap.objectField(
+              'consumer_profile_id',
+              mtMap.passthrough()
+            ),
+            consumerName: mtMap.objectField(
+              'consumer_name',
+              mtMap.passthrough()
+            ),
+            consumerEmail: mtMap.objectField(
+              'consumer_email',
+              mtMap.passthrough()
+            ),
+            consumerProfileName: mtMap.objectField(
+              'consumer_profile_name',
+              mtMap.passthrough()
+            ),
+            consumerProfileEmail: mtMap.objectField(
+              'consumer_profile_email',
+              mtMap.passthrough()
+            )
+          })
+        )
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/magic-mcp-servers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/magic-mcp-servers/get.ts
@@ -129,6 +129,17 @@ export type DashboardInstanceMagicMcpServersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  integrationId: string | null;
+  integrationInstanceId: string | null;
+  consumerOwners: {
+    consumerIntegrationId: string | null;
+    consumerId: string;
+    consumerProfileId: string;
+    consumerName: string;
+    consumerEmail: string;
+    consumerProfileName: string;
+    consumerProfileEmail: string;
+  }[];
   providers: ({
     object: 'magic_mcp.server.provider';
     id: string;
@@ -542,7 +553,44 @@ export let mapDashboardInstanceMagicMcpServersGetOutput = mtMap.union([
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      consumerOwners: mtMap.objectField(
+        'consumer_owners',
+        mtMap.array(
+          mtMap.object({
+            consumerIntegrationId: mtMap.objectField(
+              'consumer_integration_id',
+              mtMap.passthrough()
+            ),
+            consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+            consumerProfileId: mtMap.objectField(
+              'consumer_profile_id',
+              mtMap.passthrough()
+            ),
+            consumerName: mtMap.objectField(
+              'consumer_name',
+              mtMap.passthrough()
+            ),
+            consumerEmail: mtMap.objectField(
+              'consumer_email',
+              mtMap.passthrough()
+            ),
+            consumerProfileName: mtMap.objectField(
+              'consumer_profile_name',
+              mtMap.passthrough()
+            ),
+            consumerProfileEmail: mtMap.objectField(
+              'consumer_profile_email',
+              mtMap.passthrough()
+            )
+          })
+        )
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/magic-mcp-servers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/magic-mcp-servers/list.ts
@@ -136,6 +136,17 @@ export type DashboardInstanceMagicMcpServersListOutput = {
     createdAt: Date;
     updatedAt: Date;
   } & {
+    integrationId: string | null;
+    integrationInstanceId: string | null;
+    consumerOwners: {
+      consumerIntegrationId: string | null;
+      consumerId: string;
+      consumerProfileId: string;
+      consumerName: string;
+      consumerEmail: string;
+      consumerProfileName: string;
+      consumerProfileEmail: string;
+    }[];
     providers: ({
       object: 'magic_mcp.server.provider';
       id: string;
@@ -694,7 +705,50 @@ export let mapDashboardInstanceMagicMcpServersListOutput =
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              consumerOwners: mtMap.objectField(
+                'consumer_owners',
+                mtMap.array(
+                  mtMap.object({
+                    consumerIntegrationId: mtMap.objectField(
+                      'consumer_integration_id',
+                      mtMap.passthrough()
+                    ),
+                    consumerId: mtMap.objectField(
+                      'consumer_id',
+                      mtMap.passthrough()
+                    ),
+                    consumerProfileId: mtMap.objectField(
+                      'consumer_profile_id',
+                      mtMap.passthrough()
+                    ),
+                    consumerName: mtMap.objectField(
+                      'consumer_name',
+                      mtMap.passthrough()
+                    ),
+                    consumerEmail: mtMap.objectField(
+                      'consumer_email',
+                      mtMap.passthrough()
+                    ),
+                    consumerProfileName: mtMap.objectField(
+                      'consumer_profile_name',
+                      mtMap.passthrough()
+                    ),
+                    consumerProfileEmail: mtMap.objectField(
+                      'consumer_profile_email',
+                      mtMap.passthrough()
+                    )
+                  })
+                )
+              )
             })
           )
         ])
@@ -727,6 +781,12 @@ export type DashboardInstanceMagicMcpServersListQuery = {
     | undefined;
   magicMcpGroupId?: string | string[] | undefined;
   providerTemplateId?: string | string[] | undefined;
+  integrationInstanceId?: string | string[] | undefined;
+  owner?:
+    | 'organization'
+    | 'consumer'
+    | ('organization' | 'consumer')[]
+    | undefined;
   providerId?: string | string[] | undefined;
   consumerId?: string | string[] | undefined;
   consumerProfileId?: string | string[] | undefined;
@@ -767,6 +827,20 @@ export let mapDashboardInstanceMagicMcpServersListQuery = mtMap.union([
             mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
           )
         ])
+      ),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
+      owner: mtMap.objectField(
+        'owner',
+        mtMap.union([mtMap.unionOption('array', mtMap.union([]))])
       ),
       providerId: mtMap.objectField(
         'provider_id',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/magic-mcp-servers/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/magic-mcp-servers/update.ts
@@ -129,6 +129,17 @@ export type DashboardInstanceMagicMcpServersUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  integrationId: string | null;
+  integrationInstanceId: string | null;
+  consumerOwners: {
+    consumerIntegrationId: string | null;
+    consumerId: string;
+    consumerProfileId: string;
+    consumerName: string;
+    consumerEmail: string;
+    consumerProfileName: string;
+    consumerProfileEmail: string;
+  }[];
   providers: ({
     object: 'magic_mcp.server.provider';
     id: string;
@@ -542,7 +553,44 @@ export let mapDashboardInstanceMagicMcpServersUpdateOutput = mtMap.union([
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      consumerOwners: mtMap.objectField(
+        'consumer_owners',
+        mtMap.array(
+          mtMap.object({
+            consumerIntegrationId: mtMap.objectField(
+              'consumer_integration_id',
+              mtMap.passthrough()
+            ),
+            consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+            consumerProfileId: mtMap.objectField(
+              'consumer_profile_id',
+              mtMap.passthrough()
+            ),
+            consumerName: mtMap.objectField(
+              'consumer_name',
+              mtMap.passthrough()
+            ),
+            consumerEmail: mtMap.objectField(
+              'consumer_email',
+              mtMap.passthrough()
+            ),
+            consumerProfileName: mtMap.objectField(
+              'consumer_profile_name',
+              mtMap.passthrough()
+            ),
+            consumerProfileEmail: mtMap.objectField(
+              'consumer_profile_email',
+              mtMap.passthrough()
+            )
+          })
+        )
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/magic-mcp-servers/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/magic-mcp-servers/create.ts
@@ -129,6 +129,17 @@ export type MagicMcpServersCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  integrationId: string | null;
+  integrationInstanceId: string | null;
+  consumerOwners: {
+    consumerIntegrationId: string | null;
+    consumerId: string;
+    consumerProfileId: string;
+    consumerName: string;
+    consumerEmail: string;
+    consumerProfileName: string;
+    consumerProfileEmail: string;
+  }[];
   providers: ({
     object: 'magic_mcp.server.provider';
     id: string;
@@ -542,7 +553,44 @@ export let mapMagicMcpServersCreateOutput = mtMap.union([
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      consumerOwners: mtMap.objectField(
+        'consumer_owners',
+        mtMap.array(
+          mtMap.object({
+            consumerIntegrationId: mtMap.objectField(
+              'consumer_integration_id',
+              mtMap.passthrough()
+            ),
+            consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+            consumerProfileId: mtMap.objectField(
+              'consumer_profile_id',
+              mtMap.passthrough()
+            ),
+            consumerName: mtMap.objectField(
+              'consumer_name',
+              mtMap.passthrough()
+            ),
+            consumerEmail: mtMap.objectField(
+              'consumer_email',
+              mtMap.passthrough()
+            ),
+            consumerProfileName: mtMap.objectField(
+              'consumer_profile_name',
+              mtMap.passthrough()
+            ),
+            consumerProfileEmail: mtMap.objectField(
+              'consumer_profile_email',
+              mtMap.passthrough()
+            )
+          })
+        )
+      )
     })
   )
 ]);
@@ -552,6 +600,7 @@ export type MagicMcpServersCreateBody = {
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
   providerTemplateId?: string | undefined;
+  integrationInstanceId?: string | undefined;
   consumerProfileId?: string | undefined;
 };
 
@@ -562,6 +611,10 @@ export let mapMagicMcpServersCreateBody =
     metadata: mtMap.objectField('metadata', mtMap.passthrough()),
     providerTemplateId: mtMap.objectField(
       'provider_template_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
       mtMap.passthrough()
     ),
     consumerProfileId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/magic-mcp-servers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/magic-mcp-servers/delete.ts
@@ -129,6 +129,17 @@ export type MagicMcpServersDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  integrationId: string | null;
+  integrationInstanceId: string | null;
+  consumerOwners: {
+    consumerIntegrationId: string | null;
+    consumerId: string;
+    consumerProfileId: string;
+    consumerName: string;
+    consumerEmail: string;
+    consumerProfileName: string;
+    consumerProfileEmail: string;
+  }[];
   providers: ({
     object: 'magic_mcp.server.provider';
     id: string;
@@ -542,7 +553,44 @@ export let mapMagicMcpServersDeleteOutput = mtMap.union([
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      consumerOwners: mtMap.objectField(
+        'consumer_owners',
+        mtMap.array(
+          mtMap.object({
+            consumerIntegrationId: mtMap.objectField(
+              'consumer_integration_id',
+              mtMap.passthrough()
+            ),
+            consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+            consumerProfileId: mtMap.objectField(
+              'consumer_profile_id',
+              mtMap.passthrough()
+            ),
+            consumerName: mtMap.objectField(
+              'consumer_name',
+              mtMap.passthrough()
+            ),
+            consumerEmail: mtMap.objectField(
+              'consumer_email',
+              mtMap.passthrough()
+            ),
+            consumerProfileName: mtMap.objectField(
+              'consumer_profile_name',
+              mtMap.passthrough()
+            ),
+            consumerProfileEmail: mtMap.objectField(
+              'consumer_profile_email',
+              mtMap.passthrough()
+            )
+          })
+        )
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/magic-mcp-servers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/magic-mcp-servers/get.ts
@@ -129,6 +129,17 @@ export type MagicMcpServersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  integrationId: string | null;
+  integrationInstanceId: string | null;
+  consumerOwners: {
+    consumerIntegrationId: string | null;
+    consumerId: string;
+    consumerProfileId: string;
+    consumerName: string;
+    consumerEmail: string;
+    consumerProfileName: string;
+    consumerProfileEmail: string;
+  }[];
   providers: ({
     object: 'magic_mcp.server.provider';
     id: string;
@@ -542,7 +553,44 @@ export let mapMagicMcpServersGetOutput = mtMap.union([
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      consumerOwners: mtMap.objectField(
+        'consumer_owners',
+        mtMap.array(
+          mtMap.object({
+            consumerIntegrationId: mtMap.objectField(
+              'consumer_integration_id',
+              mtMap.passthrough()
+            ),
+            consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+            consumerProfileId: mtMap.objectField(
+              'consumer_profile_id',
+              mtMap.passthrough()
+            ),
+            consumerName: mtMap.objectField(
+              'consumer_name',
+              mtMap.passthrough()
+            ),
+            consumerEmail: mtMap.objectField(
+              'consumer_email',
+              mtMap.passthrough()
+            ),
+            consumerProfileName: mtMap.objectField(
+              'consumer_profile_name',
+              mtMap.passthrough()
+            ),
+            consumerProfileEmail: mtMap.objectField(
+              'consumer_profile_email',
+              mtMap.passthrough()
+            )
+          })
+        )
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/magic-mcp-servers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/magic-mcp-servers/list.ts
@@ -136,6 +136,17 @@ export type MagicMcpServersListOutput = {
     createdAt: Date;
     updatedAt: Date;
   } & {
+    integrationId: string | null;
+    integrationInstanceId: string | null;
+    consumerOwners: {
+      consumerIntegrationId: string | null;
+      consumerId: string;
+      consumerProfileId: string;
+      consumerName: string;
+      consumerEmail: string;
+      consumerProfileName: string;
+      consumerProfileEmail: string;
+    }[];
     providers: ({
       object: 'magic_mcp.server.provider';
       id: string;
@@ -694,7 +705,50 @@ export let mapMagicMcpServersListOutput =
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              consumerOwners: mtMap.objectField(
+                'consumer_owners',
+                mtMap.array(
+                  mtMap.object({
+                    consumerIntegrationId: mtMap.objectField(
+                      'consumer_integration_id',
+                      mtMap.passthrough()
+                    ),
+                    consumerId: mtMap.objectField(
+                      'consumer_id',
+                      mtMap.passthrough()
+                    ),
+                    consumerProfileId: mtMap.objectField(
+                      'consumer_profile_id',
+                      mtMap.passthrough()
+                    ),
+                    consumerName: mtMap.objectField(
+                      'consumer_name',
+                      mtMap.passthrough()
+                    ),
+                    consumerEmail: mtMap.objectField(
+                      'consumer_email',
+                      mtMap.passthrough()
+                    ),
+                    consumerProfileName: mtMap.objectField(
+                      'consumer_profile_name',
+                      mtMap.passthrough()
+                    ),
+                    consumerProfileEmail: mtMap.objectField(
+                      'consumer_profile_email',
+                      mtMap.passthrough()
+                    )
+                  })
+                )
+              )
             })
           )
         ])
@@ -727,6 +781,12 @@ export type MagicMcpServersListQuery = {
     | undefined;
   magicMcpGroupId?: string | string[] | undefined;
   providerTemplateId?: string | string[] | undefined;
+  integrationInstanceId?: string | string[] | undefined;
+  owner?:
+    | 'organization'
+    | 'consumer'
+    | ('organization' | 'consumer')[]
+    | undefined;
   providerId?: string | string[] | undefined;
   consumerId?: string | string[] | undefined;
   consumerProfileId?: string | string[] | undefined;
@@ -767,6 +827,20 @@ export let mapMagicMcpServersListQuery = mtMap.union([
             mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
           )
         ])
+      ),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
+      owner: mtMap.objectField(
+        'owner',
+        mtMap.union([mtMap.unionOption('array', mtMap.union([]))])
       ),
       providerId: mtMap.objectField(
         'provider_id',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/magic-mcp-servers/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/magic-mcp-servers/update.ts
@@ -129,6 +129,17 @@ export type MagicMcpServersUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  integrationId: string | null;
+  integrationInstanceId: string | null;
+  consumerOwners: {
+    consumerIntegrationId: string | null;
+    consumerId: string;
+    consumerProfileId: string;
+    consumerName: string;
+    consumerEmail: string;
+    consumerProfileName: string;
+    consumerProfileEmail: string;
+  }[];
   providers: ({
     object: 'magic_mcp.server.provider';
     id: string;
@@ -542,7 +553,44 @@ export let mapMagicMcpServersUpdateOutput = mtMap.union([
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      consumerOwners: mtMap.objectField(
+        'consumer_owners',
+        mtMap.array(
+          mtMap.object({
+            consumerIntegrationId: mtMap.objectField(
+              'consumer_integration_id',
+              mtMap.passthrough()
+            ),
+            consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+            consumerProfileId: mtMap.objectField(
+              'consumer_profile_id',
+              mtMap.passthrough()
+            ),
+            consumerName: mtMap.objectField(
+              'consumer_name',
+              mtMap.passthrough()
+            ),
+            consumerEmail: mtMap.objectField(
+              'consumer_email',
+              mtMap.passthrough()
+            ),
+            consumerProfileName: mtMap.objectField(
+              'consumer_profile_name',
+              mtMap.passthrough()
+            ),
+            consumerProfileEmail: mtMap.objectField(
+              'consumer_profile_email',
+              mtMap.passthrough()
+            )
+          })
+        )
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/magic-mcp-servers/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/magic-mcp-servers/create.ts
@@ -129,6 +129,17 @@ export type ManagementInstanceMagicMcpServersCreateOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  integrationId: string | null;
+  integrationInstanceId: string | null;
+  consumerOwners: {
+    consumerIntegrationId: string | null;
+    consumerId: string;
+    consumerProfileId: string;
+    consumerName: string;
+    consumerEmail: string;
+    consumerProfileName: string;
+    consumerProfileEmail: string;
+  }[];
   providers: ({
     object: 'magic_mcp.server.provider';
     id: string;
@@ -542,7 +553,44 @@ export let mapManagementInstanceMagicMcpServersCreateOutput = mtMap.union([
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      consumerOwners: mtMap.objectField(
+        'consumer_owners',
+        mtMap.array(
+          mtMap.object({
+            consumerIntegrationId: mtMap.objectField(
+              'consumer_integration_id',
+              mtMap.passthrough()
+            ),
+            consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+            consumerProfileId: mtMap.objectField(
+              'consumer_profile_id',
+              mtMap.passthrough()
+            ),
+            consumerName: mtMap.objectField(
+              'consumer_name',
+              mtMap.passthrough()
+            ),
+            consumerEmail: mtMap.objectField(
+              'consumer_email',
+              mtMap.passthrough()
+            ),
+            consumerProfileName: mtMap.objectField(
+              'consumer_profile_name',
+              mtMap.passthrough()
+            ),
+            consumerProfileEmail: mtMap.objectField(
+              'consumer_profile_email',
+              mtMap.passthrough()
+            )
+          })
+        )
+      )
     })
   )
 ]);
@@ -552,6 +600,7 @@ export type ManagementInstanceMagicMcpServersCreateBody = {
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
   providerTemplateId?: string | undefined;
+  integrationInstanceId?: string | undefined;
   consumerProfileId?: string | undefined;
 };
 
@@ -562,6 +611,10 @@ export let mapManagementInstanceMagicMcpServersCreateBody =
     metadata: mtMap.objectField('metadata', mtMap.passthrough()),
     providerTemplateId: mtMap.objectField(
       'provider_template_id',
+      mtMap.passthrough()
+    ),
+    integrationInstanceId: mtMap.objectField(
+      'integration_instance_id',
       mtMap.passthrough()
     ),
     consumerProfileId: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/magic-mcp-servers/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/magic-mcp-servers/delete.ts
@@ -129,6 +129,17 @@ export type ManagementInstanceMagicMcpServersDeleteOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  integrationId: string | null;
+  integrationInstanceId: string | null;
+  consumerOwners: {
+    consumerIntegrationId: string | null;
+    consumerId: string;
+    consumerProfileId: string;
+    consumerName: string;
+    consumerEmail: string;
+    consumerProfileName: string;
+    consumerProfileEmail: string;
+  }[];
   providers: ({
     object: 'magic_mcp.server.provider';
     id: string;
@@ -542,7 +553,44 @@ export let mapManagementInstanceMagicMcpServersDeleteOutput = mtMap.union([
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      consumerOwners: mtMap.objectField(
+        'consumer_owners',
+        mtMap.array(
+          mtMap.object({
+            consumerIntegrationId: mtMap.objectField(
+              'consumer_integration_id',
+              mtMap.passthrough()
+            ),
+            consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+            consumerProfileId: mtMap.objectField(
+              'consumer_profile_id',
+              mtMap.passthrough()
+            ),
+            consumerName: mtMap.objectField(
+              'consumer_name',
+              mtMap.passthrough()
+            ),
+            consumerEmail: mtMap.objectField(
+              'consumer_email',
+              mtMap.passthrough()
+            ),
+            consumerProfileName: mtMap.objectField(
+              'consumer_profile_name',
+              mtMap.passthrough()
+            ),
+            consumerProfileEmail: mtMap.objectField(
+              'consumer_profile_email',
+              mtMap.passthrough()
+            )
+          })
+        )
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/magic-mcp-servers/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/magic-mcp-servers/get.ts
@@ -129,6 +129,17 @@ export type ManagementInstanceMagicMcpServersGetOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  integrationId: string | null;
+  integrationInstanceId: string | null;
+  consumerOwners: {
+    consumerIntegrationId: string | null;
+    consumerId: string;
+    consumerProfileId: string;
+    consumerName: string;
+    consumerEmail: string;
+    consumerProfileName: string;
+    consumerProfileEmail: string;
+  }[];
   providers: ({
     object: 'magic_mcp.server.provider';
     id: string;
@@ -542,7 +553,44 @@ export let mapManagementInstanceMagicMcpServersGetOutput = mtMap.union([
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      consumerOwners: mtMap.objectField(
+        'consumer_owners',
+        mtMap.array(
+          mtMap.object({
+            consumerIntegrationId: mtMap.objectField(
+              'consumer_integration_id',
+              mtMap.passthrough()
+            ),
+            consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+            consumerProfileId: mtMap.objectField(
+              'consumer_profile_id',
+              mtMap.passthrough()
+            ),
+            consumerName: mtMap.objectField(
+              'consumer_name',
+              mtMap.passthrough()
+            ),
+            consumerEmail: mtMap.objectField(
+              'consumer_email',
+              mtMap.passthrough()
+            ),
+            consumerProfileName: mtMap.objectField(
+              'consumer_profile_name',
+              mtMap.passthrough()
+            ),
+            consumerProfileEmail: mtMap.objectField(
+              'consumer_profile_email',
+              mtMap.passthrough()
+            )
+          })
+        )
+      )
     })
   )
 ]);

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/magic-mcp-servers/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/magic-mcp-servers/list.ts
@@ -136,6 +136,17 @@ export type ManagementInstanceMagicMcpServersListOutput = {
     createdAt: Date;
     updatedAt: Date;
   } & {
+    integrationId: string | null;
+    integrationInstanceId: string | null;
+    consumerOwners: {
+      consumerIntegrationId: string | null;
+      consumerId: string;
+      consumerProfileId: string;
+      consumerName: string;
+      consumerEmail: string;
+      consumerProfileName: string;
+      consumerProfileEmail: string;
+    }[];
     providers: ({
       object: 'magic_mcp.server.provider';
       id: string;
@@ -694,7 +705,50 @@ export let mapManagementInstanceMagicMcpServersListOutput =
               ),
               metadata: mtMap.objectField('metadata', mtMap.passthrough()),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
-              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+              integrationId: mtMap.objectField(
+                'integration_id',
+                mtMap.passthrough()
+              ),
+              integrationInstanceId: mtMap.objectField(
+                'integration_instance_id',
+                mtMap.passthrough()
+              ),
+              consumerOwners: mtMap.objectField(
+                'consumer_owners',
+                mtMap.array(
+                  mtMap.object({
+                    consumerIntegrationId: mtMap.objectField(
+                      'consumer_integration_id',
+                      mtMap.passthrough()
+                    ),
+                    consumerId: mtMap.objectField(
+                      'consumer_id',
+                      mtMap.passthrough()
+                    ),
+                    consumerProfileId: mtMap.objectField(
+                      'consumer_profile_id',
+                      mtMap.passthrough()
+                    ),
+                    consumerName: mtMap.objectField(
+                      'consumer_name',
+                      mtMap.passthrough()
+                    ),
+                    consumerEmail: mtMap.objectField(
+                      'consumer_email',
+                      mtMap.passthrough()
+                    ),
+                    consumerProfileName: mtMap.objectField(
+                      'consumer_profile_name',
+                      mtMap.passthrough()
+                    ),
+                    consumerProfileEmail: mtMap.objectField(
+                      'consumer_profile_email',
+                      mtMap.passthrough()
+                    )
+                  })
+                )
+              )
             })
           )
         ])
@@ -727,6 +781,12 @@ export type ManagementInstanceMagicMcpServersListQuery = {
     | undefined;
   magicMcpGroupId?: string | string[] | undefined;
   providerTemplateId?: string | string[] | undefined;
+  integrationInstanceId?: string | string[] | undefined;
+  owner?:
+    | 'organization'
+    | 'consumer'
+    | ('organization' | 'consumer')[]
+    | undefined;
   providerId?: string | string[] | undefined;
   consumerId?: string | string[] | undefined;
   consumerProfileId?: string | string[] | undefined;
@@ -767,6 +827,20 @@ export let mapManagementInstanceMagicMcpServersListQuery = mtMap.union([
             mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
           )
         ])
+      ),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.union([
+          mtMap.unionOption('string', mtMap.passthrough()),
+          mtMap.unionOption(
+            'array',
+            mtMap.union([mtMap.unionOption('string', mtMap.passthrough())])
+          )
+        ])
+      ),
+      owner: mtMap.objectField(
+        'owner',
+        mtMap.union([mtMap.unionOption('array', mtMap.union([]))])
       ),
       providerId: mtMap.objectField(
         'provider_id',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/magic-mcp-servers/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/magic-mcp-servers/update.ts
@@ -129,6 +129,17 @@ export type ManagementInstanceMagicMcpServersUpdateOutput = {
   createdAt: Date;
   updatedAt: Date;
 } & {
+  integrationId: string | null;
+  integrationInstanceId: string | null;
+  consumerOwners: {
+    consumerIntegrationId: string | null;
+    consumerId: string;
+    consumerProfileId: string;
+    consumerName: string;
+    consumerEmail: string;
+    consumerProfileName: string;
+    consumerProfileEmail: string;
+  }[];
   providers: ({
     object: 'magic_mcp.server.provider';
     id: string;
@@ -542,7 +553,44 @@ export let mapManagementInstanceMagicMcpServersUpdateOutput = mtMap.union([
       description: mtMap.objectField('description', mtMap.passthrough()),
       metadata: mtMap.objectField('metadata', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
-      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      integrationId: mtMap.objectField('integration_id', mtMap.passthrough()),
+      integrationInstanceId: mtMap.objectField(
+        'integration_instance_id',
+        mtMap.passthrough()
+      ),
+      consumerOwners: mtMap.objectField(
+        'consumer_owners',
+        mtMap.array(
+          mtMap.object({
+            consumerIntegrationId: mtMap.objectField(
+              'consumer_integration_id',
+              mtMap.passthrough()
+            ),
+            consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+            consumerProfileId: mtMap.objectField(
+              'consumer_profile_id',
+              mtMap.passthrough()
+            ),
+            consumerName: mtMap.objectField(
+              'consumer_name',
+              mtMap.passthrough()
+            ),
+            consumerEmail: mtMap.objectField(
+              'consumer_email',
+              mtMap.passthrough()
+            ),
+            consumerProfileName: mtMap.objectField(
+              'consumer_profile_name',
+              mtMap.passthrough()
+            ),
+            consumerProfileEmail: mtMap.objectField(
+              'consumer_profile_email',
+              mtMap.passthrough()
+            )
+          })
+        )
+      )
     })
   )
 ]);

--- a/src/backend/apis/core/src/controllers/instance/magic-mcp/magicMcpServer.ts
+++ b/src/backend/apis/core/src/controllers/instance/magic-mcp/magicMcpServer.ts
@@ -7,7 +7,11 @@ import {
   consumerService,
   grantConsumerOwnedMagicMcpServerAccess
 } from '@metorial/module-consumer';
-import { ensureMagicMcpServerBacking, magicMcpServerService } from '@metorial/module-magic';
+import {
+  ensureMagicMcpServerBacking,
+  magicMcpServerService,
+  type MagicMcpServerOwnerFilter
+} from '@metorial/module-magic';
 import {
   subspaceIntegrationInstanceService,
   subspaceIntegrationService,
@@ -50,6 +54,45 @@ export let magicMcpServerGroup = instanceGroup.use(async ctx => {
 });
 
 let magicMcpServerStatusValues = ['active', 'archived', 'deleted'] as const;
+let magicMcpServerOwnerFilterValues = ['organization', 'consumer'] as const;
+
+let validateLinkedIntegrationInstanceForMagicMcpServer = async (d: {
+  instance: Parameters<typeof subspaceIntegrationInstanceService.get>[0]['instance'];
+  integrationInstanceId: string;
+}) => {
+  let integrationInstance = await subspaceIntegrationInstanceService.get({
+    instance: d.instance,
+    integrationInstanceId: d.integrationInstanceId
+  });
+
+  if (integrationInstance.status !== 'active') {
+    throw new ServiceError(
+      badRequestError({
+        message: 'Magic MCP servers can only be linked to active integration instances.',
+        code: 'integration_instance_not_active',
+        data: {
+          integration_instance_id: integrationInstance.id,
+          status: integrationInstance.status
+        }
+      })
+    );
+  }
+
+  if (!integrationInstance.providers.length) {
+    throw new ServiceError(
+      badRequestError({
+        message:
+          'Magic MCP servers require an integration instance with configured providers.',
+        code: 'integration_instance_has_no_providers',
+        data: {
+          integration_instance_id: integrationInstance.id
+        }
+      })
+    );
+  }
+
+  return integrationInstance;
+};
 
 let getAccessTagsForConsumerProfiles = async (d: {
   consumerProfiles: Awaited<
@@ -301,6 +344,13 @@ export let magicMcpServerController = Controller.create(
             ),
             magic_mcp_group_id: v.optional(v.union([v.string(), v.array(v.string())])),
             provider_template_id: v.optional(v.union([v.string(), v.array(v.string())])),
+            integration_instance_id: v.optional(v.union([v.string(), v.array(v.string())])),
+            owner: v.optional(
+              v.union([
+                v.enumOf([...magicMcpServerOwnerFilterValues]),
+                v.array(v.enumOf([...magicMcpServerOwnerFilterValues]))
+              ])
+            ),
             provider_id: v.optional(v.union([v.string(), v.array(v.string())])),
             consumer_id: v.optional(v.union([v.string(), v.array(v.string())])),
             consumer_profile_id: v.optional(v.union([v.string(), v.array(v.string())])),
@@ -324,6 +374,10 @@ export let magicMcpServerController = Controller.create(
           status: normalizeArrayParam<MagicMcpServerStatus>(ctx.query.status),
           groupIds: normalizeArrayParam(ctx.query.magic_mcp_group_id),
           providerTemplateIds: normalizeArrayParam(ctx.query.provider_template_id),
+          subspaceIntegrationInstanceIds: normalizeArrayParam(
+            ctx.query.integration_instance_id
+          ),
+          owners: normalizeArrayParam<MagicMcpServerOwnerFilter>(ctx.query.owner),
           providerIds: normalizeArrayParam(ctx.query.provider_id),
           ids: normalizeArrayParam(ctx.query.id),
           search: ctx.query.search,
@@ -672,6 +726,7 @@ export let magicMcpServerController = Controller.create(
           description: v.optional(v.string()),
           metadata: v.optional(v.record(v.any())),
           provider_template_id: v.optional(v.string()),
+          integration_instance_id: v.optional(v.string()),
           consumer_profile_id: v.optional(v.string())
         })
       )
@@ -686,6 +741,23 @@ export let magicMcpServerController = Controller.create(
             })
           : undefined;
 
+        if (ctx.body.provider_template_id && ctx.body.integration_instance_id) {
+          throw new ServiceError(
+            badRequestError({
+              message:
+                'provider_template_id and integration_instance_id cannot be specified together.',
+              code: 'magic_mcp_server_backing_conflict'
+            })
+          );
+        }
+
+        if (ctx.body.integration_instance_id) {
+          await validateLinkedIntegrationInstanceForMagicMcpServer({
+            instance: ctx.instance,
+            integrationInstanceId: ctx.body.integration_instance_id
+          });
+        }
+
         let magicMcpServer = await magicMcpServerService.createMagicMcpServer({
           organization: ctx.organization,
           performedBy: ctx.actor!,
@@ -695,7 +767,8 @@ export let magicMcpServerController = Controller.create(
             name: ctx.body.name,
             description: ctx.body.description,
             metadata: ctx.body.metadata,
-            providerTemplateId: ctx.body.provider_template_id
+            providerTemplateId: ctx.body.provider_template_id,
+            subspaceIntegrationInstanceId: ctx.body.integration_instance_id
           }
         });
 

--- a/src/backend/apis/core/src/presenters/implementation/provider/magicMcp/magicMcpServer.ts
+++ b/src/backend/apis/core/src/presenters/implementation/provider/magicMcp/magicMcpServer.ts
@@ -35,6 +35,83 @@ let magicMcpServerSchema = v.object({
   updated_at: v.date()
 });
 
+let dashboardMagicMcpServerConsumerOwnerSchema = v.object({
+  consumer_integration_id: v.nullable(v.string()),
+  consumer_id: v.string(),
+  consumer_profile_id: v.string(),
+  consumer_name: v.string(),
+  consumer_email: v.string(),
+  consumer_profile_name: v.string(),
+  consumer_profile_email: v.string()
+});
+
+let getDashboardConsumerOwners = (magicMcpServer: {
+  consumerIntegrations: {
+    id: string;
+    consumer: { id: string; name: string; email: string };
+    consumerProfile: { id: string; name: string; email: string };
+  }[];
+  accessTagEntities?: {
+    accessTagPolicy: { systemIdentifier: string | null };
+    accessTag: {
+      consumerGroup: {
+        personalOwner: {
+          id: string;
+          name: string;
+          email: string;
+          consumer: { id: string; name: string; email: string };
+        } | null;
+      } | null;
+    };
+  }[];
+}) => {
+  let owners = new Map<
+    string,
+    {
+      consumer_integration_id: string | null;
+      consumer_id: string;
+      consumer_profile_id: string;
+      consumer_name: string;
+      consumer_email: string;
+      consumer_profile_name: string;
+      consumer_profile_email: string;
+    }
+  >();
+
+  for (let consumerIntegration of magicMcpServer.consumerIntegrations) {
+    owners.set(consumerIntegration.consumerProfile.id, {
+      consumer_integration_id: consumerIntegration.id,
+      consumer_id: consumerIntegration.consumer.id,
+      consumer_profile_id: consumerIntegration.consumerProfile.id,
+      consumer_name: consumerIntegration.consumer.name,
+      consumer_email: consumerIntegration.consumer.email,
+      consumer_profile_name: consumerIntegration.consumerProfile.name,
+      consumer_profile_email: consumerIntegration.consumerProfile.email
+    });
+  }
+
+  for (let accessTagEntity of magicMcpServer.accessTagEntities ?? []) {
+    if (accessTagEntity.accessTagPolicy.systemIdentifier !== 'consumer_magic_mcp_write') {
+      continue;
+    }
+
+    let consumerProfile = accessTagEntity.accessTag.consumerGroup?.personalOwner;
+    if (!consumerProfile || owners.has(consumerProfile.id)) continue;
+
+    owners.set(consumerProfile.id, {
+      consumer_integration_id: null,
+      consumer_id: consumerProfile.consumer.id,
+      consumer_profile_id: consumerProfile.id,
+      consumer_name: consumerProfile.consumer.name,
+      consumer_email: consumerProfile.consumer.email,
+      consumer_profile_name: consumerProfile.name,
+      consumer_profile_email: consumerProfile.email
+    });
+  }
+
+  return Array.from(owners.values());
+};
+
 export let v1MagicMcpServerPresenter = Presenter.create(magicMcpServerType)
   .presenter(
     async (
@@ -90,6 +167,10 @@ export let dashboardMagicMcpServerPresenter = Presenter.create(magicMcpServerTyp
     return {
       ...inner,
 
+      integration_id: input.integration?.id ?? null,
+      integration_instance_id: input.integrationInstance?.id ?? null,
+      consumer_owners: getDashboardConsumerOwners(input.magicMcpServer),
+
       providers: await Promise.all(
         (input.magicMcpServerProviders ?? []).map(magicMcpServerProvider =>
           dashboardMagicMcpServerProviderPresenter
@@ -103,6 +184,9 @@ export let dashboardMagicMcpServerPresenter = Presenter.create(magicMcpServerTyp
     v.intersection([
       magicMcpServerSchema,
       v.object({
+        integration_id: v.nullable(v.string()),
+        integration_instance_id: v.nullable(v.string()),
+        consumer_owners: v.array(dashboardMagicMcpServerConsumerOwnerSchema),
         providers: v.array(dashboardMagicMcpServerProviderPresenter.schema)
       })
     ])

--- a/src/backend/apis/core/src/presenters/types.ts
+++ b/src/backend/apis/core/src/presenters/types.ts
@@ -7,6 +7,9 @@ import {
   AccessPolicyVersion,
   AccessRole,
   AccessRoleVersion,
+  AccessTag,
+  AccessTagEntity,
+  AccessTagPolicy,
   ApiKey,
   ApiKeySecret,
   ApiKeyType,
@@ -635,6 +638,20 @@ export let flagsType = PresentableType.create<{
 export let magicMcpServerType = PresentableType.create<{
   magicMcpServer: MagicMcpServer & {
     aliases: MagicMcpServerAlias[];
+    accessTagEntities?: (AccessTagEntity & {
+      accessTagPolicy: AccessTagPolicy;
+      accessTag: AccessTag & {
+        consumerGroup:
+          | (ConsumerGroup & {
+              personalOwner:
+                | (ConsumerProfile & {
+                    consumer: Consumer;
+                  })
+                | null;
+            })
+          | null;
+      };
+    })[];
     consumerIntegrations: (ConsumerIntegration & {
       consumer: Consumer;
       consumerProfile: ConsumerProfile;

--- a/src/backend/modules/consumer/src/services/consumerEntities/consumerProviderDeployment.ts
+++ b/src/backend/modules/consumer/src/services/consumerEntities/consumerProviderDeployment.ts
@@ -6,6 +6,7 @@ import {
   MagicMcpServer,
   Organization,
   OrganizationActor,
+  db,
   type Instance
 } from '@metorial/db';
 import { type AnyAccessTagSelector } from '@metorial/module-access';
@@ -15,6 +16,7 @@ import {
   type ConsumerProviderTemplateContext
 } from '../../lib/consumerProviderContext';
 import { consumerAccessPolicyService } from '../consumerAccess/accessPolicy';
+import { consumerIntegrationService } from './consumerIntegration';
 import { consumerProviderSetupSessionService } from './consumerProviderSetupSession';
 
 type ConsumerProviderDeployRollbackState = {
@@ -145,6 +147,28 @@ let assertActiveSetupSessionInstance = (setupSession: any) => {
   }
 };
 
+let getConsumerOwnerForProfile = async (d: {
+  instance: Instance;
+  consumerProfile: ConsumerProfile;
+}) => {
+  let actor = await db.consumerActor.findFirst({
+    where: {
+      instanceOid: d.instance.oid,
+      consumerProfileOid: d.consumerProfile.oid,
+      isDefault: true
+    },
+    select: {
+      id: true,
+      defaultIdentityId: true
+    }
+  });
+
+  return {
+    identityActorId: actor?.id ?? null,
+    identityId: actor?.defaultIdentityId ?? null
+  };
+};
+
 class ConsumerProviderDeploymentServiceImpl {
   async deployProvider(d: {
     organization: Organization;
@@ -176,6 +200,11 @@ class ConsumerProviderDeploymentServiceImpl {
 
       assertActiveSetupSessionInstance(setupSession);
 
+      let consumerOwner = await getConsumerOwnerForProfile({
+        instance: d.instance,
+        consumerProfile: d.consumerProfile
+      });
+
       let magicMcpServer = await magicMcpServerService.createMagicMcpServer({
         organization: d.organization,
         performedBy: d.performedBy,
@@ -192,11 +221,18 @@ class ConsumerProviderDeploymentServiceImpl {
             providerDeploymentDescription: providerContext.deployment.description,
             providerTemplateId: providerContext.providerTemplate.id
           }),
-          subspaceIntegrationInstanceId: setupSession.integrationInstance.id
+          subspaceIntegrationInstanceId: setupSession.integrationInstance.id,
+          consumerOwner
         }
       });
 
       rollbackState.magicMcpServer = magicMcpServer;
+
+      await consumerIntegrationService.upsertConsumerIntegration({
+        consumerProfile: d.consumerProfile,
+        magicMcpServer,
+        isManaged: true
+      });
 
       await Promise.all(
         (['magic_mcp_read', 'magic_mcp_write'] as const).map(permission => {

--- a/src/backend/modules/magic/src/lib/backing.ts
+++ b/src/backend/modules/magic/src/lib/backing.ts
@@ -7,7 +7,10 @@ import {
   Prisma,
   ProviderTemplate
 } from '@metorial/db';
-import { subspaceMagicMcpBackingService } from '@metorial/module-subspace';
+import {
+  subspaceIntegrationInstanceService,
+  subspaceMagicMcpBackingService
+} from '@metorial/module-subspace';
 
 let magicMcpEndpointBackingInclude = {
   consumerProfile: true,
@@ -22,7 +25,7 @@ type MagicMcpEndpointWithBackingRelations = Prisma.MagicMcpEndpointGetPayload<{
   include: typeof magicMcpEndpointBackingInclude;
 }>;
 
-type ConsumerOwner = {
+export type ConsumerOwner = {
   identityActorId?: string | null;
   identityId?: string | null;
 };
@@ -209,12 +212,21 @@ export let ensureMagicMcpServerBacking = async (d: {
         providerTemplateBackingId = providerTemplate.id;
       }
     }
+    let ownerIntegrationId: string | null = null;
+    if (d.server.subspaceIntegrationInstanceId && !providerTemplateBackingId) {
+      let integrationInstance = await subspaceIntegrationInstanceService.get({
+        instance: d.instance,
+        integrationInstanceId: d.server.subspaceIntegrationInstanceId
+      });
+      ownerIntegrationId = integrationInstance.integrationId;
+    }
 
     let providers = d.providers ?? undefined;
     let backing = await (subspaceMagicMcpBackingService.upsertServer as any)({
       instance: d.instance,
       magicMcpServerBackingId: d.server.id,
       providerTemplateBackingId,
+      ownerIntegrationId,
       ownerIntegrationInstanceId: d.server.subspaceIntegrationInstanceId,
       name: d.server.name,
       description: d.server.description,

--- a/src/backend/modules/magic/src/queues/lifecycle/index.ts
+++ b/src/backend/modules/magic/src/queues/lifecycle/index.ts
@@ -14,6 +14,7 @@ import {
   magicMcpServerDeletedQueueProcessor,
   magicMcpServerUpdatedQueueProcessor
 } from './magicMcpServer';
+import { magicMcpBackingCleanupQueueProcessor } from './magicMcpBackingCleanup';
 import {
   providerTemplateArchivedQueueProcessor,
   providerTemplateCreatedQueueProcessor,
@@ -23,6 +24,7 @@ import {
 export * from './magicMcpEndpoint';
 export * from './magicMcpGroup';
 export * from './magicMcpServer';
+export * from './magicMcpBackingCleanup';
 export * from './providerTemplate';
 
 export let magicLifecycleQueueProcessor = combineQueueProcessors([
@@ -35,6 +37,7 @@ export let magicLifecycleQueueProcessor = combineQueueProcessors([
   magicMcpServerCreatedQueueProcessor,
   magicMcpServerUpdatedQueueProcessor,
   magicMcpServerDeletedQueueProcessor,
+  magicMcpBackingCleanupQueueProcessor,
   providerTemplateCreatedQueueProcessor,
   providerTemplateUpdatedQueueProcessor,
   providerTemplateArchivedQueueProcessor

--- a/src/backend/modules/magic/src/queues/lifecycle/magicMcpBackingCleanup.ts
+++ b/src/backend/modules/magic/src/queues/lifecycle/magicMcpBackingCleanup.ts
@@ -1,0 +1,111 @@
+import { db, withTransaction } from '@metorial/db';
+import { Fabric } from '@metorial/fabric';
+import { subspaceMagicMcpBackingService } from '@metorial/module-subspace';
+import { createQueue } from '@metorial/queue';
+import { magicMcpServerDeletedQueue } from './magicMcpServer';
+
+type MagicMcpBackingCleanupQueueInput = {
+  instanceId: string;
+  integrationId?: string | null;
+  integrationInstanceId?: string | null;
+};
+
+let archiveLinkedMagicMcpServer = async (d: { magicMcpServerId: string }) => {
+  let magicMcpServer = await db.magicMcpServer.findFirst({
+    where: {
+      id: d.magicMcpServerId,
+      ownerType: 'integration',
+      status: 'active'
+    },
+    include: {
+      instance: {
+        include: {
+          organization: true
+        }
+      }
+    }
+  });
+  if (!magicMcpServer) return;
+
+  let archived = await withTransaction(async db => {
+    await db.magicMcpEndpointServer.deleteMany({
+      where: {
+        magicMcpServerOid: magicMcpServer.oid
+      }
+    });
+
+    return await db.magicMcpServer.update({
+      where: { oid: magicMcpServer.oid },
+      data: {
+        status: 'archived',
+        deletedAt: new Date()
+      }
+    });
+  });
+
+  await magicMcpServerDeletedQueue.add({ magicMcpServerId: archived.id });
+  await Fabric.fire('magic_mcp.server.archived:after', {
+    organization: magicMcpServer.instance.organization,
+    instance: magicMcpServer.instance,
+    magicMcpServer: archived
+  });
+};
+
+export let magicMcpBackingCleanupQueue =
+  createQueue<MagicMcpBackingCleanupQueueInput>({
+    name: 'mgc/lc/magicMcpBacking/cleanup'
+  });
+
+export let enqueueMagicMcpBackingCleanup = async (
+  d: MagicMcpBackingCleanupQueueInput
+) => {
+  if (!d.integrationId && !d.integrationInstanceId) return;
+
+  await magicMcpBackingCleanupQueue.add(d);
+};
+
+export let magicMcpBackingCleanupQueueProcessor =
+  magicMcpBackingCleanupQueue.process(async data => {
+    let instance = await db.instance.findUnique({
+      where: { id: data.instanceId }
+    });
+    if (!instance) return;
+
+    let { magicMcpServerBackingIds } =
+      await subspaceMagicMcpBackingService.resolveServerBackingIdsByIntegrationResource({
+        instance,
+        integrationId: data.integrationId,
+        integrationInstanceId: data.integrationInstanceId
+      });
+    if (!magicMcpServerBackingIds.length) return;
+
+    let linkedServers = await db.magicMcpServer.findMany({
+      where: {
+        instanceOid: instance.oid,
+        ownerType: 'integration',
+        status: 'active',
+        id: { in: magicMcpServerBackingIds }
+      },
+      select: {
+        id: true
+      }
+    });
+
+    for (let server of linkedServers) {
+      await archiveLinkedMagicMcpServer({ magicMcpServerId: server.id });
+    }
+  });
+
+Fabric.listen('provider.integration.deleted:after', async event => {
+  await enqueueMagicMcpBackingCleanup({
+    instanceId: event.instance.id,
+    integrationId: event.integration.id
+  });
+});
+
+Fabric.listen('provider.integration_instance.deleted:after', async event => {
+  await enqueueMagicMcpBackingCleanup({
+    instanceId: event.instance.id,
+    integrationInstanceId: event.integrationInstance.id
+  });
+});

--- a/src/backend/modules/magic/src/queues/lifecycle/magicMcpBackingCleanup.ts
+++ b/src/backend/modules/magic/src/queues/lifecycle/magicMcpBackingCleanup.ts
@@ -1,4 +1,4 @@
-import { db, withTransaction } from '@metorial/db';
+import { db, type Prisma, withTransaction } from '@metorial/db';
 import { Fabric } from '@metorial/fabric';
 import { subspaceMagicMcpBackingService } from '@metorial/module-subspace';
 import { createQueue } from '@metorial/queue';
@@ -14,7 +14,7 @@ let archiveLinkedMagicMcpServer = async (d: { magicMcpServerId: string }) => {
   let magicMcpServer = await db.magicMcpServer.findFirst({
     where: {
       id: d.magicMcpServerId,
-      ownerType: 'integration',
+      ownerType: { in: ['integration', 'server_owned'] },
       status: 'active'
     },
     include: {
@@ -51,21 +51,18 @@ let archiveLinkedMagicMcpServer = async (d: { magicMcpServerId: string }) => {
   });
 };
 
-export let magicMcpBackingCleanupQueue =
-  createQueue<MagicMcpBackingCleanupQueueInput>({
-    name: 'mgc/lc/magicMcpBacking/cleanup'
-  });
+export let magicMcpBackingCleanupQueue = createQueue<MagicMcpBackingCleanupQueueInput>({
+  name: 'mgc/lc/magicMcpBacking/cleanup'
+});
 
-export let enqueueMagicMcpBackingCleanup = async (
-  d: MagicMcpBackingCleanupQueueInput
-) => {
+export let enqueueMagicMcpBackingCleanup = async (d: MagicMcpBackingCleanupQueueInput) => {
   if (!d.integrationId && !d.integrationInstanceId) return;
 
   await magicMcpBackingCleanupQueue.add(d);
 };
 
-export let magicMcpBackingCleanupQueueProcessor =
-  magicMcpBackingCleanupQueue.process(async data => {
+export let magicMcpBackingCleanupQueueProcessor = magicMcpBackingCleanupQueue.process(
+  async data => {
     let instance = await db.instance.findUnique({
       where: { id: data.instanceId }
     });
@@ -77,14 +74,28 @@ export let magicMcpBackingCleanupQueueProcessor =
         integrationId: data.integrationId,
         integrationInstanceId: data.integrationInstanceId
       });
-    if (!magicMcpServerBackingIds.length) return;
+    let linkedServerFilters: Prisma.MagicMcpServerWhereInput[] = [];
+
+    if (magicMcpServerBackingIds.length) {
+      linkedServerFilters.push({
+        id: { in: magicMcpServerBackingIds }
+      });
+    }
+
+    if (data.integrationInstanceId) {
+      linkedServerFilters.push({
+        subspaceIntegrationInstanceId: data.integrationInstanceId
+      });
+    }
+
+    if (!linkedServerFilters.length) return;
 
     let linkedServers = await db.magicMcpServer.findMany({
       where: {
         instanceOid: instance.oid,
-        ownerType: 'integration',
+        ownerType: { in: ['integration', 'server_owned'] },
         status: 'active',
-        id: { in: magicMcpServerBackingIds }
+        OR: linkedServerFilters
       },
       select: {
         id: true
@@ -94,7 +105,8 @@ export let magicMcpBackingCleanupQueueProcessor =
     for (let server of linkedServers) {
       await archiveLinkedMagicMcpServer({ magicMcpServerId: server.id });
     }
-  });
+  }
+);
 
 Fabric.listen('provider.integration.deleted:after', async event => {
   await enqueueMagicMcpBackingCleanup({

--- a/src/backend/modules/magic/src/queues/lifecycle/magicMcpServer.ts
+++ b/src/backend/modules/magic/src/queues/lifecycle/magicMcpServer.ts
@@ -2,6 +2,7 @@ import { db } from '@metorial/db';
 import { subspaceMagicMcpBackingService } from '@metorial/module-subspace';
 import { createQueue } from '@metorial/queue';
 import {
+  type ConsumerOwner,
   ensureMagicMcpServerBacking,
   MAGIC_MCP_BACKING_READY_WORKER_ATTEMPTS,
   waitForMagicMcpServerBackingReady
@@ -20,6 +21,7 @@ type MagicMcpServerLifecycleQueueInput = {
     providerAuthConfigId?: string | null;
     toolFilters?: any;
   }[];
+  owner?: ConsumerOwner;
   isReconciliation?: boolean;
 };
 
@@ -34,6 +36,7 @@ let ensureQueuedMagicMcpServerBacking = async (data: MagicMcpServerLifecycleQueu
     instance: magicMcpServer.instance,
     server: magicMcpServer,
     providers: data.providers,
+    owner: data.owner,
     isReconciliation: data.isReconciliation,
     deferReconcile: true
   });

--- a/src/backend/modules/magic/src/services/magicMcpServer.ts
+++ b/src/backend/modules/magic/src/services/magicMcpServer.ts
@@ -34,7 +34,7 @@ import {
   subspaceMagicMcpBackingService,
   subspaceSessionTemplateService
 } from '@metorial/module-subspace';
-import { ensureMagicMcpServerBacking } from '../lib/backing';
+import { type ConsumerOwner, ensureMagicMcpServerBacking } from '../lib/backing';
 import {
   magicMcpServerCreatedQueue,
   magicMcpServerDeletedQueue,
@@ -44,6 +44,24 @@ import { getAccessTagFilter, getActiveStatusFilter } from './consumerAccess';
 
 let include = {
   aliases: true,
+  accessTagEntities: {
+    include: {
+      accessTagPolicy: true,
+      accessTag: {
+        include: {
+          consumerGroup: {
+            include: {
+              personalOwner: {
+                include: {
+                  consumer: true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   consumerIntegrations: {
     include: {
       consumer: true,
@@ -56,6 +74,18 @@ let include = {
 type MagicMcpServerWithRelations = Prisma.MagicMcpServerGetPayload<{
   include: typeof include;
 }>;
+
+export type MagicMcpServerOwnerFilter = 'organization' | 'consumer';
+
+let getOwnerSources = (owners?: MagicMcpServerOwnerFilter[]) => {
+  if (!owners?.length) return undefined;
+
+  let sources = new Set<MagicMcpServerSource>();
+  if (owners.includes('organization')) sources.add('manual');
+  if (owners.includes('consumer')) sources.add('consumer_provider_template');
+
+  return Array.from(sources);
+};
 
 let buildAlias = (name?: string | null) => {
   let base = slugify(name ?? '');
@@ -191,6 +221,7 @@ class MagicMcpServerImpl {
         providerAuthConfigId?: string | null;
         toolFilters?: any;
       }[];
+      consumerOwner?: ConsumerOwner;
     };
   }) {
     await Fabric.fire('magic_mcp.server.created:before', {
@@ -227,6 +258,7 @@ class MagicMcpServerImpl {
     await magicMcpServerCreatedQueue.add({
       magicMcpServerId: magicMcpServer.id,
       providers: d.input.providers,
+      owner: d.input.consumerOwner,
       isReconciliation: false
     });
 
@@ -624,8 +656,10 @@ class MagicMcpServerImpl {
     search?: string;
     groupIds?: string[];
     providerTemplateIds?: string[];
+    subspaceIntegrationInstanceIds?: string[];
     providerIds?: string[];
     ids?: string[];
+    owners?: MagicMcpServerOwnerFilter[];
     preconfiguredOnly?: boolean;
     accessTags?: AnyAccessTagSelector;
     filterAccessTags?: AnyAccessTagSelector;
@@ -666,6 +700,7 @@ class MagicMcpServerImpl {
       status: d.status,
       activeStatus: 'active'
     });
+    let ownerSources = getOwnerSources(d.owners);
     let andFilters: Prisma.MagicMcpServerWhereInput[] = [];
 
     if (normalizedSearch) {
@@ -703,9 +738,32 @@ class MagicMcpServerImpl {
       }
     }
 
-    if (!d.accessTags && !d.filterAccessTags && !d.consumerSurface) {
+    if (!ownerSources && !d.accessTags && !d.filterAccessTags && !d.consumerSurface) {
       andFilters.push({
         source: 'manual'
+      });
+    }
+
+    if (d.subspaceIntegrationInstanceIds?.length) {
+      let backingIds = await Promise.all(
+        d.subspaceIntegrationInstanceIds.map(async integrationInstanceId => {
+          let { magicMcpServerBackingIds } =
+            await subspaceMagicMcpBackingService.resolveServerBackingIdsForIntegrationInstanceUsage(
+              {
+                instance: d.instance,
+                integrationInstanceId,
+                ownerTypes: ['server_owned', 'provider_template', 'integration']
+              }
+            );
+
+          return magicMcpServerBackingIds;
+        })
+      );
+
+      andFilters.push({
+        id: {
+          in: Array.from(new Set(backingIds.flat()))
+        }
       });
     }
 
@@ -731,7 +789,11 @@ class MagicMcpServerImpl {
             instanceOid: d.instance.oid,
             id: d.ids ? { in: d.ids } : undefined,
             status: statusFilter ? { in: statusFilter } : { not: 'archived' as const },
-            source: d.preconfiguredOnly ? { not: 'consumer_provider_template' } : undefined,
+            source: d.preconfiguredOnly
+              ? { not: 'consumer_provider_template' }
+              : ownerSources
+                ? { in: ownerSources }
+                : undefined,
             providerTemplateId: d.providerTemplateIds?.length
               ? { in: d.providerTemplateIds }
               : undefined,

--- a/src/backend/modules/subspace/src/services/magicMcpBacking.ts
+++ b/src/backend/modules/subspace/src/services/magicMcpBacking.ts
@@ -17,6 +17,8 @@ export let subspaceMagicMcpBackingService = createSubspaceService(
     'getServerSession',
     'listServerProviders',
     'resolveServerProviderBackingIds',
+    'resolveServerBackingIdsByIntegrationResource',
+    'resolveServerBackingIdsForIntegrationInstanceUsage',
     'getServerProvider',
     'createServerProvider',
     'updateServerProvider',

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration-instance/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration-instance/index.tsx
@@ -1,12 +1,29 @@
-import { renderWithLoader } from '@metorial/data-hooks';
+import { renderWithLoader, renderWithPagination, useForm } from '@metorial/data-hooks';
+import { Paths } from '@metorial/frontend-config';
 import {
+  useCreateMagicMcpServer,
   useCurrentInstance,
+  useCurrentOrganization,
+  useCurrentProject,
   useIntegration,
-  useIntegrationInstance
+  useIntegrationInstance,
+  useMagicMcpServers,
+  type IntegrationInstance
 } from '@metorial/state';
-import { Attributes, Badge, Callout, Spacer } from '@metorial/ui';
-import { Box, ID } from '@metorial/ui-product';
-import { useParams } from 'react-router-dom';
+import {
+  Attributes,
+  Badge,
+  Button,
+  Callout,
+  Input,
+  Panel,
+  RenderDate,
+  showModal,
+  Spacer,
+  Text
+} from '@metorial/ui';
+import { Box, ID, Table } from '@metorial/ui-product';
+import { useNavigate, useParams } from 'react-router-dom';
 import { IntegrationInstanceProvidersManager } from '../../../scenes/integrations/providersManager';
 
 let getIntegrationInstanceStatusColor = (status: string) => {
@@ -17,6 +34,178 @@ let getIntegrationInstanceStatusColor = (status: string) => {
 };
 
 let capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
+
+let getProviderManagementMode = (mode: string) => {
+  if (mode === 'inherited_from_provider_template') {
+    return { label: 'Provider Template', color: 'purple' as const };
+  }
+  if (mode === 'inherited_from_integration') {
+    return { label: 'Integration Instance', color: 'blue' as const };
+  }
+  return { label: 'Server Owned', color: 'gray' as const };
+};
+
+let CreateLinkedMagicMcpServerModal = (p: {
+  instanceId: string;
+  integrationInstance: IntegrationInstance;
+  close: () => void;
+  dialogProps: any;
+  onCreate: () => void;
+}) => {
+  let instance = useCurrentInstance();
+  let navigate = useNavigate();
+  let createMutator = useCreateMagicMcpServer();
+
+  let form = useForm({
+    initialValues: {
+      name: `${p.integrationInstance.name} MCP Server`,
+      description: p.integrationInstance.description ?? ''
+    },
+    schema: yup =>
+      yup.object({
+        name: yup.string().trim().required('Name is required'),
+        description: yup.string()
+      }),
+    onSubmit: async values => {
+      let [server] = await createMutator.mutate({
+        instanceId: p.instanceId,
+        name: values.name.trim(),
+        description: values.description.trim() || undefined,
+        integrationInstanceId: p.integrationInstance.id
+      });
+      if (!server || !instance.data) return;
+
+      p.onCreate();
+      p.close();
+
+      navigate(
+        Paths.instance.magicMcp.server(
+          instance.data.organization,
+          instance.data.project,
+          instance.data,
+          server.id
+        )
+      );
+    }
+  });
+
+  return (
+    <Panel.Wrapper {...p.dialogProps}>
+      <Panel.Header>
+        <Panel.Title>Create Magic MCP Server</Panel.Title>
+        <Panel.Description>
+          Create a Magic MCP server linked to this integration instance. Providers will be
+          inherited from the integration instance and cannot be changed on the server.
+        </Panel.Description>
+      </Panel.Header>
+
+      <Panel.Content>
+        <form onSubmit={form.handleSubmit}>
+          <Input label="Name" required {...form.getFieldProps('name')} />
+          <form.RenderError field="name" />
+
+          <Spacer size={15} />
+
+          <Input label="Description" {...form.getFieldProps('description')} />
+          <form.RenderError field="description" />
+
+          <Spacer size={15} />
+
+          <createMutator.RenderError />
+
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10 }}>
+            <Button type="button" variant="outline" onClick={p.close}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={createMutator.isLoading}>
+              Create Server
+            </Button>
+          </div>
+        </form>
+      </Panel.Content>
+    </Panel.Wrapper>
+  );
+};
+
+let LinkedMagicMcpServersBox = (p: {
+  instanceId: string;
+  integrationInstance: IntegrationInstance;
+}) => {
+  let organization = useCurrentOrganization();
+  let project = useCurrentProject();
+  let instance = useCurrentInstance();
+  let servers = useMagicMcpServers(p.instanceId, {
+    integrationInstanceId: p.integrationInstance.id,
+    owner: ['organization', 'consumer'],
+    status: ['active'],
+    limit: 100
+  });
+  let canCreate =
+    p.integrationInstance.status === 'active' && p.integrationInstance.providers.length > 0;
+
+  let openCreate = () => {
+    if (!canCreate) return;
+
+    showModal(({ dialogProps, close }) => (
+      <CreateLinkedMagicMcpServerModal
+        instanceId={p.instanceId}
+        integrationInstance={p.integrationInstance}
+        close={close}
+        dialogProps={dialogProps}
+        onCreate={() => servers.refetch()}
+      />
+    ));
+  };
+
+  return (
+    <Box
+      title="Magic MCP Servers"
+      description="Magic MCP servers using this integration instance, including servers created from provider templates."
+      rightActions={
+        <Button size="2" onClick={openCreate} disabled={!canCreate}>
+          Create Magic MCP Server
+        </Button>
+      }
+    >
+      {renderWithPagination(servers)(servers => (
+        <>
+          <Table
+            headers={['Name', 'Providers', 'Created']}
+            data={servers.data.items.map(server => {
+              let providerManagementMode = getProviderManagementMode(
+                server.providerManagementMode
+              );
+
+              return {
+                data: [
+                  <Text size="2" weight="strong">
+                    {server.name ?? 'Magic MCP Server'}
+                  </Text>,
+                  <Badge color={providerManagementMode.color}>
+                    {providerManagementMode.label}
+                  </Badge>,
+                  <RenderDate date={server.createdAt} />
+                ],
+                href: Paths.instance.magicMcp.server(
+                  organization.data,
+                  project.data,
+                  instance.data,
+                  server.id
+                )
+              };
+            })}
+          />
+
+          {servers.data.items.length === 0 && (
+            <Text size="2" color="gray600" align="center" style={{ marginTop: 10 }}>
+              No Magic MCP servers use this integration instance yet.
+            </Text>
+          )}
+        </>
+      ))}
+    </Box>
+  );
+};
 
 export let IntegrationInstanceOverviewPage = () => {
   let instance = useCurrentInstance();
@@ -78,6 +267,13 @@ export let IntegrationInstanceOverviewPage = () => {
               onComplete={onComplete}
             />
           </Box>
+
+          <Spacer height={20} />
+
+          <LinkedMagicMcpServersBox
+            instanceId={instance.data!.id}
+            integrationInstance={integrationInstance.data}
+          />
         </>
       );
     }

--- a/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/_layout.tsx
@@ -68,6 +68,13 @@ export let MagicMcpServerLayout = () => {
     <ContentLayout>
       {renderWithLoader({ server })(({ server }) => {
         let serverLabel = server.data.name ?? server.data.id;
+        let canAddProviders = server.data.providerManagementMode === 'manual';
+        let addProviderDisabledReason =
+          server.data.providerManagementMode === 'inherited_from_integration'
+            ? 'Providers are inherited from the integration and cannot be changed here.'
+            : server.data.providerManagementMode === 'inherited_from_provider_template'
+              ? 'Providers are inherited from the provider template and cannot be changed here.'
+              : undefined;
 
         return (
           <>
@@ -101,11 +108,15 @@ export let MagicMcpServerLayout = () => {
 
                   <Button
                     size="2"
+                    disabled={!isTokensPage && !canAddProviders}
+                    title={!isTokensPage ? addProviderDisabledReason : undefined}
                     onClick={() => {
                       if (isTokensPage) {
                         createMagicMcpTokenModal();
                         return;
                       }
+
+                      if (!canAddProviders) return;
 
                       showAddProviderSidePanel({
                         instanceId: instance.data!.id,

--- a/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/overview.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/overview.tsx
@@ -1,13 +1,22 @@
 import { renderWithLoader } from '@metorial/data-hooks';
-import { useCurrentInstance, useMagicMcpServer, useMagicMcpTokens } from '@metorial/state';
+import { Paths } from '@metorial/frontend-config';
+import {
+  useCurrentInstance,
+  useCurrentOrganization,
+  useCurrentProject,
+  useMagicMcpServer,
+  useMagicMcpTokens
+} from '@metorial/state';
 import { Attributes, Flex, RenderDate, Text } from '@metorial/ui';
 import { Box, ID } from '@metorial/ui-product';
 import { useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { McpConnectionInstructionsScene } from '../../../scenes/mcpConnectionInstructions';
 
 export let MagicMcpServerOverviewPage = () => {
   let instance = useCurrentInstance();
+  let organization = useCurrentOrganization();
+  let project = useCurrentProject();
   let { magicMcpServerId } = useParams();
 
   let server = useMagicMcpServer(instance.data?.id, magicMcpServerId);
@@ -82,43 +91,79 @@ export let MagicMcpServerOverviewPage = () => {
     tokens.isLoading
   ]);
 
-  return renderWithLoader({ server, tokens })(({ server, tokens }) => {
-    let streamableHttpUrl = server.data.endpoints[0]?.url;
-    let createdToken =
-      createdInitialToken?.instanceId === instance.data?.id &&
-      createdInitialToken?.serverId === server.data.id
-        ? createdInitialToken
-        : null;
-    let activeToken =
-      tokens.data.items.find(t => t.status === 'active' && t.server?.id === server.data.id) ??
-      createdToken;
-    let activeTokenSecret = activeToken?.secret;
-    let fullUrl =
-      streamableHttpUrl && activeTokenSecret
-        ? `${streamableHttpUrl}?key=${activeTokenSecret}`
-        : null;
+  return renderWithLoader({ server, tokens, organization, project, instance })(
+    ({ server, tokens, organization, project, instance }) => {
+      let streamableHttpUrl = server.data.endpoints[0]?.url;
+      let createdToken =
+        createdInitialToken?.instanceId === instance.data?.id &&
+        createdInitialToken?.serverId === server.data.id
+          ? createdInitialToken
+          : null;
+      let activeToken =
+        tokens.data.items.find(
+          t => t.status === 'active' && t.server?.id === server.data.id
+        ) ?? createdToken;
+      let activeTokenSecret = activeToken?.secret;
+      let consumerOwners = server.data.consumerOwners;
+      let consumerOwner = consumerOwners[0];
 
-    return (
-      <Flex direction="column" gap={16}>
-        <Attributes
-          itemWidth="300px"
-          attributes={[
-            {
-              label: 'ID',
-              content: <ID id={server.data.id} />
-            },
-            {
-              label: 'Server Identifier',
-              content: <ID id={server.data.endpoints[0]?.alias ?? '...'} />
-            },
-            {
-              label: 'Created At',
-              content: <RenderDate date={server.data.createdAt} />
-            }
-          ]}
-        />
+      let fullUrl =
+        streamableHttpUrl && activeTokenSecret
+          ? `${streamableHttpUrl}?key=${activeTokenSecret}`
+          : null;
 
-        {/* <Spacer height={16} />
+      return (
+        <Flex direction="column" gap={16}>
+          <Attributes
+            itemWidth="300px"
+            attributes={[
+              {
+                label: 'ID',
+                content: <ID id={server.data.id} />
+              },
+              {
+                label: 'Server Identifier',
+                content: <ID id={server.data.endpoints[0]?.alias ?? '...'} />
+              },
+              {
+                label: 'Created At',
+                content: <RenderDate date={server.data.createdAt} />
+              }
+            ]}
+          />
+
+          {consumerOwner && (
+            <Attributes
+              itemWidth="300px"
+              attributes={[
+                {
+                  label: 'Name',
+                  content: consumerOwner.consumerProfileName || consumerOwner.consumerName
+                },
+                {
+                  label: 'Email',
+                  content: (
+                    <Link
+                      to={Paths.instance.identity.consumer(
+                        organization.data,
+                        project.data,
+                        instance.data,
+                        consumerOwner.consumerId
+                      )}
+                    >
+                      {consumerOwner.consumerProfileEmail || consumerOwner.consumerEmail}
+                    </Link>
+                  )
+                },
+                {
+                  label: 'Consumer ID',
+                  content: <ID id={consumerOwner.consumerId} />
+                }
+              ]}
+            />
+          )}
+
+          {/* <Spacer height={16} />
 
             <Copy
               label="Primary Endpoint"
@@ -126,7 +171,7 @@ export let MagicMcpServerOverviewPage = () => {
               copyValue={streamableHttpUrl ?? ''}
             /> */}
 
-        {/* <Box
+          {/* <Box
             title="Providers"
             description="Sessions created through this server inherit providers from its session template."
             rightActions={
@@ -190,32 +235,33 @@ export let MagicMcpServerOverviewPage = () => {
             </Flex>
           </Box> */}
 
-        <Box
-          title={`Connect to ${server.data.name ?? 'Magic MCP Server'}`}
-          description="Use this Magic MCP endpoint to connect to your server."
-        >
-          <McpConnectionInstructionsScene
-            name={server.data.name ?? 'Magic MCP Server'}
-            tokenLabel="Magic MCP Token"
-            tokenValue={activeTokenSecret ?? null}
-            tokenCopyValue={activeTokenSecret ?? ''}
-            endpointLabel="Endpoint"
-            endpointValue={fullUrl ?? streamableHttpUrl ?? '...'}
-            endpointCopyValue={fullUrl ?? streamableHttpUrl ?? ''}
-            snippetUrl={streamableHttpUrl ?? null}
-            snippetToken={activeTokenSecret ?? null}
-            emptyState={
-              <Flex direction="column" gap={12} style={{ alignItems: 'flex-start' }}>
-                <Text size="2">
-                  {creatingInitialToken
-                    ? 'Creating a Magic MCP token for this server...'
-                    : 'No active Magic MCP token found for this server. Create one from the Tokens tab to connect clients.'}
-                </Text>
-              </Flex>
-            }
-          />
-        </Box>
-      </Flex>
-    );
-  });
+          <Box
+            title={`Connect to ${server.data.name ?? 'Magic MCP Server'}`}
+            description="Use this Magic MCP endpoint to connect to your server."
+          >
+            <McpConnectionInstructionsScene
+              name={server.data.name ?? 'Magic MCP Server'}
+              tokenLabel="Magic MCP Token"
+              tokenValue={activeTokenSecret ?? null}
+              tokenCopyValue={activeTokenSecret ?? ''}
+              endpointLabel="Endpoint"
+              endpointValue={fullUrl ?? streamableHttpUrl ?? '...'}
+              endpointCopyValue={fullUrl ?? streamableHttpUrl ?? ''}
+              snippetUrl={streamableHttpUrl ?? null}
+              snippetToken={activeTokenSecret ?? null}
+              emptyState={
+                <Flex direction="column" gap={12} style={{ alignItems: 'flex-start' }}>
+                  <Text size="2">
+                    {creatingInitialToken
+                      ? 'Creating a Magic MCP token for this server...'
+                      : 'No active Magic MCP token found for this server. Create one from the Tokens tab to connect clients.'}
+                  </Text>
+                </Flex>
+              }
+            />
+          </Box>
+        </Flex>
+      );
+    }
+  );
 };

--- a/src/systems/subspace/apps/controller/src/controllers/magicMcpBacking.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/magicMcpBacking.ts
@@ -370,6 +370,58 @@ export let magicMcpBackingController = app.controller({
       return { magicMcpServerBackingIds };
     }),
 
+  resolveServerBackingIdsByIntegrationResource: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        integrationId: v.optional(v.nullable(v.string())),
+        integrationInstanceId: v.optional(v.nullable(v.string()))
+      })
+    )
+    .do(async ctx => {
+      let magicMcpServerBackingIds =
+        await magicMcpServerBackingService.resolveMagicMcpServerBackingIdsByIntegrationResource(
+          {
+            tenant: ctx.tenant,
+            solution: ctx.solution,
+            environment: ctx.environment,
+            integrationId: ctx.input.integrationId,
+            integrationInstanceId: ctx.input.integrationInstanceId
+          }
+        );
+
+      return { magicMcpServerBackingIds };
+    }),
+
+  resolveServerBackingIdsForIntegrationInstanceUsage: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        integrationInstanceId: v.string(),
+        ownerTypes: v.optional(
+          v.array(v.enumOf(['server_owned', 'provider_template', 'integration']))
+        )
+      })
+    )
+    .do(async ctx => {
+      let magicMcpServerBackingIds =
+        await magicMcpServerBackingService.resolveMagicMcpServerBackingIdsForIntegrationInstanceUsage(
+          {
+            tenant: ctx.tenant,
+            solution: ctx.solution,
+            environment: ctx.environment,
+            integrationInstanceId: ctx.input.integrationInstanceId,
+            ownerTypes: ctx.input.ownerTypes
+          }
+        );
+
+      return { magicMcpServerBackingIds };
+    }),
+
   getServerProvider: tenantApp
     .handler()
     .input(

--- a/src/systems/subspace/db/prisma/schema/intergration/backing.prisma
+++ b/src/systems/subspace/db/prisma/schema/intergration/backing.prisma
@@ -26,7 +26,7 @@ model MagicMcpServerBacking {
   integrationOid BigInt?      @unique
   integration    Integration? @relation("MagicMcpServerBackingIntegration", fields: [integrationOid], references: [oid], onDelete: Cascade)
 
-  integrationInstanceOid BigInt              @unique
+  integrationInstanceOid BigInt
   integrationInstance    IntegrationInstance @relation(fields: [integrationInstanceOid], references: [oid], onDelete: Cascade)
 
   sessionTemplateOid BigInt
@@ -42,6 +42,8 @@ model MagicMcpServerBacking {
 
   endpoints               MagicMcpEndpointServerBacking[]
   magicMcpServerProviders MagicMcpServerProvider[]
+
+  @@index([integrationInstanceOid, ownerType])
 }
 
 model MagicMcpServerProvider {
@@ -57,7 +59,7 @@ model MagicMcpServerProvider {
   integrationProviderOid BigInt
   integrationProvider    IntegrationProvider @relation(fields: [integrationProviderOid], references: [oid], onDelete: Cascade)
 
-  integrationInstanceProviderOid BigInt?                      @unique
+  integrationInstanceProviderOid BigInt?
   integrationInstanceProvider    IntegrationInstanceProvider? @relation(fields: [integrationInstanceProviderOid], references: [oid], onDelete: SetNull)
 
   createdAt DateTime @default(now())
@@ -67,6 +69,7 @@ model MagicMcpServerProvider {
   @@index([status])
   @@index([magicMcpServerBackingOid, status])
   @@index([integrationProviderOid, status])
+  @@index([integrationInstanceProviderOid])
 }
 
 model MagicMcpEndpointBacking {

--- a/src/systems/subspace/db/prisma/schema/intergration/instance.prisma
+++ b/src/systems/subspace/db/prisma/schema/intergration/instance.prisma
@@ -53,7 +53,7 @@ model IntegrationInstance {
   sessionTemplates                  SessionTemplate[]
   integrationInstanceGroupSources   IntegrationInstanceGroupSource[]
   integrationInstanceGroupProviders IntegrationInstanceGroupProvider[]
-  magicMcpServerBacking             MagicMcpServerBacking?
+  magicMcpServerBackings            MagicMcpServerBacking[]
 
   @@index([tenantOid, solutionOid, environmentOid, status, isHiddenDraft])
   @@index([integrationOid, status])

--- a/src/systems/subspace/modules/integration/src/services/integrationInstance.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstance.ts
@@ -85,6 +85,15 @@ export let integrationInstanceInclude = {
   identityActor: true,
   identity: true,
   defaultSessionTemplate: true,
+  magicMcpServerBackings: {
+    orderBy: {
+      createdAt: 'asc' as const
+    },
+    take: 1,
+    select: {
+      id: true
+    }
+  },
   integrationInstanceProviders: {
     where: { status: 'active' as const, isParentDeleted: false },
     include: integrationInstanceProviderInclude

--- a/src/systems/subspace/modules/integration/src/services/integrationInstance.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstance.ts
@@ -88,8 +88,7 @@ export let integrationInstanceInclude = {
   integrationInstanceProviders: {
     where: { status: 'active' as const, isParentDeleted: false },
     include: integrationInstanceProviderInclude
-  },
-  magicMcpServerBacking: true
+  }
 } as const;
 
 export let magicMcpBackingIntegrationInstanceInclude = {

--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/server.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/server.ts
@@ -22,10 +22,11 @@ import {
 } from '../../queues/lifecycle/magicMcpBackingReconcile';
 import {
   type BackingProviderInput,
-  getMagicMcpOwnerType,
   type MagicMcpBackingInputBase,
+  type MagicMcpOwnerType,
   magicMcpProviderTemplateBackingInclude,
   magicMcpServerBackingInclude,
+  resolveMagicMcpBackingPolicy,
   resolveActorOid,
   withMagicMcpBackingLock
 } from './shared';
@@ -390,14 +391,30 @@ class magicMcpServerBackingServiceImpl {
     let backing = await this.getMagicMcpServerBackingById(d);
     checkTenant(d, backing.integrationInstance);
 
-    await integrationInstanceService.archiveIntegrationInstance({
-      tenant: d.tenant,
-      solution: d.solution,
-      environment: d.environment,
-      integrationInstance: backing.integrationInstance,
-      _canModifyMagicMcpBacking: true
+    let policy = resolveMagicMcpBackingPolicy(backing);
+    let archivedAt = new Date();
+
+    await db.magicMcpServerProvider.updateMany({
+      where: {
+        magicMcpServerBackingOid: backing.oid,
+        status: { in: ['pending', 'active'] }
+      },
+      data: {
+        status: 'archived',
+        archivedAt
+      }
     });
-    if (getMagicMcpOwnerType(backing) === 'server_owned' && backing.integration) {
+
+    if (policy.archivesIntegrationInstance) {
+      await integrationInstanceService.archiveIntegrationInstance({
+        tenant: d.tenant,
+        solution: d.solution,
+        environment: d.environment,
+        integrationInstance: backing.integrationInstance,
+        _canModifyMagicMcpBacking: true
+      });
+    }
+    if (policy.archivesIntegration && backing.integration) {
       await integrationService.archiveIntegration({
         tenant: d.tenant,
         solution: d.solution,
@@ -427,6 +444,78 @@ class magicMcpServerBackingServiceImpl {
     });
 
     return await this.getMagicMcpServerBackingById(d);
+  }
+
+  async resolveMagicMcpServerBackingIdsByIntegrationResource(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    integrationId?: string | null;
+    integrationInstanceId?: string | null;
+  }) {
+    if (!d.integrationId && !d.integrationInstanceId) return [];
+
+    let rows = await db.magicMcpServerBacking.findMany({
+      where: {
+        ownerType: 'integration',
+        integrationInstance: {
+          tenantOid: d.tenant.oid,
+          solutionOid: d.solution.oid,
+          environmentOid: d.environment.oid,
+          id: d.integrationInstanceId ?? undefined,
+          integration: d.integrationId ? { id: d.integrationId } : undefined
+        }
+      },
+      select: {
+        id: true
+      }
+    });
+
+    return [...new Set(rows.map(row => row.id))].sort();
+  }
+
+  async resolveMagicMcpServerBackingIdsForIntegrationInstanceUsage(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    integrationInstanceId: string;
+    ownerTypes?: MagicMcpOwnerType[];
+  }) {
+    let integrationInstance = await db.integrationInstance.findFirst({
+      where: {
+        id: d.integrationInstanceId,
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid
+      },
+      select: {
+        oid: true
+      }
+    });
+    if (!integrationInstance) {
+      throw new ServiceError(notFoundError('integration.instance', d.integrationInstanceId));
+    }
+
+    let ownerTypes = d.ownerTypes?.length
+      ? d.ownerTypes
+      : (['server_owned', 'provider_template', 'integration'] satisfies MagicMcpOwnerType[]);
+
+    let rows = await db.magicMcpServerBacking.findMany({
+      where: {
+        ownerType: { in: ownerTypes },
+        integrationInstance: {
+          tenantOid: d.tenant.oid,
+          solutionOid: d.solution.oid,
+          environmentOid: d.environment.oid
+        },
+        integrationInstanceOid: integrationInstance.oid
+      },
+      select: {
+        id: true
+      }
+    });
+
+    return [...new Set(rows.map(row => row.id))].sort();
   }
 }
 

--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/serverProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/serverProvider.ts
@@ -29,8 +29,8 @@ import {
 } from '../integrationProvider';
 import {
   getMagicMcpOwnerIntegration,
-  getMagicMcpOwnerType,
   magicMcpServerBackingInclude,
+  resolveMagicMcpBackingPolicy,
   withMagicMcpBackingLock
 } from './shared';
 
@@ -310,9 +310,9 @@ let getMagicMcpServerProviderByIdentityOrThrow = async (d: {
 
 let assertCanArchiveMagicMcpServerProvider = (d: {
   row: MagicMcpServerProvider;
-  ownerType: ReturnType<typeof getMagicMcpOwnerType>;
+  policy: ReturnType<typeof resolveMagicMcpBackingPolicy>;
 }) => {
-  if (d.ownerType === 'server_owned') return;
+  if (d.policy.canArchiveProviders) return;
 
   throw new ServiceError(
     badRequestError({
@@ -323,15 +323,29 @@ let assertCanArchiveMagicMcpServerProvider = (d: {
 };
 
 let assertCanMutateIntegrationProvider = (
-  ownerType: ReturnType<typeof getMagicMcpOwnerType>
+  policy: ReturnType<typeof resolveMagicMcpBackingPolicy>
 ) => {
-  if (ownerType === 'server_owned') return;
+  if (policy.canMutateIntegrationProviders) return;
 
   throw new ServiceError(
     badRequestError({
       message:
         'This magic MCP server inherits its integration providers and those providers cannot be changed directly.',
       code: 'magic_mcp_server_provider_inherited'
+    })
+  );
+};
+
+let assertCanMutateIntegrationInstanceProvider = (
+  policy: ReturnType<typeof resolveMagicMcpBackingPolicy>
+) => {
+  if (policy.canMutateIntegrationInstanceProviders) return;
+
+  throw new ServiceError(
+    badRequestError({
+      message:
+        'This magic MCP server is linked to an integration instance and its providers cannot be changed directly.',
+      code: 'magic_mcp_server_provider_linked'
     })
   );
 };
@@ -555,8 +569,8 @@ class magicMcpServerProviderServiceImpl {
       async () => {
         let created = await withTransaction(async () => {
           let backing = await loadMagicMcpServerBackingForProviders(d);
-          let ownerType = getMagicMcpOwnerType(backing);
-          assertCanMutateIntegrationProvider(ownerType);
+          let policy = resolveMagicMcpBackingPolicy(backing);
+          assertCanMutateIntegrationProvider(policy);
 
           let ownerIntegration = getMagicMcpOwnerIntegration(backing);
           if (!ownerIntegration) {
@@ -647,7 +661,7 @@ class magicMcpServerProviderServiceImpl {
       async () => {
         let updated = await withTransaction(async () => {
           let row = await getMagicMcpServerProviderOrThrow(d);
-          let ownerType = getMagicMcpOwnerType(row.magicMcpServerBacking);
+          let policy = resolveMagicMcpBackingPolicy(row.magicMcpServerBacking);
           let backing = await loadMagicMcpServerBackingForProviders({
             tenant: d.tenant,
             solution: d.solution,
@@ -678,7 +692,7 @@ class magicMcpServerProviderServiceImpl {
             providerDeploymentId = materialInput.providerDeploymentId ?? providerDeploymentId;
           }
 
-          if (ownerType === 'server_owned') {
+          if (policy.canMutateIntegrationProviders) {
             await integrationProviderService.updateIntegrationProvider({
               tenant: d.tenant,
               solution: d.solution,
@@ -703,6 +717,8 @@ class magicMcpServerProviderServiceImpl {
               })
             );
           }
+
+          assertCanMutateIntegrationInstanceProvider(policy);
 
           await integrationInstanceProviderService.setIntegrationInstanceProvider({
             tenant: d.tenant,
@@ -760,8 +776,8 @@ class magicMcpServerProviderServiceImpl {
     let row = await getMagicMcpServerProviderOrThrow(d);
     checkDeletedEdit(row, 'archive');
 
-    let ownerType = getMagicMcpOwnerType(row.magicMcpServerBacking);
-    assertCanArchiveMagicMcpServerProvider({ row, ownerType });
+    let policy = resolveMagicMcpBackingPolicy(row.magicMcpServerBacking);
+    assertCanArchiveMagicMcpServerProvider({ row, policy });
 
     if (row.integrationInstanceProvider) {
       await integrationInstanceProviderService.archiveIntegrationInstanceProvider({

--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/shared.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/shared.ts
@@ -133,6 +133,54 @@ export let getMagicMcpOwnerIntegration = <
   return backing.integration ?? null;
 };
 
+export type MagicMcpBackingPolicy = {
+  ownerType: MagicMcpOwnerType;
+  canMutateIntegrationProviders: boolean;
+  canMutateIntegrationInstanceProviders: boolean;
+  canArchiveProviders: boolean;
+  archivesIntegration: boolean;
+  archivesIntegrationInstance: boolean;
+};
+
+export let resolveMagicMcpBackingPolicy = (d: {
+  ownerType: MagicMcpOwnerType;
+  providerTemplateBackingOid?: bigint | null;
+  ownerIntegrationOid?: bigint | null;
+}): MagicMcpBackingPolicy => {
+  let ownerType = getMagicMcpOwnerType(d);
+
+  if (ownerType === 'server_owned') {
+    return {
+      ownerType,
+      canMutateIntegrationProviders: true,
+      canMutateIntegrationInstanceProviders: true,
+      canArchiveProviders: true,
+      archivesIntegration: true,
+      archivesIntegrationInstance: true
+    };
+  }
+
+  if (ownerType === 'provider_template') {
+    return {
+      ownerType,
+      canMutateIntegrationProviders: false,
+      canMutateIntegrationInstanceProviders: true,
+      canArchiveProviders: false,
+      archivesIntegration: false,
+      archivesIntegrationInstance: true
+    };
+  }
+
+  return {
+    ownerType,
+    canMutateIntegrationProviders: false,
+    canMutateIntegrationInstanceProviders: false,
+    canArchiveProviders: false,
+    archivesIntegration: false,
+    archivesIntegrationInstance: false
+  };
+};
+
 export let magicMcpEndpointBackingInclude = {
   integrationGroup: {
     include: integrationInstanceGroupInclude

--- a/src/systems/subspace/packages/presenters/src/integrationInstance.ts
+++ b/src/systems/subspace/packages/presenters/src/integrationInstance.ts
@@ -60,9 +60,12 @@ export let integrationInstancePresenter = (
         | null;
     })[];
     defaultSessionTemplate: SessionTemplate | null;
+    magicMcpServerBackings: {
+      id: string;
+    }[];
   }
 ) => {
-  let magicMcpServerBackingId: string | null = null;
+  let magicMcpServerBackingId = integrationInstance.magicMcpServerBackings[0]?.id ?? null;
 
   return {
     object: 'integration.instance',

--- a/src/systems/subspace/packages/presenters/src/integrationInstance.ts
+++ b/src/systems/subspace/packages/presenters/src/integrationInstance.ts
@@ -7,7 +7,6 @@ import type {
   IntegrationInstanceProviderVersion,
   IntegrationProvider,
   IntegrationProviderVersion,
-  MagicMcpServerBacking,
   Provider,
   ProviderAuthConfig,
   ProviderAuthCredentials,
@@ -61,30 +60,33 @@ export let integrationInstancePresenter = (
         | null;
     })[];
     defaultSessionTemplate: SessionTemplate | null;
-    magicMcpServerBacking: MagicMcpServerBacking | null;
   }
-) => ({
-  object: 'integration.instance',
+) => {
+  let magicMcpServerBackingId: string | null = null;
 
-  id: integrationInstance.id,
-  status: integrationInstance.status,
+  return {
+    object: 'integration.instance',
 
-  name: integrationInstance.name,
-  description: integrationInstance.description,
-  metadata: integrationInstance.metadata,
-  privateMetadata: integrationInstance.privateMetadata,
+    id: integrationInstance.id,
+    status: integrationInstance.status,
 
-  integrationId: integrationInstance.integration.id,
-  identityActorId: integrationInstance.identityActor?.id ?? null,
-  identityId: integrationInstance.identity?.id ?? null,
-  defaultSessionTemplateId: integrationInstance.defaultSessionTemplate?.id ?? null,
-  magicMcpServerBackingId: integrationInstance.magicMcpServerBacking?.id ?? null,
+    name: integrationInstance.name,
+    description: integrationInstance.description,
+    metadata: integrationInstance.metadata,
+    privateMetadata: integrationInstance.privateMetadata,
 
-  providers: integrationInstance.integrationInstanceProviders.map(provider =>
-    integrationInstanceProviderPresenter(provider)
-  ),
+    integrationId: integrationInstance.integration.id,
+    identityActorId: integrationInstance.identityActor?.id ?? null,
+    identityId: integrationInstance.identity?.id ?? null,
+    defaultSessionTemplateId: integrationInstance.defaultSessionTemplate?.id ?? null,
+    magicMcpServerBackingId,
 
-  createdAt: integrationInstance.createdAt,
-  updatedAt: integrationInstance.updatedAt,
-  archivedAt: integrationInstance.archivedAt
-});
+    providers: integrationInstance.integrationInstanceProviders.map(provider =>
+      integrationInstanceProviderPresenter(provider)
+    ),
+
+    createdAt: integrationInstance.createdAt,
+    updatedAt: integrationInstance.updatedAt,
+    archivedAt: integrationInstance.archivedAt
+  };
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches subspace schema (1:1 → many backings per instance), auto-archives linked servers on integration deletion, and changes provider mutation rules for integration-owned servers—easy to break existing deployments if migrations or cleanup miss edge cases.
> 
> **Overview**
> Adds **integration-instance–linked Magic MCP servers**: create can take `integration_instance_id` (mutually exclusive with `provider_template_id`), with validation that the instance is active and has providers. List gains **`integration_instance_id`** and **`owner`** (`organization` / `consumer`) filters; dashboard payloads expose **`integration_id`**, **`integration_instance_id`**, and **`consumer_owners`**.
> 
> **Subspace backing** moves from one backing per integration instance to **many** (`magicMcpServerBackings`), with **`resolveMagicMcpBackingPolicy`** locking provider edits for integration-linked servers and softer archive behavior (no longer always archiving the whole integration instance). New RPCs resolve server backing IDs by integration resource / instance usage. **Lifecycle cleanup** archives active integration-linked Magic MCP servers when an integration or integration instance is deleted.
> 
> **Consumer provider deploy** passes consumer identity into server creation and **upserts a managed consumer integration**. **Dashboard**: integration instance overview lists linked servers and a create modal; server UI blocks adding providers when inherited and shows consumer owner on overview. Generated dashboard client types/maps are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc41106fc77206a620ec0327ff5b5eda177aadc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->