### PR TITLE
Reset auth credentials on auth method changes

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/integrations/providerPanelFlow.tsx
@@ -433,6 +433,7 @@ let IntegrationProviderAuthSection = (p: {
                     <Flex gap={8} align="end">
                       <div style={{ flex: 1 }}>
                         <Combobox
+                          key={p.selectedAuthMethodId || 'auth-credentials'}
                           label="Auth Credentials"
                           placeholder="Search auth credentials"
                           value={p.selectedAuthCredentialsId || null}
@@ -529,6 +530,7 @@ let IntegrationProviderSetupStep = (p: {
   let updateIntegrationProvider = useUpdateIntegrationProvider();
   let autoSubmitAttemptedRef = useRef(false);
   let managedAuthCredentialsDefaultedKeysRef = useRef(new Set<string>());
+  let manuallySelectedAuthMethodIdsRef = useRef(new Set<string>());
   let [createdAuthCredentialsSelection, setCreatedAuthCredentialsSelection] = useState<{
     id: string;
     label: string;
@@ -709,6 +711,7 @@ let IntegrationProviderSetupStep = (p: {
         selectedToolKeys: yup.array().of(yup.string().required()).defined()
       })
   });
+  let previousAuthMethodIdRef = useRef(form.values.selectedAuthMethodId);
   let selectedAuthMethod = authMethods.data?.items.find(
     method => method.id === form.values.selectedAuthMethodId
   );
@@ -718,7 +721,9 @@ let IntegrationProviderSetupStep = (p: {
     instance.data?.id,
     effectiveShowAuth && requiresAuthCredentials
       ? {
-          providerId: p.providerId,
+          ...(p.integrationProvider?.deployment.id
+            ? { providerDeploymentId: p.integrationProvider.deployment.id }
+            : { providerId: p.providerId }),
           ...(form.values.selectedAuthMethodId
             ? { providerAuthMethodId: form.values.selectedAuthMethodId }
             : {}),
@@ -752,6 +757,19 @@ let IntegrationProviderSetupStep = (p: {
     instance.data?.id,
     form.values.selectedAuthCredentialsId || null
   );
+  let resetSelectedAuthCredentials = () => {
+    form.setFieldValue('selectedAuthCredentialsId', '');
+    form.setFieldTouched('selectedAuthCredentialsId', false, false);
+    form.setFieldError('selectedAuthCredentialsId', undefined);
+    setCreatedAuthCredentialsSelection(null);
+  };
+
+  useEffect(() => {
+    if (previousAuthMethodIdRef.current === form.values.selectedAuthMethodId) return;
+
+    previousAuthMethodIdRef.current = form.values.selectedAuthMethodId;
+    resetSelectedAuthCredentials();
+  }, [form.values.selectedAuthMethodId]);
 
   useEffect(() => {
     if (!effectiveShowAuth) return;
@@ -772,10 +790,7 @@ let IntegrationProviderSetupStep = (p: {
     if (selectedAuthMethod?.type === 'oauth' && !oauthAutoRegistrationEnabled) return;
     if (!form.values.selectedAuthCredentialsId) return;
 
-    form.setFieldValue('selectedAuthCredentialsId', '');
-    form.setFieldTouched('selectedAuthCredentialsId', false, false);
-    form.setFieldError('selectedAuthCredentialsId', undefined);
-    setCreatedAuthCredentialsSelection(null);
+    resetSelectedAuthCredentials();
   }, [
     authMethods.isLoading,
     oauthAutoRegistrationEnabled,
@@ -790,6 +805,7 @@ let IntegrationProviderSetupStep = (p: {
     if (form.values.selectedAuthCredentialsId) return;
     if (managedAuthCredentials.isLoading) return;
     if (!preferredManagedAuthCredential) return;
+    if (manuallySelectedAuthMethodIdsRef.current.has(form.values.selectedAuthMethodId)) return;
     if (managedAuthCredentialsDefaultedKeysRef.current.has(managedAuthCredentialsDefaultKey)) {
       return;
     }
@@ -817,26 +833,21 @@ let IntegrationProviderSetupStep = (p: {
     if (!effectiveShowAuth) return;
     if (!form.values.selectedAuthCredentialsId) return;
     if (authCredentials.isLoading) return;
-    if (selectedAuthCredential.isLoading) return;
 
     let credentialExists = (authCredentials.data?.items ?? []).some(
       credential => credential.id === form.values.selectedAuthCredentialsId
     );
-    let selectedCredentialExists =
-      selectedAuthCredential.data?.id === form.values.selectedAuthCredentialsId;
+    let createdCredentialSelected =
+      createdAuthCredentialsSelection?.id === form.values.selectedAuthCredentialsId;
 
-    if (!credentialExists && !selectedCredentialExists) {
-      form.setFieldValue('selectedAuthCredentialsId', '');
-      form.setFieldTouched('selectedAuthCredentialsId', false, false);
-      form.setFieldError('selectedAuthCredentialsId', undefined);
-      setCreatedAuthCredentialsSelection(null);
+    if (!credentialExists && !createdCredentialSelected) {
+      resetSelectedAuthCredentials();
     }
   }, [
     effectiveShowAuth,
     authCredentials.isLoading,
     authCredentials.data?.items,
-    selectedAuthCredential.isLoading,
-    selectedAuthCredential.data?.id,
+    createdAuthCredentialsSelection?.id,
     form.values.selectedAuthCredentialsId
   ]);
 
@@ -916,28 +927,27 @@ let IntegrationProviderSetupStep = (p: {
           selectedAuthMethod={selectedAuthMethod}
           selectedAuthMethodId={form.values.selectedAuthMethodId}
           onSelectedAuthMethodIdChange={value => {
+            if (value === form.values.selectedAuthMethodId) return;
+
+            manuallySelectedAuthMethodIdsRef.current.add(value);
             form.setFieldValue('selectedAuthMethodId', value);
             form.setFieldTouched('selectedAuthMethodId', false, false);
             form.setFieldError('selectedAuthMethodId', undefined);
-
-            if (value !== form.values.selectedAuthMethodId) {
-              form.setFieldValue('selectedAuthCredentialsId', '');
-              form.setFieldTouched('selectedAuthCredentialsId', false, false);
-              form.setFieldError('selectedAuthCredentialsId', undefined);
-              setCreatedAuthCredentialsSelection(null);
-            }
+            resetSelectedAuthCredentials();
           }}
           selectedAuthCredentialsId={form.values.selectedAuthCredentialsId}
           selectedAuthCredentialsLabel={
-            selectedAuthCredential.data?.name ??
-            selectedAuthCredential.data?.id ??
-            (createdAuthCredentialsSelection?.id === form.values.selectedAuthCredentialsId
-              ? createdAuthCredentialsSelection.label
-              : undefined) ??
-            authCredentials.data?.items.find(
-              credential => credential.id === form.values.selectedAuthCredentialsId
-            )?.name ??
             form.values.selectedAuthCredentialsId
+              ? (selectedAuthCredential.data?.name ??
+                selectedAuthCredential.data?.id ??
+                (createdAuthCredentialsSelection?.id === form.values.selectedAuthCredentialsId
+                  ? createdAuthCredentialsSelection.label
+                  : undefined) ??
+                authCredentials.data?.items.find(
+                  credential => credential.id === form.values.selectedAuthCredentialsId
+                )?.name ??
+                form.values.selectedAuthCredentialsId)
+              : undefined
           }
           onSelectedAuthCredentialsIdChange={(value, credentials) => {
             managedAuthCredentialsDefaultedKeysRef.current.add(

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
@@ -884,8 +884,28 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
   let destructiveTools = normalizedTools.filter(tool => tool.group === 'destructive');
   let requiresAuthConfig = showAuthSection && provider.data?.type.auth.status == 'enabled';
   let pendingCreatedAuthConfigIdRef = useRef<string | null>(null);
+  let previousProviderAuthMethodIdRef = useRef<string | undefined>(providerAuthMethodId);
   let selectedToolKeys = p.selectedToolKeys ?? [];
   let toolFilterMode = p.toolFilterMode ?? 'all';
+  let selectedAuthConfigForMethod = useProviderAuthConfigs(
+    requiresAuthConfig && providerAuthMethodId && p.selectedAuthConfigId
+      ? p.instanceId
+      : null,
+    {
+      providerId: p.providerId,
+      id: p.selectedAuthConfigId,
+      limit: 1,
+      ...(filterAvailableResources
+        ? {
+            availableForUse: true,
+            availableForProviderDeploymentId: p.providerDeploymentId ?? undefined
+          }
+        : {
+            providerDeploymentId: p.providerDeploymentId ?? undefined
+          }),
+      providerAuthMethodId
+    }
+  );
 
   useEffect(() => {
     if (provider.isLoading || requiresProviderConfig) return;
@@ -930,6 +950,56 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
     selectedAuthConfig.isLoading,
     selectedAuthConfig.data,
     selectedAuthConfig.error
+  ]);
+
+  useEffect(() => {
+    if (previousProviderAuthMethodIdRef.current === providerAuthMethodId) return;
+
+    previousProviderAuthMethodIdRef.current = providerAuthMethodId;
+    let createdAuthConfigSelected =
+      createdAuthConfigSelection?.id === p.selectedAuthConfigId;
+    let pendingCreatedAuthConfigSelected =
+      pendingCreatedAuthConfigIdRef.current === p.selectedAuthConfigId;
+
+    if (createdAuthConfigSelected || pendingCreatedAuthConfigSelected) return;
+
+    pendingCreatedAuthConfigIdRef.current = null;
+    setCreatedAuthConfigSelection(null);
+    if (p.selectedAuthConfigId) {
+      p.onSelectedAuthConfigIdChange('');
+    }
+  }, [
+    providerAuthMethodId,
+    p.selectedAuthConfigId,
+    p.onSelectedAuthConfigIdChange,
+    createdAuthConfigSelection?.id
+  ]);
+
+  useEffect(() => {
+    if (!requiresAuthConfig) return;
+    if (!providerAuthMethodId) return;
+    if (!p.selectedAuthConfigId) return;
+    if (selectedAuthConfigForMethod.isLoading) return;
+
+    let authConfigMatchesMethod = (selectedAuthConfigForMethod.data?.items ?? []).some(
+      config => config.id === p.selectedAuthConfigId
+    );
+    let createdAuthConfigSelected =
+      createdAuthConfigSelection?.id === p.selectedAuthConfigId;
+
+    if (!authConfigMatchesMethod && !createdAuthConfigSelected) {
+      pendingCreatedAuthConfigIdRef.current = null;
+      setCreatedAuthConfigSelection(null);
+      p.onSelectedAuthConfigIdChange('');
+    }
+  }, [
+    requiresAuthConfig,
+    providerAuthMethodId,
+    p.selectedAuthConfigId,
+    p.onSelectedAuthConfigIdChange,
+    selectedAuthConfigForMethod.isLoading,
+    selectedAuthConfigForMethod.data?.items,
+    createdAuthConfigSelection?.id
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches integration and session-template provider auth wiring; wrong resets or scoping could block saves or pick invalid credential/config pairings, but changes are localized to form state and list queries.
> 
> **Overview**
> **Clears stale auth selections when the authentication method changes** in integration provider setup and shared session-template provider setup.
> 
> In **integration provider** flows, changing the auth method now resets OAuth **auth credentials** through a shared `resetSelectedAuthCredentials` helper and a dedicated effect (instead of only clearing in the picker handler). The credentials combobox **remounts** via a `key` tied to the selected method. Credential lists are scoped to **`providerDeploymentId`** when editing an existing integration provider. **Managed credential auto-default** is skipped after the user **manually** picks an auth method, and invalid selections are cleared without relying on a separate single-credential fetch.
> 
> In **`ProviderSetupSections`** (session templates / add provider), changing **`providerAuthMethodId`** clears the selected **auth config** unless it was just created or is still pending, and a follow-up check drops configs that **no longer match** the active auth method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e1259f78aa187d9fbdc521531b5daeb5047be8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->