### PR TITLE
Add internal oauth apps

### DIFF
--- a/src/backend/db/prisma/schema/machine-access/machineAccess.prisma
+++ b/src/backend/db/prisma/schema/machine-access/machineAccess.prisma
@@ -48,4 +48,5 @@ model MachineAccess {
   oauthAuthorizations OAuthAuthorization[]
   oauthInstallations  OAuthInstallation[]
   oauthApplications   OAuthApplication[]
+  internalOAuthTokens  InternalOAuthToken[]
 }

--- a/src/backend/db/prisma/schema/machine-access/oauth.prisma
+++ b/src/backend/db/prisma/schema/machine-access/oauth.prisma
@@ -60,9 +60,65 @@ model OAuthApplication {
   oauthInstallations         OAuthInstallation[]
   oauthAuthorizations        OAuthAuthorization[]
   oauthAuthorizationRequests OAuthAuthorizationFlow[]
+  internalOAuthTokens        InternalOAuthToken[]
   serviceAccount             ServiceAccount?
 
   @@unique([organizationOid, systemIdentifier])
+}
+
+enum InternalOAuthTokenSubjectType {
+  member
+  machine
+}
+
+enum InternalOAuthTokenScopeType {
+  organization
+  instance
+}
+
+model InternalOAuthToken {
+  oid BigInt @id @default(autoincrement())
+  id  String @unique
+
+  cacheKeyHash String @unique
+
+  subjectType       InternalOAuthTokenSubjectType
+  subjectIdentifier String
+
+  scopeType InternalOAuthTokenScopeType
+  scopes    String[]
+  scopeHash String
+
+  oauthApplicationOid BigInt
+  oauthApplication    OAuthApplication @relation(fields: [oauthApplicationOid], references: [oid], onDelete: Cascade)
+
+  oauthInstallationOid BigInt
+  oauthInstallation    OAuthInstallation @relation(fields: [oauthInstallationOid], references: [oid], onDelete: Cascade)
+
+  oauthAuthorizationOid BigInt             @unique
+  oauthAuthorization    OAuthAuthorization @relation(fields: [oauthAuthorizationOid], references: [oid], onDelete: Cascade)
+
+  oauthTokenOid BigInt     @unique
+  oauthToken    OAuthToken @relation(fields: [oauthTokenOid], references: [oid], onDelete: Cascade)
+
+  organizationOid BigInt
+  organization    Organization @relation(fields: [organizationOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
+  organizationMemberOid BigInt?
+  organizationMember    OrganizationMember? @relation(fields: [organizationMemberOid], references: [oid], onDelete: Cascade)
+
+  machineAccessOid BigInt?
+  machineAccess    MachineAccess? @relation(fields: [machineAccessOid], references: [oid], onDelete: Cascade)
+
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  @@index([oauthApplicationOid, organizationOid])
+  @@index([expiresAt])
 }
 
 model OAuthApplicationClientSecret {
@@ -113,6 +169,7 @@ model OAuthInstallation {
 
   oauthAuthorizations        OAuthAuthorization[]
   oauthTokens                OAuthToken[]
+  internalOAuthTokens        InternalOAuthToken[]
   serverSideOAuthApplication OAuthApplication[]   @relation("ScopedInstallation")
 
   @@unique([oauthApplicationOid, organizationOid])
@@ -169,6 +226,7 @@ model OAuthAuthorization {
 
   oauthAuthorizationRequests OAuthAuthorizationFlow[]
   oauthTokens                OAuthToken[]
+  internalOAuthToken         InternalOAuthToken?
   cliDevices                 CliDevice[]
   serviceAccountCredential   ServiceAccountCredential?
 
@@ -252,4 +310,6 @@ model OAuthToken {
   createdAt            DateTime  @default(now())
   lastRefreshedAt      DateTime?
   lastUsedAt           DateTime?
+
+  internalOAuthToken InternalOAuthToken?
 }

--- a/src/backend/db/prisma/schema/organization/instance.prisma
+++ b/src/backend/db/prisma/schema/organization/instance.prisma
@@ -135,6 +135,7 @@ model Instance {
   sandbox                              Sandbox?
   oauthAuthorizations                  OAuthAuthorization[]
   oauthAuthorizationFlows              OAuthAuthorizationFlow[]
+  internalOAuthTokens                  InternalOAuthToken[]
 
   @@index([previousSlugs])
 }

--- a/src/backend/db/prisma/schema/organization/member.prisma
+++ b/src/backend/db/prisma/schema/organization/member.prisma
@@ -37,6 +37,7 @@ model OrganizationMember {
   usedInvites             OrganizationInviteJoin[]
   userConfigs             OrganizationUserConfig[]
   oauthAuthorizations     OAuthAuthorization[]
+  internalOAuthTokens     InternalOAuthToken[]
   policies                AccessPolicyAssignment[]
   apiKeyCreatedEmailSends ApiKeyCreatedEmailSend[]
   apiKeyExpiredEmailSends ApiKeyExpiredEmailSend[]

--- a/src/backend/db/prisma/schema/organization/organization.prisma
+++ b/src/backend/db/prisma/schema/organization/organization.prisma
@@ -76,6 +76,7 @@ model Organization {
   oauthApplications              OAuthApplication[]
   oauthInstallations             OAuthInstallation[]
   oauthAuthorizations            OAuthAuthorization[]
+  internalOAuthTokens            InternalOAuthToken[]
   cliDevices                     CliDevice[]
   serviceAccounts                ServiceAccount[]
   oauthAuthorizationFlows        OAuthAuthorizationFlow[]

--- a/src/backend/db/src/id.ts
+++ b/src/backend/db/src/id.ts
@@ -29,6 +29,7 @@ export let ID = createIdGenerator({
   oauthAuthorization: idType.sorted('oaa'),
   oauthAuthorizationRequest: idType.sorted('oar'),
   oauthToken: idType.sorted('otk'),
+  internalOAuthToken: idType.sorted('oit'),
   serviceAccount: idType.sorted('sac'),
   serviceAccountCredential: idType.sorted('scc'),
   cliDevice: idType.sorted('cli'),

--- a/src/backend/modules/access/src/services/authentication.ts
+++ b/src/backend/modules/access/src/services/authentication.ts
@@ -287,11 +287,10 @@ class AuthenticationService {
         apiKey: res.type == 'api_key' ? res.secret!.apiKey : undefined,
         oauthToken: res.type == 'oauth_token' ? res.oauthToken! : undefined,
         machineAccess,
-        user: undefined,
-        // user:
-        //   (res.type == 'oauth_token'
-        //     ? res.oauthToken.oauthAuthorization.user
-        //     : machineAccess.user) ?? undefined,
+        user:
+          (res.type == 'oauth_token'
+            ? (res.oauthToken.oauthAuthorization.user ?? machineAccess.user)
+            : machineAccess.user) ?? undefined,
         orgScopes:
           res.type == 'oauth_token'
             ? (res.oauthToken!.oauthAuthorization.scopes as Scope[])
@@ -322,7 +321,7 @@ class AuthenticationService {
         machineAccess,
         user:
           (res.type == 'oauth_token'
-            ? res.oauthToken.oauthAuthorization.user
+            ? (res.oauthToken.oauthAuthorization.user ?? machineAccess.user)
             : machineAccess.user) ?? undefined,
         orgScopes:
           res.type == 'oauth_token'

--- a/src/backend/modules/access/test/authentication.test.ts
+++ b/src/backend/modules/access/test/authentication.test.ts
@@ -797,6 +797,46 @@ describe('AuthenticationService', () => {
       }
     });
 
+    it('uses machine access user fallback for oauth organization tokens', async () => {
+      let mockOrg = { id: 'org-1', slug: 'test-org', name: 'Test Org' };
+      let mockActor = { id: 'actor-1', organizationId: 'org-1' };
+      let mockUser = { id: 'user-1' };
+      let mockMachineAccess = {
+        type: 'organization_management',
+        organization: mockOrg,
+        actor: mockActor,
+        user: mockUser
+      };
+      let mockOAuthToken = {
+        id: 'oauth-token-1',
+        oauthAuthorization: {
+          scopes: ['organization:read'],
+          user: null,
+          machineAccess: mockMachineAccess
+        }
+      };
+
+      vi.mocked(machineAccessAuthService.authenticateWithMachineAccessToken).mockResolvedValue(
+        {
+          type: 'oauth_token',
+          oauthToken: mockOAuthToken
+        } as any
+      );
+
+      let result = await authenticationService.authenticate({
+        type: 'api_key',
+        apiKey: 'metorial_oa_123',
+        context: mockContext
+      });
+
+      expect(result.type).toBe('machine');
+      if (result.type === 'machine') {
+        expect(result.oauthToken).toEqual(mockOAuthToken);
+        expect(result.user).toEqual(mockUser);
+        expect(result.orgScopes).toEqual(['organization:read']);
+      }
+    });
+
     it('should throw error if organization token is missing required fields', async () => {
       let mockMachineAccess = {
         type: 'organization_management',

--- a/src/backend/modules/machine-access/src/services/index.ts
+++ b/src/backend/modules/machine-access/src/services/index.ts
@@ -1,5 +1,6 @@
 export * from './apiKey';
 export * from './cliDevice';
+export * from './internalOAuth';
 export * from './machineAccess';
 export * from './machineAccessAuth';
 export * from './oauthApplication';

--- a/src/backend/modules/machine-access/src/services/internalOAuth.ts
+++ b/src/backend/modules/machine-access/src/services/internalOAuth.ts
@@ -1,0 +1,749 @@
+import {
+  badRequestError,
+  forbiddenError,
+  notFoundError,
+  ServiceError
+} from '@lowerdeck/error';
+import { Hash } from '@lowerdeck/hash';
+import { Service } from '@lowerdeck/service';
+import { Context } from '@metorial/context';
+import {
+  addAfterTransactionHook,
+  db,
+  ID,
+  Instance,
+  MachineAccess,
+  OAuthApplication,
+  Organization,
+  OrganizationActor,
+  OrganizationMember,
+  User,
+  withTransaction
+} from '@metorial/db';
+import { Fabric } from '@metorial/fabric';
+import { generateCustomId } from '@metorial/id';
+import { organizationActorService } from '@metorial/module-organization/src/services/organizationActor';
+import { addHours } from 'date-fns';
+import { ensureScopesAllowed } from '../lib/oauthAuthorizationGuards';
+import { validateOAuthScopes } from '../lib/oauthScopeValidation';
+import { machineAccessService } from './machineAccess';
+import { machineAccessInclude } from './machineAccessAuth';
+import { authorizationInclude, oauthAuthorizationService } from './oauthAuthorization';
+import {
+  installationInclude,
+  oauthAuthorizationInstallationService
+} from './oauthAuthorizationInstallation';
+
+let INTERNAL_TOKEN_REFRESH_BEFORE_HOURS = 1;
+
+let internalOAuthApplicationInclude = {
+  organization: true,
+  scopedInstallation: {
+    include: installationInclude
+  },
+  serverSideMachineAccess: {
+    include: machineAccessInclude
+  }
+} as const;
+
+let internalOAuthTokenInclude = {
+  oauthApplication: {
+    include: internalOAuthApplicationInclude
+  },
+  oauthInstallation: {
+    include: installationInclude
+  },
+  oauthAuthorization: {
+    include: authorizationInclude
+  },
+  oauthToken: {
+    include: {
+      oauthAuthorization: {
+        include: authorizationInclude
+      }
+    }
+  },
+  machineAccess: {
+    include: machineAccessInclude
+  }
+} as const;
+
+type InternalOAuthApplicationWithRelations = OAuthApplication & {
+  scopedInstallation: any;
+  organization: Organization | null;
+  serverSideMachineAccess: MachineAccess | null;
+};
+
+type InternalOAuthTokenSubject =
+  | {
+      type: 'member';
+      member: OrganizationMember & {
+        actor: OrganizationActor;
+        user: User;
+      };
+    }
+  | {
+      type: 'machine';
+      subjectIdentifier: string;
+      name?: string;
+    };
+
+type InternalOAuthTokenScope =
+  | {
+      type: 'organization';
+    }
+  | {
+      type: 'instance';
+      instance: Instance;
+    };
+
+class InternalOAuthService {
+  private normalizeSystemIdentifier(d: { systemIdentifier: string }) {
+    let systemIdentifier = d.systemIdentifier.trim();
+    if (!systemIdentifier.length) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Internal oauth application systemIdentifier cannot be empty'
+        })
+      );
+    }
+
+    return systemIdentifier;
+  }
+
+  private async hash(value: unknown) {
+    return await Hash.sha256(JSON.stringify(value));
+  }
+
+  private arraysEqual(a: string[], b: string[]) {
+    if (a.length != b.length) return false;
+    let sortedA = [...a].sort();
+    let sortedB = [...b].sort();
+    return sortedA.every((value, idx) => value == sortedB[idx]);
+  }
+
+  private jsonEqual(a: unknown, b: unknown) {
+    return JSON.stringify(a) == JSON.stringify(b);
+  }
+
+  private assertInternalApplication(d: {
+    oauthApplication: OAuthApplication;
+    organization: Organization;
+  }) {
+    if (
+      d.oauthApplication.type != 'internal' ||
+      d.oauthApplication.organizationOid != d.organization.oid
+    ) {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Internal oauth tokens require an organization-owned internal app'
+        })
+      );
+    }
+
+    if (d.oauthApplication.status != 'active') {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Internal oauth application is not active'
+        })
+      );
+    }
+  }
+
+  private assertSubjectInOrganization(d: {
+    organization: Organization;
+    subject: InternalOAuthTokenSubject;
+  }) {
+    if (d.subject.type == 'machine') return;
+
+    if (
+      d.subject.member.organizationOid != d.organization.oid ||
+      d.subject.member.actor.organizationOid != d.organization.oid
+    ) {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Internal oauth token subject belongs to another organization'
+        })
+      );
+    }
+  }
+
+  private assertScopeInOrganization(d: {
+    organization: Organization;
+    scope: InternalOAuthTokenScope;
+  }) {
+    if (d.scope.type == 'organization') return;
+
+    if (d.scope.instance.organizationOid != d.organization.oid) {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Internal oauth token instance belongs to another organization'
+        })
+      );
+    }
+  }
+
+  private assertActorInOrganization(d: {
+    organization: Organization;
+    actor?: OrganizationActor;
+  }) {
+    if (!d.actor) return;
+
+    if (d.actor.organizationOid != d.organization.oid) {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Internal oauth application actor belongs to another organization'
+        })
+      );
+    }
+  }
+
+  private async getCacheKey(d: {
+    oauthApplication: OAuthApplication;
+    organization: Organization;
+    subjectType: InternalOAuthTokenSubject['type'];
+    subjectIdentifier: string;
+    scope: InternalOAuthTokenScope;
+    scopes: string[];
+  }) {
+    return await this.hash([
+      'internal-oauth-token',
+      d.oauthApplication.oid.toString(),
+      d.oauthApplication.systemIdentifier,
+      d.organization.oid.toString(),
+      d.subjectType,
+      d.subjectIdentifier,
+      d.scope.type,
+      d.scope.type == 'instance' ? d.scope.instance.oid.toString() : null,
+      d.scopes
+    ]);
+  }
+
+  private async getReusableMachineAccess(d: {
+    existingInternalOAuthToken: any | null;
+    organization: Organization;
+    oauthApplication: OAuthApplication;
+    subject: InternalOAuthTokenSubject;
+    scope: InternalOAuthTokenScope;
+    scopes: string[];
+    context: Context;
+  }) {
+    if (
+      d.existingInternalOAuthToken?.machineAccess &&
+      d.existingInternalOAuthToken.machineAccess.status == 'active'
+    ) {
+      return d.existingInternalOAuthToken.machineAccess;
+    }
+
+    let input = {
+      name:
+        d.subject.type == 'machine'
+          ? (d.subject.name ?? `INTERNAL OAUTH ${d.oauthApplication.name}`)
+          : `INTERNAL OAUTH ${d.oauthApplication.name}`,
+      hasCustomScopes: true,
+      scopes: d.scopes
+    };
+
+    if (d.scope.type == 'organization') {
+      return await machineAccessService.createMachineAccess({
+        type: 'organization_management',
+        organization: d.organization,
+        performedBy:
+          d.subject.type == 'member'
+            ? d.subject.member.actor
+            : await organizationActorService.getSystemActor({
+                organization: d.organization
+              }),
+        context: d.context,
+        kind: d.subject.type == 'member' ? 'user' : 'api_key',
+        linkedTo:
+          d.subject.type == 'member'
+            ? {
+                type: 'user',
+                actor: d.subject.member.actor,
+                user: d.subject.member.user
+              }
+            : { type: 'new_actor' },
+        input
+      });
+    }
+
+    return await machineAccessService.createMachineAccess({
+      type: 'instance_secret',
+      organization: d.organization,
+      instance: d.scope.instance,
+      performedBy:
+        d.subject.type == 'member'
+          ? d.subject.member.actor
+          : await organizationActorService.getSystemActor({
+              organization: d.organization
+            }),
+      context: d.context,
+      kind: d.subject.type == 'member' ? 'user' : 'api_key',
+      linkedTo:
+        d.subject.type == 'member'
+          ? {
+              type: 'user',
+              actor: d.subject.member.actor,
+              user: d.subject.member.user
+            }
+          : { type: 'new_actor' },
+      input
+    });
+  }
+
+  private async getOrCreateInstallation(d: {
+    oauthApplication: InternalOAuthApplicationWithRelations;
+    organization: Organization;
+    appActor?: OrganizationActor;
+  }) {
+    let installation = await oauthAuthorizationInstallationService.getOrCreateInstallation({
+      oauthApplication: d.oauthApplication,
+      organization: d.organization,
+      appActor: d.appActor
+    });
+
+    if (d.oauthApplication.scopedInstallationOid != installation.oid) {
+      await db.oAuthApplication.update({
+        where: {
+          oid: d.oauthApplication.oid
+        },
+        data: {
+          scopedInstallationOid: installation.oid
+        }
+      });
+    }
+
+    return installation;
+  }
+
+  async ensureInternalOAuthApplication(d: {
+    organization: Organization;
+    systemIdentifier: string;
+    performedBy: OrganizationActor;
+    appActor?: OrganizationActor;
+    context: Context;
+    input: {
+      name: string;
+      description?: string | null;
+      scopes: string[];
+      image?: PrismaJson.EntityImage;
+    };
+  }) {
+    let systemIdentifier = this.normalizeSystemIdentifier({
+      systemIdentifier: d.systemIdentifier
+    });
+    let scopes = validateOAuthScopes(d.input.scopes);
+    this.assertActorInOrganization({
+      organization: d.organization,
+      actor: d.appActor
+    });
+
+    let oauthApplication = await withTransaction(async db => {
+      let existing = await db.oAuthApplication.findFirst({
+        where: {
+          organizationOid: d.organization.oid,
+          systemIdentifier
+        },
+        include: internalOAuthApplicationInclude
+      });
+
+      let input = {
+        status: 'active' as const,
+        type: 'internal' as const,
+        accessLevel: 'organization' as const,
+        systemIdentifier,
+        allowClientSecretlessTokenExchange: false,
+        name: d.input.name,
+        description: d.input.description,
+        redirectUris: [] as string[],
+        scopes,
+        image: d.input.image ?? { type: 'default' as const }
+      };
+
+      if (!existing) {
+        await Fabric.fire('machine_access.oauth_application.created:before', {
+          organization: d.organization,
+          performedBy: d.performedBy,
+          context: d.context,
+          input,
+          serverSideMachineAccess: null
+        });
+
+        let oauthApplication = await db.oAuthApplication.create({
+          data: {
+            id: await ID.generateId('oauthApplication'),
+            clientId: generateCustomId('mt_oauth_internal_', 32),
+            ...input,
+            organizationOid: d.organization.oid,
+            websiteUrl: null,
+            privacyPolicyUrl: null,
+            termsOfServiceUrl: null,
+            serverSideMachineAccessOid: null
+          },
+          include: internalOAuthApplicationInclude
+        });
+
+        addAfterTransactionHook(() =>
+          Fabric.fire('machine_access.oauth_application.created:after', {
+            organization: d.organization,
+            performedBy: d.performedBy,
+            context: d.context,
+            input,
+            serverSideMachineAccess: null,
+            oauthApplication
+          })
+        );
+
+        return oauthApplication;
+      }
+
+      let update = {
+        status: 'active' as const,
+        name: d.input.name,
+        description:
+          d.input.description === undefined ? existing.description : d.input.description,
+        scopes,
+        image: d.input.image ?? (existing.image as PrismaJson.EntityImage),
+        redirectUris: [] as string[],
+        allowClientSecretlessTokenExchange: false
+      };
+
+      let appMatches =
+        existing.status == update.status &&
+        existing.name == update.name &&
+        existing.description == update.description &&
+        existing.allowClientSecretlessTokenExchange ==
+          update.allowClientSecretlessTokenExchange &&
+        this.arraysEqual(existing.scopes, update.scopes) &&
+        this.arraysEqual(existing.redirectUris, update.redirectUris) &&
+        this.jsonEqual(existing.image, update.image);
+      if (appMatches) return existing;
+
+      await Fabric.fire('machine_access.oauth_application.updated:before', {
+        oauthApplication: existing,
+        organization: d.organization,
+        performedBy: d.performedBy,
+        context: d.context,
+        input: update
+      });
+
+      let oauthApplication = await db.oAuthApplication.update({
+        where: {
+          oid: existing.oid
+        },
+        data: update,
+        include: internalOAuthApplicationInclude
+      });
+
+      addAfterTransactionHook(() =>
+        Fabric.fire('machine_access.oauth_application.updated:after', {
+          oauthApplication,
+          organization: d.organization,
+          performedBy: d.performedBy,
+          context: d.context,
+          input: update
+        })
+      );
+
+      return oauthApplication;
+    });
+
+    let installation = await this.getOrCreateInstallation({
+      oauthApplication,
+      organization: d.organization,
+      appActor: d.appActor
+    });
+
+    if (
+      !this.arraysEqual(installation.scopes, scopes) ||
+      (d.appActor && installation.appActorOid != d.appActor.oid)
+    ) {
+      installation = await db.oAuthInstallation.update({
+        where: {
+          oid: installation.oid
+        },
+        data: {
+          scopes,
+          ...(d.appActor ? { appActorOid: d.appActor.oid } : {})
+        },
+        include: installationInclude
+      });
+    }
+
+    return await db.oAuthApplication.findUniqueOrThrow({
+      where: {
+        oid: oauthApplication.oid
+      },
+      include: internalOAuthApplicationInclude
+    });
+  }
+
+  async getInternalOAuthApplicationById(d: {
+    organization: Organization;
+    oauthApplicationId: string;
+  }) {
+    let oauthApplication = await db.oAuthApplication.findFirst({
+      where: {
+        id: d.oauthApplicationId,
+        organizationOid: d.organization.oid,
+        type: 'internal'
+      },
+      include: internalOAuthApplicationInclude
+    });
+
+    if (!oauthApplication) {
+      throw new ServiceError(notFoundError('oauth_application', d.oauthApplicationId));
+    }
+
+    return oauthApplication;
+  }
+
+  async getInternalOAuthInstallationById(d: {
+    organization: Organization;
+    oauthInstallationId: string;
+  }) {
+    let oauthInstallation = await db.oAuthInstallation.findFirst({
+      where: {
+        id: d.oauthInstallationId,
+        organizationOid: d.organization.oid,
+        oauthApplication: {
+          type: 'internal'
+        }
+      },
+      include: installationInclude
+    });
+
+    if (!oauthInstallation) {
+      throw new ServiceError(notFoundError('oauth_installation', d.oauthInstallationId));
+    }
+
+    return oauthInstallation;
+  }
+
+  async getInternalOAuthAuthorizationById(d: {
+    organization: Organization;
+    oauthAuthorizationId: string;
+  }) {
+    let oauthAuthorization = await db.oAuthAuthorization.findFirst({
+      where: {
+        id: d.oauthAuthorizationId,
+        organizationOid: d.organization.oid,
+        oauthApplication: {
+          type: 'internal'
+        }
+      },
+      include: authorizationInclude
+    });
+
+    if (!oauthAuthorization) {
+      throw new ServiceError(notFoundError('oauth_authorization', d.oauthAuthorizationId));
+    }
+
+    return oauthAuthorization;
+  }
+
+  async getInternalOAuthTokenById(d: {
+    organization: Organization;
+    internalOAuthTokenId: string;
+  }) {
+    let internalOAuthToken = await db.internalOAuthToken.findFirst({
+      where: {
+        id: d.internalOAuthTokenId,
+        organizationOid: d.organization.oid,
+        oauthApplication: {
+          type: 'internal'
+        }
+      },
+      include: internalOAuthTokenInclude
+    });
+
+    if (!internalOAuthToken) {
+      throw new ServiceError(notFoundError('internal_oauth_token', d.internalOAuthTokenId));
+    }
+
+    return internalOAuthToken;
+  }
+
+  async ensureToken(d: {
+    oauthApplication: InternalOAuthApplicationWithRelations;
+    organization: Organization;
+    subject: InternalOAuthTokenSubject;
+    scope: InternalOAuthTokenScope;
+    scopes?: string[];
+    context: Context;
+  }) {
+    this.assertInternalApplication({
+      oauthApplication: d.oauthApplication,
+      organization: d.organization
+    });
+    this.assertSubjectInOrganization({
+      organization: d.organization,
+      subject: d.subject
+    });
+    this.assertScopeInOrganization({
+      organization: d.organization,
+      scope: d.scope
+    });
+
+    let scopes = ensureScopesAllowed({
+      allowedScopes: d.oauthApplication.scopes,
+      requestedScopes: d.scopes
+    });
+    let subjectIdentifier =
+      d.subject.type == 'member'
+        ? d.subject.member.oid.toString()
+        : this.normalizeSystemIdentifier({
+            systemIdentifier: d.subject.subjectIdentifier
+          });
+    let cacheKeyHash = await this.getCacheKey({
+      oauthApplication: d.oauthApplication,
+      organization: d.organization,
+      subjectType: d.subject.type,
+      subjectIdentifier,
+      scope: d.scope,
+      scopes
+    });
+    let scopeHash = await this.hash(scopes);
+    let reusableAfter = addHours(new Date(), INTERNAL_TOKEN_REFRESH_BEFORE_HOURS);
+
+    let existingInternalOAuthToken = await db.internalOAuthToken.findUnique({
+      where: {
+        cacheKeyHash
+      },
+      include: internalOAuthTokenInclude
+    });
+
+    if (
+      existingInternalOAuthToken &&
+      existingInternalOAuthToken.expiresAt > reusableAfter &&
+      existingInternalOAuthToken.oauthToken.accessTokenExpiresAt > reusableAfter &&
+      existingInternalOAuthToken.oauthToken.oauthAuthorization.status == 'active' &&
+      existingInternalOAuthToken.oauthToken.oauthAuthorization.oauthApplication.status ==
+        'active' &&
+      existingInternalOAuthToken.oauthToken.oauthAuthorization.oauthInstallation.status ==
+        'active' &&
+      existingInternalOAuthToken.oauthToken.oauthAuthorization.machineAccess.status == 'active'
+    ) {
+      return {
+        internalOAuthToken: existingInternalOAuthToken,
+        oauthToken: existingInternalOAuthToken.oauthToken,
+        oauthAuthorization: existingInternalOAuthToken.oauthToken.oauthAuthorization,
+        oauthInstallation:
+          existingInternalOAuthToken.oauthToken.oauthAuthorization.oauthInstallation,
+        oauthApplication:
+          existingInternalOAuthToken.oauthToken.oauthAuthorization.oauthApplication
+      };
+    }
+
+    return await withTransaction(async db => {
+      let oauthInstallation = await this.getOrCreateInstallation({
+        oauthApplication: d.oauthApplication,
+        organization: d.organization
+      });
+
+      let machineAccess = await this.getReusableMachineAccess({
+        existingInternalOAuthToken,
+        organization: d.organization,
+        oauthApplication: d.oauthApplication,
+        subject: d.subject,
+        scope: d.scope,
+        scopes,
+        context: d.context
+      });
+
+      await Fabric.fire('machine_access.oauth_authorization.created:before', {
+        oauthApplication: d.oauthApplication,
+        oauthInstallation,
+        organization: d.organization,
+        context: d.context
+      });
+
+      let oauthAuthorization = await db.oAuthAuthorization.create({
+        data: {
+          id: await ID.generateId('oauthAuthorization'),
+          status: 'active',
+          type: d.subject.type == 'member' ? 'user' : 'server_side',
+          scopes,
+          oidcScopes: [],
+          oauthInstallationOid: oauthInstallation.oid,
+          oauthApplicationOid: d.oauthApplication.oid,
+          organizationOid: d.organization.oid,
+          instanceOid: d.scope.type == 'instance' ? d.scope.instance.oid : null,
+          machineAccessOid: machineAccess.oid,
+          requestingIp: d.context.ip,
+          acceptingIp: d.context.ip
+        },
+        include: authorizationInclude
+      });
+
+      addAfterTransactionHook(() =>
+        Fabric.fire('machine_access.oauth_authorization.created:after', {
+          oauthApplication: oauthAuthorization.oauthApplication,
+          oauthInstallation: oauthAuthorization.oauthInstallation,
+          oauthAuthorization,
+          organization: oauthAuthorization.oauthInstallation.organization,
+          appActor: oauthAuthorization.oauthInstallation.appActor,
+          context: d.context
+        })
+      );
+
+      let oauthToken = await oauthAuthorizationService.issueInternalOAuthToken({
+        oauthAuthorization,
+        context: d.context
+      });
+
+      let internalOAuthToken = await db.internalOAuthToken.upsert({
+        where: {
+          cacheKeyHash
+        },
+        create: {
+          id: await ID.generateId('internalOAuthToken'),
+          cacheKeyHash,
+          subjectType: d.subject.type,
+          subjectIdentifier,
+          scopeType: d.scope.type,
+          scopes,
+          scopeHash,
+          oauthApplicationOid: d.oauthApplication.oid,
+          oauthInstallationOid: oauthInstallation.oid,
+          oauthAuthorizationOid: oauthAuthorization.oid,
+          oauthTokenOid: oauthToken.oid,
+          organizationOid: d.organization.oid,
+          instanceOid: d.scope.type == 'instance' ? d.scope.instance.oid : null,
+          organizationMemberOid: d.subject.type == 'member' ? d.subject.member.oid : null,
+          machineAccessOid: machineAccess.oid,
+          expiresAt: oauthToken.accessTokenExpiresAt
+        },
+        update: {
+          subjectType: d.subject.type,
+          subjectIdentifier,
+          scopeType: d.scope.type,
+          scopes,
+          scopeHash,
+          oauthInstallationOid: oauthInstallation.oid,
+          oauthAuthorizationOid: oauthAuthorization.oid,
+          oauthTokenOid: oauthToken.oid,
+          instanceOid: d.scope.type == 'instance' ? d.scope.instance.oid : null,
+          organizationMemberOid: d.subject.type == 'member' ? d.subject.member.oid : null,
+          machineAccessOid: machineAccess.oid,
+          expiresAt: oauthToken.accessTokenExpiresAt
+        },
+        include: internalOAuthTokenInclude
+      });
+
+      return {
+        internalOAuthToken,
+        oauthToken,
+        oauthAuthorization,
+        oauthInstallation,
+        oauthApplication: oauthAuthorization.oauthApplication
+      };
+    });
+  }
+}
+
+export let internalOAuthService = Service.create(
+  'internalOAuthService',
+  () => new InternalOAuthService()
+).build();

