### PR TITLE
Feat/add agent handoff tools

### DIFF
--- a/src/backend/apis/core/src/controllers/dashboard/assistant/conversations.ts
+++ b/src/backend/apis/core/src/controllers/dashboard/assistant/conversations.ts
@@ -69,7 +69,8 @@ export let assistantConversationHandlers = {
       'default',
       v.object({
         assistant_id: v.string(),
-        title: v.optional(v.string())
+        title: v.optional(v.string()),
+        input: v.optional(v.record(v.any()))
       })
     )
     .output(assistantConversationPresenter)
@@ -79,7 +80,8 @@ export let assistantConversationHandlers = {
         instance: ctx.instance,
         ...requireAssistantActor(ctx),
         assistantId: ctx.body.assistant_id,
-        title: ctx.body.title
+        title: ctx.body.title,
+        input: ctx.body.input
       });
 
       return assistantConversationPresenter.present({

--- a/src/backend/apis/core/src/controllers/dashboard/assistant/messages.ts
+++ b/src/backend/apis/core/src/controllers/dashboard/assistant/messages.ts
@@ -149,5 +149,55 @@ export let assistantMessageHandlers = {
       assistantMessagePresenter.present({
         assistantConversationItem: ctx.assistantConversationItem
       })
+    ),
+
+  respondToHandoffs: assistantMessageGroup
+    .post(
+      instancePath(
+        'conversations/:assistantConversationId/messages/:assistantMessageId/handoff-responses',
+        'conversations.messages.handoff_responses'
+      ),
+      {
+        name: 'Respond to assistant handoffs',
+        description: 'Submit one or more client handoff tool responses for a waiting message.'
+      }
     )
+    .use(
+      checkAccess({
+        possibleScopes: [
+          'instance.assistant.conversation:write',
+          'consumer#instance.assistant.conversation:write'
+        ]
+      })
+    )
+    .use(requireConsumerTokenForPublishableKey())
+    .body(
+      'default',
+      v.object({
+        responses: v.array(
+          v.object({
+            tool_call_id: v.string(),
+            output: v.any()
+          })
+        )
+      })
+    )
+    .output(assistantMessagePresenter)
+    .do(async ctx => {
+      let item = await assistantRequestService.respondToHandoffs({
+        organization: ctx.organization,
+        instance: ctx.instance,
+        ...requireAssistantActor(ctx),
+        conversationId: ctx.assistantConversation.id,
+        messageId: ctx.assistantConversationItem.id,
+        responses: ctx.body.responses.map(response => ({
+          toolCallId: response.tool_call_id,
+          output: response.output
+        }))
+      });
+
+      return assistantMessagePresenter.present({
+        assistantConversationItem: item
+      });
+    })
 };

--- a/src/backend/apis/core/src/presenters/implementation/assistant/assistantMessage.ts
+++ b/src/backend/apis/core/src/presenters/implementation/assistant/assistantMessage.ts
@@ -20,6 +20,7 @@ export let v1AssistantMessagePresenter = Presenter.create(assistantMessageType)
       id: assistantConversationItem.id,
       conversation_item_id: assistantConversationItem.conversationItemId,
       type: assistantConversationItem.type,
+      status: assistantConversationItem.status,
       assistant_id: assistantConversationItem.assistantId ?? null,
       parent_message_id: assistantConversationItem.parentMessageId ?? null,
       model: assistantConversationItem.model
@@ -48,13 +49,20 @@ export let v1AssistantMessagePresenter = Presenter.create(assistantMessageType)
       id: v.string(),
       conversation_item_id: v.string(),
       type: v.enumOf(['root', 'user', 'assistant']),
+      status: v.enumOf(['pending', 'waiting_for_user', 'completed']),
       assistant_id: v.nullable(v.string()),
       parent_message_id: v.nullable(v.string()),
       model: v.nullable(assistantModelSchema),
       request: v.object({
         object: v.literal('assistant.request'),
         id: v.string(),
-        status: v.enumOf(['pending', 'completed', 'cancelled', 'failed']),
+        status: v.enumOf([
+          'pending',
+          'waiting_for_user',
+          'completed',
+          'cancelled',
+          'failed'
+        ]),
         actor: v.nullable(documentParticipantActorSchema),
         created_at: v.date(),
         updated_at: v.date()

--- a/src/backend/modules/assistant/src/services/conversation.ts
+++ b/src/backend/modules/assistant/src/services/conversation.ts
@@ -98,6 +98,7 @@ export let assistantConversationService = createSynthesisService(
         instance: Instance;
         assistantId: string;
         title?: string | null;
+        input?: unknown;
       } & AssistantActorInput
     ) => {
       assertAssistantScope(d);
@@ -108,7 +109,8 @@ export let assistantConversationService = createSynthesisService(
           instance: d.instance,
           ...getAssistantActorInput(d),
           assistantId: d.assistantId,
-          title: d.title ?? undefined
+          title: d.title ?? undefined,
+          input: d.input
         })
       });
     },

--- a/src/backend/modules/assistant/src/services/message.ts
+++ b/src/backend/modules/assistant/src/services/message.ts
@@ -3,10 +3,10 @@ import { assertAssistantScope } from '../lib/assertAssistantScope';
 import { createSynthesisService, getSynthesisServicePayload } from '../lib/synthesisService';
 import {
   enrichSynthesisActors,
-  type AssistantActorInput,
   getAssistantActorInput,
   getSynthesisActorsByIds,
   synthesis,
+  type AssistantActorInput,
   type EnrichedAssistantActor,
   type SynthesisScope
 } from '../synthesis';

--- a/src/backend/modules/assistant/src/services/request.ts
+++ b/src/backend/modules/assistant/src/services/request.ts
@@ -50,213 +50,245 @@ let enrichRequest = async (d: {
   };
 };
 
