### PR TITLE
feat: add portal skill flag

### DIFF
--- a/src/backend/apis/custom-portal/package.json
+++ b/src/backend/apis/custom-portal/package.json
@@ -14,6 +14,7 @@
     "@metorial/config": "1.0.0",
     "@metorial/db": "1.0.0",
     "@metorial/module-consumer": "1.0.0",
+    "@metorial/module-flags": "1.0.0",
     "@metorial/rpc": "1.0.0"
   },
   "devDependencies": {

--- a/src/backend/apis/custom-portal/src/controllers/boot.ts
+++ b/src/backend/apis/custom-portal/src/controllers/boot.ts
@@ -1,6 +1,7 @@
 import { v } from '@lowerdeck/validation';
 import { getConfig } from '@metorial/config';
 import { consumerAuthService } from '@metorial/module-consumer';
+import { flagService } from '@metorial/module-flags';
 import { projectBrandService } from '@metorial/module-organization';
 import { portalFromUrlApp } from '../group';
 import {
@@ -43,7 +44,10 @@ export let bootController = portalFromUrlApp.controller({
         portalUrl: ctx.portalUrl,
         publishableApiKey: getPortalPublishableApiKey({ portal: ctx.portal }),
         brand: await brandPresenter(brand),
-        portalMagicMcpUrl: `${getConfig().urls.apiUrl}/connect/portal/${ctx.portal.slug}`
+        portalMagicMcpUrl: `${getConfig().urls.apiUrl}/connect/portal/${ctx.portal.slug}`,
+        flags: await flagService.getFlags({
+          organization: ctx.portal.organization
+        })
       };
 
       if (!sessionRes) {

--- a/src/backend/apis/custom-portal/src/lib/boot.ts
+++ b/src/backend/apis/custom-portal/src/lib/boot.ts
@@ -1,3 +1,4 @@
+import type { Flags } from '@metorial/module-flags';
 import { instancePresenter, portalPresenter, sessionPresenter } from '../presenters';
 import { brandPresenter } from '../presenters/brand';
 
@@ -8,6 +9,7 @@ type PortalBootSharedResponse = {
   publishableApiKey: string;
   brand: Awaited<ReturnType<typeof brandPresenter>>;
   portalMagicMcpUrl: string;
+  flags: Flags;
 };
 
 export let createUnauthenticatedPortalBootResponse = async (d: PortalBootSharedResponse) => ({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive boot payload field with read-only flag lookup; no auth or enforcement logic changed in this diff.
> 
> **Overview**
> The custom portal **boot** response now includes organization **feature flags**, so the portal client can read flag state (e.g. portal skill) on load without a separate flags call.
> 
> `@metorial/module-flags` is wired into the custom-portal API. The boot handler loads flags for the portal’s organization via `flagService.getFlags` and passes them through both authenticated and unauthenticated boot payloads. `PortalBootSharedResponse` is extended with a typed `flags` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef646cb6a45a8f60b3dcec04221934908b983b11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->