--- a/src/backend/modules/machine-access/src/services/oauthApplication.ts
+++ b/src/backend/modules/machine-access/src/services/oauthApplication.ts
@@ -121,6 +121,14 @@ class OAuthApplicationService {
         })
       );
     }
+
+    if (type == 'internal') {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Internal oauth applications are managed by internal services'
+        })
+      );
+    }
   }
 
   private assertGlobalUserFacingApplication(oauthApplication: OAuthApplication) {
@@ -757,6 +765,7 @@ class OAuthApplicationService {
   async createOAuthApplicationClientSecret(d: { oauthApplication: OAuthApplication }) {
     await this.assertApplicationActive(d.oauthApplication);
     this.assertApplicationOwnedLocally(d.oauthApplication);
+    this.assertSupportedType(d.oauthApplication.type);
 
     return await this.createClientSecret({
       oauthApplication: d.oauthApplication
@@ -781,6 +790,8 @@ class OAuthApplicationService {
       );
     }
 
+    this.assertSupportedType(d.oauthApplication.type);
+
     return oauthApplicationClientSecret;
   }
 
@@ -793,6 +804,7 @@ class OAuthApplicationService {
       }
     });
     this.assertApplicationOwnedLocally(oauthApplication);
+    this.assertSupportedType(oauthApplication.type);
 
     return await withTransaction(async db => {
       let updatedSecret = await db.oAuthApplicationClientSecret.update({

--- a/src/backend/modules/machine-access/src/services/oauthAuthorization.ts
+++ b/src/backend/modules/machine-access/src/services/oauthAuthorization.ts
@@ -893,6 +893,28 @@ class OAuthAuthorizationService {
     });
   }
 
+  async issueInternalOAuthToken(d: {
+    oauthAuthorization: OAuthAuthorizationWithRelations;
+    context?: Context;
+  }) {
+    if (d.oauthAuthorization.oauthApplication.type != 'internal') {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Only internal oauth applications support internal token issuance'
+        })
+      );
+    }
+
+    ensureAuthorizationUsable(d.oauthAuthorization);
+
+    return await this.issueOAuthToken({
+      oauthAuthorization: d.oauthAuthorization,
+      withRefreshToken: false,
+      accessTokenLifetimeSeconds: 24 * 60 * 60,
+      context: d.context
+    });
+  }
+
   private async refreshOAuthToken(d: {
     oauthToken: OAuthTokenWithRelations;
     withRefreshToken: boolean;
@@ -1320,6 +1342,14 @@ class OAuthAuthorizationService {
         include: authorizationInclude
       });
 
+      if (existingAuthorization.oauthApplication.type == 'internal') {
+        throw new ServiceError(
+          forbiddenError({
+            message: 'This oauth authorization cannot be revoked through the API'
+          })
+        );
+      }
+
       await Fabric.fire('machine_access.oauth_authorization.revoked:before', {
         oauthApplication: existingAuthorization.oauthApplication,
         oauthInstallation: existingAuthorization.oauthInstallation,
@@ -1364,7 +1394,12 @@ class OAuthAuthorizationService {
     let oauthAuthorization = await db.oAuthAuthorization.findFirst({
       where: {
         id: d.oauthAuthorizationId,
-        organizationOid: d.organization.oid
+        organizationOid: d.organization.oid,
+        oauthApplication: {
+          type: {
+            not: 'internal'
+          }
+        }
       },
       include: authorizationInclude
     });
@@ -1404,7 +1439,7 @@ class OAuthAuthorizationService {
                     }
                   : undefined,
                 type: {
-                  not: 'server_side'
+                  in: ['user_facing', 'cli_auth']
                 }
               }
             },

--- a/src/backend/modules/machine-access/src/services/oauthAuthorizationInstallation.ts
+++ b/src/backend/modules/machine-access/src/services/oauthAuthorizationInstallation.ts
@@ -56,6 +56,7 @@ class OAuthAuthorizationInstallationService {
         | null;
     };
     organization: Organization;
+    appActor?: OrganizationActor;
   }) {
     return await withTransaction(async db => {
       let existing = await db.oAuthInstallation.findFirst({
@@ -72,11 +73,13 @@ class OAuthAuthorizationInstallationService {
         scopes: d.oauthApplication.scopes,
         organizationOid: d.organization.oid,
         oauthApplicationOid: d.oauthApplication.oid,
-        serverSideMachineAccessOid: d.oauthApplication.serverSideMachineAccessOid
+        serverSideMachineAccessOid: d.oauthApplication.serverSideMachineAccessOid,
+        ...(d.appActor ? { appActorOid: d.appActor.oid } : {})
       };
 
       if (existing) {
-        let needsUpdate = !matchesUpdate(existing, inner) || !existing.appActorOid;
+        let needsUpdate =
+          !matchesUpdate(existing, inner) || (!existing.appActorOid && !d.appActor);
         if (!needsUpdate) return existing;
       }
 
@@ -462,6 +465,14 @@ class OAuthAuthorizationInstallationService {
         include: installationInclude
       });
 
+      if (existingInstallation.oauthApplication.type == 'internal') {
+        throw new ServiceError(
+          forbiddenError({
+            message: 'This oauth installation cannot be revoked through the API'
+          })
+        );
+      }
+
       await Fabric.fire('machine_access.oauth_installation.revoked:before', {
         oauthApplication: existingInstallation.oauthApplication,
         oauthInstallation: existingInstallation,
@@ -514,7 +525,12 @@ class OAuthAuthorizationInstallationService {
     let oauthInstallation = await db.oAuthInstallation.findFirst({
       where: {
         id: d.oauthInstallationId,
-        organizationOid: d.organization.oid
+        organizationOid: d.organization.oid,
+        oauthApplication: {
+          type: {
+            not: 'internal'
+          }
+        }
       },
       include: installationInclude
     });
@@ -541,7 +557,7 @@ class OAuthAuthorizationInstallationService {
               status: d.statuses ? { in: d.statuses } : undefined,
               oauthApplication: {
                 id: d.oauthApplicationIds ? { in: d.oauthApplicationIds } : undefined,
-                type: { not: 'server_side' }
+                type: { in: ['user_facing', 'cli_auth'] }
               }
             },
             include: installationInclude

--- a/src/backend/modules/machine-access/src/services/oauthAuthorizationLog.ts
+++ b/src/backend/modules/machine-access/src/services/oauthAuthorizationLog.ts
@@ -75,13 +75,16 @@ class OAuthAuthorizationLogService {
           ...opts,
           where: {
             organizationOid: d.organization.oid,
-            oauthApplication: d.oauthApplicationIds
-              ? {
-                  id: {
+            oauthApplication: {
+              id: d.oauthApplicationIds
+                ? {
                     in: d.oauthApplicationIds
                   }
-                }
-              : undefined,
+                : undefined,
+              type: {
+                not: 'internal'
+              }
+            },
             user: d.userIds
               ? {
                   id: {

--- a/src/backend/modules/machine-access/test/internalOAuth.test.ts
+++ b/src/backend/modules/machine-access/test/internalOAuth.test.ts
@@ -1,0 +1,531 @@
+import { ServiceError } from '@lowerdeck/error';
+import { addHours, addMinutes } from 'date-fns';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let {
+  mockDb,
+  getOrCreateInstallationMock,
+  issueInternalOAuthTokenMock,
+  machineAccessCreateMock,
+  getSystemActorMock
+} = vi.hoisted(() => ({
+  mockDb: {
+    oAuthApplication: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      findUniqueOrThrow: vi.fn()
+    },
+    oAuthInstallation: {
+      findFirst: vi.fn(),
+      update: vi.fn()
+    },
+    oAuthAuthorization: {
+      findFirst: vi.fn(),
+      create: vi.fn()
+    },
+    internalOAuthToken: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      upsert: vi.fn()
+    }
+  },
+  getOrCreateInstallationMock: vi.fn(),
+  issueInternalOAuthTokenMock: vi.fn(),
+  machineAccessCreateMock: vi.fn(),
+  getSystemActorMock: vi.fn()
+}));
+
+vi.mock('@metorial/db', () => ({
+  db: mockDb,
+  withTransaction: (fn: any) => fn(mockDb),
+  addAfterTransactionHook: vi.fn((hook: any) => hook()),
+  ID: {
+    generateId: vi.fn(async (prefix: string) => `${prefix}-generated-id`)
+  }
+}));
+
+vi.mock('@metorial/fabric', () => ({
+  Fabric: {
+    fire: vi.fn().mockResolvedValue(undefined)
+  }
+}));
+
+vi.mock('@metorial/id', () => ({
+  generateCustomId: vi.fn((prefix: string, length: number) => `${prefix}-${length}`)
+}));
+
+vi.mock('@lowerdeck/hash', () => ({
+  Hash: {
+    sha256: vi.fn(async (value: string) => `hash:${value}`)
+  }
+}));
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: (_: string, factory: any) => ({
+      build: () => factory()
+    })
+  }
+}));
+
+vi.mock('./../src/services/oauthAuthorizationInstallation', () => ({
+  installationInclude: {},
+  oauthAuthorizationInstallationService: {
+    getOrCreateInstallation: (...args: any[]) => getOrCreateInstallationMock(...args)
+  }
+}));
+
+vi.mock('./../src/services/oauthAuthorization', () => ({
+  authorizationInclude: {},
+  oauthAuthorizationService: {
+    issueInternalOAuthToken: (...args: any[]) => issueInternalOAuthTokenMock(...args)
+  }
+}));
+
+vi.mock('./../src/services/machineAccess', () => ({
+  machineAccessService: {
+    createMachineAccess: (...args: any[]) => machineAccessCreateMock(...args)
+  }
+}));
+
+vi.mock('./../src/services/machineAccessAuth', () => ({
+  machineAccessInclude: {}
+}));
+
+vi.mock('@metorial/module-organization/src/services/organizationActor', () => ({
+  organizationActorService: {
+    getSystemActor: (...args: any[]) => getSystemActorMock(...args)
+  }
+}));
+
+import { internalOAuthService } from '../src/services/internalOAuth';
+
+let baseContext = { ip: '203.0.113.10' } as any;
+let baseOrg = { oid: 1n, id: 'org_1' } as any;
+let baseActor = { oid: 10n, id: 'actor_1', organizationOid: 1n } as any;
+let baseUser = { oid: 20n, id: 'usr_1' } as any;
+let baseMember = {
+  oid: 30n,
+  id: 'mem_1',
+  organizationOid: 1n,
+  actor: baseActor,
+  user: baseUser
+} as any;
+let baseApp = {
+  oid: 40n,
+  id: 'oauth_app_1',
+  type: 'internal',
+  status: 'active',
+  accessLevel: 'organization',
+  systemIdentifier: 'explorer',
+  name: 'Explorer',
+  description: undefined,
+  redirectUris: [],
+  scopes: ['organization:read', 'organization.instance:read'],
+  image: { type: 'default' },
+  allowClientSecretlessTokenExchange: false,
+  organizationOid: 1n,
+  scopedInstallationOid: 50n,
+  scopedInstallation: null,
+  organization: baseOrg,
+  serverSideMachineAccess: null,
+  serverSideMachineAccessOid: null
+} as any;
+let baseInstallation = {
+  oid: 50n,
+  id: 'oauth_installation_1',
+  status: 'active',
+  scopes: ['organization:read', 'organization.instance:read'],
+  organization: baseOrg,
+  organizationOid: 1n,
+  oauthApplication: baseApp,
+  appActor: baseActor,
+  appActorOid: 10n
+} as any;
+let baseMachineAccess = {
+  oid: 60n,
+  id: 'macc_1',
+  status: 'active',
+  type: 'organization_management',
+  actor: baseActor,
+  organization: baseOrg
+} as any;
+let baseAuthorization = {
+  oid: 70n,
+  id: 'oauth_auth_1',
+  status: 'active',
+  type: 'user',
+  scopes: ['organization:read'],
+  oauthApplication: baseApp,
+  oauthInstallation: baseInstallation,
+  oauthInstallationOid: 50n,
+  machineAccess: baseMachineAccess,
+  machineAccessOid: 60n
+} as any;
+let baseToken = {
+  oid: 80n,
+  id: 'oauth_token_1',
+  accessToken: 'access-token',
+  refreshToken: null,
+  accessTokenExpiresAt: addHours(new Date(), 24),
+  oauthAuthorization: baseAuthorization
+} as any;
+
+describe('internalOAuthService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockDb.oAuthApplication.findFirst.mockResolvedValue(null);
+    mockDb.oAuthApplication.create.mockImplementation(async ({ data }: any) => ({
+      ...baseApp,
+      ...data,
+      oid: 40n
+    }));
+    mockDb.oAuthApplication.update.mockImplementation(async ({ data }: any) => ({
+      ...baseApp,
+      ...data
+    }));
+    mockDb.oAuthApplication.findUniqueOrThrow.mockResolvedValue(baseApp);
+    mockDb.oAuthInstallation.findFirst.mockResolvedValue(baseInstallation);
+    mockDb.oAuthInstallation.update.mockImplementation(async ({ data }: any) => ({
+      ...baseInstallation,
+      ...data
+    }));
+    mockDb.oAuthAuthorization.findFirst.mockResolvedValue(baseAuthorization);
+    mockDb.oAuthAuthorization.create.mockResolvedValue(baseAuthorization);
+    mockDb.internalOAuthToken.findFirst.mockResolvedValue({
+      id: 'oit_1',
+      organizationOid: 1n,
+      oauthApplication: baseApp,
+      oauthInstallation: baseInstallation,
+      oauthAuthorization: baseAuthorization,
+      oauthToken: baseToken,
+      machineAccess: baseMachineAccess
+    });
+    mockDb.internalOAuthToken.findUnique.mockResolvedValue(null);
+    mockDb.internalOAuthToken.upsert.mockImplementation(async ({ create, update }: any) => ({
+      ...(create ?? update),
+      oauthApplication: baseApp,
+      oauthInstallation: baseInstallation,
+      oauthAuthorization: baseAuthorization,
+      oauthToken: baseToken,
+      machineAccess: baseMachineAccess
+    }));
+
+    getOrCreateInstallationMock.mockResolvedValue(baseInstallation);
+    issueInternalOAuthTokenMock.mockResolvedValue(baseToken);
+    machineAccessCreateMock.mockResolvedValue(baseMachineAccess);
+    getSystemActorMock.mockResolvedValue(baseActor);
+  });
+
+  it('creates an internal app and syncs its scoped installation', async () => {
+    await internalOAuthService.ensureInternalOAuthApplication({
+      organization: baseOrg,
+      systemIdentifier: ' explorer ',
+      performedBy: baseActor,
+      context: baseContext,
+      input: {
+        name: 'Explorer',
+        scopes: ['organization.instance:read', 'organization:read']
+      }
+    });
+
+    expect(mockDb.oAuthApplication.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: 'internal',
+          accessLevel: 'organization',
+          systemIdentifier: 'explorer',
+          scopes: ['organization.instance:read', 'organization:read'],
+          redirectUris: [],
+          allowClientSecretlessTokenExchange: false
+        })
+      })
+    );
+    expect(getOrCreateInstallationMock).toHaveBeenCalledWith({
+      oauthApplication: expect.objectContaining({
+        type: 'internal',
+        systemIdentifier: 'explorer'
+      }),
+      organization: baseOrg
+    });
+  });
+
+  it('updates internal app scopes and installation scopes', async () => {
+    mockDb.oAuthApplication.findFirst.mockResolvedValue({
+      ...baseApp,
+      scopes: ['organization:read']
+    });
+    getOrCreateInstallationMock.mockResolvedValue({
+      ...baseInstallation,
+      scopes: ['organization:read']
+    });
+
+    await internalOAuthService.ensureInternalOAuthApplication({
+      organization: baseOrg,
+      systemIdentifier: 'explorer',
+      performedBy: baseActor,
+      context: baseContext,
+      input: {
+        name: 'Explorer',
+        scopes: ['organization:read', 'organization.instance:read']
+      }
+    });
+
+    expect(mockDb.oAuthApplication.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          scopes: ['organization.instance:read', 'organization:read']
+        })
+      })
+    );
+    expect(mockDb.oAuthInstallation.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          scopes: ['organization.instance:read', 'organization:read']
+        }
+      })
+    );
+  });
+
+  it('links internal app installations to an existing organization actor', async () => {
+    let appActor = {
+      oid: 90n,
+      id: 'actor_existing',
+      organizationOid: 1n
+    } as any;
+
+    await internalOAuthService.ensureInternalOAuthApplication({
+      organization: baseOrg,
+      systemIdentifier: 'explorer',
+      performedBy: baseActor,
+      appActor,
+      context: baseContext,
+      input: {
+        name: 'Explorer',
+        scopes: ['organization:read', 'organization.instance:read']
+      }
+    });
+
+    expect(getOrCreateInstallationMock).toHaveBeenCalledWith({
+      oauthApplication: expect.any(Object),
+      organization: baseOrg,
+      appActor
+    });
+  });
+
+  it('short circuits internal app updates when no changes are needed', async () => {
+    mockDb.oAuthApplication.findFirst.mockResolvedValue({
+      ...baseApp,
+      scopedInstallation: baseInstallation
+    });
+    getOrCreateInstallationMock.mockResolvedValue(baseInstallation);
+
+    await internalOAuthService.ensureInternalOAuthApplication({
+      organization: baseOrg,
+      systemIdentifier: 'explorer',
+      performedBy: baseActor,
+      context: baseContext,
+      input: {
+        name: 'Explorer',
+        scopes: ['organization:read', 'organization.instance:read']
+      }
+    });
+
+    expect(mockDb.oAuthApplication.update).not.toHaveBeenCalled();
+    expect(mockDb.oAuthInstallation.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects linking internal app installations to actors from another organization', async () => {
+    await expect(
+      internalOAuthService.ensureInternalOAuthApplication({
+        organization: baseOrg,
+        systemIdentifier: 'explorer',
+        performedBy: baseActor,
+        appActor: {
+          oid: 91n,
+          id: 'actor_other',
+          organizationOid: 2n
+        } as any,
+        context: baseContext,
+        input: {
+          name: 'Explorer',
+          scopes: ['organization:read']
+        }
+      })
+    ).rejects.toBeInstanceOf(ServiceError);
+
+    expect(mockDb.oAuthApplication.create).not.toHaveBeenCalled();
+    expect(mockDb.oAuthApplication.update).not.toHaveBeenCalled();
+  });
+
+  it('retrieves internal apps and linked records individually by id', async () => {
+    mockDb.oAuthApplication.findFirst.mockResolvedValueOnce(baseApp);
+
+    await internalOAuthService.getInternalOAuthApplicationById({
+      organization: baseOrg,
+      oauthApplicationId: 'oauth_app_1'
+    });
+    await internalOAuthService.getInternalOAuthInstallationById({
+      organization: baseOrg,
+      oauthInstallationId: 'oauth_installation_1'
+    });
+    await internalOAuthService.getInternalOAuthAuthorizationById({
+      organization: baseOrg,
+      oauthAuthorizationId: 'oauth_auth_1'
+    });
+    await internalOAuthService.getInternalOAuthTokenById({
+      organization: baseOrg,
+      internalOAuthTokenId: 'oit_1'
+    });
+
+    expect(mockDb.oAuthApplication.findFirst).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'oauth_app_1',
+          organizationOid: baseOrg.oid,
+          type: 'internal'
+        }
+      })
+    );
+    expect(mockDb.oAuthInstallation.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'oauth_installation_1',
+          organizationOid: baseOrg.oid,
+          oauthApplication: {
+            type: 'internal'
+          }
+        }
+      })
+    );
+    expect(mockDb.oAuthAuthorization.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'oauth_auth_1',
+          organizationOid: baseOrg.oid,
+          oauthApplication: {
+            type: 'internal'
+          }
+        }
+      })
+    );
+    expect(mockDb.internalOAuthToken.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'oit_1',
+          organizationOid: baseOrg.oid,
+          oauthApplication: {
+            type: 'internal'
+          }
+        }
+      })
+    );
+  });
+
+  it('reuses a matching token when it expires in more than one hour', async () => {
+    let internalOAuthToken = {
+      cacheKeyHash: 'hash',
+      expiresAt: addHours(new Date(), 2),
+      oauthToken: {
+        ...baseToken,
+        accessTokenExpiresAt: addHours(new Date(), 2),
+        oauthAuthorization: baseAuthorization
+      },
+      machineAccess: baseMachineAccess
+    };
+    mockDb.internalOAuthToken.findUnique.mockResolvedValue(internalOAuthToken);
+
+    let result = await internalOAuthService.ensureToken({
+      oauthApplication: baseApp,
+      organization: baseOrg,
+      subject: {
+        type: 'member',
+        member: baseMember
+      },
+      scope: {
+        type: 'organization'
+      },
+      scopes: ['organization:read'],
+      context: baseContext
+    });
+
+    expect(result.oauthToken.accessToken).toBe('access-token');
+    expect(mockDb.oAuthAuthorization.create).not.toHaveBeenCalled();
+    expect(issueInternalOAuthTokenMock).not.toHaveBeenCalled();
+  });
+
+  it('creates and caches a new member-linked token when the cached token expires soon', async () => {
+    mockDb.internalOAuthToken.findUnique.mockResolvedValue({
+      expiresAt: addMinutes(new Date(), 30),
+      oauthToken: {
+        ...baseToken,
+        accessTokenExpiresAt: addMinutes(new Date(), 30),
+        oauthAuthorization: baseAuthorization
+      },
+      machineAccess: baseMachineAccess
+    });
+
+    await internalOAuthService.ensureToken({
+      oauthApplication: baseApp,
+      organization: baseOrg,
+      subject: {
+        type: 'member',
+        member: baseMember
+      },
+      scope: {
+        type: 'organization'
+      },
+      scopes: ['organization:read'],
+      context: baseContext
+    });
+
+    expect(machineAccessCreateMock).not.toHaveBeenCalled();
+    expect(mockDb.oAuthAuthorization.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: 'user',
+          scopes: ['organization:read'],
+          machineAccessOid: 60n
+        })
+      })
+    );
+    let createCall = mockDb.oAuthAuthorization.create.mock.calls[0][0];
+    expect(createCall.data).not.toHaveProperty('organizationMemberOid');
+    expect(createCall.data).not.toHaveProperty('userOid');
+    expect(issueInternalOAuthTokenMock).toHaveBeenCalledWith({
+      oauthAuthorization: baseAuthorization,
+      context: baseContext
+    });
+    expect(mockDb.internalOAuthToken.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          organizationMemberOid: 30n,
+          machineAccessOid: 60n,
+          scopes: ['organization:read']
+        })
+      })
+    );
+  });
+
+  it('rejects token scopes outside the internal app scope range', async () => {
+    await expect(
+      internalOAuthService.ensureToken({
+        oauthApplication: baseApp,
+        organization: baseOrg,
+        subject: {
+          type: 'member',
+          member: baseMember
+        },
+        scope: {
+          type: 'organization'
+        },
+        scopes: ['organization:write'],
+        context: baseContext
+      })
+    ).rejects.toBeInstanceOf(ServiceError);
+
+    expect(mockDb.oAuthAuthorization.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/backend/modules/machine-access/test/oauthApplication.test.ts
+++ b/src/backend/modules/machine-access/test/oauthApplication.test.ts
@@ -351,6 +351,51 @@ describe('oauthApplicationService', () => {
     expect(mockDb.oAuthApplication.update).not.toHaveBeenCalled();
   });
 
+  it('rejects managing internal oauth apps through the public application service', async () => {
+    await expect(
+      oauthApplicationService.updateOAuthApplication({
+        oauthApplication: {
+          oid: 'oauth-app-oid',
+          type: 'internal',
+          status: 'active',
+          accessLevel: 'organization',
+          isImportedFromOtherInstance: false
+        } as any,
+        organization: baseOrg,
+        performedBy: baseActor,
+        context: baseContext,
+        input: {
+          name: 'Internal App'
+        }
+      })
+    ).rejects.toThrow(ServiceError);
+
+    await expect(
+      oauthApplicationService.archiveOAuthApplication({
+        oauthApplication: {
+          oid: 'oauth-app-oid',
+          type: 'internal',
+          status: 'active',
+          isImportedFromOtherInstance: false
+        } as any,
+        organization: baseOrg,
+        performedBy: baseActor,
+        context: baseContext
+      })
+    ).rejects.toThrow(ServiceError);
+
+    await expect(
+      oauthApplicationService.createOAuthApplicationClientSecret({
+        oauthApplication: {
+          oid: 'oauth-app-oid',
+          type: 'internal',
+          status: 'active',
+          isImportedFromOtherInstance: false
+        } as any
+      })
+    ).rejects.toThrow(ServiceError);
+  });
+
   it('updates a global user-facing oauth app', async () => {
     mockDb.oAuthApplication.update.mockImplementationOnce(async ({ data }: any) => ({
       oid: 'oauth-app-oid',

--- a/src/backend/modules/machine-access/test/oauthAuthorization.test.ts
+++ b/src/backend/modules/machine-access/test/oauthAuthorization.test.ts
@@ -32,6 +32,8 @@ let {
     },
     oAuthAuthorization: {
       findFirst: vi.fn(),
+      findFirstOrThrow: vi.fn(),
+      findMany: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
       updateMany: vi.fn(),
@@ -227,6 +229,7 @@ describe('oauthAuthorizationService', () => {
     mockDb.organizationMember.findFirst.mockResolvedValue(baseMember);
     mockDb.accessPolicyAssignment.findMany.mockResolvedValue([]);
     mockDb.serviceAccount.findFirst.mockResolvedValue(null);
+    mockDb.oAuthAuthorization.findMany.mockResolvedValue([]);
     mockDb.oAuthAuthorizationFlow.findFirst.mockResolvedValue(null);
     mockDb.oAuthAuthorizationFlow.upsert.mockImplementation(
       async ({ create, update }: any) => {
@@ -964,5 +967,111 @@ describe('oauthAuthorizationService', () => {
         deviceCode: 'device-1'
       })
     ).rejects.toThrow(ServiceError);
+  });
+
+  it('allows direct authorization get requests for non-internal apps', async () => {
+    mockDb.oAuthAuthorization.findFirst.mockResolvedValue({
+      oid: 300n,
+      id: 'oauth_auth_1',
+      oauthApplication: {
+        type: 'server_side'
+      }
+    });
+
+    await oauthAuthorizationService.getOAuthAuthorizationById({
+      organization: baseOrg,
+      oauthAuthorizationId: 'oauth_auth_1'
+    });
+
+    expect(mockDb.oAuthAuthorization.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: 'oauth_auth_1',
+          organizationOid: baseOrg.oid,
+          oauthApplication: {
+            type: {
+              not: 'internal'
+            }
+          }
+        })
+      })
+    );
+  });
+
+  it('keeps generic authorization lists visible for user and cli auth only', async () => {
+    let paginator = await oauthAuthorizationService.listOAuthAuthorizations({
+      organization: baseOrg
+    });
+    await paginator.run({});
+
+    expect(mockDb.oAuthAuthorization.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          oauthApplication: {
+            id: undefined,
+            type: {
+              in: ['user_facing', 'cli_auth']
+            }
+          }
+        })
+      })
+    );
+  });
+
+  it('allows revoking server-side service account authorizations through the public service', async () => {
+    mockDb.oAuthAuthorization.findFirstOrThrow.mockResolvedValue({
+      oid: 300n,
+      status: 'active',
+      oauthApplication: {
+        type: 'server_side'
+      },
+      oauthInstallation: {
+        organization: baseOrg,
+        appActor: null
+      }
+    });
+
+    await oauthAuthorizationService.revokeOAuthAuthorization({
+      oauthAuthorization: {
+        oid: 300n
+      } as any,
+      performedBy: baseMember.actor,
+      context: baseContext
+    });
+
+    expect(mockDb.oAuthAuthorization.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: 'revoked',
+          revokedAt: expect.any(Date)
+        })
+      })
+    );
+  });
+
+  it('blocks revoking internal authorizations through the public service', async () => {
+    mockDb.oAuthAuthorization.findFirstOrThrow.mockResolvedValue({
+      oid: 300n,
+      status: 'active',
+      oauthApplication: {
+        type: 'internal'
+      },
+      oauthInstallation: {
+        organization: baseOrg,
+        appActor: null
+      }
+    });
+
+    await expect(
+      oauthAuthorizationService.revokeOAuthAuthorization({
+        oauthAuthorization: {
+          oid: 300n
+        } as any,
+        performedBy: baseMember.actor,
+        context: baseContext
+      })
+    ).rejects.toThrow(ServiceError);
+
+    expect(mockDb.oAuthAuthorization.update).not.toHaveBeenCalled();
   });
 });

