### PR TITLE
Feat/add conduit health check

### DIFF
--- a/src/backend/db/prisma/schema/machine-access/oauth.prisma
+++ b/src/backend/db/prisma/schema/machine-access/oauth.prisma
@@ -7,6 +7,7 @@ enum OAuthApplicationType {
   user_facing
   cli_auth
   server_side
+  internal
 }
 
 enum OAuthAuthorizationAccessLevel {
@@ -21,6 +22,8 @@ model OAuthApplication {
   status      OAuthApplicationStatus
   type        OAuthApplicationType
   accessLevel OAuthAuthorizationAccessLevel
+
+  systemIdentifier String?
 
   name        String
   description String?
@@ -58,6 +61,8 @@ model OAuthApplication {
   oauthAuthorizations        OAuthAuthorization[]
   oauthAuthorizationRequests OAuthAuthorizationFlow[]
   serviceAccount             ServiceAccount?
+
+  @@unique([organizationOid, systemIdentifier])
 }
 
 model OAuthApplicationClientSecret {
@@ -142,6 +147,9 @@ model OAuthAuthorization {
   organizationOid BigInt
   organization    Organization @relation(fields: [organizationOid], references: [oid], onDelete: Cascade)
 
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
   userOid BigInt?
   user    User?   @relation(fields: [userOid], references: [oid], onDelete: Cascade)
 
@@ -207,6 +215,9 @@ model OAuthAuthorizationFlow {
 
   organizationOid BigInt
   organization    Organization @relation(fields: [organizationOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
 
   codeChallengeMethod OAuthAuthorizationFlowChallengeMethod
   codeChallenge       String?

--- a/src/backend/db/prisma/schema/organization/instance.prisma
+++ b/src/backend/db/prisma/schema/organization/instance.prisma
@@ -133,6 +133,8 @@ model Instance {
   consumerAuthTestAuthorizations       ConsumerAuthTestAuthorization[]
   environment                          Environment?
   sandbox                              Sandbox?
+  oauthAuthorizations                  OAuthAuthorization[]
+  oauthAuthorizationFlows              OAuthAuthorizationFlow[]
 
   @@index([previousSlugs])
 }

--- a/src/systems/subspace/apps/controller/src/endpoints.ts
+++ b/src/systems/subspace/apps/controller/src/endpoints.ts
@@ -1,5 +1,9 @@
 import { withTracingSuppressed } from '@lowerdeck/telemetry';
 import { db } from '@metorial-subspace/db';
+import {
+  checkConduitHeartbeat,
+  checkNatsHealth
+} from '@metorial-subspace/module-connection/src/health';
 import { syncProtoGuardFilters } from '@metorial-subspace/module-connection/src/protoguard/registry';
 import { RedisClient } from 'bun';
 import { subspaceControllerApi } from './controllers';
@@ -27,6 +31,9 @@ if (process.env.NODE_ENV === 'production') {
           await db.backend.count();
 
           await redis.ping();
+
+          await checkNatsHealth();
+          await checkConduitHeartbeat();
 
           return new Response('OK');
         } catch (e) {

--- a/src/systems/subspace/apps/controller/src/server.ts
+++ b/src/systems/subspace/apps/controller/src/server.ts
@@ -18,9 +18,29 @@ main().catch(error => {
 });
 
 if (process.env.HEARTBEAT_URL) {
+  let captureHeartbeatError = async (error: unknown) => {
+    try {
+      let { getSentry } = await import('@lowerdeck/sentry');
+      getSentry().captureException(error);
+    } catch {}
+
+    console.error('Failed to send heartbeat:', error);
+  };
+
+  let sendHeartbeat = async () => {
+    try {
+      let { checkConduitHeartbeat, checkNatsHealth } =
+        await import('@metorial-subspace/module-connection/src/health');
+
+      await checkNatsHealth();
+      await checkConduitHeartbeat();
+      await fetch(process.env.HEARTBEAT_URL!, { method: 'POST' });
+    } catch (error) {
+      await captureHeartbeatError(error);
+    }
+  };
+
   setInterval(() => {
-    fetch(process.env.HEARTBEAT_URL!, { method: 'POST' }).catch(error => {
-      console.error('Failed to send heartbeat:', error);
-    });
+    void sendHeartbeat();
   }, 45 * 1000); // Send heartbeat every 45 seconds
 }

--- a/src/systems/subspace/apps/worker/src/endpoints.ts
+++ b/src/systems/subspace/apps/worker/src/endpoints.ts
@@ -1,5 +1,6 @@
 import { withTracingSuppressed } from '@lowerdeck/telemetry';
 import { db } from '@metorial-subspace/db';
+import { checkNatsHealth } from '@metorial-subspace/module-connection/src/health';
 import { RedisClient } from 'bun';
 
 let redis = new RedisClient(process.env.REDIS_URL?.replace('rediss://', 'redis://'), {
@@ -14,6 +15,8 @@ if (process.env.NODE_ENV === 'production') {
           await db.backend.count();
 
           await redis.ping();
+
+          await checkNatsHealth();
 
           return new Response('OK');
         } catch (e) {

--- a/src/systems/subspace/apps/worker/src/server.ts
+++ b/src/systems/subspace/apps/worker/src/server.ts
@@ -19,9 +19,28 @@ main().catch(error => {
 });
 
 if (process.env.HEARTBEAT_URL) {
+  let captureHeartbeatError = async (error: unknown) => {
+    try {
+      let { getSentry } = await import('@lowerdeck/sentry');
+      getSentry().captureException(error);
+    } catch {}
+
+    console.error('Failed to send heartbeat:', error);
+  };
+
+  let sendHeartbeat = async () => {
+    try {
+      let { checkNatsHealth } =
+        await import('@metorial-subspace/module-connection/src/health');
+
+      await checkNatsHealth();
+      await fetch(process.env.HEARTBEAT_URL!, { method: 'POST' });
+    } catch (error) {
+      await captureHeartbeatError(error);
+    }
+  };
+
   setInterval(() => {
-    fetch(process.env.HEARTBEAT_URL!, { method: 'POST' }).catch(error => {
-      console.error('Failed to send heartbeat:', error);
-    });
+    void sendHeartbeat();
   }, 45 * 1000); // Send heartbeat every 45 seconds
 }

--- a/src/systems/subspace/modules/connection/src/controller/receiver.ts
+++ b/src/systems/subspace/modules/connection/src/controller/receiver.ts
@@ -3,10 +3,12 @@ import { getSentry } from '@lowerdeck/sentry';
 import { serialize } from '@lowerdeck/serialize';
 import type {
   BroadcastMessage,
+  ConduitHeartbeatPong,
   ConduitInput,
   ConduitResult
 } from '@metorial-subspace/connection-utils';
 import { db, ID, type SessionMessage } from '@metorial-subspace/db';
+import { isConduitHeartbeatPing } from '../health/conduitHeartbeat';
 import { conduit } from '../lib/conduit';
 import { broadcastNats } from '../lib/nats';
 import { topics } from '../lib/topic';
@@ -26,6 +28,23 @@ const NO_OUTPUT_ERROR = {
 export let startReceiver = () => {
   let receiver = conduit.createConduitReceiver(async ctx => {
     ctx.extendTtl(1000 * 60);
+
+    if (topics.workerHeartbeat.is(ctx.topic)) {
+      ctx.extendTtl(5000);
+      ctx.onMessage(async data => {
+        if (!isConduitHeartbeatPing(data)) {
+          throw new Error('Invalid conduit heartbeat ping');
+        }
+
+        return {
+          type: 'health.pong',
+          id: data.id,
+          sentAt: data.sentAt,
+          receivedAt: Date.now()
+        } satisfies ConduitHeartbeatPong;
+      });
+      return;
+    }
 
     let topic = topics.instance.decode(ctx.topic);
     if (!topic) {

--- a/src/systems/subspace/modules/connection/src/health/conduitHeartbeat.test.ts
+++ b/src/systems/subspace/modules/connection/src/health/conduitHeartbeat.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import type { ConduitHeartbeatPong } from '@metorial-subspace/connection-utils';
+import type { ConduitResponse } from '@metorial-subspace/conduit';
+import {
+  checkConduitHeartbeat,
+  ConduitHeartbeatError,
+  type ConduitHeartbeatSender
+} from './conduitHeartbeat';
+import { topics } from '../lib/topic';
+
+describe('checkConduitHeartbeat', () => {
+  it('sends a health ping and returns the matching pong', async () => {
+    let sentPayload: unknown;
+    let sentTopic: string | undefined;
+    let sentTimeout: number | undefined;
+
+    let sender: ConduitHeartbeatSender = {
+      send: async (topic, payload, timeout) => {
+        sentTopic = topic;
+        sentPayload = payload;
+        sentTimeout = timeout;
+
+        return {
+          messageId: 'message-id',
+          success: true,
+          processedAt: 124,
+          result: {
+            type: 'health.pong',
+            id: 'heartbeat-id',
+            sentAt: 123,
+            receivedAt: 124
+          } satisfies ConduitHeartbeatPong
+        } satisfies ConduitResponse;
+      }
+    };
+
+    let result = await checkConduitHeartbeat({
+      sender,
+      id: 'heartbeat-id',
+      now: () => 123,
+      timeoutMs: 250
+    });
+
+    expect(sentTopic).toBe(topics.workerHeartbeat.encode());
+    expect(sentTimeout).toBe(250);
+    expect(sentPayload).toEqual({
+      type: 'health.ping',
+      id: 'heartbeat-id',
+      sentAt: 123
+    });
+    expect(result).toEqual({
+      type: 'health.pong',
+      id: 'heartbeat-id',
+      sentAt: 123,
+      receivedAt: 124
+    });
+  });
+
+  it('wraps failed conduit sends in ConduitHeartbeatError', async () => {
+    let sender: ConduitHeartbeatSender = {
+      send: async () => {
+        throw new Error('No receiver available for topic v1-health-worker');
+      }
+    };
+
+    await expect(checkConduitHeartbeat({ sender })).rejects.toBeInstanceOf(
+      ConduitHeartbeatError
+    );
+    await expect(checkConduitHeartbeat({ sender })).rejects.toThrow('No receiver available');
+  });
+
+  it('rejects malformed worker pong responses', async () => {
+    let sender: ConduitHeartbeatSender = {
+      send: async () =>
+        ({
+          messageId: 'message-id',
+          success: true,
+          processedAt: 124,
+          result: { type: 'health.pong', id: 'wrong-id', sentAt: 123, receivedAt: 124 }
+        }) satisfies ConduitResponse
+    };
+
+    await expect(
+      checkConduitHeartbeat({ sender, id: 'heartbeat-id', now: () => 123 })
+    ).rejects.toBeInstanceOf(ConduitHeartbeatError);
+  });
+});

--- a/src/systems/subspace/modules/connection/src/health/conduitHeartbeat.ts
+++ b/src/systems/subspace/modules/connection/src/health/conduitHeartbeat.ts
@@ -1,0 +1,106 @@
+import type { ConduitResponse } from '@metorial-subspace/conduit';
+import type {
+  ConduitHeartbeatPing,
+  ConduitHeartbeatPong
+} from '@metorial-subspace/connection-utils';
+import { conduit } from '../lib/conduit';
+import { topics } from '../lib/topic';
+
+let HEARTBEAT_TIMEOUT_MS = 1500;
+
+export class ConduitHeartbeatError extends Error {
+  originalError?: Error;
+
+  constructor(message: string, originalError?: Error) {
+    super(message);
+    this.name = 'ConduitHeartbeatError';
+    this.originalError = originalError;
+  }
+}
+
+export interface ConduitHeartbeatSender {
+  send(topic: string, payload: unknown, timeout?: number): Promise<ConduitResponse>;
+}
+
+export interface CheckConduitHeartbeatOpts {
+  sender?: ConduitHeartbeatSender;
+  timeoutMs?: number;
+  now?: () => number;
+  id?: string;
+}
+
+let heartbeatSender: ConduitHeartbeatSender | null = null;
+
+let getHeartbeatSender = async () => {
+  if (!heartbeatSender) {
+    heartbeatSender = conduit.createSender({
+      defaultTimeout: HEARTBEAT_TIMEOUT_MS,
+      maxRetries: 0
+    });
+  }
+
+  return heartbeatSender;
+};
+
+export let isConduitHeartbeatPing = (value: unknown): value is ConduitHeartbeatPing => {
+  if (!value || typeof value !== 'object') return false;
+
+  let d = value as Record<string, unknown>;
+  return d.type === 'health.ping' && typeof d.id === 'string' && typeof d.sentAt === 'number';
+};
+
+export let isConduitHeartbeatPong = (value: unknown): value is ConduitHeartbeatPong => {
+  if (!value || typeof value !== 'object') return false;
+
+  let d = value as Record<string, unknown>;
+  return (
+    d.type === 'health.pong' &&
+    typeof d.id === 'string' &&
+    typeof d.sentAt === 'number' &&
+    typeof d.receivedAt === 'number'
+  );
+};
+
+export let checkConduitHeartbeat = async (opts: CheckConduitHeartbeatOpts = {}) => {
+  let id = opts.id ?? crypto.randomUUID();
+  let sentAt = opts.now?.() ?? Date.now();
+  let timeoutMs = opts.timeoutMs ?? HEARTBEAT_TIMEOUT_MS;
+  let sender = opts.sender ?? (await getHeartbeatSender());
+  let topic = topics.workerHeartbeat.encode();
+
+  let ping = {
+    type: 'health.ping',
+    id,
+    sentAt
+  } satisfies ConduitHeartbeatPing;
+
+  let response: ConduitResponse;
+  try {
+    response = await sender.send(topic, ping, timeoutMs);
+  } catch (err) {
+    throw new ConduitHeartbeatError(
+      `Conduit heartbeat failed: ${err instanceof Error ? err.message : String(err)}`,
+      err instanceof Error ? err : undefined
+    );
+  }
+
+  if (!response.success) {
+    throw new ConduitHeartbeatError(
+      `Conduit heartbeat failed: ${response.error ?? 'worker returned an unsuccessful response'}`
+    );
+  }
+
+  if (!isConduitHeartbeatPong(response.result)) {
+    throw new ConduitHeartbeatError(
+      'Conduit heartbeat failed: worker returned an invalid pong'
+    );
+  }
+
+  if (response.result.id !== id || response.result.sentAt !== sentAt) {
+    throw new ConduitHeartbeatError(
+      'Conduit heartbeat failed: worker returned a mismatched pong'
+    );
+  }
+
+  return response.result;
+};

--- a/src/systems/subspace/modules/connection/src/health/index.ts
+++ b/src/systems/subspace/modules/connection/src/health/index.ts
@@ -1,0 +1,2 @@
+export * from './conduitHeartbeat';
+export * from './nats';

--- a/src/systems/subspace/modules/connection/src/health/nats.test.ts
+++ b/src/systems/subspace/modules/connection/src/health/nats.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { checkNatsHealth, NatsHealthError, type NatsHealthConnection } from './nats';
+
+describe('checkNatsHealth', () => {
+  it('flushes the NATS connection', async () => {
+    let flush = vi.fn(async () => {});
+    let connection = { flush } satisfies NatsHealthConnection;
+
+    await checkNatsHealth({ connection });
+
+    expect(flush).toHaveBeenCalledOnce();
+  });
+
+  it('wraps NATS flush failures in NatsHealthError', async () => {
+    let connection = {
+      flush: async () => {
+        throw new Error('nats unavailable');
+      }
+    } satisfies NatsHealthConnection;
+
+    await expect(checkNatsHealth({ connection })).rejects.toBeInstanceOf(NatsHealthError);
+    await expect(checkNatsHealth({ connection })).rejects.toThrow('nats unavailable');
+  });
+});

--- a/src/systems/subspace/modules/connection/src/health/nats.ts
+++ b/src/systems/subspace/modules/connection/src/health/nats.ts
@@ -1,0 +1,58 @@
+let NATS_HEALTH_TIMEOUT_MS = 1500;
+
+export class NatsHealthError extends Error {
+  originalError?: Error;
+
+  constructor(message: string, originalError?: Error) {
+    super(message);
+    this.name = 'NatsHealthError';
+    this.originalError = originalError;
+  }
+}
+
+export interface NatsHealthConnection {
+  flush(): Promise<void>;
+}
+
+export interface CheckNatsHealthOpts {
+  connection?: NatsHealthConnection;
+  timeoutMs?: number;
+}
+
+let getNatsConnection = async () => {
+  let { broadcastNats } = await import('../lib/nats');
+  return broadcastNats;
+};
+
+let withTimeout = async <T>(promise: Promise<T>, timeoutMs: number, message: string) => {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+      })
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+};
+
+export let checkNatsHealth = async (opts: CheckNatsHealthOpts = {}) => {
+  let connection = opts.connection ?? (await getNatsConnection());
+  let timeoutMs = opts.timeoutMs ?? NATS_HEALTH_TIMEOUT_MS;
+
+  try {
+    await withTimeout(
+      connection.flush(),
+      timeoutMs,
+      `NATS health check timed out after ${timeoutMs}ms`
+    );
+  } catch (err) {
+    throw new NatsHealthError(
+      `NATS health check failed: ${err instanceof Error ? err.message : String(err)}`,
+      err instanceof Error ? err : undefined
+    );
+  }
+};

--- a/src/systems/subspace/modules/connection/src/index.ts
+++ b/src/systems/subspace/modules/connection/src/index.ts
@@ -1,4 +1,5 @@
 export * from './controller';
+export * from './health';
 export * from './mcp';
 export * from './presenter';
 export * from './sender';

--- a/src/systems/subspace/modules/connection/src/lib/topic.ts
+++ b/src/systems/subspace/modules/connection/src/lib/topic.ts
@@ -7,6 +7,7 @@ import type {
 let INSTANCE_PREFIX = 'v1-spi-';
 let SESSION_PREFIX = 'v1-ses-';
 let MCP_PREFIX = 'v1-mcp-';
+let WORKER_HEALTH_TOPIC = 'v1-health-worker';
 
 export let topics = {
   instance: {
@@ -32,5 +33,10 @@ export let topics = {
   mcpConnection: {
     encode: (d: { session: Session; connection: SessionConnection }) =>
       `${MCP_PREFIX}${d.session.oid}-${d.connection.oid}`
+  },
+
+  workerHeartbeat: {
+    encode: () => WORKER_HEALTH_TOPIC,
+    is: (topic: string) => topic === WORKER_HEALTH_TOPIC
   }
 };

--- a/src/systems/subspace/packages/connection-utils/src/conduitMessage.ts
+++ b/src/systems/subspace/packages/connection-utils/src/conduitMessage.ts
@@ -22,6 +22,19 @@ export type ConduitInput =
       mcpMessage: JSONRPCMessage;
     };
 
+export type ConduitHeartbeatPing = {
+  type: 'health.ping';
+  id: string;
+  sentAt: number;
+};
+
+export type ConduitHeartbeatPong = {
+  type: 'health.pong';
+  id: string;
+  sentAt: number;
+  receivedAt: number;
+};
+
 export type ConduitResult = {
   status: SessionMessageStatus;
   completedAt: Date | null;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Health checks change when services report healthy (503/heartbeat), and the OAuth schema migration affects authorization data modeling in a security-sensitive area.
> 
> **Overview**
> Adds **subspace connection health checks** so production readiness and external heartbeats verify more than DB/Redis: **NATS** (`flush` with timeout) and, on the controller, a **Conduit round-trip** to the worker on topic `v1-health-worker` (`health.ping` / `health.pong` with id/timestamp validation). The worker receiver handles that topic before normal instance traffic; failures surface as **503** on the prod health port and block the **HEARTBEAT_URL** POST (with **Sentry** reporting on heartbeat errors).
> 
> Separately extends the **OAuth Prisma models**: `internal` application type, optional `systemIdentifier` with `@@unique([organizationOid, systemIdentifier])`, optional **instance** links on `OAuthAuthorization` / `OAuthAuthorizationFlow`, and matching `Instance` back-relations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d5fa5ef859d21ce657fb6eadb73d603177cd331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->