### PR TITLE
Add agent service tests

### DIFF
--- a/src/systems/subspace/modules/agent/src/services/agent.test.ts
+++ b/src/systems/subspace/modules/agent/src/services/agent.test.ts
@@ -1,0 +1,431 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let agentFindFirst = vi.fn();
+let agentFindMany = vi.fn();
+let agentFindUnique = vi.fn();
+let agentFindFirstOrThrow = vi.fn();
+let identityActorFindFirstOrThrow = vi.fn();
+
+let createIdentityActor = vi.fn();
+let getIdentityActorById = vi.fn();
+let updateIdentityActor = vi.fn();
+let archiveIdentityActor = vi.fn();
+
+let voyagerSearch = vi.fn();
+let resolveIdentityActors = vi.fn();
+let checkTenantFn = vi.fn();
+
+vi.mock('@metorial-subspace/db', () => ({
+  db: {
+    agent: {
+      findFirst: agentFindFirst,
+      findMany: agentFindMany,
+      findUnique: agentFindUnique,
+      findFirstOrThrow: agentFindFirstOrThrow
+    },
+    identityActor: {
+      findFirstOrThrow: identityActorFindFirstOrThrow
+    }
+  },
+  withTransaction: async (fn: (db: any) => Promise<unknown>) =>
+    await fn({
+      agent: {
+        findFirstOrThrow: agentFindFirstOrThrow
+      }
+    })
+}));
+
+vi.mock('@lowerdeck/pagination', () => ({
+  Paginator: {
+    create: (factory: any) => ({
+      run: async () => await factory({ prisma: async (fn: any) => await fn({}) })
+    })
+  }
+}));
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: (_name: string, factory: () => unknown) => ({
+      build: factory
+    })
+  }
+}));
+
+vi.mock('@lowerdeck/error', () => ({
+  notFoundError: (resource: string, id: string) => ({ resource, id, kind: 'not_found' }),
+  badRequestError: (info: any) => ({ ...info, kind: 'bad_request' }),
+  ServiceError: class ServiceError extends Error {
+    payload: any;
+    constructor(payload: any) {
+      super(typeof payload === 'object' ? JSON.stringify(payload) : String(payload));
+      this.payload = payload;
+    }
+  }
+}));
+
+vi.mock('@lowerdeck/hash', () => ({
+  Hash: {
+    sha256: vi.fn(async (input: string) => `hash_${input.length}`)
+  }
+}));
+
+vi.mock('@lowerdeck/id', () => ({
+  generatePlainId: () => 'plainid7'
+}));
+
+vi.mock('@lowerdeck/slugify', () => ({
+  slugify: (value: string) => value.toLowerCase().replace(/\s+/g, '-')
+}));
+
+vi.mock('@metorial-subspace/list-utils', () => ({
+  normalizeDateFilter: (filter: unknown) => filter,
+  normalizeStatusForGet: () => ({ hasParent: {} }),
+  normalizeStatusForList: () => ({ noParent: {} }),
+  resolveIdentityActors
+}));
+
+vi.mock('@metorial-subspace/module-identity', () => ({
+  identityActorService: {
+    createIdentityActor,
+    getIdentityActorById,
+    updateIdentityActor,
+    archiveIdentityActor
+  }
+}));
+
+vi.mock('@metorial-subspace/module-search', () => ({
+  voyager: {
+    record: {
+      search: voyagerSearch
+    }
+  },
+  voyagerIndex: {
+    agent: { id: 'idx_agent' }
+  },
+  voyagerSource: Promise.resolve({ id: 'src_1' })
+}));
+
+vi.mock('@metorial-subspace/module-tenant', () => ({
+  checkTenant: checkTenantFn
+}));
+
+let tenant = { oid: BigInt(1), id: 'tenant_1' } as any;
+let solution = { oid: 2 } as any;
+let environment = { oid: BigInt(3) } as any;
+
+describe('agentService', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    agentFindFirst.mockReset();
+    agentFindMany.mockReset();
+    agentFindUnique.mockReset();
+    agentFindFirstOrThrow.mockReset();
+    identityActorFindFirstOrThrow.mockReset();
+    createIdentityActor.mockReset();
+    getIdentityActorById.mockReset();
+    updateIdentityActor.mockReset();
+    archiveIdentityActor.mockReset();
+    voyagerSearch.mockReset();
+    resolveIdentityActors.mockReset();
+    resolveIdentityActors.mockResolvedValue(undefined);
+    checkTenantFn.mockReset();
+    agentFindMany.mockResolvedValue([]);
+  });
+
+  describe('listAgents', () => {
+    it('scopes list queries by tenant, environment, and solution', async () => {
+      let { agentService } = await import('./agent');
+
+      let paginator = await agentService.listAgents({ tenant, solution, environment });
+      await paginator.run({});
+
+      expect(agentFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tenantOid: tenant.oid,
+            solutionOid: solution.oid,
+            environmentOid: environment.oid
+          }),
+          include: { actor: true }
+        })
+      );
+    });
+
+    it('runs voyager search when a search string is provided', async () => {
+      voyagerSearch.mockResolvedValue([{ documentId: 'agent_a' }, { documentId: 'agent_b' }]);
+
+      let { agentService } = await import('./agent');
+
+      let paginator = await agentService.listAgents({
+        tenant,
+        solution,
+        environment,
+        search: 'support bot'
+      });
+      await paginator.run({});
+
+      expect(voyagerSearch).toHaveBeenCalledWith({
+        tenantId: tenant.id,
+        sourceId: 'src_1',
+        indexId: 'idx_agent',
+        query: 'support bot'
+      });
+      let call = agentFindMany.mock.calls[0]![0];
+      expect(call.where.AND).toEqual(
+        expect.arrayContaining([{ id: { in: ['agent_a', 'agent_b'] } }])
+      );
+    });
+
+    it('does not call voyager when no search string is provided', async () => {
+      let { agentService } = await import('./agent');
+
+      let paginator = await agentService.listAgents({ tenant, solution, environment });
+      await paginator.run({});
+
+      expect(voyagerSearch).not.toHaveBeenCalled();
+    });
+
+    it('forwards id, type, and date filters into the prisma query', async () => {
+      let { agentService } = await import('./agent');
+
+      let paginator = await agentService.listAgents({
+        tenant,
+        solution,
+        environment,
+        ids: ['agent_1'],
+        types: ['custom'] as any,
+        createdAt: { after: new Date('2026-01-01') } as any
+      });
+      await paginator.run({});
+
+      let call = agentFindMany.mock.calls[0]![0];
+      expect(call.where.AND).toEqual(
+        expect.arrayContaining([
+          { id: { in: ['agent_1'] } },
+          { type: { in: ['custom'] } },
+          { createdAt: { after: new Date('2026-01-01') } }
+        ])
+      );
+    });
+  });
+
+  describe('getAgentById', () => {
+    it('returns the agent when found', async () => {
+      let stored = { id: 'agent_1', actor: { id: 'actor_1' } };
+      agentFindFirst.mockResolvedValue(stored);
+
+      let { agentService } = await import('./agent');
+
+      let result = await agentService.getAgentById({
+        tenant,
+        solution,
+        environment,
+        agentId: 'agent_1'
+      });
+
+      expect(result).toBe(stored);
+      expect(agentFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            id: 'agent_1',
+            tenantOid: tenant.oid,
+            environmentOid: environment.oid
+          }),
+          include: { actor: true }
+        })
+      );
+    });
+
+    it('throws a ServiceError when the agent is missing', async () => {
+      agentFindFirst.mockResolvedValue(null);
+
+      let { agentService } = await import('./agent');
+
+      await expect(
+        agentService.getAgentById({
+          tenant,
+          solution,
+          environment,
+          agentId: 'agent_missing'
+        })
+      ).rejects.toMatchObject({
+        payload: { resource: 'agent', id: 'agent_missing', kind: 'not_found' }
+      });
+    });
+  });
+
+  describe('createAgent', () => {
+    it('creates an identity actor tagged as a custom agent', async () => {
+      createIdentityActor.mockResolvedValue({ oid: BigInt(42) });
+      agentFindFirstOrThrow.mockResolvedValue({ id: 'agent_new' });
+
+      let { agentService } = await import('./agent');
+
+      let result = await agentService.createAgent({
+        tenant,
+        solution,
+        environment,
+        input: { name: 'Support Bot', slug: 'support', description: 'Support bot' }
+      });
+
+      expect(createIdentityActor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            name: 'Support Bot',
+            type: 'agent',
+            _agentSlug: 'support',
+            _agentType: 'custom'
+          })
+        })
+      );
+      expect(agentFindFirstOrThrow).toHaveBeenCalledWith({
+        where: { actorOid: BigInt(42) },
+        include: { actor: true }
+      });
+      expect(result).toEqual({ id: 'agent_new' });
+    });
+  });
+
+  describe('updateAgent', () => {
+    it('rejects when the agent belongs to a different tenant', async () => {
+      checkTenantFn.mockImplementation(() => {
+        throw new Error('tenant mismatch');
+      });
+
+      let { agentService } = await import('./agent');
+
+      await expect(
+        agentService.updateAgent({
+          tenant,
+          solution,
+          environment,
+          agent: { actorOid: BigInt(7) } as any,
+          input: { name: 'Renamed' }
+        })
+      ).rejects.toThrow('tenant mismatch');
+    });
+
+    it('updates the underlying identity actor and returns the refreshed agent', async () => {
+      identityActorFindFirstOrThrow.mockResolvedValue({ id: 'actor_99' });
+      getIdentityActorById.mockResolvedValue({ id: 'actor_99' });
+      updateIdentityActor.mockResolvedValue({ oid: BigInt(99) });
+      agentFindFirstOrThrow.mockResolvedValue({ id: 'agent_99' });
+
+      let { agentService } = await import('./agent');
+
+      let result = await agentService.updateAgent({
+        tenant,
+        solution,
+        environment,
+        agent: { actorOid: BigInt(99) } as any,
+        input: { name: 'Renamed', description: 'New description' }
+      });
+
+      expect(updateIdentityActor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          identityActor: { id: 'actor_99' },
+          input: { name: 'Renamed', description: 'New description', metadata: undefined }
+        })
+      );
+      expect(result).toEqual({ id: 'agent_99' });
+    });
+  });
+
+  describe('upsertAgent', () => {
+    it('returns the existing agent when the hash already matches', async () => {
+      let existing = { id: 'agent_existing' };
+      agentFindUnique.mockResolvedValue(existing);
+
+      let { agentService } = await import('./agent');
+
+      let result = await agentService.upsertAgent({
+        tenant,
+        solution,
+        environment,
+        input: { name: 'Support', type: 'custom' as any }
+      });
+
+      expect(result).toBe(existing);
+      expect(createIdentityActor).not.toHaveBeenCalled();
+    });
+
+    it('creates a new agent with a generated slug when none is provided', async () => {
+      agentFindUnique.mockResolvedValueOnce(null);
+      createIdentityActor.mockResolvedValue({ oid: BigInt(11) });
+      agentFindFirstOrThrow.mockResolvedValue({ id: 'agent_new' });
+
+      let { agentService } = await import('./agent');
+
+      await agentService.upsertAgent({
+        tenant,
+        solution,
+        environment,
+        input: { name: 'Support Bot', type: 'custom' as any }
+      });
+
+      let call = createIdentityActor.mock.calls[0]![0];
+      expect(call.input._agentSlug).toMatch(/^support-bot-/);
+      expect(call.input._agentType).toBe('custom');
+      expect(call.input._agentHash).toBeDefined();
+    });
+
+    it('retries via the unique-constraint path when a concurrent insert wins the race', async () => {
+      let existing = { id: 'agent_raced' };
+      agentFindUnique.mockResolvedValueOnce(null).mockResolvedValueOnce(existing);
+      createIdentityActor.mockRejectedValue({ code: 'P2002' });
+
+      let { agentService } = await import('./agent');
+
+      let result = await agentService.upsertAgent({
+        tenant,
+        solution,
+        environment,
+        input: { name: 'Support', type: 'custom' as any }
+      });
+
+      expect(result).toBe(existing);
+      expect(agentFindUnique).toHaveBeenCalledTimes(2);
+    });
+
+    it('rethrows non-unique-constraint errors raised during creation', async () => {
+      agentFindUnique.mockResolvedValueOnce(null);
+      let boom = new Error('boom');
+      createIdentityActor.mockRejectedValue(boom);
+
+      let { agentService } = await import('./agent');
+
+      await expect(
+        agentService.upsertAgent({
+          tenant,
+          solution,
+          environment,
+          input: { name: 'Support', type: 'custom' as any }
+        })
+      ).rejects.toBe(boom);
+    });
+  });
+
+  describe('archiveAgent', () => {
+    it('checks tenant ownership and archives the underlying identity actor', async () => {
+      identityActorFindFirstOrThrow.mockResolvedValue({ id: 'actor_50' });
+      getIdentityActorById.mockResolvedValue({ id: 'actor_50' });
+      archiveIdentityActor.mockResolvedValue({ oid: BigInt(50) });
+      agentFindFirstOrThrow.mockResolvedValue({ id: 'agent_50', archivedAt: new Date() });
+
+      let { agentService } = await import('./agent');
+
+      let result = await agentService.archiveAgent({
+        tenant,
+        solution,
+        environment,
+        agent: { actorOid: BigInt(50) } as any
+      });
+
+      expect(checkTenantFn).toHaveBeenCalled();
+      expect(archiveIdentityActor).toHaveBeenCalledWith(
+        expect.objectContaining({ identityActor: { id: 'actor_50' } })
+      );
+      expect(result.id).toBe('agent_50');
+    });
+  });
+});

