### PR TITLE
Harden cleanup jobs

### DIFF
--- a/src/systems/slates/apps/hub/src/queues/attachment/cleanup.ts
+++ b/src/systems/slates/apps/hub/src/queues/attachment/cleanup.ts
@@ -75,25 +75,26 @@ export let slateAttachmentCleanupSingleQueueProcessor =
     if (attachment && attachment.expiresAt >= now) return;
 
     if (attachment) {
-      await db.$transaction(async tx => {
-        let current = await tx.slateAttachment.findUnique({
-          where: {
-            oid: attachment.oid
-          }
-        });
-        if (!current || current.expiresAt >= now) return;
+      let current = await db.slateAttachment.findUnique({
+        where: {
+          oid: attachment.oid
+        }
+      });
 
-        await tx.slateInvocationAttachment.deleteMany({
+      if (current && current.expiresAt < now) {
+        await db.slateInvocationAttachment.deleteMany({
           where: {
             attachmentsOid: current.oid
           }
         });
-        await tx.slateAttachment.delete({
+
+        await db.slateAttachment.deleteMany({
           where: {
-            oid: current.oid
+            oid: current.oid,
+            expiresAt: { lt: now }
           }
         });
-      });
+      }
     }
 
     let isDigestStillTracked = await db.slateAttachment.findFirst({

--- a/src/systems/subspace/modules/callback/src/queues/delete/callback.ts
+++ b/src/systems/subspace/modules/callback/src/queues/delete/callback.ts
@@ -1,6 +1,6 @@
 import { createCron } from '@lowerdeck/cron';
 import { createQueue } from '@lowerdeck/queue';
-import { db, withTransaction } from '@metorial-subspace/db';
+import { db } from '@metorial-subspace/db';
 import { env } from '../../env';
 import { getCutoffDate } from './_config';
 
@@ -58,29 +58,27 @@ export let callbackDeleteQueueProcessor = callbackDeleteQueue.process(async data
   });
   if (!callback || callback.status !== 'archived') return;
 
-  await withTransaction(async db => {
-    await db.callbackInstance.updateMany({
-      where: { callbackOid: callback.oid },
-      data: { isParentDeleted: true }
-    });
+  await db.callbackInstance.updateMany({
+    where: { callbackOid: callback.oid },
+    data: { isParentDeleted: true }
+  });
 
-    await db.callbackProviderTrigger.deleteMany({
-      where: { callbackOid: callback.oid }
-    });
+  await db.callbackProviderTrigger.deleteMany({
+    where: { callbackOid: callback.oid }
+  });
 
-    await db.callbackDestinationLink.deleteMany({
-      where: { callbackOid: callback.oid }
-    });
+  await db.callbackDestinationLink.deleteMany({
+    where: { callbackOid: callback.oid }
+  });
 
-    await db.callback.updateMany({
-      where: { oid: callback.oid },
-      data: {
-        status: 'deleted',
-        name: '[deleted]',
-        description: null,
-        metadata: {},
-        pollIntervalSecondsOverride: null
-      }
-    });
+  await db.callback.updateMany({
+    where: { oid: callback.oid },
+    data: {
+      status: 'deleted',
+      name: '[deleted]',
+      description: null,
+      metadata: {},
+      pollIntervalSecondsOverride: null
+    }
   });
 });

--- a/src/systems/subspace/modules/tenant/src/queues/retention/cleanup.ts
+++ b/src/systems/subspace/modules/tenant/src/queues/retention/cleanup.ts
@@ -1,7 +1,7 @@
 import { createCron } from '@lowerdeck/cron';
 import { createQueue } from '@lowerdeck/queue';
 import { sessionMessageBucketRecord, storage } from '@metorial-subspace/connection-utils';
-import { db, withTransaction } from '@metorial-subspace/db';
+import { db } from '@metorial-subspace/db';
 import { env } from '../../env';
 import { getConnectionRetentionWhere } from '@metorial-subspace/list-utils';
 import {
@@ -218,75 +218,73 @@ let cleanupProviderRuns = async (d: { tenantOid: bigint; cutoffDate: Date }) => 
     deleteMany: async records => {
       let providerRunOids = records.map(record => record.oid);
 
-      await withTransaction(async tx => {
-        let slateSessions = await tx.slateSession.findMany({
-          where: { providerRunOid: { in: providerRunOids } },
+      let slateSessions = await db.slateSession.findMany({
+        where: { providerRunOid: { in: providerRunOids } },
+        select: { oid: true }
+      });
+      let slateSessionOids = slateSessions.map(session => session.oid);
+
+      if (slateSessionOids.length > 0) {
+        let slateToolCalls = await db.slateToolCall.findMany({
+          where: { sessionOid: { in: slateSessionOids } },
           select: { oid: true }
         });
-        let slateSessionOids = slateSessions.map(session => session.oid);
+        let slateToolCallOids = slateToolCalls.map(toolCall => toolCall.oid);
 
-        if (slateSessionOids.length > 0) {
-          let slateToolCalls = await tx.slateToolCall.findMany({
-            where: { sessionOid: { in: slateSessionOids } },
-            select: { oid: true }
+        if (slateToolCallOids.length > 0) {
+          await db.sessionMessage.updateMany({
+            where: { slateToolCallOid: { in: slateToolCallOids } },
+            data: { slateToolCallOid: null }
           });
-          let slateToolCallOids = slateToolCalls.map(toolCall => toolCall.oid);
 
-          if (slateToolCallOids.length > 0) {
-            await tx.sessionMessage.updateMany({
-              where: { slateToolCallOid: { in: slateToolCallOids } },
-              data: { slateToolCallOid: null }
-            });
-
-            await tx.slateToolCall.deleteMany({
-              where: { oid: { in: slateToolCallOids } }
-            });
-          }
-
-          await tx.slateSession.deleteMany({
-            where: { oid: { in: slateSessionOids } }
+          await db.slateToolCall.deleteMany({
+            where: { oid: { in: slateToolCallOids } }
           });
         }
 
-        await tx.shuttleConnection.deleteMany({
-          where: { providerRunOid: { in: providerRunOids } }
+        await db.slateSession.deleteMany({
+          where: { oid: { in: slateSessionOids } }
         });
+      }
 
-        await tx.providerRunUsageRecord.deleteMany({
-          where: { providerRunOid: { in: providerRunOids } }
-        });
+      await db.shuttleConnection.deleteMany({
+        where: { providerRunOid: { in: providerRunOids } }
+      });
 
-        await Promise.all([
-          tx.sessionEvent.updateMany({
-            where: { providerRunOid: { in: providerRunOids } },
-            data: {
-              providerRunOid: null,
-              isParentDeleted: true
-            }
-          }),
-          tx.sessionMessage.updateMany({
-            where: { providerRunOid: { in: providerRunOids } },
-            data: {
-              providerRunOid: null,
-              isParentDeleted: true
-            }
-          }),
-          tx.sessionError.updateMany({
-            where: { providerRunOid: { in: providerRunOids } },
-            data: {
-              providerRunOid: null,
-              isParentDeleted: true
-            }
-          }),
-          tx.toolCall.updateMany({
-            where: { providerRunOid: { in: providerRunOids } },
-            data: { providerRunOid: null }
-          })
-        ]);
+      await db.providerRunUsageRecord.deleteMany({
+        where: { providerRunOid: { in: providerRunOids } }
+      });
 
-        await tx.providerRun.deleteMany({
-          where: { oid: { in: providerRunOids } }
-        });
+      await Promise.all([
+        db.sessionEvent.updateMany({
+          where: { providerRunOid: { in: providerRunOids } },
+          data: {
+            providerRunOid: null,
+            isParentDeleted: true
+          }
+        }),
+        db.sessionMessage.updateMany({
+          where: { providerRunOid: { in: providerRunOids } },
+          data: {
+            providerRunOid: null,
+            isParentDeleted: true
+          }
+        }),
+        db.sessionError.updateMany({
+          where: { providerRunOid: { in: providerRunOids } },
+          data: {
+            providerRunOid: null,
+            isParentDeleted: true
+          }
+        }),
+        db.toolCall.updateMany({
+          where: { providerRunOid: { in: providerRunOids } },
+          data: { providerRunOid: null }
+        })
+      ]);
+
+      await db.providerRun.deleteMany({
+        where: { oid: { in: providerRunOids } }
       });
     }
   });
@@ -330,53 +328,51 @@ let cleanupSessionConnections = async (d: { tenantOid: bigint; cutoffDate: Date 
     deleteMany: async records => {
       let connectionOids = records.map(record => record.oid);
 
-      await withTransaction(async tx => {
-        await Promise.all([
-          tx.sessionEvent.updateMany({
-            where: { connectionOid: { in: connectionOids } },
-            data: {
-              connectionOid: null,
-              isParentDeleted: true
-            }
-          }),
-          tx.sessionMessage.updateMany({
-            where: { connectionOid: { in: connectionOids } },
-            data: {
-              connectionOid: null,
-              isParentDeleted: true
-            }
-          }),
-          tx.sessionError.updateMany({
-            where: { connectionOid: { in: connectionOids } },
-            data: {
-              connectionOid: null,
-              isParentDeleted: true
-            }
-          }),
-          tx.sessionWarning.updateMany({
-            where: { connectionOid: { in: connectionOids } },
-            data: {
-              connectionOid: null,
-              isParentDeleted: true
-            }
-          }),
-          tx.protoGuardRun.updateMany({
-            where: { connectionOid: { in: connectionOids } },
-            data: {
-              connectionOid: null
-            }
-          }),
-          tx.protoGuardAlert.updateMany({
-            where: { connectionOid: { in: connectionOids } },
-            data: {
-              connectionOid: null
-            }
-          })
-        ]);
+      await Promise.all([
+        db.sessionEvent.updateMany({
+          where: { connectionOid: { in: connectionOids } },
+          data: {
+            connectionOid: null,
+            isParentDeleted: true
+          }
+        }),
+        db.sessionMessage.updateMany({
+          where: { connectionOid: { in: connectionOids } },
+          data: {
+            connectionOid: null,
+            isParentDeleted: true
+          }
+        }),
+        db.sessionError.updateMany({
+          where: { connectionOid: { in: connectionOids } },
+          data: {
+            connectionOid: null,
+            isParentDeleted: true
+          }
+        }),
+        db.sessionWarning.updateMany({
+          where: { connectionOid: { in: connectionOids } },
+          data: {
+            connectionOid: null,
+            isParentDeleted: true
+          }
+        }),
+        db.protoGuardRun.updateMany({
+          where: { connectionOid: { in: connectionOids } },
+          data: {
+            connectionOid: null
+          }
+        }),
+        db.protoGuardAlert.updateMany({
+          where: { connectionOid: { in: connectionOids } },
+          data: {
+            connectionOid: null
+          }
+        })
+      ]);
 
-        await tx.sessionConnection.deleteMany({
-          where: { oid: { in: connectionOids } }
-        });
+      await db.sessionConnection.deleteMany({
+        where: { oid: { in: connectionOids } }
       });
     }
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> These paths perform irreversible multi-table deletes without atomic rollback; partial failure or races could leave orphaned rows or skip deletes until a retry, though guards like expiry checks reduce mistaken attachment deletion.
> 
> **Overview**
> Cleanup workers in **slates attachment**, **callback delete**, and **tenant retention** no longer wrap their DB work in `withTransaction` / `$transaction`. Deletes and updates run as separate statements on the default `db` client instead of holding one long transaction across batched cascades.
> 
> **Slate attachment cleanup** re-checks the row by `oid` outside a transaction and only removes invocation links and attachment rows when `expiresAt` is still in the past. Attachment removal uses `deleteMany` with `oid` plus `expiresAt: { lt: now }` instead of a single `delete`, so a concurrent refresh of the same logical attachment is less likely to be wiped.
> 
> **Callback archived delete** and **tenant retention** (`cleanupProviderRuns`, `cleanupSessionConnections`) keep the same cascade order but without transactional wrapping, matching the goal of shorter locks and simpler failure behavior on background jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0de580093052f201dc1885206f5792559ff64aaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->