### PR TITLE
Hide custom providers in unavailable environments

### DIFF
--- a/src/systems/subspace/apps/controller/src/controllers/customProviderCommit.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/customProviderCommit.ts
@@ -142,7 +142,9 @@ export let customProviderCommitController = app.controller({
                       tenant: ctx.tenant,
                       environment: ctx.environment,
                       solution: ctx.solution,
-                      customProviderEnvironmentId: ctx.input.action.toEnvironmentId
+                      customProviderEnvironmentId: ctx.input.action.toEnvironmentId,
+                      includeUnpublished: true,
+                      includeOtherEnvironments: true
                     })
                 }
               : {

--- a/src/systems/subspace/apps/controller/src/controllers/tests/customProviderVisibility.e2e.test.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/tests/customProviderVisibility.e2e.test.ts
@@ -1,0 +1,416 @@
+import { ID, get4ByteIntId, getId } from '@metorial-subspace/db';
+import { customProviderEnvironmentService } from '@metorial-subspace/module-custom-provider';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createSubspaceControllerRootTestClient } from '../../test/client';
+import { cleanDatabase, testDb } from '../../test/setup';
+
+let createTenantContext = async () => {
+  let anonymousClient = createSubspaceControllerRootTestClient();
+  let solution = await anonymousClient.solution.upsert({
+    name: 'Custom Provider Visibility Solution',
+    identifier: 'custom-provider-visibility-solution'
+  });
+
+  let client = createSubspaceControllerRootTestClient({
+    headers: {
+      'Subspace-Solution-Id': solution.id
+    }
+  });
+
+  let tenant = await client.tenant.upsert({
+    name: 'Custom Provider Visibility Tenant',
+    identifier: 'custom-provider-visibility-tenant',
+    environments: [
+      {
+        name: 'Development',
+        identifier: 'custom-provider-visibility-dev',
+        type: 'development'
+      },
+      {
+        name: 'Production',
+        identifier: 'custom-provider-visibility-prod',
+        type: 'production'
+      }
+    ]
+  });
+
+  let [tenantRecord, devEnvironment, prodEnvironment, solutionRecord] = await Promise.all([
+    testDb.tenant.findUniqueOrThrow({ where: { id: tenant.id } }),
+    testDb.environment.findUniqueOrThrow({
+      where: { identifier: 'custom-provider-visibility-dev' }
+    }),
+    testDb.environment.findUniqueOrThrow({
+      where: { identifier: 'custom-provider-visibility-prod' }
+    }),
+    testDb.solution.findUniqueOrThrow({ where: { id: solution.id } })
+  ]);
+
+  return { client, tenant, tenantRecord, devEnvironment, prodEnvironment, solutionRecord };
+};
+
+let createCustomProviderFixture = async (d: Awaited<ReturnType<typeof createTenantContext>>) => {
+  let actor = await testDb.tenantActor.create({
+    data: {
+      ...getId('actor'),
+      type: 'system',
+      identifier: 'custom-provider-visibility-system',
+      name: 'Custom Provider Visibility System',
+      tenantOid: d.tenantRecord.oid
+    }
+  });
+
+  let backend = await testDb.backend.create({
+    data: {
+      ...getId('backend'),
+      type: 'shuttle',
+      identifier: 'custom-provider-visibility-shuttle',
+      name: 'Custom Provider Visibility Shuttle'
+    }
+  });
+
+  let publisherTag = await testDb.providerTag.create({
+    data: {
+      ...getId('providerTag'),
+      tag: 'pub-custom-provider-visibility'
+    }
+  });
+  let providerTag = await testDb.providerTag.create({
+    data: {
+      ...getId('providerTag'),
+      tag: 'pro-custom-provider-visibility'
+    }
+  });
+  let providerVersionTag = await testDb.providerTag.create({
+    data: {
+      ...getId('providerTag'),
+      tag: 'ver-custom-provider-visibility'
+    }
+  });
+  let providerVariantTag = await testDb.providerTag.create({
+    data: {
+      ...getId('providerTag'),
+      tag: 'var-custom-provider-visibility'
+    }
+  });
+
+  let providerType = await testDb.providerType.create({
+    data: {
+      oid: get4ByteIntId(),
+      id: ID.generateIdSync('providerType'),
+      shortKey: 'cpv',
+      identifier: 'custom-provider-visibility-type',
+      name: 'Custom Provider Visibility Type',
+      attributes: {
+        provider: 'metorial-native',
+        backend: 'native',
+        triggers: { status: 'disabled' },
+        auth: { status: 'disabled' },
+        config: { status: 'disabled' }
+      }
+    }
+  });
+
+  let publisher = await testDb.publisher.create({
+    data: {
+      ...getId('publisher'),
+      type: 'tenant',
+      identifier: 'custom-provider-visibility-publisher',
+      name: 'Custom Provider Visibility Publisher',
+      description: 'Publisher for custom provider visibility tests',
+      tag: publisherTag.tag,
+      tenantOid: d.tenantRecord.oid
+    }
+  });
+
+  let providerEntry = await testDb.providerEntry.create({
+    data: {
+      ...getId('providerEntry'),
+      identifier: 'custom-provider-visibility-entry',
+      name: 'Custom Provider Visibility Entry',
+      description: 'Entry for custom provider visibility tests',
+      publisherOid: publisher.oid
+    }
+  });
+
+  let provider = await testDb.provider.create({
+    data: {
+      ...getId('provider'),
+      access: 'tenant',
+      status: 'active',
+      hasEnvironments: true,
+      identifier: 'custom-provider-visibility-provider',
+      slug: 'custom-provider-visibility-provider',
+      name: 'Custom Provider Visibility Provider',
+      description: 'Provider for custom provider visibility tests',
+      tag: providerTag.tag,
+      entryOid: providerEntry.oid,
+      publisherOid: publisher.oid,
+      ownerTenantOid: d.tenantRecord.oid,
+      ownerSolutionOid: d.solutionRecord.oid,
+      typeOid: providerType.oid
+    }
+  });
+
+  let providerVariant = await testDb.providerVariant.create({
+    data: {
+      ...getId('providerVariant'),
+      tag: providerVariantTag.tag,
+      identifier: 'custom-provider-visibility-variant',
+      name: 'Custom Provider Visibility Variant',
+      description: 'Variant for custom provider visibility tests',
+      isDefault: true,
+      backendOid: backend.oid,
+      providerOid: provider.oid,
+      publisherOid: publisher.oid
+    }
+  });
+
+  await testDb.provider.update({
+    where: { oid: provider.oid },
+    data: { defaultVariantOid: providerVariant.oid }
+  });
+
+  let providerVersion = await testDb.providerVersion.create({
+    data: {
+      ...getId('providerVersion'),
+      tag: providerVersionTag.tag,
+      identifier: 'custom-provider-visibility-version',
+      name: 'Custom Provider Visibility Version',
+      description: 'Version for custom provider visibility tests',
+      isCurrent: true,
+      isEnvironmentLocked: true,
+      specificationDiscoveryStatus: 'not_discoverable',
+      backendOid: backend.oid,
+      providerOid: provider.oid,
+      providerVariantOid: providerVariant.oid,
+      typeOid: providerType.oid
+    }
+  });
+
+  await testDb.providerVariant.update({
+    where: { oid: providerVariant.oid },
+    data: { currentVersionOid: providerVersion.oid }
+  });
+
+  let customProvider = await testDb.customProvider.create({
+    data: {
+      ...getId('customProvider'),
+      type: 'remote',
+      status: 'active',
+      name: 'Custom Provider Visibility Custom Provider',
+      description: 'Custom provider for visibility tests',
+      payload: {
+        from: {
+          type: 'remote',
+          remoteUrl: 'https://example.com/mcp',
+          protocol: 'sse'
+        }
+      },
+      tenantOid: d.tenantRecord.oid,
+      solutionOid: d.solutionRecord.oid,
+      providerOid: provider.oid,
+      providerVariantOid: providerVariant.oid
+    }
+  });
+
+  let deployment = await testDb.customProviderDeployment.create({
+    data: {
+      ...getId('customProviderDeployment'),
+      status: 'succeeded',
+      trigger: 'manual',
+      creatorActorOid: actor.oid,
+      tenantOid: d.tenantRecord.oid,
+      solutionOid: d.solutionRecord.oid,
+      customProviderOid: customProvider.oid
+    }
+  });
+
+  let customProviderVersion = await testDb.customProviderVersion.create({
+    data: {
+      ...getId('customProviderVersion'),
+      status: 'deployment_succeeded',
+      versionIndex: 1,
+      versionIdentifier: 'v1',
+      payload: customProvider.payload,
+      creatorActorOid: actor.oid,
+      customProviderOid: customProvider.oid,
+      tenantOid: d.tenantRecord.oid,
+      solutionOid: d.solutionRecord.oid,
+      providerVersionOid: providerVersion.oid,
+      deploymentOid: deployment.oid
+    }
+  });
+
+  let providerListing = await testDb.providerListing.create({
+    data: {
+      ...getId('providerListing'),
+      status: 'active',
+      isPublic: false,
+      isCustomized: false,
+      isMetorial: false,
+      isVerified: false,
+      isOfficial: false,
+      name: 'Custom Provider Visibility Listing',
+      slug: 'custom-provider-visibility-listing',
+      description: 'Listing for custom provider visibility tests',
+      skills: [],
+      ownerTenantOid: d.tenantRecord.oid,
+      ownerSolutionOid: d.solutionRecord.oid,
+      publisherOid: publisher.oid,
+      providerOid: provider.oid,
+      typeOid: providerType.oid
+    }
+  });
+
+  let devCustomProviderEnvironment = await testDb.customProviderEnvironment.create({
+    data: {
+      ...getId('customProviderEnvironment'),
+      tenantOid: d.tenantRecord.oid,
+      solutionOid: d.solutionRecord.oid,
+      environmentOid: d.devEnvironment.oid,
+      customProviderOid: customProvider.oid
+    }
+  });
+
+  let prodCustomProviderEnvironment = await testDb.customProviderEnvironment.create({
+    data: {
+      ...getId('customProviderEnvironment'),
+      tenantOid: d.tenantRecord.oid,
+      solutionOid: d.solutionRecord.oid,
+      environmentOid: d.prodEnvironment.oid,
+      customProviderOid: customProvider.oid
+    }
+  });
+
+  let publishToEnvironment = async (environmentOid: bigint, customProviderEnvironmentOid: bigint) => {
+    let providerEnvironment = await testDb.providerEnvironment.create({
+      data: {
+        ...getId('providerEnvironment'),
+        tenantOid: d.tenantRecord.oid,
+        solutionOid: d.solutionRecord.oid,
+        environmentOid,
+        providerOid: provider.oid,
+        providerVariantOid: providerVariant.oid,
+        currentVersionOid: providerVersion.oid
+      }
+    });
+
+    await testDb.providerEnvironmentVersion.create({
+      data: {
+        ...getId('providerEnvironmentVersion'),
+        providerEnvironmentOid: providerEnvironment.oid,
+        providerVersionOid: providerVersion.oid,
+        environmentOid
+      }
+    });
+
+    await testDb.customProviderEnvironment.update({
+      where: { oid: customProviderEnvironmentOid },
+      data: { providerEnvironmentOid: providerEnvironment.oid }
+    });
+  };
+
+  await publishToEnvironment(d.devEnvironment.oid, devCustomProviderEnvironment.oid);
+
+  return {
+    provider,
+    providerListing,
+    customProvider,
+    customProviderVersion,
+    devCustomProviderEnvironment,
+    prodCustomProviderEnvironment,
+    publishToEnvironment
+  };
+};
+
+describe('customProviderVisibility.e2e', () => {
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  it('only lists custom providers and listings in published environments', async () => {
+    let ctx = await createTenantContext();
+    let fixture = await createCustomProviderFixture(ctx);
+
+    let devListings = await ctx.client.providerListing.list({
+      tenantId: ctx.tenant.id,
+      environmentId: ctx.devEnvironment.id,
+      ids: [fixture.providerListing.id],
+      limit: 10
+    });
+    expect(devListings.items.map(item => item.id)).toContain(fixture.providerListing.id);
+
+    let prodListings = await ctx.client.providerListing.list({
+      tenantId: ctx.tenant.id,
+      environmentId: ctx.prodEnvironment.id,
+      ids: [fixture.providerListing.id],
+      limit: 10
+    });
+    expect(prodListings.items).toHaveLength(0);
+
+    let devCustomProviders = await ctx.client.customProvider.list({
+      tenantId: ctx.tenant.id,
+      environmentId: ctx.devEnvironment.id,
+      ids: [fixture.customProvider.id],
+      limit: 10
+    });
+    expect(devCustomProviders.items.map(item => item.id)).toContain(fixture.customProvider.id);
+
+    let prodCustomProviders = await ctx.client.customProvider.list({
+      tenantId: ctx.tenant.id,
+      environmentId: ctx.prodEnvironment.id,
+      ids: [fixture.customProvider.id],
+      limit: 10
+    });
+    expect(prodCustomProviders.items).toHaveLength(0);
+
+    await expect(
+      ctx.client.customProvider.get({
+        tenantId: ctx.tenant.id,
+        environmentId: ctx.prodEnvironment.id,
+        customProviderId: fixture.customProvider.id
+      })
+    ).rejects.toThrow();
+
+    await fixture.publishToEnvironment(
+      ctx.prodEnvironment.oid,
+      fixture.prodCustomProviderEnvironment.oid
+    );
+
+    let publishedProdCustomProviders = await ctx.client.customProvider.list({
+      tenantId: ctx.tenant.id,
+      environmentId: ctx.prodEnvironment.id,
+      ids: [fixture.customProvider.id],
+      limit: 10
+    });
+    expect(publishedProdCustomProviders.items.map(item => item.id)).toContain(
+      fixture.customProvider.id
+    );
+  });
+
+  it('keeps unpublished target environments resolvable for publish commits', async () => {
+    let ctx = await createTenantContext();
+    let fixture = await createCustomProviderFixture(ctx);
+
+    await expect(
+      customProviderEnvironmentService.getCustomProviderEnvironmentById({
+        tenant: ctx.tenantRecord,
+        solution: ctx.solutionRecord,
+        environment: ctx.devEnvironment,
+        customProviderEnvironmentId: fixture.prodCustomProviderEnvironment.id
+      })
+    ).rejects.toThrow();
+
+    let targetEnvironment =
+      await customProviderEnvironmentService.getCustomProviderEnvironmentById({
+        tenant: ctx.tenantRecord,
+        solution: ctx.solutionRecord,
+        environment: ctx.devEnvironment,
+        customProviderEnvironmentId: fixture.prodCustomProviderEnvironment.id,
+        includeUnpublished: true,
+        includeOtherEnvironments: true
+      });
+
+    expect(targetEnvironment.id).toBe(fixture.prodCustomProviderEnvironment.id);
+  });
+});