--- a/src/backend/modules/machine-access/test/oauthAuthorizationInstallation.test.ts
+++ b/src/backend/modules/machine-access/test/oauthAuthorizationInstallation.test.ts
@@ -1,0 +1,186 @@
+import { ServiceError } from '@lowerdeck/error';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    oAuthInstallation: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      findFirstOrThrow: vi.fn(),
+      update: vi.fn(),
+      upsert: vi.fn()
+    },
+    oAuthAuthorization: {
+      updateMany: vi.fn()
+    }
+  }
+}));
+
+vi.mock('@metorial/db', () => ({
+  db: mockDb,
+  withTransaction: (fn: any) => fn(mockDb),
+  addAfterTransactionHook: vi.fn((hook: any) => hook()),
+  ID: {
+    generateId: vi.fn(async (prefix: string) => `${prefix}-generated-id`)
+  }
+}));
+
+vi.mock('@metorial/fabric', () => ({
+  Fabric: {
+    fire: vi.fn().mockResolvedValue(undefined)
+  }
+}));
+
+vi.mock('bun', () => ({
+  deepEquals: vi.fn((a: any, b: any) => JSON.stringify(a) === JSON.stringify(b))
+}));
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: (_: string, factory: any) => ({
+      build: () => factory()
+    })
+  }
+}));
+
+vi.mock('@lowerdeck/pagination', () => ({
+  Paginator: {
+    create: (factory: any) => factory({ prisma: (cb: any) => cb({}) })
+  }
+}));
+
+vi.mock('@metorial/lock', () => ({
+  createLock: vi.fn(() => ({
+    usingLock: vi.fn(async (_key: string, fn: any) => await fn())
+  }))
+}));
+
+vi.mock('@metorial/module-organization/src/services/organizationActor', () => ({
+  organizationActorService: {
+    getSystemActor: vi.fn(),
+    createOrganizationActor: vi.fn()
+  }
+}));
+
+vi.mock('./../src/services/machineAccess', () => ({
+  machineAccessService: {}
+}));
+
+vi.mock('./../src/services/machineAccessAuth', () => ({
+  machineAccessInclude: {}
+}));
+
+vi.mock('./../src/services/oauthAuthorization', () => ({
+  authorizationInclude: {}
+}));
+
+import { oauthAuthorizationInstallationService } from '../src/services/oauthAuthorizationInstallation';
+
+let baseOrg = { oid: 1n, id: 'org_1' } as any;
+let baseActor = { oid: 2n, id: 'actor_1' } as any;
+let baseInstallation = {
+  oid: 10n,
+  id: 'oauth_install_1',
+  organization: baseOrg,
+  oauthApplication: {
+    type: 'user_facing'
+  },
+  appActor: null
+} as any;
+
+describe('oauthAuthorizationInstallationService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockDb.oAuthInstallation.findFirst.mockResolvedValue(baseInstallation);
+    mockDb.oAuthInstallation.findMany.mockResolvedValue([]);
+    mockDb.oAuthInstallation.findFirstOrThrow.mockResolvedValue(baseInstallation);
+    mockDb.oAuthInstallation.update.mockResolvedValue(baseInstallation);
+    mockDb.oAuthAuthorization.updateMany.mockResolvedValue({ count: 0 });
+  });
+
+  it('allows direct installation get requests for non-internal apps', async () => {
+    await oauthAuthorizationInstallationService.getOAuthInstallationById({
+      organization: baseOrg,
+      oauthInstallationId: 'oauth_install_1'
+    });
+
+    expect(mockDb.oAuthInstallation.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: 'oauth_install_1',
+          organizationOid: baseOrg.oid,
+          oauthApplication: {
+            type: {
+              not: 'internal'
+            }
+          }
+        })
+      })
+    );
+  });
+
+  it('keeps generic installation lists visible for user and cli auth only', async () => {
+    await oauthAuthorizationInstallationService.listOAuthInstallations({
+      organization: baseOrg
+    });
+
+    expect(mockDb.oAuthInstallation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          oauthApplication: {
+            id: undefined,
+            type: {
+              in: ['user_facing', 'cli_auth']
+            }
+          }
+        })
+      })
+    );
+  });
+
+  it('allows revoking server-side installations through the public service', async () => {
+    mockDb.oAuthInstallation.findFirstOrThrow.mockResolvedValue({
+      ...baseInstallation,
+      oauthApplication: {
+        type: 'server_side'
+      }
+    });
+
+    await oauthAuthorizationInstallationService.revokeOAuthInstallation({
+      oauthInstallation: {
+        oid: 10n
+      } as any,
+      performedBy: baseActor
+    });
+
+    expect(mockDb.oAuthInstallation.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: 'revoked',
+          revokedAt: expect.any(Date)
+        })
+      })
+    );
+  });
+
+  it('blocks revoking internal installations through the public service', async () => {
+    mockDb.oAuthInstallation.findFirstOrThrow.mockResolvedValue({
+      ...baseInstallation,
+      oauthApplication: {
+        type: 'internal'
+      }
+    });
+
+    await expect(
+      oauthAuthorizationInstallationService.revokeOAuthInstallation({
+        oauthInstallation: {
+          oid: 10n
+        } as any,
+        performedBy: baseActor
+      })
+    ).rejects.toThrow(ServiceError);
+
+    expect(mockDb.oAuthInstallation.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/backend/modules/machine-access/test/oauthAuthorizationLog.test.ts
+++ b/src/backend/modules/machine-access/test/oauthAuthorizationLog.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    oAuthAuthorizationFlow: {
+      findMany: vi.fn()
+    },
+    organizationMember: {
+      findMany: vi.fn()
+    }
+  }
+}));
+
+vi.mock('@metorial/db', () => ({
+  db: mockDb
+}));
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: (_: string, factory: any) => ({
+      build: () => factory()
+    })
+  }
+}));
+
+vi.mock('@lowerdeck/pagination', () => ({
+  Paginator: {
+    create: (factory: any) => factory({ prisma: (cb: any) => cb({}) })
+  }
+}));
+
+import { oauthAuthorizationLogService } from '../src/services/oauthAuthorizationLog';
+
+let baseOrg = { oid: 1n, id: 'org_1' } as any;
+
+describe('oauthAuthorizationLogService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockDb.oAuthAuthorizationFlow.findMany.mockResolvedValue([]);
+    mockDb.organizationMember.findMany.mockResolvedValue([]);
+  });
+
+  it('filters only internal oauth apps out of authorization logs', async () => {
+    await oauthAuthorizationLogService.listOAuthAuthorizationLogs({
+      organization: baseOrg,
+      oauthApplicationIds: ['oauth_app_1']
+    });
+
+    expect(mockDb.oAuthAuthorizationFlow.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organizationOid: baseOrg.oid,
+          oauthApplication: {
+            id: {
+              in: ['oauth_app_1']
+            },
+            type: {
+              not: 'internal'
+            }
+          }
+        })
+      })
+    );
+  });
+});

