### PR TITLE
Add agent inputs

### DIFF
--- a/src/backend/apis/core/src/controllers/dashboard/assistant/conversations.ts
+++ b/src/backend/apis/core/src/controllers/dashboard/assistant/conversations.ts
@@ -69,7 +69,8 @@ export let assistantConversationHandlers = {
       'default',
       v.object({
         assistant_id: v.string(),
-        title: v.optional(v.string())
+        title: v.optional(v.string()),
+        input: v.optional(v.record(v.any()))
       })
     )
     .output(assistantConversationPresenter)
@@ -79,7 +80,8 @@ export let assistantConversationHandlers = {
         instance: ctx.instance,
         ...requireAssistantActor(ctx),
         assistantId: ctx.body.assistant_id,
-        title: ctx.body.title
+        title: ctx.body.title,
+        input: ctx.body.input
       });
 
       return assistantConversationPresenter.present({

--- a/src/backend/modules/assistant/src/services/conversation.ts
+++ b/src/backend/modules/assistant/src/services/conversation.ts
@@ -98,6 +98,7 @@ export let assistantConversationService = createSynthesisService(
         instance: Instance;
         assistantId: string;
         title?: string | null;
+        input?: unknown;
       } & AssistantActorInput
     ) => {
       assertAssistantScope(d);
@@ -108,7 +109,8 @@ export let assistantConversationService = createSynthesisService(
           instance: d.instance,
           ...getAssistantActorInput(d),
           assistantId: d.assistantId,
-          title: d.title ?? undefined
+          title: d.title ?? undefined,
+          input: d.input
         })
       });
     },

--- a/src/backend/modules/assistant/src/services/message.ts
+++ b/src/backend/modules/assistant/src/services/message.ts
@@ -3,10 +3,10 @@ import { assertAssistantScope } from '../lib/assertAssistantScope';
 import { createSynthesisService, getSynthesisServicePayload } from '../lib/synthesisService';
 import {
   enrichSynthesisActors,
-  type AssistantActorInput,
   getAssistantActorInput,
   getSynthesisActorsByIds,
   synthesis,
+  type AssistantActorInput,
   type EnrichedAssistantActor,
   type SynthesisScope
 } from '../synthesis';

--- a/src/systems/synthesis/service/prisma/schema/conversation.prisma
+++ b/src/systems/synthesis/service/prisma/schema/conversation.prisma
@@ -4,6 +4,9 @@ model AssistantConversation {
 
   title String?
 
+  /// [AssistantConversationInput]
+  input Json?
+
   assistantInstanceOid BigInt
   assistantInstance    AssistantInstance @relation(fields: [assistantInstanceOid], references: [oid], onDelete: Cascade)
 

--- a/src/systems/synthesis/service/src/controllers/conversation.ts
+++ b/src/systems/synthesis/service/src/controllers/conversation.ts
@@ -108,7 +108,8 @@ export let conversationController = app.controller({
         environmentId: v.string(),
         actorId: v.string(),
         assistantId: v.string(),
-        title: v.optional(v.string())
+        title: v.optional(v.string()),
+        input: v.optional(v.any())
       })
     )
     .do(async ctx =>
@@ -119,7 +120,8 @@ export let conversationController = app.controller({
           actor: ctx.actor,
           input: {
             assistantId: ctx.input.assistantId,
-            title: ctx.input.title
+            title: ctx.input.title,
+            input: ctx.input.input
           }
         })
       )