--- a/src/systems/subspace/modules/catalog/src/services/provider.ts
+++ b/src/systems/subspace/modules/catalog/src/services/provider.ts
@@ -25,6 +25,23 @@ let include = {
 
 export let providerInclude = include;
 
+export let getProviderEnvironmentVisibilityFilter = (d: { environment?: Environment }) =>
+  d.environment
+    ? {
+        OR: [
+          { hasEnvironments: false },
+          {
+            providerEnvironments: {
+              some: {
+                environmentOid: d.environment.oid,
+                currentVersionOid: { not: null }
+              }
+            }
+          }
+        ]
+      }
+    : undefined!;
+
 export let getProviderTenantFilter = (d: {
   solution: Solution;
   tenant?: Tenant;
@@ -33,6 +50,7 @@ export let getProviderTenantFilter = (d: {
 }) => ({
   AND: [
     d.includeDeprecated ? undefined! : { isDeprecated: false },
+    getProviderEnvironmentVisibilityFilter(d),
     {
       OR: [
         { access: 'public' as const },

--- a/src/systems/subspace/modules/catalog/src/services/providerListing.ts
+++ b/src/systems/subspace/modules/catalog/src/services/providerListing.ts
@@ -12,7 +12,11 @@ import {
 } from '@metorial-subspace/list-utils';
 import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
 import type { ProviderCapabilityFilter } from './provider';
-import { getProviderCapabilityFilter, providerInclude } from './provider';
+import {
+  getProviderCapabilityFilter,
+  getProviderEnvironmentVisibilityFilter,
+  providerInclude
+} from './provider';
 
 export type ProviderListingOrderByUse =
   | 'deployments'
@@ -83,7 +87,13 @@ class ProviderListingService {
                   }
                 : undefined!
             ].filter(Boolean)
-          }
+          },
+
+          d.environment
+            ? {
+                provider: getProviderEnvironmentVisibilityFilter(d)
+              }
+            : undefined!
         ].filter(Boolean)
       },
       include: getInclude(d.tenant, d.solution)
@@ -192,6 +202,11 @@ class ProviderListingService {
                     : undefined!
                 ].filter(Boolean)
               },
+              d.environment
+                ? {
+                    provider: getProviderEnvironmentVisibilityFilter(d)
+                  }
+                : undefined!,
 
               // d.tenant.onlyIncludeVerifiedOfficialOrFromTenant
               //   ? {

--- a/src/systems/subspace/modules/custom-provider/src/internal/ensureEnvironments.ts
+++ b/src/systems/subspace/modules/custom-provider/src/internal/ensureEnvironments.ts
@@ -23,35 +23,6 @@ export let ensureEnvironments = async (
       }))
     });
 