-let getRequest = async (
-  d: {
-    organization: Organization;
-    instance: Instance;
-    requestId: string;
-  } & AssistantActorInput
-) => {
-  assertAssistantScope(d);
-
-  let { context, payload } = await getSynthesisServicePayload({
-    instance: d.instance,
-    ...getAssistantActorInput(d),
-    requestId: d.requestId
-  });
-
-  return await enrichRequest({
-    scope: context.scope,
-    instance: d.instance,
-    request: await synthesis.request.get(
-      payload as Parameters<typeof synthesis.request.get>[0]
-    )
-  });
-};
-
-let createRequest = async (
-  d: {
-    organization: Organization;
-    instance: Instance;
-    conversationId: string;
-    message: AssistantInputMessage;
-    parentMessageId?: string;
-    modelId?: string;
-  } & AssistantActorInput
-) => {
-  assertAssistantScope(d);
-
-  let { context, payload } = await getSynthesisServicePayload({
-    instance: d.instance,
-    ...getAssistantActorInput(d),
-    conversationId: d.conversationId,
-    message: d.message,
-    parentMessageId: d.parentMessageId,
-    modelId: d.modelId
-  });
-  let result = await synthesis.request.create(
-    payload as Parameters<typeof synthesis.request.create>[0]
-  );
-
-  return {
-    request: await enrichRequest({
-      scope: context.scope,
-      instance: d.instance,
-      request: result.request
-    }),
-    item: await enrichMessage({
-      scope: context.scope,
-      instance: d.instance,
-      message: result.message
-    })
-  };
-};
-
-let lookup = async (d: { requestId: string }) => {
-  let lookup = await synthesis.request.lookup({
-    requestId: d.requestId
-  });
-  let instance = await resolveMetorialInstanceBySynthesisScope({
-    tenantIdentifier: lookup.tenant.identifier,
-    environmentIdentifier: lookup.environment.identifier
-  });
-  let lookupActor =
-    lookup.request.actorId != null
-      ? await synthesis.actor.get({
-          tenantId: lookup.tenant.id,
-          actorId: lookup.request.actorId
-        })
-      : null;
-
-  return {
-    request: lookup.request,
-    organization: instance.organization,
-    instance,
-    actorId:
-      lookupActor?.organizationActorId ??
-      lookupActor?.consumerId ??
-      lookup.request.actorId ??
-      null
-  };
-};
-
-let listenToDeltas = async (
-  d: {
-    organization: Organization;
-    instance: Instance;
-    requestId: string;
-    signal?: AbortSignal;
-    onMessage: (message: AgentRunWireMessage) => void | Promise<void>;
-    onError?: (error: Error) => void | Promise<void>;
-    onDone?: (message: {
-      status: 'completed' | 'cancelled' | 'failed';
-    }) => void | Promise<void>;
-  } & AssistantActorInput
-) => {
-  let request = await getRequest(d);
-  let connection = createAssistantRequestDeltasConnection(
-    {
-      liveEndpoint: getSynthesisLiveEndpoint()
-    },
-    {
-      assistantRequestId: request.id
-    }
-  );
-  let finished = false;
-
-  let close = () => {
-    if (finished) return;
-    finished = true;
-    connection.close();
-  };
-
-  let emitError = async (error: unknown) => {
-    if (finished) return;
-    let nextError = error instanceof Error ? error : new Error('Assistant stream failed');
-    if (d.onError) {
-      await d.onError(nextError);
-    }
-    close();
-  };
-
-  let onAbort = () => {
-    close();
-  };
-
-  d.signal?.addEventListener('abort', onAbort, { once: true });
-
-  connection.addEventListener('snapshot', (event: Event) => {
-    void (async () => {
-      try {
-        await d.onMessage(
-          JSON.parse((event as MessageEvent<string>).data) as AgentRunWireMessage
-        );
-      } catch (error) {
-        await emitError(error);
-      }
-    })();
-  });
-
-  connection.addEventListener('delta', (event: Event) => {
-    void (async () => {
-      try {
-        await d.onMessage(
-          JSON.parse((event as MessageEvent<string>).data) as AgentRunWireMessage
-        );
-      } catch (error) {
-        await emitError(error);
-      }
-    })();
-  });
-
-  connection.addEventListener('done', (event: Event) => {
-    void (async () => {
-      try {
-        if (d.onDone) {
-          await d.onDone(
-            JSON.parse((event as MessageEvent<string>).data) as {
-              status: 'completed' | 'cancelled' | 'failed';
-            }
-          );
-        }
-      } finally {
-        close();
-      }
-    })();
-  });
-
-  connection.addEventListener('error', (event: Event) => {
-    void (async () => {
-      let payload = (event as MessageEvent<string>).data;
-      if (typeof payload == 'string' && payload) {
-        try {
-          let parsed = JSON.parse(payload) as { message?: string };
-          await emitError(new Error(parsed.message ?? 'Assistant stream failed'));
-          return;
-        } catch {
-          await emitError(new Error(payload));
-          return;
-        }
-      }
-
-      await emitError(new Error('Assistant stream connection failed'));
-    })();
-  });
-
-  return async () => {
-    d.signal?.removeEventListener('abort', onAbort);
-    close();
-  };
-};
-
 export let assistantRequestService = createSynthesisService(
   'assistantRequestService',
   synthesis.request,
   ['get', 'create'],
-  () => ({
-    get: getRequest,
-    lookup,
-    create: createRequest,
-    listenToDeltas
-  })
+  () => {
+    let service = {
+      get: async (
+        d: {
+          organization: Organization;
+          instance: Instance;
+          requestId: string;
+        } & AssistantActorInput
+      ) => {
+        assertAssistantScope(d);
+
+        let { context, payload } = await getSynthesisServicePayload({
+          instance: d.instance,
+          ...getAssistantActorInput(d),
+          requestId: d.requestId
+        });
+
+        return await enrichRequest({
+          scope: context.scope,
+          instance: d.instance,
+          request: await synthesis.request.get(
+            payload as Parameters<typeof synthesis.request.get>[0]
+          )
+        });
+      },
+
+      lookup: async (d: { requestId: string }) => {
+        let lookup = await synthesis.request.lookup({
+          requestId: d.requestId
+        });
+        let instance = await resolveMetorialInstanceBySynthesisScope({
+          tenantIdentifier: lookup.tenant.identifier,
+          environmentIdentifier: lookup.environment.identifier
+        });
+        let lookupActor =
+          lookup.request.actorId != null
+            ? await synthesis.actor.get({
+                tenantId: lookup.tenant.id,
+                actorId: lookup.request.actorId
+              })
+            : null;
+
+        return {
+          request: lookup.request,
+          organization: instance.organization,
+          instance,
+          actorId:
+            lookupActor?.organizationActorId ??
+            lookupActor?.consumerId ??
+            lookup.request.actorId ??
+            null
+        };
+      },
+
+      create: async (
+        d: {
+          organization: Organization;
+          instance: Instance;
+          conversationId: string;
+          message: AssistantInputMessage;
+          parentMessageId?: string;
+          modelId?: string;
+        } & AssistantActorInput
+      ) => {
+        assertAssistantScope(d);
+
+        let { context, payload } = await getSynthesisServicePayload({
+          instance: d.instance,
+          ...getAssistantActorInput(d),
+          conversationId: d.conversationId,
+          message: d.message,
+          parentMessageId: d.parentMessageId,
+          modelId: d.modelId
+        });
+        let result = await synthesis.request.create(
+          payload as Parameters<typeof synthesis.request.create>[0]
+        );
+
+        return {
+          request: await enrichRequest({
+            scope: context.scope,
+            instance: d.instance,
+            request: result.request
+          }),
+          item: await enrichMessage({
+            scope: context.scope,
+            instance: d.instance,
+            message: result.message
+          })
+        };
+      },
+
+      respondToHandoffs: async (
+        d: {
+          organization: Organization;
+          instance: Instance;
+          conversationId: string;
+          messageId: string;
+          responses: Array<{
+            toolCallId: string;
+            output: unknown;
+          }>;
+        } & AssistantActorInput
+      ) => {
+        assertAssistantScope(d);
+
+        let { context, payload } = await getSynthesisServicePayload({
+          instance: d.instance,
+          ...getAssistantActorInput(d),
+          conversationId: d.conversationId,
+          messageId: d.messageId,
+          responses: d.responses
+        });
+        let message = await synthesis.request.respondToHandoffs(
+          payload as Parameters<typeof synthesis.request.respondToHandoffs>[0]
+        );
+
+        return await enrichMessage({
+          scope: context.scope,
+          instance: d.instance,
+          message
+        });
+      },
+
+      listenToDeltas: async (
+        d: {
+          organization: Organization;
+          instance: Instance;
+          requestId: string;
+          signal?: AbortSignal;
+          onMessage: (message: AgentRunWireMessage) => void | Promise<void>;
+          onError?: (error: Error) => void | Promise<void>;
+          onDone?: (message: {
+            status: 'completed' | 'waiting_for_user' | 'cancelled' | 'failed';
+          }) => void | Promise<void>;
+        } & AssistantActorInput
+      ) => {
+        let request = await service.get(d);
+        let connection = createAssistantRequestDeltasConnection(
+          {
+            liveEndpoint: getSynthesisLiveEndpoint()
+          },
+          {
+            assistantRequestId: request.id
+          }
+        );
+        let finished = false;
+
+        let close = () => {
+          if (finished) return;
+          finished = true;
+          connection.close();
+        };
+
+        let emitError = async (error: unknown) => {
+          if (finished) return;
+          let nextError =
+            error instanceof Error ? error : new Error('Assistant stream failed');
+          if (d.onError) {
+            await d.onError(nextError);
+          }
+          close();
+        };
+
+        let onAbort = () => {
+          close();
+        };
+
+        d.signal?.addEventListener('abort', onAbort, { once: true });
+
+        connection.addEventListener('snapshot', (event: Event) => {
+          void (async () => {
+            try {
+              await d.onMessage(
+                JSON.parse((event as MessageEvent<string>).data) as AgentRunWireMessage
+              );
+            } catch (error) {
+              await emitError(error);
+            }
+          })();
+        });
+
+        connection.addEventListener('delta', (event: Event) => {
+          void (async () => {
+            try {
+              await d.onMessage(
+                JSON.parse((event as MessageEvent<string>).data) as AgentRunWireMessage
+              );
+            } catch (error) {
+              await emitError(error);
+            }
+          })();
+        });
+
+        connection.addEventListener('done', (event: Event) => {
+          void (async () => {
+            try {
+              if (d.onDone) {
+                await d.onDone(
+                  JSON.parse((event as MessageEvent<string>).data) as {
+                    status: 'completed' | 'waiting_for_user' | 'cancelled' | 'failed';
+                  }
+                );
+              }
+            } finally {
+              close();
+            }
+          })();
+        });
+
+        connection.addEventListener('error', (event: Event) => {
+          void (async () => {
+            let payload = (event as MessageEvent<string>).data;
+            if (typeof payload == 'string' && payload) {
+              try {
+                let parsed = JSON.parse(payload) as { message?: string };
+                await emitError(new Error(parsed.message ?? 'Assistant stream failed'));
+                return;
+              } catch {
+                await emitError(new Error(payload));
+                return;
+              }
+            }
+
+            await emitError(new Error('Assistant stream connection failed'));
+          })();
+        });
+
+        return async () => {
+          d.signal?.removeEventListener('abort', onAbort);
+          close();
+        };
+      }
+    };
+
+    return service;
+  }
 );

--- a/src/systems/synthesis/service/prisma/schema/conversation.prisma
+++ b/src/systems/synthesis/service/prisma/schema/conversation.prisma
@@ -4,6 +4,9 @@ model AssistantConversation {
 
   title String?
 
+  /// [AssistantConversationInput]
+  input Json?
+
   assistantInstanceOid BigInt
   assistantInstance    AssistantInstance @relation(fields: [assistantInstanceOid], references: [oid], onDelete: Cascade)
 

--- a/src/systems/synthesis/service/prisma/schema/conversation.prisma
+++ b/src/systems/synthesis/service/prisma/schema/conversation.prisma
@@ -57,6 +57,7 @@ model AssistantConversationParticipant {
 
 enum AssistantRequestStatus {
   pending
+  waiting_for_user
   completed
   cancelled
   failed
@@ -105,11 +106,18 @@ enum AssistantMessageType {
   assistant
 }
 
+enum AssistantMessageStatus {
+  pending
+  waiting_for_user
+  completed
+}
+
 model AssistantMessage {
   oid BigInt @id
   id  String @unique
 
   type AssistantMessageType
+  status AssistantMessageStatus @default(completed)
 
   runOid BigInt?
   run    ModelRun? @relation(fields: [runOid], references: [oid], onDelete: Cascade)

--- a/src/systems/synthesis/service/prisma/schema/model.prisma
+++ b/src/systems/synthesis/service/prisma/schema/model.prisma
@@ -37,9 +37,10 @@ model ModelProvider {
   models Model[]
 }
 
-enum AssistantRunStatus {
+enum ModelRunStatus {
   pending
   running
+  waiting_for_user
   completed
   cancelled
   failed
@@ -49,7 +50,7 @@ model ModelRun {
   oid BigInt @id
   id  String @unique
 
-  status AssistantRunStatus
+  status ModelRunStatus
 
   tenantOid BigInt
   tenant    Tenant @relation(fields: [tenantOid], references: [oid], onDelete: Cascade)

--- a/src/systems/synthesis/service/src/controllers/conversation.ts
+++ b/src/systems/synthesis/service/src/controllers/conversation.ts
@@ -108,7 +108,8 @@ export let conversationController = app.controller({
         environmentId: v.string(),
         actorId: v.string(),
         assistantId: v.string(),
-        title: v.optional(v.string())
+        title: v.optional(v.string()),
+        input: v.optional(v.any())
       })
     )
     .do(async ctx =>
@@ -119,7 +120,8 @@ export let conversationController = app.controller({
           actor: ctx.actor,
           input: {
             assistantId: ctx.input.assistantId,
-            title: ctx.input.title
+            title: ctx.input.title,
+            input: ctx.input.input
           }
         })
       )

--- a/src/systems/synthesis/service/src/controllers/request.ts
+++ b/src/systems/synthesis/service/src/controllers/request.ts
@@ -135,5 +135,40 @@ export let requestController = app.controller({
         request: assistantRequestPresenter(request),
         message: assistantMessagePresenter(result.item)
       };
+    }),
+
+  respondToHandoffs: conversationActorApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        conversationId: v.string(),
+        actorId: v.string(),
+        messageId: v.string(),
+        responses: v.array(
+          v.object({
+            toolCallId: v.string(),
+            output: v.any()
+          })
+        )
+      })
+    )
+    .do(async ctx => {
+      let item = await assistantRequestService.respondToAssistantHandoffs({
+        tenant: ctx.tenant,
+        environment: ctx.environment,
+        actor: ctx.actor,
+        conversation: ctx.conversation,
+        input: {
+          messageId: ctx.input.messageId,
+          responses: ctx.input.responses.map(response => ({
+            toolCallId: response.toolCallId,
+            output: response.output
+          }))
+        }
+      });
+
+      return assistantMessagePresenter(item);
     })
 });

