### PR TITLE
Ajv -> json schema

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -856,6 +856,7 @@
         "framer-motion": "^11.5.4",
         "fuse.js": "7.4.2",
         "json-schema": "^0.4.0",
+        "jsonschema": "^1.5.0",
         "lodash": "^4.17.21",
         "lodash.throttle": "^4.1.1",
         "nanoid": "^5.0.7",
@@ -6888,6 +6889,8 @@
     "jsonata": ["jsonata@2.1.0", "", {}, "sha512-OCzaRMK8HobtX8fp37uIVmL8CY1IGc/a6gLsDqz3quExFR09/U78HUzWYr7T31UEB6+Eu0/8dkVD5fFDOl9a8w=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
+
+    "jsonschema": ["jsonschema@1.5.0", "", {}, "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw=="],
 
     "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
 

--- a/src/frontend/apps/dashboard/package.json
+++ b/src/frontend/apps/dashboard/package.json
@@ -66,6 +66,7 @@
     "framer-motion": "^11.5.4",
     "fuse.js": "7.4.2",
     "json-schema": "^0.4.0",
+    "jsonschema": "^1.5.0",
     "lodash": "^4.17.21",
     "lodash.throttle": "^4.1.1",
     "nanoid": "^5.0.7",

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/explorer/components/schemaForm.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/explorer/components/schemaForm.tsx
@@ -1,8 +1,7 @@
 import { Button, Checkbox, Input, Select, Text, TextArrayInput, theme } from '@metorial/ui';
-import addFormats from 'ajv-formats';
-import Ajv2020 from 'ajv/dist/2020';
 import { getIn, setIn, useFormik } from 'formik';
 import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
+import { Validator } from 'jsonschema';
 import { useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { MarkdownDescription } from './markdownDescription';
@@ -103,18 +102,7 @@ let FieldError = styled.div`
   margin-top: -4px;
 `;
 
-let createAjv = () => {
-  let ajv = new Ajv2020({
-    allErrors: true,
-    strict: false,
-    allowUnionTypes: true,
-    validateSchema: false
-  });
-
-  addFormats(ajv as unknown as Parameters<typeof addFormats>[0]);
-
-  return ajv;
-};
+let jsonSchemaValidator = new Validator();
 
 let stripSchemaDialect = (schema?: JSONSchema7 | null): JSONSchema7 => {
   let normalized = normalizeSchema(schema);
@@ -189,22 +177,14 @@ let buildInitialValues = (schema?: JSONSchema7 | null): JsonObject => {
   return values;
 };
 
-let toPath = (instancePath: string) =>
-  instancePath
-    .replace(/^\//, '')
-    .split('/')
-    .filter(Boolean)
-    .map(segment => segment.replace(/~1/g, '/').replace(/~0/g, '~'))
-    .join('.');
-
-let mapAjvErrors = (errors: any[] | null | undefined) => {
+let mapValidationErrors = (errors: any[] | null | undefined) => {
   let mapped: Record<string, unknown> = {};
 
   for (let error of errors ?? []) {
-    let path = toPath(error.instancePath ?? '');
+    let path = error.property?.replace(/^instance\.?/, '') ?? '';
 
-    if (error.keyword === 'required' && error.params?.missingProperty) {
-      path = path ? `${path}.${error.params.missingProperty}` : error.params.missingProperty;
+    if (error.name === 'required' && typeof error.argument === 'string') {
+      path = path ? `${path}.${error.argument}` : error.argument;
     }
 
     let message = error.message ?? 'Invalid value';
@@ -489,22 +469,6 @@ export let SchemaForm = ({
   isSubmitting?: boolean;
 }) => {
   let normalizedSchema = useMemo(() => stripSchemaDialect(schema), [schema]);
-  let compiled = useMemo(() => {
-    let ajv = createAjv();
-
-    try {
-      return {
-        validator: ajv.compile(normalizedSchema),
-        compileError: null
-      };
-    } catch (error) {
-      return {
-        validator: null,
-        compileError:
-          error instanceof Error ? error.message : 'This schema could not be compiled.'
-      };
-    }
-  }, [normalizedSchema]);
 
   let formik = useFormik<JsonObject>({
     initialValues: buildInitialValues(normalizedSchema),
@@ -515,18 +479,17 @@ export let SchemaForm = ({
       let sanitizedValues = sanitizeOptionalValues(normalizedSchema, values) as JsonObject;
       let requiredFieldErrors = validateRequiredFields(normalizedSchema, sanitizedValues);
 
-      if (!compiled.validator) {
+      try {
+        let result = jsonSchemaValidator.validate(sanitizedValues, normalizedSchema as any);
+        if (result.valid) return requiredFieldErrors;
+        return mergeErrors(requiredFieldErrors, mapValidationErrors(result.errors));
+      } catch (error) {
         return mergeErrors(requiredFieldErrors, {
-          _form: compiled.compileError ?? 'This schema could not be compiled.'
+          _form: error instanceof Error ? error.message : 'This schema could not be validated.'
         });
       }
-
-      let valid = compiled.validator(sanitizedValues);
-      if (valid) return requiredFieldErrors;
-      return mergeErrors(requiredFieldErrors, mapAjvErrors(compiled.validator.errors));
     },
     onSubmit: async values => {
-      if (!compiled.validator) return;
       let sanitizedValues = sanitizeOptionalValues(normalizedSchema, values) as JsonObject;
       await onSubmit(sanitizedValues);
     }
@@ -571,7 +534,6 @@ export let SchemaForm = ({
           size="2"
           style={blackButtonStyle}
           loading={isSubmitting}
-          disabled={!compiled.validator}
         >
           {submitLabel}
         </Button>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how MCP explorer tool inputs are validated; error paths and format/draft support may differ from Ajv, affecting what users can submit.
> 
> **Overview**
> **Replaces Ajv with the `jsonschema` package** for JSON Schema validation in the explorer **`SchemaForm`** (MCP tool argument forms).
> 
> Validation no longer **compiles** the schema up front with Ajv 2020 and `ajv-formats`. A shared **`Validator`** runs on each Formik validate pass, still after optional-field sanitization and custom required-field checks. Error mapping is updated for **`jsonschema`** (`property`, `name`, `argument`) instead of Ajv paths and keywords. Schema problems surface via **try/catch** as a form-level `_form` error rather than disabling submit when compile fails—the submit button stays enabled.
> 
> Adds **`jsonschema@^1.5.0`** to the dashboard app and lockfile; **`ajv`** / **`ajv-formats`** remain listed as dependencies but are no longer imported from this form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa1d247b439749b6fdda8cf66a7b6a2c0f2e839a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->