--- a/src/systems/subspace/modules/agent/src/services/agentClient.test.ts
+++ b/src/systems/subspace/modules/agent/src/services/agentClient.test.ts
@@ -1,0 +1,288 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let agentClientFindFirst = vi.fn();
+let agentClientFindMany = vi.fn();
+let agentClientUpsert = vi.fn();
+let agentClientRegistrationUpsert = vi.fn();
+let voyagerSearch = vi.fn();
+let indexAgentClientAdd = vi.fn();
+let addAfterTransactionHookFn = vi.fn(async (cb: () => Promise<unknown>) => {
+  await cb();
+});
+
+vi.mock('@metorial-subspace/db', () => ({
+  db: {
+    agentClient: {
+      findFirst: agentClientFindFirst,
+      findMany: agentClientFindMany,
+      upsert: agentClientUpsert
+    },
+    agentClientRegistration: {
+      upsert: agentClientRegistrationUpsert
+    }
+  },
+  getId: (model: string) => ({ oid: BigInt(1), id: `${model}_1` }),
+  withTransaction: async (fn: (db: any) => Promise<unknown>) =>
+    await fn({
+      agentClient: { upsert: agentClientUpsert },
+      agentClientRegistration: { upsert: agentClientRegistrationUpsert }
+    }),
+  addAfterTransactionHook: addAfterTransactionHookFn
+}));
+
+vi.mock('@lowerdeck/pagination', () => ({
+  Paginator: {
+    create: (factory: any) => ({
+      run: async () => await factory({ prisma: async (fn: any) => await fn({}) })
+    })
+  }
+}));
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: (_name: string, factory: () => unknown) => ({
+      build: factory
+    })
+  }
+}));
+
+vi.mock('@lowerdeck/error', () => ({
+  notFoundError: (resource: string, id: string) => ({ resource, id, kind: 'not_found' }),
+  badRequestError: (info: any) => ({ ...info, kind: 'bad_request' }),
+  ServiceError: class ServiceError extends Error {
+    payload: any;
+    constructor(payload: any) {
+      super(typeof payload === 'object' ? JSON.stringify(payload) : String(payload));
+      this.payload = payload;
+    }
+  }
+}));
+
+vi.mock('@metorial-subspace/list-utils', () => ({
+  normalizeDateFilter: (filter: unknown) => filter
+}));
+
+vi.mock('@metorial-subspace/module-search', () => ({
+  voyager: {
+    record: {
+      search: voyagerSearch
+    }
+  },
+  voyagerIndex: {
+    agentClient: { id: 'idx_agentClient' }
+  },
+  voyagerSource: Promise.resolve({ id: 'src_1' })
+}));
+
+vi.mock('../queues/search/agentClient', () => ({
+  indexAgentClientQueue: {
+    add: indexAgentClientAdd
+  }
+}));
+
+let tenant = { oid: BigInt(1), id: 'tenant_1' } as any;
+let solution = { oid: 2 } as any;
+let environment = { oid: BigInt(3) } as any;
+
+describe('agentClientService', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    agentClientFindFirst.mockReset();
+    agentClientFindMany.mockReset();
+    agentClientFindMany.mockResolvedValue([]);
+    agentClientUpsert.mockReset();
+    agentClientRegistrationUpsert.mockReset();
+    voyagerSearch.mockReset();
+    indexAgentClientAdd.mockReset();
+    addAfterTransactionHookFn.mockClear();
+  });
+
+  describe('listAgentClients', () => {
+    it('scopes list queries by tenant, environment, and solution', async () => {
+      let { agentClientService } = await import('./agentClient');
+
+      let paginator = await agentClientService.listAgentClients({
+        tenant,
+        solution,
+        environment
+      });
+      await paginator.run({});
+
+      expect(agentClientFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tenantOid: tenant.oid,
+            solutionOid: solution.oid,
+            environmentOid: environment.oid
+          })
+        })
+      );
+    });
+
+    it('treats a whitespace-only search string as no search', async () => {
+      let { agentClientService } = await import('./agentClient');
+
+      let paginator = await agentClientService.listAgentClients({
+        tenant,
+        solution,
+        environment,
+        search: '   '
+      });
+      await paginator.run({});
+
+      expect(voyagerSearch).not.toHaveBeenCalled();
+    });
+
+    it('runs voyager search when a non-empty search string is provided', async () => {
+      voyagerSearch.mockResolvedValue([{ documentId: 'ac_1' }]);
+
+      let { agentClientService } = await import('./agentClient');
+
+      let paginator = await agentClientService.listAgentClients({
+        tenant,
+        solution,
+        environment,
+        search: 'claude'
+      });
+      await paginator.run({});
+
+      expect(voyagerSearch).toHaveBeenCalledWith({
+        tenantId: tenant.id,
+        sourceId: 'src_1',
+        indexId: 'idx_agentClient',
+        query: 'claude'
+      });
+    });
+  });
+
+  describe('getAgentClientById', () => {
+    it('returns the client when found', async () => {
+      let client = { id: 'ac_1', name: 'Claude' };
+      agentClientFindFirst.mockResolvedValue(client);
+
+      let { agentClientService } = await import('./agentClient');
+
+      let result = await agentClientService.getAgentClientById({
+        tenant,
+        solution,
+        environment,
+        agentClientId: 'ac_1'
+      });
+
+      expect(result).toBe(client);
+    });
+
+    it('throws a ServiceError when the client is missing', async () => {
+      agentClientFindFirst.mockResolvedValue(null);
+
+      let { agentClientService } = await import('./agentClient');
+
+      await expect(
+        agentClientService.getAgentClientById({
+          tenant,
+          solution,
+          environment,
+          agentClientId: 'ac_missing'
+        })
+      ).rejects.toMatchObject({
+        payload: { resource: 'agent.client', id: 'ac_missing', kind: 'not_found' }
+      });
+    });
+  });
+
+  describe('upsertAgentClient', () => {
+    it('creates an OAuth registration alongside an mcp_client_oauth client', async () => {
+      agentClientUpsert.mockResolvedValue({ id: 'agentClient_1', oid: BigInt(1) });
+      agentClientRegistrationUpsert.mockResolvedValue({ id: 'reg_1' });
+
+      let { agentClientService } = await import('./agentClient');
+
+      let result = await agentClientService.upsertAgentClient({
+        tenant,
+        solution,
+        environment,
+        input: {
+          name: 'Claude',
+          type: 'mcp_client_oauth',
+          foreignId: 'foreign_claude',
+          oauthRegistrationId: 'oauth_reg_1'
+        }
+      });
+
+      expect(agentClientRegistrationUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { oauthRegistrationId: 'oauth_reg_1' }
+        })
+      );
+      expect(result.agentClientRegistration).toEqual({ id: 'reg_1' });
+    });
+
+    it('does not create a registration for system_client type', async () => {
+      agentClientUpsert.mockResolvedValue({ id: 'agentClient_1', oid: BigInt(1) });
+
+      let { agentClientService } = await import('./agentClient');
+
+      let result = await agentClientService.upsertAgentClient({
+        tenant,
+        solution,
+        environment,
+        input: {
+          name: 'Internal',
+          type: 'system_client',
+          foreignId: 'foreign_sys'
+        }
+      });
+
+      expect(agentClientRegistrationUpsert).not.toHaveBeenCalled();
+      expect(result.agentClientRegistration).toBeNull();
+    });
+
+    it('schedules indexing only when the upsert created a new client', async () => {
+      agentClientUpsert.mockResolvedValue({ id: 'agentClient_1', oid: BigInt(1) });
+
+      let { agentClientService } = await import('./agentClient');
+
+      await agentClientService.upsertAgentClient({
+        tenant,
+        solution,
+        environment,
+        input: { name: 'Claude', type: 'system_client', foreignId: 'foreign_new' }
+      });
+
+      expect(addAfterTransactionHookFn).toHaveBeenCalled();
+      expect(indexAgentClientAdd).toHaveBeenCalledWith({ agentClientId: 'agentClient_1' });
+    });
+
+    it('does not schedule indexing when the upsert returned an existing client', async () => {
+      agentClientUpsert.mockResolvedValue({ id: 'agentClient_existing', oid: BigInt(9) });
+
+      let { agentClientService } = await import('./agentClient');
+
+      await agentClientService.upsertAgentClient({
+        tenant,
+        solution,
+        environment,
+        input: { name: 'Claude', type: 'system_client', foreignId: 'foreign_existing' }
+      });
+
+      expect(indexAgentClientAdd).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createAgentClient', () => {
+    it('delegates to upsertAgentClient', async () => {
+      agentClientUpsert.mockResolvedValue({ id: 'agentClient_1', oid: BigInt(1) });
+
+      let { agentClientService } = await import('./agentClient');
+
+      let result = await agentClientService.createAgentClient({
+        tenant,
+        solution,
+        environment,
+        input: { name: 'Claude', type: 'system_client', foreignId: 'foreign_1' }
+      });
+
+      expect(result.agentClient).toEqual({ id: 'agentClient_1', oid: BigInt(1) });
+    });
+  });
+});