--- a/src/backend/multi-region/src/sync/fromDeployment/oauth.ts
+++ b/src/backend/multi-region/src/sync/fromDeployment/oauth.ts
@@ -15,6 +15,7 @@ let syncOAuthApp = async (_app: { id: string }) => {
 
   // Only sync apps what we own
   if (app.isImportedFromOtherInstance) return;
+  if (app.type == 'internal') return;
 
   // // Only sync apps that can be used in other deployments
   // if (app.type == 'server_side') return;
@@ -132,6 +133,8 @@ let syncOAuthTokenToGlobal = async (d: {
 };
 
 Fabric.listen('machine_access.oauth_token.created:after', async event => {
+  if (event.oauthApplication.type == 'internal') return;
+
   addAfterTransactionHook(() =>
     syncOAuthTokenToGlobal({
       oauthToken: event.oauthToken,
@@ -141,6 +144,8 @@ Fabric.listen('machine_access.oauth_token.created:after', async event => {
 });
 
 Fabric.listen('machine_access.oauth_token.refreshed:after', async event => {
+  if (event.oauthApplication.type == 'internal') return;
+
   addAfterTransactionHook(() =>
     syncOAuthTokenToGlobal({
       oauthToken: event.oauthToken,

--- a/src/packages/backend/fabric/src/types.ts
+++ b/src/packages/backend/fabric/src/types.ts
@@ -79,11 +79,12 @@ export type MachineAccessInput =
 
 export type OAuthApplicationCreateInput = {
   status?: 'active' | 'archived';
-  type: 'user_facing' | 'server_side' | 'cli_auth';
+  type: 'user_facing' | 'server_side' | 'cli_auth' | 'internal';
   accessLevel: 'organization' | 'global';
+  systemIdentifier?: string | null;
   allowClientSecretlessTokenExchange?: boolean;
   name: string;
-  description?: string;
+  description?: string | null;
   websiteUrl?: string;
   privacyPolicyUrl?: string;
   termsOfServiceUrl?: string;

--- a/src/systems/synthesis/service/src/definitions/assistants/_shared/subspace.ts
+++ b/src/systems/synthesis/service/src/definitions/assistants/_shared/subspace.ts
@@ -285,7 +285,7 @@ export class SubspaceAssistant {
     return {
       'Metorial-Proxy-URL': d.url,
       'Metorial-Agent-Client': JSON.stringify({
-        name: 'Metorial Explorer',
+        name: 'Metorial Assistant',
         type: 'system_client',
         foreignId: `synthesis:${d.tenant.id}:${d.environment.id}:${d.input.sessionId}`
       }),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Large auth/schema change: new token issuance paths, API exclusions for internal OAuth, and authentication behavior changes in security-sensitive machine-access code.
> 
> **Overview**
> Introduces **organization-scoped internal OAuth applications** (`type: internal`) keyed by `systemIdentifier`, plus an **`InternalOAuthToken`** cache that ties together installation, authorization, access token, and machine access for first-party/system use.
> 
> A new **`internalOAuthService`** provisions or updates internal apps, ensures org installations (optional `appActor`), and **`ensureToken`** mints or reuses tokens (hash cache key, refresh when expiry is within ~1 hour) for **member** or **machine** subjects at **organization** or **instance** scope, with scope checks and org-boundary guards.
> 
> **Public OAuth APIs are tightened:** internal apps cannot be created/updated/archived or get client secrets via `oauthApplicationService`; internal authorizations/installations cannot be revoked or listed through the generic services/logs; **`issueInternalOAuthToken`** issues 24h access tokens without refresh. Multi-region sync **skips** internal apps and their tokens.
> 
> **Authentication** now resolves `user` on machine OAuth tokens from authorization **or** linked machine access (supports internal tokens without a user on the authorization). Fabric types add `internal` app input; synthesis renames the proxy client to **Metorial Assistant**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca12d6d7095649014a7f76fd893942d220a12a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->