--- a/src/systems/synthesis/service/src/db.ts
+++ b/src/systems/synthesis/service/src/db.ts
@@ -40,6 +40,7 @@ export let db = baseClient;
 
 declare global {
   namespace PrismaJson {
+    type AssistantConversationInput = unknown;
     type AssistantMessageStateContent = import('./types').State;
     type AssistantMessageSerializedContent =
       import('./types').AssistantMessageSerializedContent;

--- a/src/systems/synthesis/service/src/lib/definitions/assistantDefinition.ts
+++ b/src/systems/synthesis/service/src/lib/definitions/assistantDefinition.ts
@@ -1,0 +1,19 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { assistants } from '../../definitions/assistants';
+
+export type AssistantDefinition = Awaited<(typeof assistants)[keyof typeof assistants]>;
+
+export let getAssistantDefinition = async (
+  implementationSlug: string
+): Promise<AssistantDefinition> => {
+  let definitions = await Promise.all(Object.values(assistants));
+  let definition = definitions.find(
+    definition => definition.implementation._persisted.slug == implementationSlug
+  );
+
+  if (!definition) {
+    throw new ServiceError(notFoundError('assistant_implementation', implementationSlug));
+  }
+
+  return definition;
+};

--- a/src/systems/synthesis/service/src/lib/definitions/implementation.ts
+++ b/src/systems/synthesis/service/src/lib/definitions/implementation.ts
@@ -1,4 +1,12 @@
-import type { Assistant, AssistantImplementation, Environment, Tenant } from '../../db';
+import type { ValidationType } from '@lowerdeck/validation';
+import type {
+  Assistant,
+  AssistantImplementation,
+  AssistantInstance,
+  Environment,
+  Tenant,
+  TenantActor
+} from '../../db';
 import { db, Prisma } from '../../db';
 import { getId } from '../../id';
 import { Agent } from '../open-harness';
@@ -12,19 +20,86 @@ export type ImplementationModelWithProvider = Prisma.ModelGetPayload<{
   include: typeof implementationModelInclude;
 }>;
 
-export let implementation = async (d: {
+type MaybePromise<T> = T | Promise<T>;
+
+type ImplementationBase = {
   defaultModel: Promise<Model>;
   availableModels: Promise<Model>[];
   slug: string;
   name: string;
-  getAgent: (d: {
-    model: Model;
-    tenant: Tenant;
-    environment: Environment;
-    assistant: Assistant;
-    assistantImplementation: AssistantImplementation;
-  }) => Promise<Agent>;
-}) => {
+};
+
+export type ImplementationHandleInputContext<Input> = {
+  input: Input;
+  tenant: Tenant;
+  environment: Environment;
+  actor: TenantActor;
+  assistant: Assistant;
+  assistantInstance: AssistantInstance;
+  assistantImplementation: AssistantImplementation;
+};
+
+export type ImplementationGetAgentContext<Input> = {
+  input: Input;
+  model: Model;
+  tenant: Tenant;
+  environment: Environment;
+  assistant: Assistant;
+  assistantInstance: AssistantInstance;
+  assistantImplementation: AssistantImplementation;
+};
+
+type ImplementationWithoutInput = ImplementationBase & {
+  input?: undefined;
+  handleInput?: undefined;
+  getAgent: (
+    d: {
+      input: undefined;
+    } & Omit<ImplementationGetAgentContext<undefined>, 'input'>
+  ) => Promise<Agent>;
+};
+
+type ImplementationWithInput<Input, HandledInput> = ImplementationBase & {
+  input: ValidationType<Input>;
+  handleInput: (d: ImplementationHandleInputContext<Input>) => MaybePromise<HandledInput>;
+  getAgent: (d: ImplementationGetAgentContext<HandledInput>) => Promise<Agent>;
+};
+
+export type ImplementationDefinition<Input = undefined, HandledInput = Input> =
+  | ImplementationWithoutInput
+  | ImplementationWithInput<Input, HandledInput>;
+
+type PersistedImplementationBase = Omit<
+  ImplementationBase,
+  'defaultModel' | 'availableModels'
+> & {
+  _persisted: AssistantImplementation;
+  persistedDefaultModel: ImplementationModelWithProvider | null;
+  persistedAvailableModels: ImplementationModelWithProvider[];
+  defaultModel: Model;
+  availableModels: Model[];
+};
+
+export type ImplementationWithoutInputResult = PersistedImplementationBase &
+  Omit<ImplementationWithoutInput, 'defaultModel' | 'availableModels'>;
+
+export type ImplementationWithInputResult<Input, HandledInput> = PersistedImplementationBase &
+  Omit<ImplementationWithInput<Input, HandledInput>, 'defaultModel' | 'availableModels'>;
+
+export type Implementation =
+  | ImplementationWithoutInputResult
+  | ImplementationWithInputResult<any, any>;
+
+type ImplementationFactory = {
+  (d: ImplementationWithoutInput): Promise<ImplementationWithoutInputResult>;
+  <Input, HandledInput>(
+    d: ImplementationWithInput<Input, HandledInput>
+  ): Promise<ImplementationWithInputResult<Input, HandledInput>>;
+};
+
+let buildImplementation = async (
+  d: ImplementationDefinition<any, any>
+): Promise<Implementation> => {
   let defaultModel = await d.defaultModel;
   let availableModels = Array.from(
     new Map(
@@ -70,4 +145,4 @@ export let implementation = async (d: {
   };
 };
 
-export type Implementation = Awaited<ReturnType<typeof implementation>>;
+export let implementation = buildImplementation as ImplementationFactory;

--- a/src/systems/synthesis/service/src/queues/processRequest.ts
+++ b/src/systems/synthesis/service/src/queues/processRequest.ts
@@ -1,12 +1,12 @@
 import { notFoundError, ServiceError } from '@lowerdeck/error';
 import { createQueue, QueueRetryError, type IQueue } from '@lowerdeck/queue';
-import { Prisma, db, withTransaction } from '../db';
-import { assistants } from '../definitions/assistants';
+import { db, withTransaction } from '../db';
 import { env } from '../env';
 import { getId } from '../id';
 import { type Model } from '../lib/definitions';
-import { AgentRun } from '../lib/run';
+import { getAssistantDefinition } from '../lib/definitions/assistantDefinition';
 import type { AgentRunUsage } from '../lib/run';
+import { AgentRun } from '../lib/run';
 import { createAssistantRunDeltaPublisher } from '../lib/run/redisDeltas';
 import type { InputMessage, State } from '../types';
 
@@ -19,8 +19,6 @@ export let processAssistantRequestQueue: IQueue<ProcessAssistantRequestJob, any>
     name: 'assistant/request/process',
     redisUrl: env.service.REDIS_URL
   });
-
-type AssistantDefinition = Awaited<(typeof assistants)[keyof typeof assistants]>;
 
 let isRecord = (value: unknown): value is Record<string, unknown> =>
   !!value && typeof value == 'object' && !Array.isArray(value);
@@ -52,21 +50,6 @@ let getInputMessage = (state: unknown): InputMessage => {
   return {
     parts: item.message.parts
   };
-};
-
-let getAssistantDefinition = async (
-  implementationSlug: string
-): Promise<AssistantDefinition> => {
-  let definitions = await Promise.all(Object.values(assistants));
-  let definition = definitions.find(
-    definition => definition.implementation._persisted.slug == implementationSlug
-  );
-
-  if (!definition) {
-    throw new ServiceError(notFoundError('assistant_implementation', implementationSlug));
-  }
-
-  return definition;
 };
 
 let calculateCost = (usage: AgentRunUsage, model: Model): PrismaJson.AssistantRunCost => {
@@ -185,17 +168,24 @@ export let processAssistantRequestQueueProcessor = processAssistantRequestQueue.
       let definition = await getAssistantDefinition(
         conversation.assistant.implementation.slug
       );
-      let model = definition.implementation.availableModels.find(
+      let assistantImplementation = definition.implementation;
+      let model = assistantImplementation.availableModels.find(
         model => model._persisted.oid == request.modelOid
       );
       if (!model) throw new ServiceError(notFoundError('model', requestModel.id));
 
-      let agent = await definition.implementation.getAgent({
+      let getAgent = assistantImplementation.getAgent as (
+        d: Parameters<typeof assistantImplementation.getAgent>[0] & { input: unknown }
+      ) => ReturnType<typeof assistantImplementation.getAgent>;
+
+      let agent = await getAgent({
+        input: assistantImplementation.input ? conversation.input : undefined,
         model,
         tenant: conversation.tenant,
         environment: conversation.environment,
         assistant: conversation.assistant,
-        assistantImplementation: definition.implementation._persisted
+        assistantInstance: conversation.assistantInstance,
+        assistantImplementation: assistantImplementation._persisted
       });
 
       let runner = new AgentRun(
@@ -204,8 +194,8 @@ export let processAssistantRequestQueueProcessor = processAssistantRequestQueue.
         conversation.tenant,
         conversation.environment,
         conversation.assistant,
-        definition.implementation._persisted,
-        definition.implementation
+        assistantImplementation._persisted,
+        assistantImplementation
       );
       let result = await runner.run({
         input: getInputMessage(inputMessage.state),

--- a/src/systems/synthesis/service/src/services/conversation.ts
+++ b/src/systems/synthesis/service/src/services/conversation.ts
@@ -1,9 +1,21 @@
-import { notFoundError, ServiceError } from '@lowerdeck/error';
+import {
+  badRequestError,
+  notFoundError,
+  ServiceError,
+  validationError
+} from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import type { AssistantConversation, Environment, Tenant, TenantActor } from '../db';
+import type {
+  AssistantConversation,
+  AssistantInstance,
+  Environment,
+  Tenant,
+  TenantActor
+} from '../db';
 import { db, Prisma, withTransaction } from '../db';
 import { getId } from '../id';
+import { getAssistantDefinition } from '../lib/definitions/assistantDefinition';
 import type { State } from '../types';
 import type { AvailableAssistant } from './assistant';
 import { assistantService } from './assistant';
@@ -40,6 +52,60 @@ let emptySerializedMessage = {
   b: 'ai-sdk-1',
   messages: []
 } satisfies PrismaJson.AssistantMessageSerializedContent;
+
+let hasOwn = (value: object, key: string) => Object.prototype.hasOwnProperty.call(value, key);
+
+let toNullableJson = (value: unknown) => {
+  if (value === undefined) return undefined;
+  if (value === null) return Prisma.JsonNull;
+
+  return value as Prisma.InputJsonValue;
+};
+
+let resolveConversationInput = async (d: {
+  tenant: Tenant;
+  environment: Environment;
+  actor: TenantActor;
+  assistant: AvailableAssistant;
+  assistantInstance: AssistantInstance;
+  rawInput: unknown;
+  rawInputProvided: boolean;
+}) => {
+  let definition = await getAssistantDefinition(d.assistant.implementation.slug);
+  let assistantImplementation = definition.implementation;
+
+  if (!assistantImplementation.input || !assistantImplementation.handleInput) {
+    if (d.rawInputProvided) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'This assistant does not accept conversation input.'
+        })
+      );
+    }
+
+    return undefined;
+  }
+
+  let valRes = assistantImplementation.input.validate(d.rawInput);
+  if (!valRes.success) {
+    throw new ServiceError(
+      validationError({
+        entity: 'assistant_conversation.input',
+        errors: valRes.errors
+      })
+    );
+  }
+
+  return await assistantImplementation.handleInput({
+    input: valRes.value,
+    tenant: d.tenant,
+    environment: d.environment,
+    actor: d.actor,
+    assistant: d.assistant,
+    assistantInstance: d.assistantInstance,
+    assistantImplementation: assistantImplementation._persisted
+  });
+};
 
 class AssistantConversationServiceImpl {
   private async enrichConversations(d: {
@@ -175,6 +241,7 @@ class AssistantConversationServiceImpl {
     input: {
       assistantId: string;
       title?: string | null;
+      input?: unknown;
     };
   }) {
     this.ensureScope(d);
@@ -191,6 +258,15 @@ class AssistantConversationServiceImpl {
       throw new ServiceError(notFoundError('model', assistant.id));
     }
     let defaultModel = assistant.defaultModel;
+    let conversationInput = await resolveConversationInput({
+      tenant: d.tenant,
+      environment: d.environment,
+      actor: d.actor,
+      assistant,
+      assistantInstance,
+      rawInput: d.input.input,
+      rawInputProvided: hasOwn(d.input, 'input')
+    });
 
     return await withTransaction(async tx => {
       let rootMessage = await tx.assistantMessage.create({
@@ -208,6 +284,7 @@ class AssistantConversationServiceImpl {
         data: {
           ...getId('assistantConversation'),
           title: d.input.title,
+          input: toNullableJson(conversationInput),
           assistantOid: assistant.oid,
           assistantInstanceOid: assistantInstance.oid,
           tenantOid: d.tenant.oid,

--- a/src/systems/synthesis/service/src/services/request.ts
+++ b/src/systems/synthesis/service/src/services/request.ts
@@ -8,9 +8,9 @@ import type {
   TenantActor
 } from '../db';
 import { db, Prisma, withTransaction } from '../db';
-import { assistants } from '../definitions/assistants';
 import { getId } from '../id';
 import type { Implementation } from '../lib/definitions';
+import { getAssistantDefinition } from '../lib/definitions/assistantDefinition';
 import { listenToAssistantRunDeltas } from '../lib/run/redisDeltas';
 import { createItemId, type AgentRunWireMessage } from '../lib/run/state';
 import { generateAssistantConversationTitleQueue } from '../queues/generateConversationTitle';
@@ -63,8 +63,6 @@ let inputMessageState = (input: InputMessage) =>
     ]
   }) satisfies State;
 
-type AssistantDefinition = Awaited<(typeof assistants)[keyof typeof assistants]>;
-
 export let assistantRequestInclude = {
   tenantActor: true,
   conversation: true,
@@ -86,21 +84,6 @@ export let assistantRequestInclude = {
 export type AssistantRequestWithRelations = Prisma.AssistantRequestGetPayload<{
   include: typeof assistantRequestInclude;
 }>;
-
-let getAssistantDefinition = async (
-  implementationSlug: string
-): Promise<AssistantDefinition> => {
-  let definitions = await Promise.all(Object.values(assistants));
-  let definition = definitions.find(
-    definition => definition.implementation._persisted.slug == implementationSlug
-  );
-
-  if (!definition) {
-    throw new ServiceError(notFoundError('assistant_implementation', implementationSlug));
-  }
-
-  return definition;
-};
 
 let chooseModel = (d: {
   implementation: Implementation;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches conversation creation, schema migration, and the assistant run path where stored JSON is passed into agent construction; behavior changes only when clients send `input` or implementations adopt the new hooks.
> 
> **Overview**
> Adds optional **conversation `input`** when creating assistant conversations, persisted on `AssistantConversation` and threaded through the dashboard API, assistant module, and synthesis service.
> 
> On create, implementations that declare an `input` schema validate the payload, run **`handleInput`**, and store the result; assistants without input reject a provided `input` field. **Implementation definitions** are extended so `getAgent` receives **`assistantInstance`**, validated/handled input, and typed optional `input` + `handleInput` hooks.
> 
> The **request processor** passes stored `conversation.input` into `getAgent` when the implementation supports inputs. **`getAssistantDefinition`** is centralized in a shared module (replacing duplicated lookups in request/process queues).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00a4a97a1c7ae7676360b1b742ca1a90c2f4005d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->