### PR TITLE
Harden magic connections

### DIFF
--- a/src/backend/apis/connection/src/magic.ts
+++ b/src/backend/apis/connection/src/magic.ts
@@ -5,12 +5,17 @@ import {
   unauthorizedError
 } from '@lowerdeck/error';
 import { createExecutionContext, provideExecutionContext } from '@lowerdeck/execution-context';
+import type { Context } from '@lowerdeck/hono';
 import { useRequestContext } from '@lowerdeck/hono';
+import { getSentry } from '@lowerdeck/sentry';
 import { extractToken } from '@metorial/bearer';
 import { Instance } from '@metorial/db';
 import { generateSnowflakeId } from '@metorial/id';
 import { AuthInfo } from '@metorial/module-access';
-import { consumerIntegrationService } from '@metorial/module-consumer';
+import {
+  consumerIntegrationService,
+  enqueueMaterializeMagicMcpSessionOwnership
+} from '@metorial/module-consumer';
 import {
   ensureMagicMcpSubspaceSession,
   magicMcpEndpointService,
@@ -25,8 +30,9 @@ import {
   type SubspaceProxyAgentClient
 } from '@metorial/module-subspace';
 import { Authenticator } from '@metorial/rest';
-import type { Context } from '@lowerdeck/hono';
 import { authenticateAndResolveInstance } from './getSession';
+
+let Sentry = getSentry();
 
 type MagicMcpTargetForRouting = Awaited<ReturnType<typeof resolveMagicMcpTargetByIdOrAlias>>;
 type MagicMcpTokenForRouting = Awaited<
@@ -85,6 +91,17 @@ let resolveMagicMcpTargetFromToken = async (d: { token: MagicMcpTokenForRouting 
   }
 
   return await resolveMagicMcpTargetByIdOrAlias(magicMcpTargetIdOrAlias);
+};
+
+let isMagicMcpTokenLinkedToTarget = (
+  token: MagicMcpTokenForRouting,
+  target: MagicMcpTargetForRouting
+) => {
+  if (target.type === 'server') {
+    return token.magicMcpServerOid === target.target.oid;
+  }
+
+  return token.magicMcpEndpointOid === target.target.oid;
 };
 
 let toApiKeyRequest = (request: Request, tokenSecret: string | null) => {
@@ -173,6 +190,7 @@ let resolveAgentClientForConsumerToken = (d: {
 
 export let resolveMagicMcpSubspaceSession = async (d: {
   magicMcpTargetIdOrAlias?: string;
+  magicMcpTarget?: MagicMcpTargetForRouting | null;
   instanceForTokenRouting?: Instance;
   request: Request;
   url: URL;
@@ -191,9 +209,11 @@ export let resolveMagicMcpSubspaceSession = async (d: {
     );
   }
 
-  let magicMcpTarget = d.magicMcpTargetIdOrAlias
-    ? await resolveMagicMcpTargetByIdOrAliasSafe(d.magicMcpTargetIdOrAlias)
-    : null;
+  let magicMcpTarget = d.magicMcpTarget
+    ? d.magicMcpTarget
+    : d.magicMcpTargetIdOrAlias
+      ? await resolveMagicMcpTargetByIdOrAliasSafe(d.magicMcpTargetIdOrAlias)
+      : null;
 
   let instance = magicMcpTarget?.target.instance ?? d.instanceForTokenRouting;
 
@@ -206,7 +226,9 @@ export let resolveMagicMcpSubspaceSession = async (d: {
 
   if (
     magicMcpToken &&
-    (!magicMcpTarget || magicMcpToken?.magicMcpEndpointOid || magicMcpToken?.magicMcpServerOid)
+    (!magicMcpTarget ||
+      ((magicMcpToken.magicMcpEndpointOid || magicMcpToken.magicMcpServerOid) &&
+        !isMagicMcpTokenLinkedToTarget(magicMcpToken, magicMcpTarget)))
   ) {
     let tokenTarget = await resolveMagicMcpTargetFromToken({ token: magicMcpToken });
 
@@ -237,13 +259,15 @@ export let resolveMagicMcpSubspaceSession = async (d: {
       magicMcpTarget
     });
 
-    await magicMcpTokenService.recordMagicMcpTokenUse({
-      token: magicMcpToken,
-      server: magicMcpTarget.type === 'server' ? magicMcpTarget.target : undefined,
-      endpoint: magicMcpTarget.type === 'endpoint' ? magicMcpTarget.target : undefined,
-      ip: d.ip,
-      ua: d.ua
-    });
+    magicMcpTokenService
+      .recordMagicMcpTokenUse({
+        token: magicMcpToken,
+        server: magicMcpTarget.type === 'server' ? magicMcpTarget.target : undefined,
+        endpoint: magicMcpTarget.type === 'endpoint' ? magicMcpTarget.target : undefined,
+        ip: d.ip,
+        ua: d.ua
+      })
+      .catch(error => Sentry.captureException(error));
   } else {
     consumerProfileForOwnership = await ensureMagicMcpApiKeyAccess({
       tokenSecret,
@@ -277,6 +301,7 @@ export let resolveMagicMcpSubspaceSession = async (d: {
 export let handleMagicMcpRequest = async (d: {
   c: Context;
   magicMcpTargetIdOrAlias?: string;
+  magicMcpTarget?: MagicMcpTargetForRouting | null;
   instanceForTokenRouting?: Instance;
   authenticate: Authenticator<AuthInfo>;
 }) => {
@@ -294,6 +319,7 @@ export let handleMagicMcpRequest = async (d: {
     async () => {
       let sessionInfo = await resolveMagicMcpSubspaceSession({
         magicMcpTargetIdOrAlias: d.magicMcpTargetIdOrAlias,
+        magicMcpTarget: d.magicMcpTarget,
         instanceForTokenRouting: d.instanceForTokenRouting,
         request,
         url,
@@ -317,11 +343,22 @@ export let handleMagicMcpRequest = async (d: {
               sessionInfo.subspaceSessionId
             );
             if (!sessionInfo.consumerProfileForOwnership) return;
+            if (magicMcpSession.isConsumerReconciled) return;
 
-            await consumerIntegrationService.materializeMagicMcpSessionOwnership({
-              consumerProfile: sessionInfo.consumerProfileForOwnership,
-              magicMcpTarget: sessionInfo.magicMcpTarget,
-              magicMcpSession
+            await enqueueMaterializeMagicMcpSessionOwnership({
+              consumerProfileOid: sessionInfo.consumerProfileForOwnership.oid.toString(),
+              magicMcpSessionOid: magicMcpSession.oid.toString(),
+              magicMcpTokenId: sessionInfo.magicMcpToken?.id,
+              magicMcpTarget:
+                sessionInfo.magicMcpTarget.type === 'server'
+                  ? {
+                      type: 'server',
+                      magicMcpServerId: sessionInfo.magicMcpTarget.target.id
+                    }
+                  : {
+                      type: 'endpoint',
+                      magicMcpEndpointId: sessionInfo.magicMcpTarget.target.id
+                    }
             });
           }
         }

--- a/src/backend/apis/connection/src/oauth/skeleton.ts
+++ b/src/backend/apis/connection/src/oauth/skeleton.ts
@@ -37,6 +37,7 @@ export let buildOAuthClientConfig = (base: string) => ({
 
 type OAuthRouteHandlers<TInput, TRoute> = {
   resolveRoute: (route: TInput) => Promise<TRoute>;
+  resolveConnectRoute?: (route: TInput, c: Context) => Promise<TRoute>;
   metadata: (d: { route: TRoute }, c: Context) => Promise<Response>;
   portal: (d: { route: TRoute }, c: Context) => Promise<Response>;
   protectedResource: (d: { route: TRoute }, c: Context) => Promise<Response>;
@@ -112,10 +113,22 @@ let createOAuthRouteServers = <TInput, TRoute>(d: {
   handlers: OAuthRouteHandlers<TInput, TRoute>;
 }) => {
   let resolveRoute = async (c: Context) => await d.handlers.resolveRoute(d.parseRouteInput(c));
+  let resolveConnectRoute = async (c: Context) => {
+    let input = d.parseRouteInput(c);
+    if (d.handlers.resolveConnectRoute) {
+      return await d.handlers.resolveConnectRoute(input, c);
+    }
+
+    return await d.handlers.resolveRoute(input);
+  };
 
   let withResolvedRoute =
-    (handler: (d: { route: TRoute }, c: Context) => Promise<Response>) => async (c: Context) =>
-      await handler({ route: await resolveRoute(c) }, c);
+    (
+      handler: (d: { route: TRoute }, c: Context) => Promise<Response>,
+      resolver: (c: Context) => Promise<TRoute> = resolveRoute
+    ) =>
+    async (c: Context) =>
+      await handler({ route: await resolver(c) }, c);
 
   let metadataServer = createConnectionHono();
   for (let path of d.paths.metadata) {
@@ -124,7 +137,10 @@ let createOAuthRouteServers = <TInput, TRoute>(d: {
 
   let connectServer = createConnectionHono();
   for (let path of d.paths.connect) {
-    connectServer = connectServer.all(path, withResolvedRoute(d.handlers.portal));
+    connectServer = connectServer.all(
+      path,
+      withResolvedRoute(d.handlers.portal, resolveConnectRoute)
+    );
   }
 
   for (let path of d.paths.metadata) {

--- a/src/backend/apis/connection/src/portal.ts
+++ b/src/backend/apis/connection/src/portal.ts
@@ -1,4 +1,4 @@
-import { useRequestContext, useValidatedBody } from '@lowerdeck/hono';
+import { Context, useRequestContext, useValidatedBody } from '@lowerdeck/hono';
 import { v } from '@lowerdeck/validation';
 import { getConfig } from '@metorial/config';
 import { AuthInfo } from '@metorial/module-access';
@@ -12,7 +12,6 @@ import {
   consumerOAuthTokenService
 } from '@metorial/module-consumer';
 import { Authenticator } from '@metorial/rest';
-import { Context } from '@lowerdeck/hono';
 import { getMagicMcpTokenSecretFromRequest, handleMagicMcpRequest } from './magic';
 import {
   buildOAuthClientConfig,
@@ -111,13 +110,12 @@ export let createPortalHandler = (d: {
 
     portal: async ({ route }, c) => {
       let { instance, magicMcpTarget, base } = route;
-      let routeMagicMcpTargetIdOrAlias = magicMcpTarget?.target.id;
 
       let token = getMagicMcpTokenSecretFromRequest(c.req.raw, new URL(c.req.url));
       if (token) {
         return await handleMagicMcpRequest({
           c,
-          magicMcpTargetIdOrAlias: routeMagicMcpTargetIdOrAlias,
+          magicMcpTarget,
           instanceForTokenRouting: instance,
           authenticate: d.authenticate
         });

--- a/src/backend/apis/connection/src/portal.ts
+++ b/src/backend/apis/connection/src/portal.ts
@@ -103,6 +103,12 @@ export let createPortalHandler = (d: {
         magicMcpTargetId
       });
     },
+    resolveConnectRoute: async ({ portalId, magicMcpTargetId }) => {
+      return await consumerOAuthRoutingService.resolvePortalMcpRoute({
+        portalId,
+        magicMcpTargetId
+      });
+    },
 
     metadata: async ({ route }, c) => {
       return c.json(buildOAuthClientConfig(route.base));

--- a/src/backend/apis/connection/test/magic.test.ts
+++ b/src/backend/apis/connection/test/magic.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lowerdeck/sentry', () => ({
+  getSentry: () => ({
+    captureException: vi.fn()
+  })
+}));
+
+vi.mock('@metorial/module-consumer', () => ({
+  consumerIntegrationService: {
+    findConsumerTokenByMagicMcpToken: vi.fn()
+  },
+  enqueueMaterializeMagicMcpSessionOwnership: vi.fn()
+}));
+
+vi.mock('@metorial/module-magic', () => ({
+  ensureMagicMcpSubspaceSession: vi.fn(),
+  magicMcpEndpointService: {
+    checkConsumerReadAccess: vi.fn()
+  },
+  magicMcpServerService: {
+    checkConsumerReadAccess: vi.fn()
+  },
+  magicMcpTokenService: {
+    getMagicMcpTokenBySecret: vi.fn(),
+    checkMagicMcpTokenAccess: vi.fn(),
+    recordMagicMcpTokenUse: vi.fn()
+  },
+  resolveMagicMcpTargetByIdOrAlias: vi.fn(),
+  resolveMagicMcpTargetByIdOrAliasSafe: vi.fn()
+}));
+
+vi.mock('@metorial/module-subspace', () => ({
+  proxyMcpRequestToSubspace: vi.fn()
+}));
+
+import { consumerIntegrationService } from '@metorial/module-consumer';
+import {
+  ensureMagicMcpSubspaceSession,
+  magicMcpTokenService,
+  resolveMagicMcpTargetByIdOrAlias,
+  resolveMagicMcpTargetByIdOrAliasSafe
+} from '@metorial/module-magic';
+import { resolveMagicMcpSubspaceSession } from '../src/magic';
+
+describe('resolveMagicMcpSubspaceSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses a pre-resolved target without resolving it again', async () => {
+    let target = {
+      type: 'server',
+      target: {
+        id: 'mms_1',
+        oid: 11n,
+        instance: {
+          id: 'ins_1',
+          oid: 22n
+        }
+      }
+    } as any;
+
+    vi.mocked(magicMcpTokenService.getMagicMcpTokenBySecret).mockResolvedValue({
+      id: 'mmt_1',
+      oid: 33n,
+      magicMcpServerOid: 11n,
+      magicMcpEndpointOid: null
+    } as any);
+    vi.mocked(magicMcpTokenService.checkMagicMcpTokenAccess).mockResolvedValue(true);
+    vi.mocked(magicMcpTokenService.recordMagicMcpTokenUse).mockResolvedValue(undefined);
+    vi.mocked(ensureMagicMcpSubspaceSession).mockResolvedValue('backing_session_1');
+    vi.mocked(consumerIntegrationService.findConsumerTokenByMagicMcpToken).mockResolvedValue(
+      null
+    );
+
+    await resolveMagicMcpSubspaceSession({
+      magicMcpTarget: target,
+      request: new Request('https://api.metorial.test/connect/portal/test?key=secret'),
+      url: new URL('https://api.metorial.test/connect/portal/test?key=secret'),
+      authenticate: vi.fn() as any
+    });
+
+    expect(resolveMagicMcpTargetByIdOrAliasSafe).not.toHaveBeenCalled();
+    expect(resolveMagicMcpTargetByIdOrAlias).not.toHaveBeenCalled();
+    expect(ensureMagicMcpSubspaceSession).toHaveBeenCalledWith(target);
+  });
+});

--- a/src/backend/modules/consumer/src/index.ts
+++ b/src/backend/modules/consumer/src/index.ts
@@ -3,6 +3,7 @@ import { combineQueueProcessors } from '@metorial/queue';
 import { sendApprovedConsumerAccessRequestEmailQueueProcessor } from './queues/accessRequest/sendApprovedConsumerAccessRequestEmail';
 import { sendRejectedConsumerAccessRequestEmailQueueProcessor } from './queues/accessRequest/sendRejectedConsumerAccessRequestEmail';
 import { consumerLifecycleQueueProcessor } from './queues/lifecycle';
+import { materializeMagicMcpSessionOwnershipQueueProcessor } from './queues/materializeMagicMcpSessionOwnership';
 import { consumerSearchQueueProcessor } from './queues/search';
 import {
   reconcileConsumerActorQueueProcessor,
@@ -23,6 +24,7 @@ export * from './lib/magicMcpServerAccess';
 export * from './lib/magicMcpTokenAccess';
 export * from './lib/oauth';
 export * from './portalUrlTemplate';
+export * from './queues/materializeMagicMcpSessionOwnership';
 export * from './services';
 
 export let consumerQueueProcessor = combineQueueProcessors([
@@ -32,6 +34,7 @@ export let consumerQueueProcessor = combineQueueProcessors([
   sendRejectedConsumerAccessRequestEmailQueueProcessor,
   syncIdentityConsumerQueueProcessor,
   reconcileConsumerActorQueueProcessor,
+  materializeMagicMcpSessionOwnershipQueueProcessor,
 
   syncOrgMemberQueueProcessor,
   syncOrgMemberConsumerQueueProcessor,

--- a/src/backend/modules/consumer/src/queues/materializeMagicMcpSessionOwnership.ts
+++ b/src/backend/modules/consumer/src/queues/materializeMagicMcpSessionOwnership.ts
@@ -1,0 +1,117 @@
+import { db } from '@metorial/db';
+import { createQueue, QueueRetryError } from '@metorial/queue';
+import { consumerIntegrationService } from '../services';
+
+type MaterializeMagicMcpSessionOwnershipInput = {
+  consumerProfileOid: string;
+  magicMcpSessionOid: string;
+  magicMcpTokenId?: string | null;
+  magicMcpTarget:
+    | {
+        type: 'server';
+        magicMcpServerId: string;
+      }
+    | {
+        type: 'endpoint';
+        magicMcpEndpointId: string;
+      };
+};
+
+let toBigInt = (value: string) => BigInt(value);
+
+export let materializeMagicMcpSessionOwnershipQueue =
+  createQueue<MaterializeMagicMcpSessionOwnershipInput>({
+    name: 'cons/magic/sessionOwn'
+  });
+
+export let enqueueMaterializeMagicMcpSessionOwnership = async (
+  data: MaterializeMagicMcpSessionOwnershipInput
+) =>
+  await materializeMagicMcpSessionOwnershipQueue.add(data, {
+    id: `${data.consumerProfileOid}:${data.magicMcpSessionOid}`
+  });
+
+export let materializeMagicMcpSessionOwnershipQueueProcessor =
+  materializeMagicMcpSessionOwnershipQueue.process(async data => {
+    let [consumerProfile, magicMcpSession, magicMcpToken] = await Promise.all([
+      db.consumerProfile.findUnique({
+        where: { oid: toBigInt(data.consumerProfileOid) }
+      }),
+      db.magicMcpSession.findUnique({
+        where: { oid: toBigInt(data.magicMcpSessionOid) }
+      }),
+      data.magicMcpTokenId
+        ? db.magicMcpToken.findUnique({
+            where: { id: data.magicMcpTokenId },
+            select: { oid: true }
+          })
+        : null
+    ]);
+
+    if (!consumerProfile || !magicMcpSession) throw new QueueRetryError();
+    if (magicMcpSession.isConsumerReconciled) return;
+
+    if (data.magicMcpTarget.type === 'server') {
+      let magicMcpServer = await db.magicMcpServer.findUnique({
+        where: { id: data.magicMcpTarget.magicMcpServerId },
+        select: {
+          oid: true,
+          instanceOid: true
+        }
+      });
+      if (!magicMcpServer) throw new QueueRetryError();
+
+      await consumerIntegrationService.materializeMagicMcpSessionOwnership({
+        consumerProfile,
+        magicMcpTarget: {
+          type: 'server',
+          target: magicMcpServer
+        },
+        magicMcpSession
+      });
+
+      await consumerIntegrationService.markMagicMcpResourcesConsumerReconciled({
+        magicMcpToken,
+        magicMcpServer,
+        magicMcpSession
+      });
+      return;
+    }
+
+    let magicMcpEndpoint = await db.magicMcpEndpoint.findUnique({
+      where: { id: data.magicMcpTarget.magicMcpEndpointId },
+      select: {
+        oid: true,
+        instanceOid: true,
+        consumerProfileOid: true,
+        servers: {
+          select: {
+            magicMcpServerOid: true,
+            magicMcpServer: {
+              select: {
+                oid: true,
+                instanceOid: true
+              }
+            }
+          }
+        }
+      }
+    });
+    if (!magicMcpEndpoint) throw new QueueRetryError();
+
+    await consumerIntegrationService.materializeMagicMcpSessionOwnership({
+      consumerProfile,
+      magicMcpTarget: {
+        type: 'endpoint',
+        target: magicMcpEndpoint
+      },
+      magicMcpSession
+    });
+
+    await consumerIntegrationService.markMagicMcpResourcesConsumerReconciled({
+      magicMcpToken,
+      magicMcpEndpoint,
+      magicMcpServers: magicMcpEndpoint.servers.map(server => server.magicMcpServer),
+      magicMcpSession
+    });
+  });

--- a/src/backend/modules/consumer/src/services/consumerEntities/consumerIntegration.ts
+++ b/src/backend/modules/consumer/src/services/consumerEntities/consumerIntegration.ts
@@ -344,67 +344,65 @@ class ConsumerIntegrationServiceImpl {
     magicMcpTarget: ConsumerOwnedMagicMcpTarget;
     magicMcpSession: Pick<MagicMcpSession, 'oid' | 'instanceOid'>;
   }) {
-    return await withTransaction(async () => {
-      if (d.magicMcpTarget.type === 'server') {
-        let consumerIntegration = await this.upsertConsumerIntegration({
-          consumerProfile: d.consumerProfile,
-          magicMcpServer: d.magicMcpTarget.target,
-          isManaged: true
-        });
+    if (d.magicMcpTarget.type === 'server') {
+      let consumerIntegration = await this.upsertConsumerIntegration({
+        consumerProfile: d.consumerProfile,
+        magicMcpServer: d.magicMcpTarget.target,
+        isManaged: true
+      });
 
-        let session = await this.upsertConsumerIntegrationSession({
+      let session = await this.upsertConsumerIntegrationSession({
+        consumerProfile: d.consumerProfile,
+        consumerIntegration,
+        magicMcpSession: d.magicMcpSession
+      });
+
+      return {
+        consumerIntegrationEndpoints: [],
+        consumerIntegrations: [consumerIntegration],
+        consumerIntegrationSessions: [session]
+      };
+    }
+
+    let consumerIntegrationEndpoint = await this.upsertConsumerIntegrationEndpoint({
+      consumerProfile: d.consumerProfile,
+      magicMcpEndpoint: d.magicMcpTarget.target,
+      isManaged: d.magicMcpTarget.target.consumerProfileOid !== d.consumerProfile.oid
+    });
+    let seenServerOids = new Set<bigint>();
+    let consumerIntegrations: ConsumerIntegrationWithRelations[] = [];
+
+    for (let server of d.magicMcpTarget.target.servers) {
+      if (seenServerOids.has(server.magicMcpServerOid)) {
+        continue;
+      }
+
+      seenServerOids.add(server.magicMcpServerOid);
+      consumerIntegrations.push(
+        await this.upsertConsumerIntegration({
+          consumerProfile: d.consumerProfile,
+          magicMcpServer: server.magicMcpServer,
+          isManaged: true
+        })
+      );
+    }
+
+    let consumerIntegrationSessions = [];
+    for (let consumerIntegration of consumerIntegrations) {
+      consumerIntegrationSessions.push(
+        await this.upsertConsumerIntegrationSession({
           consumerProfile: d.consumerProfile,
           consumerIntegration,
           magicMcpSession: d.magicMcpSession
-        });
+        })
+      );
+    }
 
-        return {
-          consumerIntegrationEndpoints: [],
-          consumerIntegrations: [consumerIntegration],
-          consumerIntegrationSessions: [session]
-        };
-      }
-
-      let consumerIntegrationEndpoint = await this.upsertConsumerIntegrationEndpoint({
-        consumerProfile: d.consumerProfile,
-        magicMcpEndpoint: d.magicMcpTarget.target,
-        isManaged: d.magicMcpTarget.target.consumerProfileOid !== d.consumerProfile.oid
-      });
-      let seenServerOids = new Set<bigint>();
-      let consumerIntegrations: ConsumerIntegrationWithRelations[] = [];
-
-      for (let server of d.magicMcpTarget.target.servers) {
-        if (seenServerOids.has(server.magicMcpServerOid)) {
-          continue;
-        }
-
-        seenServerOids.add(server.magicMcpServerOid);
-        consumerIntegrations.push(
-          await this.upsertConsumerIntegration({
-            consumerProfile: d.consumerProfile,
-            magicMcpServer: server.magicMcpServer,
-            isManaged: true
-          })
-        );
-      }
-
-      let consumerIntegrationSessions = [];
-      for (let consumerIntegration of consumerIntegrations) {
-        consumerIntegrationSessions.push(
-          await this.upsertConsumerIntegrationSession({
-            consumerProfile: d.consumerProfile,
-            consumerIntegration,
-            magicMcpSession: d.magicMcpSession
-          })
-        );
-      }
-
-      return {
-        consumerIntegrationEndpoints: [consumerIntegrationEndpoint],
-        consumerIntegrations,
-        consumerIntegrationSessions
-      };
-    });
+    return {
+      consumerIntegrationEndpoints: [consumerIntegrationEndpoint],
+      consumerIntegrations,
+      consumerIntegrationSessions
+    };
   }
 
   async markMagicMcpResourcesConsumerReconciled(d: {

--- a/src/backend/modules/consumer/src/services/consumerOAuth/routing.ts
+++ b/src/backend/modules/consumer/src/services/consumerOAuth/routing.ts
@@ -7,6 +7,12 @@ import { portalService } from '../portal';
 import { DashboardConsumerSurface } from './_types';
 
 class ConsumerOAuthRoutingService {
+  private portalBase(d: { portalId: string; magicMcpTargetId?: string }) {
+    return `${getConfig().urls.apiUrl}/connect/portal/${d.portalId}${
+      d.magicMcpTargetId ? `/${d.magicMcpTargetId}` : ''
+    }`;
+  }
+
   async resolvePortalRoute(d: { portalId: string; magicMcpTargetId?: string }) {
     let portal: Awaited<ReturnType<typeof portalService.getPortalPublic>> | null = null;
     let consumerSurface:
@@ -58,9 +64,65 @@ class ConsumerOAuthRoutingService {
       consumerSurface,
       instance,
       magicMcpTarget,
-      base: `${getConfig().urls.apiUrl}/connect/portal/${d.portalId}${
-        d.magicMcpTargetId ? `/${d.magicMcpTargetId}` : ''
-      }`
+      base: this.portalBase(d)
+    };
+  }
+
+  async resolvePortalMcpRoute(d: { portalId: string; magicMcpTargetId?: string }) {
+    let portal = await db.portal.findFirst({
+      where: {
+        status: 'active',
+        surface: {
+          status: 'active'
+        },
+        OR: [{ id: d.portalId }, { slug: d.portalId }]
+      },
+      include: {
+        instance: {
+          include: {
+            project: true,
+            organization: true
+          }
+        }
+      }
+    });
+
+    let consumerSurface = portal
+      ? null
+      : await db.consumerSurface.findFirst({
+          where: {
+            id: d.portalId,
+            status: 'active'
+          },
+          include: {
+            instance: {
+              include: {
+                project: true,
+                organization: true
+              }
+            }
+          }
+        });
+
+    if (!portal && !consumerSurface) {
+      throw new ServiceError(notFoundError('portal'));
+    }
+
+    let instance = portal?.instance ?? consumerSurface!.instance;
+    let magicMcpTarget = d.magicMcpTargetId
+      ? await resolveMagicMcpTargetByIdOrAlias(d.magicMcpTargetId)
+      : null;
+
+    if (magicMcpTarget && instance.oid != magicMcpTarget.target.instance.oid) {
+      throw new ServiceError(notFoundError('magic_mcp.target'));
+    }
+
+    return {
+      portal: null,
+      consumerSurface: null,
+      instance,
+      magicMcpTarget,
+      base: this.portalBase(d)
     };
   }
 

--- a/src/backend/modules/consumer/test/consumerIntegration.test.ts
+++ b/src/backend/modules/consumer/test/consumerIntegration.test.ts
@@ -50,7 +50,7 @@ vi.mock('@lowerdeck/service', () => ({
   }
 }));
 
-import { db } from '@metorial/db';
+import { db, withTransaction } from '@metorial/db';
 import { consumerIntegrationService } from '../src/services/consumerEntities/consumerIntegration';
 
 describe('consumerIntegrationService', () => {
@@ -150,6 +150,7 @@ describe('consumerIntegrationService', () => {
     );
     expect(db.consumerIntegrationSession.upsert).toHaveBeenCalledTimes(2);
     expect(result.consumerIntegrationSessions).toHaveLength(2);
+    expect(withTransaction).not.toHaveBeenCalled();
   });
 
   it('forces managed integrations back to owned when explicitly created by a consumer', async () => {

--- a/src/backend/modules/consumer/test/consumerOAuthRouting.test.ts
+++ b/src/backend/modules/consumer/test/consumerOAuthRouting.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: vi.fn((_: string, factory: () => unknown) => ({
+      build: () => factory()
+    }))
+  }
+}));
+
+vi.mock('@metorial/config', () => ({
+  getConfig: () => ({
+    urls: {
+      apiUrl: 'https://api.metorial.test'
+    }
+  })
+}));
+
+vi.mock('@metorial/db', () => ({
+  db: {
+    portal: {
+      findFirst: vi.fn()
+    },
+    consumerSurface: {
+      findFirst: vi.fn()
+    }
+  }
+}));
+
+vi.mock('@metorial/module-magic', () => ({
+  resolveMagicMcpTargetByIdOrAlias: vi.fn()
+}));
+
+vi.mock('../src/services/portal', () => ({
+  portalService: {
+    getPortalPublic: vi.fn()
+  }
+}));
+
+import { db } from '@metorial/db';
+import { resolveMagicMcpTargetByIdOrAlias } from '@metorial/module-magic';
+import { portalService } from '../src/services/portal';
+import { consumerOAuthRoutingService } from '../src/services/consumerOAuth/routing';
+
+describe('consumerOAuthRoutingService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves MCP portal routes without enriching the portal', async () => {
+    (db.portal.findFirst as any).mockResolvedValue({
+      instance: {
+        oid: 10n,
+        id: 'ins_1'
+      }
+    });
+    vi.mocked(resolveMagicMcpTargetByIdOrAlias).mockResolvedValue({
+      type: 'server',
+      target: {
+        oid: 20n,
+        instance: {
+          oid: 10n
+        }
+      }
+    } as any);
+
+    let route = await consumerOAuthRoutingService.resolvePortalMcpRoute({
+      portalId: 'portal_1',
+      magicMcpTargetId: 'target_1'
+    });
+
+    expect(portalService.getPortalPublic).not.toHaveBeenCalled();
+    expect(db.portal.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [{ id: 'portal_1' }, { slug: 'portal_1' }]
+        })
+      })
+    );
+    expect(route.portal).toBeNull();
+    expect(route.consumerSurface).toBeNull();
+    expect(route.instance.id).toBe('ins_1');
+    expect(route.magicMcpTarget?.target.oid).toBe(20n);
+  });
+});

--- a/src/backend/modules/consumer/test/materializeMagicMcpSessionOwnershipQueue.test.ts
+++ b/src/backend/modules/consumer/test/materializeMagicMcpSessionOwnershipQueue.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => {
+  let state: {
+    processHandler: ((data: any) => Promise<void>) | null;
+  } = {
+    processHandler: null
+  };
+  let queue = {
+    add: vi.fn(),
+    process: vi.fn((handler: (data: any) => Promise<void>) => {
+      state.processHandler = handler;
+      return {};
+    })
+  };
+
+  return { queue, state };
+});
+
+vi.mock('@metorial/queue', () => ({
+  createQueue: vi.fn(() => mocks.queue),
+  QueueRetryError: class QueueRetryError extends Error {}
+}));
+
+vi.mock('@metorial/db', () => ({
+  db: {
+    consumerProfile: {
+      findUnique: vi.fn()
+    },
+    magicMcpSession: {
+      findUnique: vi.fn()
+    },
+    magicMcpToken: {
+      findUnique: vi.fn()
+    },
+    magicMcpServer: {
+      findUnique: vi.fn()
+    },
+    magicMcpEndpoint: {
+      findUnique: vi.fn()
+    }
+  }
+}));
+
+vi.mock('../src/services', () => ({
+  consumerIntegrationService: {
+    materializeMagicMcpSessionOwnership: vi.fn(),
+    markMagicMcpResourcesConsumerReconciled: vi.fn()
+  }
+}));
+
+import { db } from '@metorial/db';
+import { consumerIntegrationService } from '../src/services';
+import { enqueueMaterializeMagicMcpSessionOwnership } from '../src/queues/materializeMagicMcpSessionOwnership';
+
+describe('materializeMagicMcpSessionOwnershipQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('dedupes enqueueing by consumer profile and session', async () => {
+    await enqueueMaterializeMagicMcpSessionOwnership({
+      consumerProfileOid: '30',
+      magicMcpSessionOid: '70',
+      magicMcpTarget: {
+        type: 'server',
+        magicMcpServerId: 'mms_1'
+      }
+    });
+
+    expect(mocks.queue.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        consumerProfileOid: '30',
+        magicMcpSessionOid: '70'
+      }),
+      { id: '30:70' }
+    );
+  });
+
+  it('does not materialize sessions that are already reconciled', async () => {
+    (db.consumerProfile.findUnique as any).mockResolvedValue({ oid: 30n });
+    (db.magicMcpSession.findUnique as any).mockResolvedValue({
+      oid: 70n,
+      isConsumerReconciled: true
+    });
+
+    await mocks.state.processHandler!({
+      consumerProfileOid: '30',
+      magicMcpSessionOid: '70',
+      magicMcpTarget: {
+        type: 'server',
+        magicMcpServerId: 'mms_1'
+      }
+    });
+
+    expect(
+      consumerIntegrationService.materializeMagicMcpSessionOwnership
+    ).not.toHaveBeenCalled();
+    expect(
+      consumerIntegrationService.markMagicMcpResourcesConsumerReconciled
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/src/backend/modules/magic/src/lib/ensureSession.ts
+++ b/src/backend/modules/magic/src/lib/ensureSession.ts
@@ -1,5 +1,5 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
-import { ID, Instance, withTransaction } from '@metorial/db';
+import { db, ID, Instance, MagicMcpSession, Prisma } from '@metorial/db';
 import {
   ensureMagicMcpEndpointBacking,
   ensureMagicMcpServerBacking,
@@ -122,6 +122,32 @@ export let ensureMagicMcpSubspaceSession = async (target: MagicMcpResolvedTarget
   return await ensureEndpointBackingSession(target);
 };
 
+let getLoadedMagicMcpSession = (target: MagicMcpResolvedTarget) => {
+  if (target.type === 'server') {
+    return target.target.subspaceSession ?? null;
+  }
+
+  let subspaceSession = target.target.subspaceSession;
+  if (Array.isArray(subspaceSession)) return subspaceSession[0] ?? null;
+
+  return subspaceSession ?? null;
+};
+
+let isCurrentMagicMcpSession = (
+  session: MagicMcpSession,
+  d: {
+    subspaceSessionId: string;
+    backingSessionId: string;
+  }
+) =>
+  session.subspaceSessionId === d.subspaceSessionId &&
+  session.subspaceSessionTemplateId === d.backingSessionId &&
+  session.isActive &&
+  session.expiresAt == null;
+
+let isUniqueConstraintError = (error: unknown) =>
+  error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002';
+
 export let syncMagicMcpSubspaceSession = async (
   target: MagicMcpResolvedTarget,
   subspaceSessionId: string,
@@ -132,37 +158,82 @@ export let syncMagicMcpSubspaceSession = async (
     subspaceSessionId,
     subspaceSessionTemplateId: backingSessionId,
     expiresAt: null,
-    isActive: true,
-    isConsumerReconciled: false
+    isActive: true
   };
 
-  return await withTransaction(async db => {
-    if (target.type === 'server') {
-      return await db.magicMcpSession.upsert({
-        where: {
+  let uniqueWhere =
+    target.type === 'server'
+      ? { magicMcpServerOid: target.target.oid }
+      : { magicMcpEndpointOid: target.target.oid };
+  let loadedSession = getLoadedMagicMcpSession(target);
+
+  if (
+    loadedSession &&
+    isCurrentMagicMcpSession(loadedSession, { subspaceSessionId, backingSessionId })
+  ) {
+    return loadedSession;
+  }
+
+  let existingSession =
+    loadedSession ??
+    (await db.magicMcpSession.findUnique({
+      where: uniqueWhere
+    }));
+
+  if (
+    existingSession &&
+    isCurrentMagicMcpSession(existingSession, { subspaceSessionId, backingSessionId })
+  ) {
+    return existingSession;
+  }
+
+  if (existingSession) {
+    return await db.magicMcpSession.update({
+      where: { oid: existingSession.oid },
+      data: {
+        ...baseData,
+        isConsumerReconciled: false
+      }
+    });
+  }
+
+  let createData =
+    target.type === 'server'
+      ? {
           magicMcpServerOid: target.target.oid
-        },
-        create: {
-          id: await ID.generateId('magicMcpServerSubspaceSession'),
-          magicMcpServerOid: target.target.oid,
-          ...baseData
-        },
-        update: baseData
-      });
+        }
+      : {
+          magicMcpEndpointOid: target.target.oid
+        };
+
+  try {
+    return await db.magicMcpSession.create({
+      data: {
+        id: await ID.generateId('magicMcpServerSubspaceSession'),
+        ...createData,
+        ...baseData,
+        isConsumerReconciled: false
+      }
+    });
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error;
+
+    let current = await db.magicMcpSession.findUniqueOrThrow({
+      where: uniqueWhere
+    });
+
+    if (isCurrentMagicMcpSession(current, { subspaceSessionId, backingSessionId })) {
+      return current;
     }
 
-    return await db.magicMcpSession.upsert({
-      where: {
-        magicMcpEndpointOid: target.target.oid
-      },
-      create: {
-        id: await ID.generateId('magicMcpServerSubspaceSession'),
-        magicMcpEndpointOid: target.target.oid,
-        ...baseData
-      },
-      update: baseData
+    return await db.magicMcpSession.update({
+      where: { oid: current.oid },
+      data: {
+        ...baseData,
+        isConsumerReconciled: false
+      }
     });
-  });
+  }
 };
 
 export type MagicMcpSubspaceMapping = Awaited<

--- a/src/backend/modules/magic/src/lib/magicMcpConnectHealth.ts
+++ b/src/backend/modules/magic/src/lib/magicMcpConnectHealth.ts
@@ -40,6 +40,23 @@ export let assertMagicMcpTargetLinkedResourcesActive = async (
     );
   }
 
+  if (target.target.servers?.length) {
+    let hasInactiveServer = target.target.servers.some(
+      server => server.magicMcpServer.status !== 'active'
+    );
+
+    if (hasInactiveServer) {
+      throw new ServiceError(
+        preconditionFailedError({
+          message:
+            'The magic MCP endpoint is linked to one or more magic MCP servers that are no longer active'
+        })
+      );
+    }
+
+    return;
+  }
+
   let inactiveEndpointServerCount = await db.magicMcpEndpointServer.count({
     where: {
       magicMcpEndpointOid: target.target.oid,

--- a/src/backend/modules/magic/src/services/magicMcpEndpoint.ts
+++ b/src/backend/modules/magic/src/services/magicMcpEndpoint.ts
@@ -269,31 +269,34 @@ class MagicMcpEndpointImpl {
     );
 
     try {
-      let magicMcpEndpoint = await withTransaction(async db => {
-        return await db.magicMcpEndpoint.create({
-          data: {
-            id: await ID.generateId('magicMcpEndpoint'),
-            status: 'active',
-            isConsumerReconciled: true,
-            isSubspaceBackingReconciling: true,
-            instanceOid: d.instance.oid,
-            consumerProfileOid: d.input.consumerProfile?.oid,
-            skillPluginOid: d.input.skillPlugin?.oid,
-            name: d.input.name,
-            description: d.input.description,
-            slug: buildSlug(d.input.name),
-            metadata: d.input.metadata ?? {},
-            servers: endpointServerRows.length
-              ? {
-                  createMany: {
-                    data: endpointServerRows
+      let magicMcpEndpoint = await withTransaction(
+        async db => {
+          return await db.magicMcpEndpoint.create({
+            data: {
+              id: await ID.generateId('magicMcpEndpoint'),
+              status: 'active',
+              isConsumerReconciled: true,
+              isSubspaceBackingReconciling: true,
+              instanceOid: d.instance.oid,
+              consumerProfileOid: d.input.consumerProfile?.oid,
+              skillPluginOid: d.input.skillPlugin?.oid,
+              name: d.input.name,
+              description: d.input.description,
+              slug: buildSlug(d.input.name),
+              metadata: d.input.metadata ?? {},
+              servers: endpointServerRows.length
+                ? {
+                    createMany: {
+                      data: endpointServerRows
+                    }
                   }
-                }
-              : undefined
-          },
-          include: magicMcpEndpointInclude
-        });
-      });
+                : undefined
+            },
+            include: magicMcpEndpointInclude
+          });
+        },
+        { ifExists: true }
+      );
 
       await magicMcpEndpointCreatedQueue.add({ magicMcpEndpointId: magicMcpEndpoint.id });
 
@@ -419,6 +422,22 @@ class MagicMcpEndpointImpl {
       );
     }
 
+    let existingEndpointServers = servers.length
+      ? await db.magicMcpEndpointServer.findMany({
+          where: {
+            magicMcpEndpointOid: d.endpoint.oid,
+            magicMcpServerOid: { in: servers.map(server => server.oid) }
+          },
+          select: {
+            magicMcpServerOid: true
+          }
+        })
+      : [];
+    let existingServerOids = new Set(
+      existingEndpointServers.map(server => server.magicMcpServerOid)
+    );
+    let hasNewServers = servers.some(server => !existingServerOids.has(server.oid));
+
     let magicMcpEndpoint = await withTransaction(async db => {
       if (servers.length) {
         await Promise.all(
@@ -446,6 +465,17 @@ class MagicMcpEndpointImpl {
             });
           })
         );
+      }
+
+      if (hasNewServers) {
+        await db.magicMcpSession.updateMany({
+          where: {
+            magicMcpEndpointOid: d.endpoint.oid
+          },
+          data: {
+            isConsumerReconciled: false
+          }
+        });
       }
 
       return await db.magicMcpEndpoint.update({
@@ -477,12 +507,23 @@ class MagicMcpEndpointImpl {
 
     let magicMcpEndpoint = await withTransaction(async db => {
       if (servers.length) {
-        await db.magicMcpEndpointServer.deleteMany({
+        let result = await db.magicMcpEndpointServer.deleteMany({
           where: {
             magicMcpEndpointOid: d.endpoint.oid,
             magicMcpServerOid: { in: servers.map(server => server.oid) }
           }
         });
+
+        if (result.count > 0) {
+          await db.magicMcpSession.updateMany({
+            where: {
+              magicMcpEndpointOid: d.endpoint.oid
+            },
+            data: {
+              isConsumerReconciled: false
+            }
+          });
+        }
       }
 
       return await db.magicMcpEndpoint.update({

--- a/src/backend/modules/magic/src/services/magicMcpServer.ts
+++ b/src/backend/modules/magic/src/services/magicMcpServer.ts
@@ -34,7 +34,7 @@ import {
   subspaceMagicMcpBackingService,
   subspaceSessionTemplateService
 } from '@metorial/module-subspace';
-import { type ConsumerOwner, ensureMagicMcpServerBacking } from '../lib/backing';
+import { ensureMagicMcpServerBacking, type ConsumerOwner } from '../lib/backing';
 import {
   magicMcpServerCreatedQueue,
   magicMcpServerDeletedQueue,
@@ -229,31 +229,34 @@ class MagicMcpServerImpl {
       instance: d.instance
     });
 
-    let magicMcpServer = await withTransaction(async db => {
-      return await db.magicMcpServer.create({
-        data: {
-          id: await ID.generateId('magicMcpServer'),
-          status: 'active',
-          source: d.input.source ?? 'manual',
-          isConsumerReconciled: true,
-          isSubspaceBackingReconciling: true,
-          providerTemplateId: d.input.providerTemplateId,
-          subspaceIntegrationInstanceId: d.input.subspaceIntegrationInstanceId,
-          name: d.input.name,
-          description: d.input.description,
-          metadata: d.input.metadata ?? {},
-          instanceOid: d.instance.oid,
-          aliases: {
-            create: {
-              slug: buildAlias(d.input.name)
+    let magicMcpServer = await withTransaction(
+      async db => {
+        return await db.magicMcpServer.create({
+          data: {
+            id: await ID.generateId('magicMcpServer'),
+            status: 'active',
+            source: d.input.source ?? 'manual',
+            isConsumerReconciled: true,
+            isSubspaceBackingReconciling: true,
+            providerTemplateId: d.input.providerTemplateId,
+            subspaceIntegrationInstanceId: d.input.subspaceIntegrationInstanceId,
+            name: d.input.name,
+            description: d.input.description,
+            metadata: d.input.metadata ?? {},
+            instanceOid: d.instance.oid,
+            aliases: {
+              create: {
+                slug: buildAlias(d.input.name)
+              }
             }
+          },
+          include: {
+            instance: true
           }
-        },
-        include: {
-          instance: true
-        }
-      });
-    });
+        });
+      },
+      { ifExists: true }
+    );
 
     await magicMcpServerCreatedQueue.add({
       magicMcpServerId: magicMcpServer.id,
@@ -331,11 +334,33 @@ class MagicMcpServerImpl {
     }
 
     let magicMcpServer = await withTransaction(async db => {
+      let endpointLinks = await db.magicMcpEndpointServer.findMany({
+        where: {
+          magicMcpServerOid: d.server.oid
+        },
+        select: {
+          magicMcpEndpointOid: true
+        }
+      });
+
       await db.magicMcpEndpointServer.deleteMany({
         where: {
           magicMcpServerOid: d.server.oid
         }
       });
+
+      if (endpointLinks.length) {
+        await db.magicMcpSession.updateMany({
+          where: {
+            magicMcpEndpointOid: {
+              in: endpointLinks.map(link => link.magicMcpEndpointOid)
+            }
+          },
+          data: {
+            isConsumerReconciled: false
+          }
+        });
+      }
 
       return await db.magicMcpServer.update({
         where: { id: d.server.id },

--- a/src/backend/modules/magic/src/services/magicMcpToken.ts
+++ b/src/backend/modules/magic/src/services/magicMcpToken.ts
@@ -789,13 +789,18 @@ class MagicMcpTokenImpl {
     token: Pick<
       MagicMcpToken,
       'oid' | 'magicMcpServerOid' | 'magicMcpEndpointOid' | 'isGroupLocked'
-    >;
+    > & {
+      magicMcpServer?: Pick<MagicMcpServer, 'status'> | null;
+      magicMcpEndpoint?: Pick<MagicMcpEndpoint, 'oid' | 'status'> | null;
+    };
   }) {
     if (d.token.magicMcpServerOid) {
-      let magicMcpServer = await db.magicMcpServer.findUnique({
-        where: { oid: d.token.magicMcpServerOid },
-        select: { status: true }
-      });
+      let magicMcpServer =
+        d.token.magicMcpServer ??
+        (await db.magicMcpServer.findUnique({
+          where: { oid: d.token.magicMcpServerOid },
+          select: { status: true }
+        }));
 
       if (!magicMcpServer || magicMcpServer.status !== 'active') {
         return getInactiveLinkedResourceMessage('server');
@@ -803,13 +808,15 @@ class MagicMcpTokenImpl {
     }
 
     if (d.token.magicMcpEndpointOid) {
-      let magicMcpEndpoint = await db.magicMcpEndpoint.findUnique({
-        where: { oid: d.token.magicMcpEndpointOid },
-        select: {
-          oid: true,
-          status: true
-        }
-      });
+      let magicMcpEndpoint =
+        d.token.magicMcpEndpoint ??
+        (await db.magicMcpEndpoint.findUnique({
+          where: { oid: d.token.magicMcpEndpointOid },
+          select: {
+            oid: true,
+            status: true
+          }
+        }));
 
       if (!magicMcpEndpoint || magicMcpEndpoint.status !== 'active') {
         return getInactiveLinkedResourceMessage('endpoint');

--- a/src/backend/modules/magic/test/ensureSession.test.ts
+++ b/src/backend/modules/magic/test/ensureSession.test.ts
@@ -12,13 +12,33 @@ vi.mock('../src/lib/magicMcpConnectHealth', () => ({
   assertMagicMcpTargetReadyForConnect: vi.fn()
 }));
 
-vi.mock('@metorial/db', () => ({
-  db: {},
-  ID: {
-    generateId: vi.fn()
-  },
-  withTransaction: vi.fn()
-}));
+vi.mock('@metorial/db', () => {
+  let db = {
+    magicMcpSession: {
+      findUnique: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn()
+    }
+  };
+
+  return {
+    db,
+    ID: {
+      generateId: vi.fn(async prefix => `${prefix}-id`)
+    },
+    Prisma: {
+      PrismaClientKnownRequestError: class PrismaClientKnownRequestError extends Error {
+        code: string;
+
+        constructor(message: string, code: string) {
+          super(message);
+          this.code = code;
+        }
+      }
+    }
+  };
+});
 
 import {
   ensureMagicMcpEndpointBacking,
@@ -28,7 +48,11 @@ import {
   assertMagicMcpTargetLinkedResourcesActive,
   assertMagicMcpTargetReadyForConnect
 } from '../src/lib/magicMcpConnectHealth';
-import { ensureMagicMcpSubspaceSession } from '../src/lib/ensureSession';
+import { db } from '@metorial/db';
+import {
+  ensureMagicMcpSubspaceSession,
+  syncMagicMcpSubspaceSession
+} from '../src/lib/ensureSession';
 
 describe('ensureMagicMcpSubspaceSession', () => {
   beforeEach(() => {
@@ -97,5 +121,76 @@ describe('ensureMagicMcpSubspaceSession', () => {
     });
     expect(assertMagicMcpTargetReadyForConnect).toHaveBeenCalled();
     expect(result).toBe('ems_endpoint');
+  });
+
+  it('does not write when the loaded magic MCP session mapping is current', async () => {
+    let subspaceSession = {
+      oid: 1n,
+      id: 'mms_1',
+      instanceOid: 10n,
+      subspaceSessionId: 'sess_1',
+      subspaceSessionTemplateId: 'template_1',
+      isActive: true,
+      expiresAt: null,
+      isConsumerReconciled: true
+    } as any;
+
+    let result = await syncMagicMcpSubspaceSession(
+      {
+        type: 'server',
+        target: {
+          oid: 20n,
+          instance: { oid: 10n },
+          subspaceSession
+        }
+      } as any,
+      'sess_1',
+      'template_1'
+    );
+
+    expect(result).toBe(subspaceSession);
+    expect(db.magicMcpSession.findUnique).not.toHaveBeenCalled();
+    expect(db.magicMcpSession.create).not.toHaveBeenCalled();
+    expect(db.magicMcpSession.update).not.toHaveBeenCalled();
+  });
+
+  it('clears reconciliation only when the session mapping changes', async () => {
+    (db.magicMcpSession.update as any).mockResolvedValue({
+      oid: 1n,
+      subspaceSessionId: 'sess_2',
+      subspaceSessionTemplateId: 'template_1',
+      isConsumerReconciled: false
+    });
+
+    await syncMagicMcpSubspaceSession(
+      {
+        type: 'endpoint',
+        target: {
+          oid: 20n,
+          instance: { oid: 10n },
+          subspaceSession: [
+            {
+              oid: 1n,
+              subspaceSessionId: 'sess_1',
+              subspaceSessionTemplateId: 'template_1',
+              isActive: true,
+              expiresAt: null,
+              isConsumerReconciled: true
+            }
+          ]
+        }
+      } as any,
+      'sess_2',
+      'template_1'
+    );
+
+    expect(db.magicMcpSession.update).toHaveBeenCalledWith({
+      where: { oid: 1n },
+      data: expect.objectContaining({
+        subspaceSessionId: 'sess_2',
+        subspaceSessionTemplateId: 'template_1',
+        isConsumerReconciled: false
+      })
+    });
   });
 });

--- a/src/backend/modules/magic/test/magicMcpConnectHealth.test.ts
+++ b/src/backend/modules/magic/test/magicMcpConnectHealth.test.ts
@@ -43,6 +43,25 @@ describe('magicMcpConnectHealth', () => {
     ).rejects.toThrow('no longer active');
   });
 
+  it('uses loaded endpoint server statuses without counting again', async () => {
+    await assertMagicMcpTargetLinkedResourcesActive({
+      type: 'endpoint',
+      target: {
+        oid: 10n,
+        status: 'active',
+        servers: [
+          {
+            magicMcpServer: {
+              status: 'active'
+            }
+          }
+        ]
+      }
+    } as any);
+
+    expect(magicMcpEndpointServerCount).not.toHaveBeenCalled();
+  });
+
   it('rejects servers without active subspace providers', async () => {
     listServerProviders.mockResolvedValue({
       items: []


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the live portal MCP connect and consumer-ownership flow (routing, token targeting, async queue vs inline DB work) but adds deduplication, reconciliation guards, and tests around session sync and routing.
> 
> **Overview**
> This PR tightens the **magic MCP connection path** and moves **consumer session ownership** off the hot request path.
> 
> **Portal MCP routing** now resolves connect traffic through a lighter `resolvePortalMcpRoute` (instance + target only) while OAuth metadata still uses the enriched portal route. Connect handlers can pass a **pre-resolved `magicMcpTarget`** so portal connects avoid a second target lookup, and token routing only overrides the route target when the token is **not** already linked to the resolved target.
> 
> **Request-path behavior**: magic token **use recording** is fire-and-forget with Sentry on failure. After subspace session sync, **consumer integration materialization** is **enqueued** (deduped by consumer profile + session) instead of awaited inline, and is skipped when `magicMcpSession.isConsumerReconciled` is already true.
> 
> **Session sync** (`syncMagicMcpSubspaceSession`) no longer uses a transactional upsert: it returns early when the loaded mapping is current, handles create races via unique constraint, and sets `isConsumerReconciled: false` only when the subspace mapping actually changes. Endpoint/server link changes and server archive similarly **invalidate** consumer reconciliation on affected endpoint sessions.
> 
> **Connect health** can validate endpoint-linked server activity from **already-loaded** relations instead of extra DB counts; token linked-resource checks can reuse included server/endpoint rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6e467a371f3a06603f8f94a1fc92bb194bb382a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->