--- a/src/systems/synthesis/service/src/db.ts
+++ b/src/systems/synthesis/service/src/db.ts
@@ -40,6 +40,7 @@ export let db = baseClient;
 
 declare global {
   namespace PrismaJson {
+    type AssistantConversationInput = unknown;
     type AssistantMessageStateContent = import('./types').State;
     type AssistantMessageSerializedContent =
       import('./types').AssistantMessageSerializedContent;

--- a/src/systems/synthesis/service/src/lib/definitions/assistantDefinition.ts
+++ b/src/systems/synthesis/service/src/lib/definitions/assistantDefinition.ts
@@ -1,0 +1,19 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { assistants } from '../../definitions/assistants';
+
+export type AssistantDefinition = Awaited<(typeof assistants)[keyof typeof assistants]>;
+
+export let getAssistantDefinition = async (
+  implementationSlug: string
+): Promise<AssistantDefinition> => {
+  let definitions = await Promise.all(Object.values(assistants));
+  let definition = definitions.find(
+    definition => definition.implementation._persisted.slug == implementationSlug
+  );
+
+  if (!definition) {
+    throw new ServiceError(notFoundError('assistant_implementation', implementationSlug));
+  }
+
+  return definition;
+};

--- a/src/systems/synthesis/service/src/lib/definitions/conversationInput.test.ts
+++ b/src/systems/synthesis/service/src/lib/definitions/conversationInput.test.ts
@@ -1,0 +1,90 @@
+import { v } from '@lowerdeck/validation';
+import { describe, expect, it, vi } from 'vitest';
+import { resolveAssistantConversationInput } from './conversationInput';
+
+let context = {
+  tenant: { id: 'tenant_1' },
+  environment: { id: 'env_1' },
+  actor: { id: 'actor_1' },
+  assistant: { id: 'assistant_1' },
+  assistantInstance: { id: 'assistant_instance_1' }
+} as any;
+
+describe('resolveAssistantConversationInput', () => {
+  it('returns undefined when a no-input assistant receives no input', async () => {
+    await expect(
+      resolveAssistantConversationInput({
+        ...context,
+        assistantImplementation: {
+          _persisted: { id: 'impl_1' }
+        } as any,
+        rawInput: undefined,
+        rawInputProvided: false
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects provided input for a no-input assistant', async () => {
+    await expect(
+      resolveAssistantConversationInput({
+        ...context,
+        assistantImplementation: {
+          _persisted: { id: 'impl_1' }
+        } as any,
+        rawInput: { project_id: 'project_1' },
+        rawInputProvided: true
+      })
+    ).rejects.toThrow('This assistant does not accept conversation input.');
+  });
+
+  it('rejects invalid input before calling handleInput', async () => {
+    let handleInput = vi.fn();
+
+    await expect(
+      resolveAssistantConversationInput({
+        ...context,
+        assistantImplementation: {
+          _persisted: { id: 'impl_1' },
+          input: v.object({
+            project_id: v.string()
+          }),
+          handleInput
+        } as any,
+        rawInput: { project_id: 123 },
+        rawInputProvided: true
+      })
+    ).rejects.toThrow();
+
+    expect(handleInput).not.toHaveBeenCalled();
+  });
+
+  it('passes validated input to handleInput and returns the mapped value', async () => {
+    let handleInput = vi.fn(async (d: { input: { project_id: string } }) => ({
+      projectId: d.input.project_id
+    }));
+
+    await expect(
+      resolveAssistantConversationInput({
+        ...context,
+        assistantImplementation: {
+          _persisted: { id: 'impl_1' },
+          input: v.object({
+            project_id: v.string()
+          }),
+          handleInput
+        } as any,
+        rawInput: { project_id: 'project_1' },
+        rawInputProvided: true
+      })
+    ).resolves.toEqual({
+      projectId: 'project_1'
+    });
+
+    expect(handleInput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: { project_id: 'project_1' },
+        assistantImplementation: { id: 'impl_1' }
+      })
+    );
+  });
+});

--- a/src/systems/synthesis/service/src/lib/definitions/conversationInput.ts
+++ b/src/systems/synthesis/service/src/lib/definitions/conversationInput.ts
@@ -1,0 +1,56 @@
+import { badRequestError, ServiceError, validationError } from '@lowerdeck/error';
+import type {
+  Assistant,
+  AssistantImplementation,
+  AssistantInstance,
+  Environment,
+  Tenant,
+  TenantActor
+} from '../../db';
+import type { Implementation } from './implementation';
+
+export let resolveAssistantConversationInput = async (d: {
+  tenant: Tenant;
+  environment: Environment;
+  actor: TenantActor;
+  assistant: Assistant;
+  assistantInstance: AssistantInstance;
+  assistantImplementation: Implementation;
+  rawInput: unknown;
+  rawInputProvided: boolean;
+}) => {
+  let assistantImplementation = d.assistantImplementation;
+
+  if (!assistantImplementation.input || !assistantImplementation.handleInput) {
+    if (d.rawInputProvided) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'This assistant does not accept conversation input.'
+        })
+      );
+    }
+
+    return undefined;
+  }
+
+  let valRes = assistantImplementation.input.validate(d.rawInput);
+  if (!valRes.success) {
+    throw new ServiceError(
+      validationError({
+        entity: 'assistant_conversation.input',
+        errors: valRes.errors
+      })
+    );
+  }
+
+  return await assistantImplementation.handleInput({
+    input: valRes.value,
+    tenant: d.tenant,
+    environment: d.environment,
+    actor: d.actor,
+    assistant: d.assistant,
+    assistantInstance: d.assistantInstance,
+    assistantImplementation:
+      assistantImplementation._persisted as unknown as AssistantImplementation
+  });
+};

--- a/src/systems/synthesis/service/src/lib/definitions/handoffTool.test.ts
+++ b/src/systems/synthesis/service/src/lib/definitions/handoffTool.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { getHandoffToolMetadata, handoffTool } from './handoffTool';
+
+describe('handoffTool', () => {
+  it('creates a schema-only tool with client handoff metadata', () => {
+    let question = handoffTool({
+      title: 'Question',
+      description: 'Ask the client a question',
+      inputSchema: z.object({
+        question: z.string()
+      })
+    });
+
+    expect(getHandoffToolMetadata(question)).toEqual({
+      title: 'Question',
+      description: 'Ask the client a question'
+    });
+    expect((question as any).execute).toBeUndefined();
+  });
+});

--- a/src/systems/synthesis/service/src/lib/definitions/handoffTool.ts
+++ b/src/systems/synthesis/service/src/lib/definitions/handoffTool.ts
@@ -1,0 +1,38 @@
+import { tool } from 'ai';
+
+export type ClientHandoffToolMetadata = {
+  title: string;
+  description?: string;
+};
+
+export let handoffToolMetadataKey = Symbol.for('metorial.synthesis.handoffTool');
+
+export type ClientHandoffTool = {
+  [handoffToolMetadataKey]?: ClientHandoffToolMetadata;
+};
+
+export let handoffTool = (d: {
+  title: string;
+  description?: string;
+  inputSchema: any;
+  outputSchema?: any;
+}) => {
+  let definition = tool({
+    description: d.description,
+    inputSchema: d.inputSchema
+  }) as ClientHandoffTool;
+
+  definition[handoffToolMetadataKey] = {
+    title: d.title,
+    description: d.description
+  };
+
+  return definition;
+};
+
+export let getHandoffToolMetadata = (
+  toolDefinition: unknown
+): ClientHandoffToolMetadata | undefined => {
+  if (!toolDefinition || typeof toolDefinition != 'object') return undefined;
+  return (toolDefinition as ClientHandoffTool)[handoffToolMetadataKey];
+};