-    if (customProvider.providerOid && customProvider.providerVariantOid) {
-      let customProviderEnvironments = await db.customProviderEnvironment.findMany({
-        where: { customProviderOid: customProvider.oid }
-      });
-      let newProviderEnvironments = await db.providerEnvironment.createManyAndReturn({
-        skipDuplicates: true,
-        data: customProviderEnvironments.map(env => ({
-          ...getId('providerEnvironment'),
-          tenantOid: customProvider.tenantOid,
-          solutionOid: customProvider.solutionOid,
-          environmentOid: env.environmentOid,
-          providerOid: customProvider.providerOid!,
-          providerVariantOid: customProvider.providerVariantOid!
-        }))
-      });
-
-      for (let env of newProviderEnvironments) {
-        let matchingCustomEnv = customProviderEnvironments.find(
-          e => e.environmentOid === env.environmentOid
-        );
-        if (!matchingCustomEnv) continue;
-
-        await db.customProviderEnvironment.updateMany({
-          where: { oid: matchingCustomEnv.oid },
-          data: { providerEnvironmentOid: env.oid }
-        });
-      }
-    }
-
     return await db.customProviderEnvironment.findMany({
       where: { customProviderOid: customProvider.oid },
       include: { environment: true }

--- a/src/systems/subspace/modules/custom-provider/src/queues/commit/apply.ts
+++ b/src/systems/subspace/modules/custom-provider/src/queues/commit/apply.ts
@@ -84,6 +84,11 @@ export let commitApplyQueueProcessor = commitApplyQueue.process(async data => {
         }
       });
 
+      await db.customProviderEnvironment.updateMany({
+        where: { oid: commit.toEnvironmentOid },
+        data: { providerEnvironmentOid: providerEnvironment.oid }
+      });
+
       let providerVersion = await db.providerEnvironmentVersion.upsert({
         where: {
           providerEnvironmentOid_providerVersionOid: {

--- a/src/systems/subspace/modules/custom-provider/src/services/customProvider.ts
+++ b/src/systems/subspace/modules/custom-provider/src/services/customProvider.ts
@@ -69,6 +69,19 @@ let include = {
   draftCodeBucket: { include: { scmRepo: true } }
 };
 
+let customProviderEnvironmentVisibilityFilter = (environment: Environment) => ({
+  customProviderEnvironments: {
+    some: {
+      environmentOid: environment.oid,
+      providerEnvironment: {
+        is: {
+          currentVersionOid: { not: null }
+        }
+      }
+    }
+  }
+});
+
 class customProviderServiceImpl {
   async enrichCustomProviders<
     T extends CustomProvider & {
@@ -140,6 +153,7 @@ class customProviderServiceImpl {
             ...normalizeStatusForList(d).noParent,
 
             AND: [
+              customProviderEnvironmentVisibilityFilter(d.environment),
               d.type ? { type: { in: d.type } } : undefined!,
               d.ids ? { id: { in: d.ids } } : undefined!,
               search ? { id: { in: search.map(r => r.documentId) } } : undefined!,
@@ -173,7 +187,8 @@ class customProviderServiceImpl {
         ],
         tenantOid: d.tenant.oid,
         solutionOid: d.solution.oid,
-        ...normalizeStatusForGet(d).noParent
+        ...normalizeStatusForGet(d).noParent,
+        AND: [customProviderEnvironmentVisibilityFilter(d.environment)]
       },
       include
     });

--- a/src/systems/subspace/modules/custom-provider/src/services/customProviderCommit.ts
+++ b/src/systems/subspace/modules/custom-provider/src/services/customProviderCommit.ts
@@ -6,13 +6,15 @@ import {
   type CustomProviderCommitTrigger,
   type CustomProviderEnvironment,
   type CustomProviderVersion,
+  addAfterTransactionHook,
   db,
   type Environment,
   getId,
   type ScmRepoPush,
   type Solution,
   type Tenant,
-  type TenantActor
+  type TenantActor,
+  withTransaction
 } from '@metorial-subspace/db';
 import {
   type DateFilter,
@@ -23,6 +25,7 @@ import {
   resolveProviders
 } from '@metorial-subspace/list-utils';
 import { checkTenant } from '@metorial-subspace/module-tenant';
+import { commitApplyQueue } from '../queues/commit/apply';
 
 let envInclude = {
   include: {
@@ -106,146 +109,152 @@ class customProviderCommitServiceImpl {
           };
     };
   }) {
-    let dataBase = {
-      ...getId('customProviderCommit'),
+    return await withTransaction(async db => {
+      let dataBase = {
+        ...getId('customProviderCommit'),
 
-      status: 'pending' as const,
-      trigger: d._internal?.trigger ?? ('manual' as const),
-      type: d.input.action.type,
+        status: 'pending' as const,
+        trigger: d._internal?.trigger ?? ('manual' as const),
+        type: d.input.action.type,
 
-      message: d.input.message,
+        message: d.input.message,
 
-      scmRepoPushOid: d._internal?.scmPush?.oid,
+        scmRepoPushOid: d._internal?.scmPush?.oid,
 
-      tenantOid: d.tenant.oid,
-      solutionOid: d.solution.oid,
-      creatorActorOid: d.actor.oid
-    };
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        creatorActorOid: d.actor.oid
+      };
 
-    let commit: CustomProviderCommit;
+      let commit: CustomProviderCommit;
 
-    if (d.input.action.type === 'rollback_to_version') {
-      checkTenant(d, d.input.action.environment);
-      checkTenant(d, d.input.action.version);
+      if (d.input.action.type === 'rollback_to_version') {
+        checkTenant(d, d.input.action.environment);
+        checkTenant(d, d.input.action.version);
 
-      let action = d.input.action;
-      if (action.environment.customProviderOid !== action.version.customProviderOid) {
-        throw new ServiceError(
-          badRequestError({
-            message: 'Environment and version must belong to the same custom provider.'
-          })
-        );
-      }
-
-      if (action.version.status !== 'deployment_succeeded') {
-        throw new ServiceError(
-          badRequestError({
-            message: 'Can only rollback to a version that has been successfully deployed.'
-          })
-        );
-      }
-
-      commit = await db.customProviderCommit.create({
-        data: {
-          ...dataBase,
-
-          toEnvironmentOid: d.input.action.environment.oid,
-
-          // Flip the versions
-          toEnvironmentVersionBeforeOid: action.version.oid,
-          targetCustomProviderVersionOid: action.version.oid,
-
-          customProviderOid: action.version.customProviderOid
+        let action = d.input.action;
+        if (action.environment.customProviderOid !== action.version.customProviderOid) {
+          throw new ServiceError(
+            badRequestError({
+              message: 'Environment and version must belong to the same custom provider.'
+            })
+          );
         }
-      });
-    } else if (d.input.action.type === 'merge_version_into_environment') {
-      checkTenant(d, d.input.action.fromEnvironment);
-      checkTenant(d, d.input.action.toEnvironment);
 
-      let action = d.input.action;
+        if (action.version.status !== 'deployment_succeeded') {
+          throw new ServiceError(
+            badRequestError({
+              message: 'Can only rollback to a version that has been successfully deployed.'
+            })
+          );
+        }
 
-      if (action.toEnvironment.oid === action.fromEnvironment.oid) {
-        throw new ServiceError(
-          badRequestError({
-            message: 'Cannot merge version into the same environment.'
-          })
-        );
-      }
-      if (
-        action.toEnvironment.customProviderOid !== action.fromEnvironment.customProviderOid
-      ) {
-        throw new ServiceError(
-          badRequestError({
-            message: 'From and to environments must belong to the same custom provider.'
-          })
-        );
-      }
+        commit = await db.customProviderCommit.create({
+          data: {
+            ...dataBase,
 
-      let toEnvironmentFull = await db.customProviderEnvironment.findUniqueOrThrow({
-        where: { oid: action.toEnvironment.oid },
-        include: {
-          providerEnvironment: {
-            include: {
-              currentVersion: {
-                include: { customProviderVersion: true }
+            toEnvironmentOid: d.input.action.environment.oid,
+
+            // Flip the versions
+            toEnvironmentVersionBeforeOid: action.version.oid,
+            targetCustomProviderVersionOid: action.version.oid,
+
+            customProviderOid: action.version.customProviderOid
+          }
+        });
+      } else if (d.input.action.type === 'merge_version_into_environment') {
+        checkTenant(d, d.input.action.fromEnvironment);
+        checkTenant(d, d.input.action.toEnvironment);
+
+        let action = d.input.action;
+
+        if (action.toEnvironment.oid === action.fromEnvironment.oid) {
+          throw new ServiceError(
+            badRequestError({
+              message: 'Cannot merge version into the same environment.'
+            })
+          );
+        }
+        if (
+          action.toEnvironment.customProviderOid !== action.fromEnvironment.customProviderOid
+        ) {
+          throw new ServiceError(
+            badRequestError({
+              message: 'From and to environments must belong to the same custom provider.'
+            })
+          );
+        }
+
+        let toEnvironmentFull = await db.customProviderEnvironment.findUniqueOrThrow({
+          where: { oid: action.toEnvironment.oid },
+          include: {
+            providerEnvironment: {
+              include: {
+                currentVersion: {
+                  include: { customProviderVersion: true }
+                }
               }
             }
           }
-        }
-      });
-      let fromEnvironmentFull = await db.customProviderEnvironment.findUniqueOrThrow({
-        where: { oid: action.fromEnvironment.oid },
-        include: {
-          providerEnvironment: {
-            include: {
-              currentVersion: {
-                include: { customProviderVersion: true }
+        });
+        let fromEnvironmentFull = await db.customProviderEnvironment.findUniqueOrThrow({
+          where: { oid: action.fromEnvironment.oid },
+          include: {
+            providerEnvironment: {
+              include: {
+                currentVersion: {
+                  include: { customProviderVersion: true }
+                }
               }
             }
           }
+        });
+
+        let toVersion =
+          toEnvironmentFull.providerEnvironment?.currentVersion?.customProviderVersion;
+        let fromVersion =
+          fromEnvironmentFull.providerEnvironment?.currentVersion?.customProviderVersion;
+
+        if (!fromVersion) {
+          throw new ServiceError(
+            badRequestError({
+              message: 'From environment has no version to merge from.'
+            })
+          );
         }
-      });
-
-      let toVersion =
-        toEnvironmentFull.providerEnvironment?.currentVersion?.customProviderVersion;
-      let fromVersion =
-        fromEnvironmentFull.providerEnvironment?.currentVersion?.customProviderVersion;
-
-      if (!fromVersion) {
-        throw new ServiceError(
-          badRequestError({
-            message: 'From environment has no version to merge from.'
-          })
-        );
-      }
-      if (toVersion && toVersion.oid === fromVersion.oid) {
-        throw new ServiceError(
-          badRequestError({
-            message: 'To environment is already at the same version as from environment.'
-          })
-        );
-      }
-
-      commit = await db.customProviderCommit.create({
-        data: {
-          ...dataBase,
-
-          fromEnvironmentOid: action.fromEnvironment.oid,
-          toEnvironmentOid: action.toEnvironment.oid,
-
-          toEnvironmentVersionBeforeOid: toVersion ? toVersion.oid : null,
-          targetCustomProviderVersionOid: fromVersion.oid,
-
-          customProviderOid: fromVersion.customProviderOid
+        if (toVersion && toVersion.oid === fromVersion.oid) {
+          throw new ServiceError(
+            badRequestError({
+              message: 'To environment is already at the same version as from environment.'
+            })
+          );
         }
-      });
-    } else {
-      throw new Error('Unhandled action type');
-    }
 
-    return await db.customProviderCommit.findUniqueOrThrow({
-      where: { oid: commit.oid },
-      include
+        commit = await db.customProviderCommit.create({
+          data: {
+            ...dataBase,
+
+            fromEnvironmentOid: action.fromEnvironment.oid,
+            toEnvironmentOid: action.toEnvironment.oid,
+
+            toEnvironmentVersionBeforeOid: toVersion ? toVersion.oid : null,
+            targetCustomProviderVersionOid: fromVersion.oid,
+
+            customProviderOid: fromVersion.customProviderOid
+          }
+        });
+      } else {
+        throw new Error('Unhandled action type');
+      }
+
+      await addAfterTransactionHook(() =>
+        commitApplyQueue.add({ customProviderCommitId: commit.id })
+      );
+
+      return await db.customProviderCommit.findUniqueOrThrow({
+        where: { oid: commit.oid },
+        include
+      });
     });
   }
 

--- a/src/systems/subspace/modules/custom-provider/src/services/customProviderEnvironment.ts
+++ b/src/systems/subspace/modules/custom-provider/src/services/customProviderEnvironment.ts
@@ -29,6 +29,25 @@ let include = {
   }
 };
 
+let customProviderEnvironmentScopeFilter = (d: {
+  environment: Environment;
+  includeUnpublished?: boolean;
+  includeOtherEnvironments?: boolean;
+}) => ({
+  AND: [
+    d.includeOtherEnvironments ? undefined! : { environmentOid: d.environment.oid },
+    d.includeUnpublished
+      ? undefined!
+      : {
+          providerEnvironment: {
+            is: {
+              currentVersionOid: { not: null }
+            }
+          }
+        }
+  ].filter(Boolean)
+});
+
 class customProviderEnvironmentServiceImpl {
   async listCustomProviderEnvironments(d: {
     tenant: Tenant;
@@ -58,6 +77,7 @@ class customProviderEnvironmentServiceImpl {
               solutionOid: d.solution.oid,
 
               AND: [
+                customProviderEnvironmentScopeFilter(d),
                 {
                   customProvider: {
                     is: {
@@ -91,12 +111,15 @@ class customProviderEnvironmentServiceImpl {
     solution: Solution;
     environment: Environment;
     customProviderEnvironmentId: string;
+    includeUnpublished?: boolean;
+    includeOtherEnvironments?: boolean;
   }) {
     let customProviderEnvironment = await db.customProviderEnvironment.findFirst({
       where: {
         id: d.customProviderEnvironmentId,
         tenantOid: d.tenant.oid,
-        solutionOid: d.solution.oid
+        solutionOid: d.solution.oid,
+        AND: [customProviderEnvironmentScopeFilter(d)]
       },
       include
     });

--- a/src/systems/subspace/packages/list-utils/src/resources/provider.ts
+++ b/src/systems/subspace/packages/list-utils/src/resources/provider.ts
@@ -1,6 +1,50 @@
 import { db } from '@metorial-subspace/db';
 import { createOptionalResolver, createPublicResolver, createResolver } from '../resolver';
 
+let providerEnvironmentVisibilityFilter = (environmentOid?: bigint) =>
+  environmentOid
+    ? {
+        OR: [
+          { hasEnvironments: false },
+          {
+            providerEnvironments: {
+              some: {
+                environmentOid,
+                currentVersionOid: { not: null }
+              }
+            }
+          }
+        ]
+      }
+    : undefined!;
+
+let providerVersionEnvironmentVisibilityFilter = (environmentOid?: bigint) =>
+  environmentOid
+    ? {
+        OR: [
+          { isEnvironmentLocked: false },
+          {
+            providerEnvironmentVersions: {
+              some: { environmentOid }
+            }
+          }
+        ]
+      }
+    : undefined!;
+
+let customProviderEnvironmentVisibilityFilter = (environmentOid: bigint) => ({
+  customProviderEnvironments: {
+    some: {
+      environmentOid,
+      providerEnvironment: {
+        is: {
+          currentVersionOid: { not: null }
+        }
+      }
+    }
+  }
+});
+
 export let resolveProviders = createOptionalResolver(async ({ ts, ids }) =>
   db.provider.findMany({
     where: {
@@ -27,6 +71,7 @@ export let resolveProviders = createOptionalResolver(async ({ ts, ids }) =>
               : undefined!
           ].filter(Boolean)
         },
+        providerEnvironmentVisibilityFilter(ts.environmentOid)
       ].filter(Boolean)
     },
     select: { oid: true }
@@ -37,17 +82,23 @@ export let resolveProviderVersions = createOptionalResolver(async ({ ts, ids }) 
   db.providerVersion.findMany({
     where: {
       id: { in: ids },
+      AND: [providerVersionEnvironmentVisibilityFilter(ts.environmentOid)].filter(Boolean),
 
       provider: {
-        OR: [
-          { access: 'public' as const },
-          ts.tenantOid && ts.solutionOid
-            ? {
-                access: 'tenant' as const,
-                ownerTenantOid: ts.tenantOid,
-                ownerSolutionOid: ts.solutionOid
-              }
-            : undefined!
+        AND: [
+          {
+            OR: [
+              { access: 'public' as const },
+              ts.tenantOid && ts.solutionOid
+                ? {
+                    access: 'tenant' as const,
+                    ownerTenantOid: ts.tenantOid,
+                    ownerSolutionOid: ts.solutionOid
+                  }
+                : undefined!
+            ].filter(Boolean)
+          },
+          providerEnvironmentVisibilityFilter(ts.environmentOid)
         ].filter(Boolean)
       }
     },
@@ -66,15 +117,20 @@ export let resolveProviderListings = createOptionalResolver(async ({ ts, ids }) 
       ],
 
       provider: {
-        OR: [
-          { access: 'public' as const },
-          ts.tenantOid && ts.solutionOid
-            ? {
-                access: 'tenant' as const,
-                ownerTenantOid: ts.tenantOid,
-                ownerSolutionOid: ts.solutionOid
-              }
-            : undefined!
+        AND: [
+          {
+            OR: [
+              { access: 'public' as const },
+              ts.tenantOid && ts.solutionOid
+                ? {
+                    access: 'tenant' as const,
+                    ownerTenantOid: ts.tenantOid,
+                    ownerSolutionOid: ts.solutionOid
+                  }
+                : undefined!
+            ].filter(Boolean)
+          },
+          providerEnvironmentVisibilityFilter(ts.environmentOid)
         ].filter(Boolean)
       }
     },
@@ -132,14 +188,19 @@ export let resolveProviderSpecifications = createResolver(async ({ ts, ids }) =>
   db.providerSpecification.findMany({
     where: {
       provider: {
-        OR: [
-          { access: 'public' as const },
+        AND: [
           {
-            access: 'tenant' as const,
-            ownerTenantOid: ts.tenantOid,
-            ownerSolutionOid: ts.solutionOid
-          }
-        ]
+            OR: [
+              { access: 'public' as const },
+              {
+                access: 'tenant' as const,
+                ownerTenantOid: ts.tenantOid,
+                ownerSolutionOid: ts.solutionOid
+              }
+            ]
+          },
+          providerEnvironmentVisibilityFilter(ts.environmentOid)
+        ].filter(Boolean)
       },
 
       id: { in: ids }
@@ -152,15 +213,20 @@ export let resolveAuthMethods = createResolver(async ({ ts, ids }) =>
   db.providerAuthMethod.findMany({
     where: {
       provider: {
-        OR: [
-          { access: 'public' as const },
-          ts.tenantOid && ts.solutionOid
-            ? {
-                access: 'tenant' as const,
-                ownerTenantOid: ts.tenantOid,
-                ownerSolutionOid: ts.solutionOid
-              }
-            : undefined!
+        AND: [
+          {
+            OR: [
+              { access: 'public' as const },
+              ts.tenantOid && ts.solutionOid
+                ? {
+                    access: 'tenant' as const,
+                    ownerTenantOid: ts.tenantOid,
+                    ownerSolutionOid: ts.solutionOid
+                  }
+                : undefined!
+            ].filter(Boolean)
+          },
+          providerEnvironmentVisibilityFilter(ts.environmentOid)
         ].filter(Boolean)
       },
 
@@ -174,15 +240,20 @@ export let resolveAuthMethodsGlobal = createResolver(async ({ ts, ids }) =>
   db.providerAuthMethodGlobal.findMany({
     where: {
       provider: {
-        OR: [
-          { access: 'public' as const },
-          ts.tenantOid && ts.solutionOid
-            ? {
-                access: 'tenant' as const,
-                ownerTenantOid: ts.tenantOid,
-                ownerSolutionOid: ts.solutionOid
-              }
-            : undefined!
+        AND: [
+          {
+            OR: [
+              { access: 'public' as const },
+              ts.tenantOid && ts.solutionOid
+                ? {
+                    access: 'tenant' as const,
+                    ownerTenantOid: ts.tenantOid,
+                    ownerSolutionOid: ts.solutionOid
+                  }
+                : undefined!
+            ].filter(Boolean)
+          },
+          providerEnvironmentVisibilityFilter(ts.environmentOid)
         ].filter(Boolean)
       },
 
@@ -197,7 +268,8 @@ export let resolveCustomProviders = createResolver(async ({ ts, ids }) =>
     where: {
       id: { in: ids },
       solutionOid: ts.solutionOid,
-      tenantOid: ts.tenantOid
+      tenantOid: ts.tenantOid,
+      AND: [customProviderEnvironmentVisibilityFilter(ts.environmentOid)]
     },
     select: { oid: true }
   })
@@ -219,7 +291,8 @@ export let resolveCustomProviderVersions = createResolver(async ({ ts, ids }) =>
     where: {
       id: { in: ids },
       solutionOid: ts.solutionOid,
-      tenantOid: ts.tenantOid
+      tenantOid: ts.tenantOid,
+      customProvider: customProviderEnvironmentVisibilityFilter(ts.environmentOid)
     },
     select: { oid: true }
   })
@@ -229,7 +302,14 @@ export let resolveCustomProviderEnvironments = createResolver(async ({ ts, ids }
   db.customProviderEnvironment.findMany({
     where: {
       id: { in: ids },
-      tenantOid: ts.tenantOid
+      tenantOid: ts.tenantOid,
+      solutionOid: ts.solutionOid,
+      environmentOid: ts.environmentOid,
+      providerEnvironment: {
+        is: {
+          currentVersionOid: { not: null }
+        }
+      }
     },
     select: { oid: true }
   })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad query-filter changes affect catalog and list APIs across environments; publish/commit behavior changed (deferred providerEnvironment linking, new apply enqueue).
> 
> **Overview**
> **Hides custom providers and related catalog entries until they are published in the current environment** (a `providerEnvironment` with a non-null `currentVersionOid`). List/get paths for custom providers, provider listings, providers, and list-utils ID resolvers now apply environment visibility filters; unpublished prod environments no longer surface the same resources as dev.
> 
> **Publish / promote flow is adjusted** so visibility rules do not block cross-environment merges: merge commits resolve the target `customProviderEnvironment` with `includeUnpublished` and `includeOtherEnvironments`, `ensureEnvironments` no longer pre-creates `providerEnvironment` rows, and commit apply links the custom environment to the upserted `providerEnvironment` when a commit is applied. Commit creation runs in a transaction and enqueues the apply queue after insert.
> 
> Adds e2e coverage for list/get visibility and for resolving unpublished target environments during publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3684fb0987b59faf6332797ccf67d4c00a412088. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->