--- a/src/systems/subspace/modules/agent/src/services/agentInstance.test.ts
+++ b/src/systems/subspace/modules/agent/src/services/agentInstance.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let agentInstanceFindFirst = vi.fn();
+let agentInstanceFindMany = vi.fn();
+let agentInstanceUpsert = vi.fn();
+let checkTenantFn = vi.fn();
+let checkDeletedRelationFn = vi.fn();
+
+vi.mock('@metorial-subspace/db', () => ({
+  db: {
+    agentInstance: {
+      findFirst: agentInstanceFindFirst,
+      findMany: agentInstanceFindMany,
+      upsert: agentInstanceUpsert
+    }
+  },
+  getId: (model: string) => ({ oid: BigInt(1), id: `${model}_1` }),
+  withTransaction: async (fn: (db: any) => Promise<unknown>) =>
+    await fn({
+      agentInstance: { upsert: agentInstanceUpsert }
+    })
+}));
+
+vi.mock('@lowerdeck/pagination', () => ({
+  Paginator: {
+    create: (factory: any) => ({
+      run: async () => await factory({ prisma: async (fn: any) => await fn({}) })
+    })
+  }
+}));
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: (_name: string, factory: () => unknown) => ({
+      build: factory
+    })
+  }
+}));
+
+vi.mock('@lowerdeck/hash', () => ({
+  Hash: {
+    sha256: vi.fn(async (input: string) => `hash_${input.length}`)
+  }
+}));
+
+vi.mock('@lowerdeck/error', () => ({
+  notFoundError: (resource: string, id: string) => ({ resource, id, kind: 'not_found' }),
+  badRequestError: (info: any) => ({ ...info, kind: 'bad_request' }),
+  ServiceError: class ServiceError extends Error {
+    payload: any;
+    constructor(payload: any) {
+      super(typeof payload === 'object' ? JSON.stringify(payload) : String(payload));
+      this.payload = payload;
+    }
+  }
+}));
+
+vi.mock('@metorial-subspace/list-utils', () => ({
+  normalizeDateFilter: (filter: unknown) => filter,
+  checkDeletedRelation: checkDeletedRelationFn
+}));
+
+vi.mock('@metorial-subspace/module-tenant', () => ({
+  checkTenant: checkTenantFn
+}));
+
+let tenant = { oid: BigInt(1), id: 'tenant_1' } as any;
+let solution = { oid: 2 } as any;
+let environment = { oid: BigInt(3) } as any;
+
+let agent = {
+  oid: BigInt(10),
+  id: 'agent_1',
+  type: 'custom',
+  isParentDeleted: false
+} as any;
+
+describe('agentInstanceService', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    agentInstanceFindFirst.mockReset();
+    agentInstanceFindMany.mockReset();
+    agentInstanceFindMany.mockResolvedValue([]);
+    agentInstanceUpsert.mockReset();
+    checkTenantFn.mockReset();
+    checkDeletedRelationFn.mockReset();
+  });
+
+  describe('listAgentInstances', () => {
+    it('checks tenant ownership of the agent and scopes the query by agentOid', async () => {
+      let { agentInstanceService } = await import('./agentInstance');
+
+      let paginator = await agentInstanceService.listAgentInstances({
+        tenant,
+        solution,
+        environment,
+        agent
+      });
+      await paginator.run({});
+
+      expect(checkTenantFn).toHaveBeenCalledWith(expect.objectContaining({ tenant }), agent);
+      expect(agentInstanceFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ agentOid: agent.oid })
+        })
+      );
+    });
+
+    it('passes through id, type, and agentClient filters', async () => {
+      let { agentInstanceService } = await import('./agentInstance');
+
+      let paginator = await agentInstanceService.listAgentInstances({
+        tenant,
+        solution,
+        environment,
+        agent,
+        ids: ['ai_1'],
+        types: ['mcp_client'] as any,
+        agentClientIds: ['ac_1']
+      });
+      await paginator.run({});
+
+      let call = agentInstanceFindMany.mock.calls[0]![0];
+      expect(call.where.AND).toEqual(
+        expect.arrayContaining([
+          { id: { in: ['ai_1'] } },
+          { type: { in: ['mcp_client'] } },
+          { agentClient: { id: { in: ['ac_1'] } } }
+        ])
+      );
+    });
+  });
+
+  describe('getAgentInstanceById', () => {
+    it('returns the instance when found', async () => {
+      let instance = { id: 'ai_1' };
+      agentInstanceFindFirst.mockResolvedValue(instance);
+
+      let { agentInstanceService } = await import('./agentInstance');
+
+      let result = await agentInstanceService.getAgentInstanceById({
+        tenant,
+        solution,
+        environment,
+        agent,
+        agentInstanceId: 'ai_1'
+      });
+
+      expect(checkTenantFn).toHaveBeenCalledWith(expect.objectContaining({ tenant }), agent);
+      expect(result).toBe(instance);
+    });
+
+    it('throws a ServiceError when the instance is missing', async () => {
+      agentInstanceFindFirst.mockResolvedValue(null);
+
+      let { agentInstanceService } = await import('./agentInstance');
+
+      await expect(
+        agentInstanceService.getAgentInstanceById({
+          tenant,
+          solution,
+          environment,
+          agent,
+          agentInstanceId: 'ai_missing'
+        })
+      ).rejects.toMatchObject({
+        payload: { resource: 'agent.instance', id: 'ai_missing', kind: 'not_found' }
+      });
+    });
+  });
+
+  describe('upsertAgentInstance', () => {
+    it('rejects when the registration belongs to a different client', async () => {
+      let { agentInstanceService } = await import('./agentInstance');
+
+      await expect(
+        agentInstanceService.upsertAgentInstance({
+          tenant,
+          solution,
+          environment,
+          agent,
+          agentClient: { oid: BigInt(5) } as any,
+          agentClientRegistration: { agentClientOid: BigInt(99) } as any,
+          input: { name: 'instance', type: 'mcp_client' as any }
+        })
+      ).rejects.toMatchObject({
+        payload: expect.objectContaining({ kind: 'bad_request' })
+      });
+    });
+
+    it('rejects tool_call agents that receive a non-tool_call instance type', async () => {
+      let { agentInstanceService } = await import('./agentInstance');
+
+      await expect(
+        agentInstanceService.upsertAgentInstance({
+          tenant,
+          solution,
+          environment,
+          agent: { ...agent, type: 'tool_call' } as any,
+          input: { name: 'instance', type: 'mcp_client' as any }
+        })
+      ).rejects.toMatchObject({
+        payload: expect.objectContaining({ kind: 'bad_request' })
+      });
+    });
+
+    it('hashes input + agent context and upserts using agentOid_hash', async () => {
+      agentInstanceUpsert.mockResolvedValue({ id: 'ai_new' });
+
+      let { agentInstanceService } = await import('./agentInstance');
+
+      let result = await agentInstanceService.upsertAgentInstance({
+        tenant,
+        solution,
+        environment,
+        agent,
+        input: { name: 'instance', version: '1.0.0', type: 'mcp_client' as any }
+      });
+
+      expect(checkTenantFn).toHaveBeenCalled();
+      expect(checkDeletedRelationFn).toHaveBeenCalledWith(agent);
+      let call = agentInstanceUpsert.mock.calls[0]![0];
+      expect(call.where).toEqual({
+        agentOid_hash: {
+          agentOid: agent.oid,
+          hash: expect.stringMatching(/^hash_/)
+        }
+      });
+      expect(call.create).toEqual(
+        expect.objectContaining({
+          name: 'instance',
+          version: '1.0.0',
+          type: 'mcp_client',
+          agentOid: agent.oid
+        })
+      );
+      expect(result).toEqual({ id: 'ai_new' });
+    });
+  });
+});


