### PR TITLE
Clean up custom providers page

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/providers.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/providers.tsx
@@ -68,13 +68,6 @@ let MagicMcpServerProvidersTable = (p: {
                 <Text size="1" color="gray600">
                   {provider.provider.slug ?? provider.provider.id}
                 </Text>
-                {provider.providerManagementMode !== 'manual' ? (
-                  <Text size="1" color="gray600">
-                    {provider.providerManagementMode === 'inherited_from_integration'
-                      ? 'Inherited from integration'
-                      : 'Inherited from provider template'}
-                  </Text>
-                ) : null}
               </div>,
               provider.config ? (
                 <Text size="2">{provider.config.name ?? provider.config.id}</Text>
@@ -98,7 +91,8 @@ let MagicMcpServerProvidersTable = (p: {
                       ? [
                           {
                             id: 'edit',
-                            label: 'Edit'
+                            label: 'Edit',
+                            disabled: provider.providerManagementMode !== 'manual'
                           }
                         ]
                       : []),
@@ -106,7 +100,8 @@ let MagicMcpServerProvidersTable = (p: {
                       ? [
                           {
                             id: 'delete',
-                            label: 'Delete'
+                            label: 'Delete',
+                            disabled: provider.providerManagementMode !== 'manual'
                           }
                         ]
                       : [])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small dashboard UX change; restricts edit/delete for non-manual providers without touching API or auth.
> 
> **Overview**
> On the magic MCP server **providers** table, inherited providers are no longer labeled with “Inherited from integration/template” under the provider name.
> 
> **Edit** and **Delete** in the row actions menu are now **disabled** when `providerManagementMode` is not `manual`, matching the server-level rule that only manually managed providers can be changed from this UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf060a3469954e142bc60bd8eefa02ec33ce8834. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->