--- a/src/systems/synthesis/service/src/lib/definitions/implementation.ts
+++ b/src/systems/synthesis/service/src/lib/definitions/implementation.ts
@@ -1,4 +1,12 @@
-import type { Assistant, AssistantImplementation, Environment, Tenant } from '../../db';
+import type { ValidationType } from '@lowerdeck/validation';
+import type {
+  Assistant,
+  AssistantImplementation,
+  AssistantInstance,
+  Environment,
+  Tenant,
+  TenantActor
+} from '../../db';
 import { db, Prisma } from '../../db';
 import { getId } from '../../id';
 import { Agent } from '../open-harness';
@@ -12,19 +20,86 @@ export type ImplementationModelWithProvider = Prisma.ModelGetPayload<{
   include: typeof implementationModelInclude;
 }>;
 
-export let implementation = async (d: {
+type MaybePromise<T> = T | Promise<T>;
+
+type ImplementationBase = {
   defaultModel: Promise<Model>;
   availableModels: Promise<Model>[];
   slug: string;
   name: string;
-  getAgent: (d: {
-    model: Model;
-    tenant: Tenant;
-    environment: Environment;
-    assistant: Assistant;
-    assistantImplementation: AssistantImplementation;
-  }) => Promise<Agent>;
-}) => {
+};
+
+export type ImplementationHandleInputContext<Input> = {
+  input: Input;
+  tenant: Tenant;
+  environment: Environment;
+  actor: TenantActor;
+  assistant: Assistant;
+  assistantInstance: AssistantInstance;
+  assistantImplementation: AssistantImplementation;
+};
+
+export type ImplementationGetAgentContext<Input> = {
+  input: Input;
+  model: Model;
+  tenant: Tenant;
+  environment: Environment;
+  assistant: Assistant;
+  assistantInstance: AssistantInstance;
+  assistantImplementation: AssistantImplementation;
+};
+
+type ImplementationWithoutInput = ImplementationBase & {
+  input?: undefined;
+  handleInput?: undefined;
+  getAgent: (
+    d: {
+      input: undefined;
+    } & Omit<ImplementationGetAgentContext<undefined>, 'input'>
+  ) => Promise<Agent>;
+};
+
+type ImplementationWithInput<Input, HandledInput> = ImplementationBase & {
+  input: ValidationType<Input>;
+  handleInput: (d: ImplementationHandleInputContext<Input>) => MaybePromise<HandledInput>;
+  getAgent: (d: ImplementationGetAgentContext<HandledInput>) => Promise<Agent>;
+};
+
+export type ImplementationDefinition<Input = undefined, HandledInput = Input> =
+  | ImplementationWithoutInput
+  | ImplementationWithInput<Input, HandledInput>;
+
+type PersistedImplementationBase = Omit<
+  ImplementationBase,
+  'defaultModel' | 'availableModels'
+> & {
+  _persisted: AssistantImplementation;
+  persistedDefaultModel: ImplementationModelWithProvider | null;
+  persistedAvailableModels: ImplementationModelWithProvider[];
+  defaultModel: Model;
+  availableModels: Model[];
+};
+
+export type ImplementationWithoutInputResult = PersistedImplementationBase &
+  Omit<ImplementationWithoutInput, 'defaultModel' | 'availableModels'>;
+
+export type ImplementationWithInputResult<Input, HandledInput> = PersistedImplementationBase &
+  Omit<ImplementationWithInput<Input, HandledInput>, 'defaultModel' | 'availableModels'>;
+
+export type Implementation =
+  | ImplementationWithoutInputResult
+  | ImplementationWithInputResult<any, any>;
+
+type ImplementationFactory = {
+  (d: ImplementationWithoutInput): Promise<ImplementationWithoutInputResult>;
+  <Input, HandledInput>(
+    d: ImplementationWithInput<Input, HandledInput>
+  ): Promise<ImplementationWithInputResult<Input, HandledInput>>;
+};
+
+let buildImplementation = async (
+  d: ImplementationDefinition<any, any>
+): Promise<Implementation> => {
   let defaultModel = await d.defaultModel;
   let availableModels = Array.from(
     new Map(
@@ -70,4 +145,4 @@ export let implementation = async (d: {
   };
 };
 
-export type Implementation = Awaited<ReturnType<typeof implementation>>;
+export let implementation = buildImplementation as ImplementationFactory;

--- a/src/systems/synthesis/service/src/lib/definitions/index.ts
+++ b/src/systems/synthesis/service/src/lib/definitions/index.ts
@@ -1,4 +1,5 @@
 export * from './assistant';
+export * from './handoffTool';
 export * from './implementation';
 export * from './model';
 export * from './models';

--- a/src/systems/synthesis/service/src/lib/open-harness/agent.ts
+++ b/src/systems/synthesis/service/src/lib/open-harness/agent.ts
@@ -7,6 +7,8 @@ import {
   type ModelMessage,
   type ToolSet
 } from 'ai';
+import type { ClientHandoffToolMetadata } from '../definitions/handoffTool';
+import { getHandoffToolMetadata } from '../definitions/handoffTool';
 import { z } from 'zod';
 import {
   AgentRegistry,
@@ -50,7 +52,13 @@ export type AgentEvent =
   | { type: 'text.done'; text: string }
   | { type: 'reasoning.delta'; text: string }
   | { type: 'reasoning.done'; text: string }
-  | { type: 'tool.start'; toolCallId: string; toolName: string; input: unknown }
+  | {
+      type: 'tool.start';
+      toolCallId: string;
+      toolName: string;
+      input: unknown;
+      handoff?: ClientHandoffToolMetadata;
+    }
   | { type: 'tool.done'; toolCallId: string; toolName: string; output: unknown }
   | { type: 'tool.error'; toolCallId: string; toolName: string; error: string }
   | { type: 'step.start'; stepNumber: number }
@@ -339,7 +347,10 @@ export class Agent {
               type: 'tool.start',
               toolCallId: part.toolCallId,
               toolName: part.toolName,
-              input: part.input
+              input: part.input,
+              handoff: tools?.[part.toolName]
+                ? getHandoffToolMetadata(tools[part.toolName])
+                : undefined
             };
             break;
 

--- a/src/systems/synthesis/service/src/lib/run/handoffState.test.ts
+++ b/src/systems/synthesis/service/src/lib/run/handoffState.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AgentRunState,
+  applyHandoffToolResponses,
+  getWaitingHandoffToolCalls
+} from './state';
+
+let createWaitingState = () => {
+  let runState = new AgentRunState();
+  runState.pipe({
+    type: 'tool.start',
+    toolCallId: 'call_1',
+    toolName: 'question',
+    input: {
+      question: 'What should we do?'
+    },
+    handoff: {
+      title: 'Question',
+      description: 'Ask the client a question'
+    }
+  });
+
+  return runState.result().state;
+};
+
+describe('handoff state', () => {
+  it('marks handoff tool calls as waiting for the client', () => {
+    let state = createWaitingState();
+    let waiting = getWaitingHandoffToolCalls(state);
+
+    expect(waiting).toHaveLength(1);
+    expect(waiting[0]?.toolName).toBe('question');
+    expect(waiting[0]?.call).toMatchObject({
+      id: 'call_1',
+      status: 'waiting_for_user',
+      handoff: {
+        title: 'Question',
+        description: 'Ask the client a question'
+      }
+    });
+  });
+
+  it('stores handoff responses and marks calls completed', () => {
+    let result = applyHandoffToolResponses(createWaitingState(), [
+      {
+        toolCallId: 'call_1',
+        output: {
+          answer: 'Ship it'
+        }
+      }
+    ]);
+
+    expect(result.remaining).toHaveLength(0);
+    expect(result.completed).toEqual([
+      {
+        toolCallId: 'call_1',
+        toolName: 'question',
+        output: {
+          answer: 'Ship it'
+        }
+      }
+    ]);
+    expect(result.state.items[0]).toMatchObject({
+      type: 'tool',
+      calls: [
+        {
+          id: 'call_1',
+          status: 'completed',
+          output: {
+            answer: 'Ship it'
+          }
+        }
+      ]
+    });
+  });
+
+  it('rejects unknown and duplicate handoff responses', () => {
+    expect(() =>
+      applyHandoffToolResponses(createWaitingState(), [
+        {
+          toolCallId: 'missing',
+          output: {}
+        }
+      ])
+    ).toThrow('No waiting handoff tool call found for missing');
+
+    expect(() =>
+      applyHandoffToolResponses(createWaitingState(), [
+        {
+          toolCallId: 'call_1',
+          output: {}
+        },
+        {
+          toolCallId: 'call_1',
+          output: {}
+        }
+      ])
+    ).toThrow('Duplicate handoff response for tool call call_1');
+  });
+});

--- a/src/systems/synthesis/service/src/lib/run/index.ts
+++ b/src/systems/synthesis/service/src/lib/run/index.ts
@@ -7,7 +7,7 @@ import type {
   Tenant
 } from '../../db';
 import { summaryModel } from '../../definitions/models/_util';
-import type { InputMessage } from '../../types';
+import type { InputMessage, State } from '../../types';
 import type { Implementation, Model } from '../definitions';
 import { getConversationHistory } from '../history/getHistory';
 import { Agent, DefaultCompactionStrategy, Session } from '../open-harness';
@@ -20,6 +20,53 @@ export type AgentRunOptions = AgentRunStateOptions & {
   onSnapshot?: (snapshot: AgentRunWireMessage) => void | Promise<void>;
   snapshotIntervalMs?: number;
 };
+
+let deserializeMessages = (
+  serialized: PrismaJson.AssistantMessageSerializedContent
+): ModelMessage[] =>
+  serialized.messages
+    .map(([ts, msg]) => ({ ts, msg }))
+    .sort((a, b) => a.ts - b.ts)
+    .map(m => m.msg as ModelMessage);
+
+let inputMessageToModelMessages = (input: InputMessage): ModelMessage[] => [
+  {
+    role: 'user',
+    content: input.parts.map(p => {
+      if (p.type === 'text') {
+        return {
+          type: 'text' as const,
+          text: p.text
+        } satisfies TextPart;
+      }
+
+      if (p.type === 'file') {
+        return {
+          type: 'file' as const,
+          filename: p.filename,
+          mediaType: p.mediaType,
+          data: Buffer.from(p.data, p.encoding)
+        } satisfies FilePart;
+      }
+
+      throw new Error(`Unsupported part type: ${JSON.stringify(p)}`);
+    })
+  }
+];
+
+let handoffResponsesToModelMessages = (
+  responses: Array<{ toolCallId: string; toolName: string; output: unknown }>
+): ModelMessage[] => [
+  {
+    role: 'tool',
+    content: responses.map(response => ({
+      type: 'tool-result',
+      toolCallId: response.toolCallId,
+      toolName: response.toolName,
+      output: response.output
+    }))
+  } as ModelMessage
+];
 
 export class AgentRun {
   abortController = new AbortController();
@@ -49,57 +96,15 @@ export class AgentRun {
     });
   }
 
-  async run(d: {
-    input: InputMessage;
-    conversation: AssistantConversation;
-    lastMessageId: string;
-    historySize: number;
+  private async runSession(d: {
+    session: Session;
+    input: ModelMessage[];
+    initialState?: State;
     delta?: AgentRunOptions;
-  }): Promise<AgentRunResult> {
-    let session = await this.createSession();
-    let history = await getConversationHistory({
-      conversation: d.conversation,
-      lastMessageId: d.lastMessageId,
-      size: d.historySize
-    });
+  }) {
+    let iterator = d.session.send(d.input, { signal: this.abortController.signal });
 
-    session.messages.push(
-      ...history
-        .flatMap(m => m.serialized.messages)
-        .map(([ts, msg]) => ({ ts, msg }))
-        .sort((a, b) => a.ts - b.ts)
-        .map(m => m.msg as ModelMessage)
-    );
-
-    let iterator = session.send(
-      [
-        {
-          role: 'user',
-          content: d.input.parts.map(p => {
-            if (p.type === 'text') {
-              return {
-                type: 'text' as const,
-                text: p.text
-              } satisfies TextPart;
-            }
-
-            if (p.type === 'file') {
-              return {
-                type: 'file' as const,
-                filename: p.filename,
-                mediaType: p.mediaType,
-                data: Buffer.from(p.data, p.encoding)
-              } satisfies FilePart;
-            }
-
-            throw new Error(`Unsupported part type: ${JSON.stringify(p)}`);
-          })
-        }
-      ],
-      { signal: this.abortController.signal }
-    );
-
-    let runState = new AgentRunState(session.messages, d.delta);
+    let runState = new AgentRunState(d.session.messages, d.delta, d.initialState);
     let snapshotInterval: ReturnType<typeof setInterval> | undefined;
     let snapshotInFlight = false;
     let writeSnapshot = async () => {
@@ -136,5 +141,45 @@ export class AgentRun {
       if (snapshotInterval) clearInterval(snapshotInterval);
       await writeSnapshot();
     }
+  }
+
+  async run(d: {
+    input: InputMessage;
+    conversation: AssistantConversation;
+    lastMessageId: string;
+    historySize: number;
+    delta?: AgentRunOptions;
+  }): Promise<AgentRunResult> {
+    let session = await this.createSession();
+    let history = await getConversationHistory({
+      conversation: d.conversation,
+      lastMessageId: d.lastMessageId,
+      size: d.historySize
+    });
+
+    session.messages.push(...history.flatMap(m => deserializeMessages(m.serialized)));
+
+    return await this.runSession({
+      session,
+      input: inputMessageToModelMessages(d.input),
+      delta: d.delta
+    });
+  }
+
+  async resume(d: {
+    serialized: PrismaJson.AssistantMessageSerializedContent;
+    state: State;
+    responses: Array<{ toolCallId: string; toolName: string; output: unknown }>;
+    delta?: AgentRunOptions;
+  }): Promise<AgentRunResult> {
+    let session = await this.createSession();
+    session.messages.push(...deserializeMessages(d.serialized));
+
+    return await this.runSession({
+      session,
+      input: handoffResponsesToModelMessages(d.responses),
+      initialState: d.state,
+      delta: d.delta
+    });
   }
 }

--- a/src/systems/synthesis/service/src/lib/run/redisDeltas.ts
+++ b/src/systems/synthesis/service/src/lib/run/redisDeltas.ts
@@ -10,7 +10,7 @@ type RedisAgentRunOptions = AgentRunStateOptions & {
 };
 
 type AssistantRunDoneMessage = {
-  status: 'completed' | 'cancelled' | 'failed';
+  status: 'completed' | 'waiting_for_user' | 'cancelled' | 'failed';
 };
 
 export let assistantRunDeltaKeys = (runId: string) => ({
@@ -26,7 +26,8 @@ let messageIndex = (message: WireMessage) =>
 
 let parseWireMessage = (raw: string) => JSON.parse(raw) as AgentRunWireMessage;
 
-let createClient = async () => await createRedisClient({ redisUrl: env.service.REDIS_URL }).eager();
+let createClient = async () =>
+  await createRedisClient({ redisUrl: env.service.REDIS_URL }).eager();
 let deltaReplayLimit = 15;
 
 export let createAssistantRunDeltaPublisher = async (d: {
@@ -138,6 +139,7 @@ export let listenToAssistantRunDeltas = async (d: {
 
     if (
       run.status == 'completed' ||
+      run.status == 'waiting_for_user' ||
       run.status == 'cancelled' ||
       run.status == 'failed'
     ) {
@@ -163,9 +165,7 @@ export let listenToAssistantRunDeltas = async (d: {
       deduped.set(index, message);
     }
 
-    return [...deduped.entries()]
-      .sort((a, b) => a[0] - b[0])
-      .map(([, message]) => message);
+    return [...deduped.entries()].sort((a, b) => a[0] - b[0]).map(([, message]) => message);
   };
 
   let fail = async (error: Error) => {

--- a/src/systems/synthesis/service/src/lib/run/state.ts
+++ b/src/systems/synthesis/service/src/lib/run/state.ts
@@ -1,6 +1,14 @@
 import { generatePlainId } from '@lowerdeck/id';
 import type { ModelMessage } from 'ai';
-import type { FileWriteChange, ItemStatus, Message, State, StateItem } from '../../types';
+import type {
+  FileWriteChange,
+  ItemStatus,
+  Message,
+  State,
+  StateItem,
+  ToolCallState
+} from '../../types';
+import type { ClientHandoffToolMetadata } from '../definitions';
 import type {
   DeltaTransportSink,
   JsonValue,
@@ -20,6 +28,7 @@ export type AgentRunStateOptions = {
 };
 
 export type AgentRunResult = {
+  status: 'completed' | 'waiting_for_user';
   state: State;
   serialized: PrismaJson.AssistantMessageSerializedContent;
   snapshotIndex: number;
@@ -35,6 +44,11 @@ export type AgentRunUsage = {
 
 type UsageEvent = AgentRunUsage & {
   eventType: string;
+};
+
+export type HandoffToolCall = {
+  toolName: string;
+  call: Extract<StateItem, { type: 'tool' }>['calls'][number];
 };
 
 let emptyUsage = (): AgentRunUsage => ({
@@ -137,6 +151,68 @@ let serializeMessages = (
   };
 };
 
+export let getHandoffToolCalls = (state: State) => {
+  let calls: HandoffToolCall[] = [];
+
+  for (let item of state.items) {
+    if (item.type != 'tool') continue;
+
+    for (let call of item.calls) {
+      if (!call.handoff) continue;
+      calls.push({
+        toolName: item.tool.key,
+        call
+      });
+    }
+  }
+
+  return calls;
+};
+
+export let getWaitingHandoffToolCalls = (state: State) =>
+  getHandoffToolCalls(state).filter(({ call }) => call.status == 'waiting_for_user');
+
+export let applyHandoffToolResponses = (
+  state: State,
+  responses: Array<{ toolCallId: string; output: unknown }>
+) => {
+  let nextState = structuredClone(state);
+  let handoffCalls = getHandoffToolCalls(nextState);
+  let handoffCallById = new Map(handoffCalls.map(({ toolName, call }) => [call.id, { toolName, call }]));
+  let seen = new Set<string>();
+
+  for (let response of responses) {
+    if (seen.has(response.toolCallId)) {
+      throw new Error(`Duplicate handoff response for tool call ${response.toolCallId}`);
+    }
+    seen.add(response.toolCallId);
+
+    let handoff = handoffCallById.get(response.toolCallId);
+    if (!handoff) {
+      throw new Error(`No waiting handoff tool call found for ${response.toolCallId}`);
+    }
+    if (handoff.call.status != 'waiting_for_user') {
+      throw new Error(`Handoff tool call ${response.toolCallId} is not waiting for a response`);
+    }
+
+    handoff.call.output = response.output;
+    handoff.call.status = 'completed';
+  }
+
+  return {
+    state: nextState,
+    remaining: getWaitingHandoffToolCalls(nextState),
+    completed: responses.map(response => {
+      let handoff = handoffCallById.get(response.toolCallId)!;
+      return {
+        toolCallId: response.toolCallId,
+        toolName: handoff.toolName,
+        output: response.output
+      };
+    })
+  };
+};
+
 let findLastItem = <T extends StateItem>(
   state: State,
   predicate: (item: StateItem) => item is T
@@ -166,9 +242,13 @@ export class AgentRunState {
   private usageEvents: UsageEvent[] = [];
   private startedAt = new Date();
 
-  constructor(initialMessages: ModelMessage[] = [], options: AgentRunStateOptions = {}) {
+  constructor(
+    initialMessages: ModelMessage[] = [],
+    options: AgentRunStateOptions = {},
+    initialState?: State
+  ) {
     this.delta = createServerState({
-      initial: { items: [] },
+      initial: structuredClone(initialState ?? { items: [] }) as unknown as JsonValue,
       emit: options.emit,
       deltaFormat: options.deltaFormat
     });
@@ -244,7 +324,8 @@ export class AgentRunState {
         this.upsertGenericToolCall({
           toolCallId: event.toolCallId,
           toolName: event.toolName,
-          input: event.input
+          input: event.input,
+          handoff: event.handoff
         });
         break;
 
@@ -321,8 +402,11 @@ export class AgentRunState {
   }
 
   result(): AgentRunResult {
+    let state = this.getSnapshot()[2] as unknown as State;
+
     return {
-      state: this.getSnapshot()[2] as unknown as State,
+      status: getWaitingHandoffToolCalls(state).length > 0 ? 'waiting_for_user' : 'completed',
+      state,
       serialized: this.serialized,
       snapshotIndex: this.version,
       usage: this.usage,
@@ -550,13 +634,25 @@ export class AgentRunState {
     return item;
   }
 
-  private upsertGenericToolCall(d: { toolCallId: string; toolName: string; input: unknown }) {
+  private upsertGenericToolCall(d: {
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+    handoff?: ClientHandoffToolMetadata;
+  }) {
     let item = this.state.items.find(
       (item): item is Extract<StateItem, { type: 'tool' }> =>
         item.type == 'tool' && item.tool.key == d.toolName
     );
 
     if (!item) {
+      let call: ToolCallState = {
+        id: d.toolCallId,
+        input: d.input,
+        status: d.handoff ? 'waiting_for_user' : 'running',
+        handoff: d.handoff
+      };
+
       item = {
         id: createItemId(),
         type: 'tool',
@@ -564,9 +660,10 @@ export class AgentRunState {
           key: d.toolName,
           name: d.toolName
         },
-        calls: []
+        calls: [call]
       };
       this.state.items.push(item);
+      return call;
     }
 
     let call = item.calls.find(call => call.id == d.toolCallId);
@@ -574,13 +671,15 @@ export class AgentRunState {
       call = {
         id: d.toolCallId,
         input: d.input,
-        status: 'running'
+        status: d.handoff ? 'waiting_for_user' : 'running',
+        handoff: d.handoff
       };
       item.calls.push(call);
     }
 
     call.input = d.input;
-    call.status = 'running';
+    call.status = d.handoff ? 'waiting_for_user' : 'running';
+    call.handoff = d.handoff;
 
     return call;
   }

--- a/src/systems/synthesis/service/src/presenters/assistantMessage.ts
+++ b/src/systems/synthesis/service/src/presenters/assistantMessage.ts
@@ -7,6 +7,7 @@ export let assistantMessagePresenter = (item: AssistantConversationItemWithMessa
   conversationItemId: item.id,
   conversationId: item.conversation.id,
   type: item.message.type,
+  status: item.message.status,
   runId: item.message.run?.id ?? null,
   requestId: item.message.request?.id ?? null,
   request: item.message.request

--- a/src/systems/synthesis/service/src/queues/processRequest.ts
+++ b/src/systems/synthesis/service/src/queues/processRequest.ts
@@ -1,6 +1,6 @@
 import { notFoundError, ServiceError } from '@lowerdeck/error';
 import { createQueue, QueueRetryError, type IQueue } from '@lowerdeck/queue';
-import { db, withTransaction } from '../db';
+import { db, type AssistantMessageStatus, withTransaction } from '../db';
 import { env } from '../env';
 import { getId } from '../id';
 import { type Model } from '../lib/definitions';
@@ -12,6 +12,11 @@ import type { InputMessage, State } from '../types';
 
 type ProcessAssistantRequestJob = {
   assistantRequestId: string;
+  handoffResponses?: Array<{
+    toolCallId: string;
+    toolName: string;
+    output: unknown;
+  }>;
 };
 
 export let processAssistantRequestQueue: IQueue<ProcessAssistantRequestJob, any> =
@@ -111,6 +116,15 @@ export let processAssistantRequestQueueProcessor = processAssistantRequestQueue.
     let parentMessage = request.message.parentMessage;
     let historySize = request.historySize ?? 100;
     let startedAt = new Date();
+    let existingAssistantMessage = await db.assistantMessage.findFirst({
+      where: {
+        requestOid: request.oid,
+        type: 'assistant'
+      },
+      orderBy: {
+        oid: 'desc'
+      }
+    });
     let run = await withTransaction(async tx => {
       let existingRun = await tx.modelRun.findFirst({
         where: {
@@ -197,46 +211,70 @@ export let processAssistantRequestQueueProcessor = processAssistantRequestQueue.
         assistantImplementation._persisted,
         assistantImplementation
       );
-      let result = await runner.run({
-        input: getInputMessage(inputMessage.state),
-        conversation,
-        lastMessageId: parentMessage.id,
-        historySize,
-        delta: publisher.delta
-      });
+      let result =
+        data.handoffResponses?.length && existingAssistantMessage
+          ? await runner.resume({
+              serialized: existingAssistantMessage.serialized,
+              state: existingAssistantMessage.state as State,
+              responses: data.handoffResponses,
+              delta: publisher.delta
+            })
+          : await runner.run({
+              input: getInputMessage(inputMessage.state),
+              conversation,
+              lastMessageId: parentMessage.id,
+              historySize,
+              delta: publisher.delta
+            });
       let completedAt = new Date();
       let cost = calculateCost(result.usage, model);
 
       await withTransaction(async tx => {
-        let assistantMessage = await tx.assistantMessage.create({
-          data: {
-            ...getId('assistantMessage'),
-            type: 'assistant',
-            runOid: run.oid,
-            requestOid: request.oid,
-            assistantOid: conversation.assistantOid,
-            assistantInstanceOid: conversation.assistantInstanceOid,
-            parentMessageOid: inputMessage.oid,
-            modelOid: model._persisted.oid,
-            state: result.state,
-            serialized: result.serialized
-          }
-        });
+        let messageStatus: AssistantMessageStatus =
+          result.status == 'waiting_for_user' ? 'waiting_for_user' : 'completed';
+        let assistantMessage = existingAssistantMessage
+          ? await tx.assistantMessage.update({
+              where: {
+                oid: existingAssistantMessage.oid
+              },
+              data: {
+                status: messageStatus,
+                state: result.state,
+                serialized: result.serialized
+              }
+            })
+          : await tx.assistantMessage.create({
+              data: {
+                ...getId('assistantMessage'),
+                type: 'assistant',
+                status: messageStatus,
+                runOid: run.oid,
+                requestOid: request.oid,
+                assistantOid: conversation.assistantOid,
+                assistantInstanceOid: conversation.assistantInstanceOid,
+                parentMessageOid: inputMessage.oid,
+                modelOid: model._persisted.oid,
+                state: result.state,
+                serialized: result.serialized
+              }
+            });
 
-        await tx.assistantConversationItem.create({
-          data: {
-            ...getId('assistantConversationItem'),
-            conversationOid: conversation.oid,
-            messageOid: assistantMessage.oid
-          }
-        });
+        if (!existingAssistantMessage) {
+          await tx.assistantConversationItem.create({
+            data: {
+              ...getId('assistantConversationItem'),
+              conversationOid: conversation.oid,
+              messageOid: assistantMessage.oid
+            }
+          });
+        }
 
         await tx.assistantRequest.update({
           where: {
             oid: request.oid
           },
           data: {
-            status: 'completed'
+            status: result.status
           }
         });
 
@@ -245,12 +283,14 @@ export let processAssistantRequestQueueProcessor = processAssistantRequestQueue.
             oid: run.oid
           },
           data: {
-            status: 'completed',
+            status: result.status,
             cost,
             metadata: {
               ...result.metadata,
               startedAt: startedAt.toISOString(),
-              completedAt: completedAt.toISOString(),
+              ...(result.status == 'completed'
+                ? { completedAt: completedAt.toISOString() }
+                : {}),
               durationMs: completedAt.getTime() - startedAt.getTime(),
               finalSnapshotIndex: result.snapshotIndex
             } satisfies PrismaJson.AssistantRunMetadata
@@ -258,7 +298,7 @@ export let processAssistantRequestQueueProcessor = processAssistantRequestQueue.
         });
       });
       await publisher.markDone({
-        status: 'completed'
+        status: result.status
       });
     } catch (error) {
       if (error instanceof QueueRetryError) throw error;

--- a/src/systems/synthesis/service/src/queues/processRequest.ts
+++ b/src/systems/synthesis/service/src/queues/processRequest.ts
@@ -1,12 +1,12 @@
 import { notFoundError, ServiceError } from '@lowerdeck/error';
 import { createQueue, QueueRetryError, type IQueue } from '@lowerdeck/queue';
-import { Prisma, db, withTransaction } from '../db';
-import { assistants } from '../definitions/assistants';
+import { db, withTransaction } from '../db';
 import { env } from '../env';
 import { getId } from '../id';
 import { type Model } from '../lib/definitions';
-import { AgentRun } from '../lib/run';
+import { getAssistantDefinition } from '../lib/definitions/assistantDefinition';
 import type { AgentRunUsage } from '../lib/run';
+import { AgentRun } from '../lib/run';
 import { createAssistantRunDeltaPublisher } from '../lib/run/redisDeltas';
 import type { InputMessage, State } from '../types';
 
@@ -19,8 +19,6 @@ export let processAssistantRequestQueue: IQueue<ProcessAssistantRequestJob, any>
     name: 'assistant/request/process',
     redisUrl: env.service.REDIS_URL
   });
-
-type AssistantDefinition = Awaited<(typeof assistants)[keyof typeof assistants]>;
 
 let isRecord = (value: unknown): value is Record<string, unknown> =>
   !!value && typeof value == 'object' && !Array.isArray(value);
@@ -52,21 +50,6 @@ let getInputMessage = (state: unknown): InputMessage => {
   return {
     parts: item.message.parts
   };
-};
-
-let getAssistantDefinition = async (
-  implementationSlug: string
-): Promise<AssistantDefinition> => {
-  let definitions = await Promise.all(Object.values(assistants));
-  let definition = definitions.find(
-    definition => definition.implementation._persisted.slug == implementationSlug
-  );
-
-  if (!definition) {
-    throw new ServiceError(notFoundError('assistant_implementation', implementationSlug));
-  }
-
-  return definition;
 };
 
 let calculateCost = (usage: AgentRunUsage, model: Model): PrismaJson.AssistantRunCost => {
@@ -185,17 +168,24 @@ export let processAssistantRequestQueueProcessor = processAssistantRequestQueue.
       let definition = await getAssistantDefinition(
         conversation.assistant.implementation.slug
       );
-      let model = definition.implementation.availableModels.find(
+      let assistantImplementation = definition.implementation;
+      let model = assistantImplementation.availableModels.find(
         model => model._persisted.oid == request.modelOid
       );
       if (!model) throw new ServiceError(notFoundError('model', requestModel.id));
 
-      let agent = await definition.implementation.getAgent({
+      let getAgent = assistantImplementation.getAgent as (
+        d: Parameters<typeof assistantImplementation.getAgent>[0] & { input: unknown }
+      ) => ReturnType<typeof assistantImplementation.getAgent>;
+
+      let agent = await getAgent({
+        input: assistantImplementation.input ? conversation.input : undefined,
         model,
         tenant: conversation.tenant,
         environment: conversation.environment,
         assistant: conversation.assistant,
-        assistantImplementation: definition.implementation._persisted
+        assistantInstance: conversation.assistantInstance,
+        assistantImplementation: assistantImplementation._persisted
       });
 
       let runner = new AgentRun(
@@ -204,8 +194,8 @@ export let processAssistantRequestQueueProcessor = processAssistantRequestQueue.
         conversation.tenant,
         conversation.environment,
         conversation.assistant,
-        definition.implementation._persisted,
-        definition.implementation
+        assistantImplementation._persisted,
+        assistantImplementation
       );
       let result = await runner.run({
         input: getInputMessage(inputMessage.state),

--- a/src/systems/synthesis/service/src/services/conversation.ts
+++ b/src/systems/synthesis/service/src/services/conversation.ts
@@ -1,21 +1,11 @@
-import {
-  badRequestError,
-  notFoundError,
-  ServiceError,
-  validationError
-} from '@lowerdeck/error';
+import { notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import type {
-  AssistantConversation,
-  AssistantInstance,
-  Environment,
-  Tenant,
-  TenantActor
-} from '../db';
+import type { AssistantConversation, Environment, Tenant, TenantActor } from '../db';
 import { db, Prisma, withTransaction } from '../db';
 import { getId } from '../id';
 import { getAssistantDefinition } from '../lib/definitions/assistantDefinition';
+import { resolveAssistantConversationInput } from '../lib/definitions/conversationInput';
 import type { State } from '../types';
 import type { AvailableAssistant } from './assistant';
 import { assistantService } from './assistant';
@@ -60,51 +50,6 @@ let toNullableJson = (value: unknown) => {
   if (value === null) return Prisma.JsonNull;
 
   return value as Prisma.InputJsonValue;
-};
-
-let resolveConversationInput = async (d: {
-  tenant: Tenant;
-  environment: Environment;
-  actor: TenantActor;
-  assistant: AvailableAssistant;
-  assistantInstance: AssistantInstance;
-  rawInput: unknown;
-  rawInputProvided: boolean;
-}) => {
-  let definition = await getAssistantDefinition(d.assistant.implementation.slug);
-  let assistantImplementation = definition.implementation;
-
-  if (!assistantImplementation.input || !assistantImplementation.handleInput) {
-    if (d.rawInputProvided) {
-      throw new ServiceError(
-        badRequestError({
-          message: 'This assistant does not accept conversation input.'
-        })
-      );
-    }
-
-    return undefined;
-  }
-
-  let valRes = assistantImplementation.input.validate(d.rawInput);
-  if (!valRes.success) {
-    throw new ServiceError(
-      validationError({
-        entity: 'assistant_conversation.input',
-        errors: valRes.errors
-      })
-    );
-  }
-
-  return await assistantImplementation.handleInput({
-    input: valRes.value,
-    tenant: d.tenant,
-    environment: d.environment,
-    actor: d.actor,
-    assistant: d.assistant,
-    assistantInstance: d.assistantInstance,
-    assistantImplementation: assistantImplementation._persisted
-  });
 };
 
 class AssistantConversationServiceImpl {
@@ -258,12 +203,14 @@ class AssistantConversationServiceImpl {
       throw new ServiceError(notFoundError('model', assistant.id));
     }
     let defaultModel = assistant.defaultModel;
-    let conversationInput = await resolveConversationInput({
+    let definition = await getAssistantDefinition(assistant.implementation.slug);
+    let conversationInput = await resolveAssistantConversationInput({
       tenant: d.tenant,
       environment: d.environment,
       actor: d.actor,
       assistant,
       assistantInstance,
+      assistantImplementation: definition.implementation,
       rawInput: d.input.input,
       rawInputProvided: hasOwn(d.input, 'input')
     });

--- a/src/systems/synthesis/service/src/services/conversation.ts
+++ b/src/systems/synthesis/service/src/services/conversation.ts
@@ -1,9 +1,21 @@
-import { notFoundError, ServiceError } from '@lowerdeck/error';
+import {
+  badRequestError,
+  notFoundError,
+  ServiceError,
+  validationError
+} from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import type { AssistantConversation, Environment, Tenant, TenantActor } from '../db';
+import type {
+  AssistantConversation,
+  AssistantInstance,
+  Environment,
+  Tenant,
+  TenantActor
+} from '../db';
 import { db, Prisma, withTransaction } from '../db';
 import { getId } from '../id';
+import { getAssistantDefinition } from '../lib/definitions/assistantDefinition';
 import type { State } from '../types';
 import type { AvailableAssistant } from './assistant';
 import { assistantService } from './assistant';
@@ -40,6 +52,60 @@ let emptySerializedMessage = {
   b: 'ai-sdk-1',
   messages: []
 } satisfies PrismaJson.AssistantMessageSerializedContent;
+
+let hasOwn = (value: object, key: string) => Object.prototype.hasOwnProperty.call(value, key);
+
+let toNullableJson = (value: unknown) => {
+  if (value === undefined) return undefined;
+  if (value === null) return Prisma.JsonNull;
+
+  return value as Prisma.InputJsonValue;
+};
+
+let resolveConversationInput = async (d: {
+  tenant: Tenant;
+  environment: Environment;
+  actor: TenantActor;
+  assistant: AvailableAssistant;
+  assistantInstance: AssistantInstance;
+  rawInput: unknown;
+  rawInputProvided: boolean;
+}) => {
+  let definition = await getAssistantDefinition(d.assistant.implementation.slug);
+  let assistantImplementation = definition.implementation;
+
+  if (!assistantImplementation.input || !assistantImplementation.handleInput) {
+    if (d.rawInputProvided) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'This assistant does not accept conversation input.'
+        })
+      );
+    }
+
+    return undefined;
+  }
+
+  let valRes = assistantImplementation.input.validate(d.rawInput);
+  if (!valRes.success) {
+    throw new ServiceError(
+      validationError({
+        entity: 'assistant_conversation.input',
+        errors: valRes.errors
+      })
+    );
+  }
+
+  return await assistantImplementation.handleInput({
+    input: valRes.value,
+    tenant: d.tenant,
+    environment: d.environment,
+    actor: d.actor,
+    assistant: d.assistant,
+    assistantInstance: d.assistantInstance,
+    assistantImplementation: assistantImplementation._persisted
+  });
+};
 
 class AssistantConversationServiceImpl {
   private async enrichConversations(d: {
@@ -175,6 +241,7 @@ class AssistantConversationServiceImpl {
     input: {
       assistantId: string;
       title?: string | null;
+      input?: unknown;
     };
   }) {
     this.ensureScope(d);
@@ -191,6 +258,15 @@ class AssistantConversationServiceImpl {
       throw new ServiceError(notFoundError('model', assistant.id));
     }
     let defaultModel = assistant.defaultModel;
+    let conversationInput = await resolveConversationInput({
+      tenant: d.tenant,
+      environment: d.environment,
+      actor: d.actor,
+      assistant,
+      assistantInstance,
+      rawInput: d.input.input,
+      rawInputProvided: hasOwn(d.input, 'input')
+    });
 
     return await withTransaction(async tx => {
       let rootMessage = await tx.assistantMessage.create({
@@ -208,6 +284,7 @@ class AssistantConversationServiceImpl {
         data: {
           ...getId('assistantConversation'),
           title: d.input.title,
+          input: toNullableJson(conversationInput),
           assistantOid: assistant.oid,
           assistantInstanceOid: assistantInstance.oid,
           tenantOid: d.tenant.oid,

--- a/src/systems/synthesis/service/src/services/request.ts
+++ b/src/systems/synthesis/service/src/services/request.ts
@@ -1,4 +1,4 @@
-import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Service } from '@lowerdeck/service';
 import type {
   AssistantConversation,
@@ -11,6 +11,11 @@ import { db, Prisma, withTransaction } from '../db';
 import { getId } from '../id';
 import type { Implementation } from '../lib/definitions';
 import { getAssistantDefinition } from '../lib/definitions/assistantDefinition';
+import {
+  applyHandoffToolResponses,
+  getHandoffToolCalls,
+  getWaitingHandoffToolCalls
+} from '../lib/run';
 import { listenToAssistantRunDeltas } from '../lib/run/redisDeltas';
 import { createItemId, type AgentRunWireMessage } from '../lib/run/state';
 import { generateAssistantConversationTitleQueue } from '../queues/generateConversationTitle';
@@ -362,6 +367,145 @@ class AssistantRequestServiceImpl {
     return result;
   }
 
+  async respondToAssistantHandoffs(d: {
+    tenant: Tenant;
+    environment: Environment;
+    actor: TenantActor;
+    conversation: AssistantConversation;
+    input: {
+      messageId: string;
+      responses: Array<{
+        toolCallId: string;
+        output: unknown;
+      }>;
+    };
+  }) {
+    if (!d.input.responses.length) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'At least one handoff response is required.'
+        })
+      );
+    }
+
+    let item = await db.assistantConversationItem.findFirst({
+      where: {
+        conversationOid: d.conversation.oid,
+        message: {
+          id: d.input.messageId
+        }
+      },
+      include: assistantConversationItemInclude
+    });
+    if (!item) throw new ServiceError(notFoundError('assistant_message', d.input.messageId));
+
+    await this.ensureScope({
+      tenant: d.tenant,
+      environment: d.environment,
+      actor: d.actor,
+      conversation: d.conversation
+    });
+
+    let message = item.message;
+    if (!message.request || message.status != 'waiting_for_user') {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Assistant message is not waiting for handoff responses.'
+        })
+      );
+    }
+    if (message.request.status != 'waiting_for_user') {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Assistant request is not waiting for handoff responses.'
+        })
+      );
+    }
+
+    let currentState = message.state as State;
+    let waitingBefore = getWaitingHandoffToolCalls(currentState);
+    if (!waitingBefore.length) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Assistant message has no waiting handoff tool calls.'
+        })
+      );
+    }
+
+    let applied: ReturnType<typeof applyHandoffToolResponses>;
+    try {
+      applied = applyHandoffToolResponses(currentState, d.input.responses);
+    } catch (error) {
+      throw new ServiceError(
+        badRequestError({
+          message: error instanceof Error ? error.message : 'Invalid handoff response.'
+        })
+      );
+    }
+
+    let shouldResume = applied.remaining.length == 0;
+    let waitingBeforeIds = new Set(waitingBefore.map(({ call }) => call.id));
+    let handoffById = new Map(
+      getHandoffToolCalls(applied.state).map(({ toolName, call }) => [call.id, { toolName, call }])
+    );
+    let resumeResponses = [...waitingBeforeIds].map(toolCallId => {
+      let handoff = handoffById.get(toolCallId)!;
+      return {
+        toolCallId,
+        toolName: handoff.toolName,
+        output: handoff.call.output
+      };
+    });
+
+    let updatedItem = await withTransaction(async tx => {
+      await tx.assistantMessage.update({
+        where: {
+          oid: message.oid
+        },
+        data: {
+          status: shouldResume ? 'pending' : 'waiting_for_user',
+          state: applied.state
+        }
+      });
+
+      await tx.assistantRequest.update({
+        where: {
+          oid: message.request!.oid
+        },
+        data: {
+          status: shouldResume ? 'pending' : 'waiting_for_user'
+        }
+      });
+
+      if (message.run) {
+        await tx.modelRun.update({
+          where: {
+            oid: message.run.oid
+          },
+          data: {
+            status: shouldResume ? 'pending' : 'waiting_for_user'
+          }
+        });
+      }
+
+      return await tx.assistantConversationItem.findUniqueOrThrow({
+        where: {
+          oid: item.oid
+        },
+        include: assistantConversationItemInclude
+      });
+    });
+
+    if (shouldResume) {
+      await processAssistantRequestQueue.add({
+        assistantRequestId: message.request.id,
+        handoffResponses: resumeResponses
+      });
+    }
+
+    return updatedItem;
+  }
+
   async listenToAssistantRequestDeltas(d: {
     requestId: string;
     signal?: AbortSignal;
@@ -371,7 +515,7 @@ class AssistantRequestServiceImpl {
     onMessage: (message: AgentRunWireMessage) => void | Promise<void>;
     onError?: (error: Error) => void | Promise<void>;
     onDone?: (message: {
-      status: 'completed' | 'cancelled' | 'failed';
+      status: 'completed' | 'waiting_for_user' | 'cancelled' | 'failed';
     }) => void | Promise<void>;
   }) {
     let request = await this.getAssistantRequestById({ requestId: d.requestId });

--- a/src/systems/synthesis/service/src/services/request.ts
+++ b/src/systems/synthesis/service/src/services/request.ts
@@ -8,9 +8,9 @@ import type {
   TenantActor
 } from '../db';
 import { db, Prisma, withTransaction } from '../db';
-import { assistants } from '../definitions/assistants';
 import { getId } from '../id';
 import type { Implementation } from '../lib/definitions';
+import { getAssistantDefinition } from '../lib/definitions/assistantDefinition';
 import { listenToAssistantRunDeltas } from '../lib/run/redisDeltas';
 import { createItemId, type AgentRunWireMessage } from '../lib/run/state';
 import { generateAssistantConversationTitleQueue } from '../queues/generateConversationTitle';
@@ -63,8 +63,6 @@ let inputMessageState = (input: InputMessage) =>
     ]
   }) satisfies State;
 
-type AssistantDefinition = Awaited<(typeof assistants)[keyof typeof assistants]>;
-
 export let assistantRequestInclude = {
   tenantActor: true,
   conversation: true,
@@ -86,21 +84,6 @@ export let assistantRequestInclude = {
 export type AssistantRequestWithRelations = Prisma.AssistantRequestGetPayload<{
   include: typeof assistantRequestInclude;
 }>;
-
-let getAssistantDefinition = async (
-  implementationSlug: string
-): Promise<AssistantDefinition> => {
-  let definitions = await Promise.all(Object.values(assistants));
-  let definition = definitions.find(
-    definition => definition.implementation._persisted.slug == implementationSlug
-  );
-
-  if (!definition) {
-    throw new ServiceError(notFoundError('assistant_implementation', implementationSlug));
-  }
-
-  return definition;
-};
 
 let chooseModel = (d: {
   implementation: Implementation;

--- a/src/systems/synthesis/service/src/types.ts
+++ b/src/systems/synthesis/service/src/types.ts
@@ -15,7 +15,7 @@ export type InputMessage = {
   parts: MessagePart[];
 };
 
-export type ItemStatus = 'running' | 'completed' | 'failed';
+export type ItemStatus = 'pending' | 'running' | 'waiting_for_user' | 'completed' | 'failed';
 
 export type Message = {
   role: 'user' | 'assistant' | 'system';
@@ -28,6 +28,10 @@ export type ToolCallState = {
   output?: unknown;
   error?: { message: string };
   status: ItemStatus;
+  handoff?: {
+    title: string;
+    description?: string;
+  };
 };
 
 export type FileExploreOperation = (
@@ -169,6 +173,13 @@ export type AssistantMessageSerializedContent = {
   b: 'ai-sdk-1';
   messages: [number, unknown][];
 };
+
+export type AssistantRequestStatus =
+  | 'pending'
+  | 'waiting_for_user'
+  | 'completed'
+  | 'cancelled'
+  | 'failed';
 
 export type AssistantRunUsage = {
   inputTokens: number;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches core assistant request processing, agent run lifecycle, DB enums, and new public APIs; incorrect handoff/resume behavior could strand or duplicate runs.
> 
> **Overview**
> Adds **client handoff tools** so agents can pause on schema-only tools (no server `execute`) and wait for the client to submit results, then resume the run.
> 
> **Handoff flow:** `handoffTool` attaches metadata to tool definitions; the agent loop emits `handoff` on `tool.start` and run state marks those calls `waiting_for_user`. Requests, messages, and model runs can end in `waiting_for_user` (renamed run enum to `ModelRunStatus`). A new **`POST …/handoff-responses`** API (dashboard + synthesis) accepts `tool_call_id` + `output`, updates state via `respondToAssistantHandoffs`, and re-queues processing with `AgentRun.resume()` when all pending handoffs are answered. Streaming/delta consumers treat `waiting_for_user` like a terminal done state where appropriate.
> 
> **Conversation input:** Creating a conversation accepts optional **`input`**, persisted on `AssistantConversation` and resolved through per-implementation `input` / `handleInput` (validation + mapping before `getAgent`).
> 
> **API surface:** Message presenters expose **`status`** on messages and **`waiting_for_user`** on request status; `assistantRequestService` is refactored into a cohesive service object including `respondToHandoffs` and extended `listenToDeltas` done statuses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 633b9182de6d08df189690a62a249b3fe216ca14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->