### PR DESCRIPTION
Adds vitest coverage for the agent module services.

`agent.test.ts` (14 tests) — `listAgents` (scoping, voyager search, filter passthrough), `getAgentById`, `createAgent`, `updateAgent` (tenant check, identity-actor flow), `upsertAgent` (hash hit, slug generation, P2002 race retry, error propagation), `archiveAgent`.

`agentClient.test.ts` (10 tests) — `listAgentClients` (scoping, whitespace search, voyager), `getAgentClientById`, `upsertAgentClient` (OAuth registration vs system_client, new-vs-existing index queue), `createAgentClient`.

`agentInstance.test.ts` (7 tests) — `listAgentInstances` (tenant check, filter passthrough), `getAgentInstanceById`, `upsertAgentInstance` (registration/client mismatch, tool_call constraint, hash + upsert).

Mocking pattern mirrors `tenant/environment.test.ts` and `monitor/alert.test.ts` (`vi.mock` `@metorial-subspace/db`, `@lowerdeck/service`, `@lowerdeck/pagination`). Source unchanged.

31 tests, prettier-clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no runtime or API behavior changes.
> 
> **Overview**
> Adds **Vitest unit tests** for the agent module’s three service layers (`agent`, `agentClient`, `agentInstance`) with **no production code changes**.
> 
> **`agentService`** (~14 tests): list scoping and Voyager search/filter passthrough; get-by-id not-found handling; create/update/archive flows through identity actors and `checkTenant`; upsert hash short-circuit, slug generation, Prisma `P2002` race retry, and error propagation.
> 
> **`agentClientService`** (~10 tests): list scoping and search (including whitespace-only search skipped); OAuth registration on `mcp_client_oauth` vs none for `system_client`; post-transaction search indexing only on **new** upserts; `createAgentClient` delegating to upsert.
> 
> **`agentInstanceService`** (~7 tests): tenant checks and filters on list/get; upsert validation (registration/client mismatch, `tool_call` agent type constraint); hash-based `agentOid_hash` upsert.
> 
> Mocks follow the same pattern as other subspace service tests (`@metorial-subspace/db`, `@lowerdeck/service`, `@lowerdeck/pagination`, plus module-specific deps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adbd73264f449da00ed5e8e5d0d058961c032424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->