### PR TITLE
Add better errors and graceful degradation for mcp connections

### DIFF
--- a/src/systems/subspace/apps/controller/src/connection/api/metorialIntegrationProtocol.ts
+++ b/src/systems/subspace/apps/controller/src/connection/api/metorialIntegrationProtocol.ts
@@ -82,7 +82,9 @@ export let metorialIntegrationProtocolRouter = createHono()
       throw new ServiceError(
         preconditionFailedError({
           message:
-            'Tool discovery failed for this connection. Please ensure that the provider supports tool discovery and that the connection is properly configured.'
+            toolRes.mcpError?.message ??
+            'Tool discovery failed for this connection. Please ensure that the provider supports tool discovery and that the connection is properly configured.',
+          _mcpError: toolRes.mcpError
         })
       );
     }

--- a/src/systems/subspace/modules/connection/src/index.ts
+++ b/src/systems/subspace/modules/connection/src/index.ts
@@ -1,5 +1,7 @@
 export * from './controller';
 export * from './health';
+export * from './lib/connectionFailedTool';
+export * from './lib/syntheticTool';
 export * from './mcp';
 export * from './presenter';
 export * from './sender';

--- a/src/systems/subspace/modules/connection/src/lib/connectionFailedTool.ts
+++ b/src/systems/subspace/modules/connection/src/lib/connectionFailedTool.ts
@@ -1,0 +1,83 @@
+import type { SessionProvider } from '@metorial-subspace/db';
+import { applySessionProviderNameTemplate } from '@metorial-subspace/module-session';
+import { buildSyntheticTool } from './syntheticTool';
+
+export let CONNECTION_FAILED_TOOL_KEY = 'connection_failed';
+
+export type ConnectionFailedProvider = SessionProvider & { provider: { name: string } };
+
+export let buildConnectionFailedDetail = (d: {
+  provider: ConnectionFailedProvider;
+  discoveryError: PrismaJson.ProviderDeploymentConfigPairDiscoveryError | null | undefined;
+}) => {
+  let { provider, discoveryError } = d;
+  let providerName = provider.provider.name;
+
+  let shortReason: string;
+  let detailLines: string[] = [];
+
+  if (!discoveryError) {
+    shortReason = 'its capabilities could not be discovered';
+    detailLines.push(
+      'Metorial could not discover the capabilities of this provider, and the provider backend did not report any additional error detail.'
+    );
+  } else if (discoveryError.type === 'timeout_error') {
+    shortReason = 'the connection timed out';
+    detailLines.push(
+      `The connection timed out${discoveryError.message ? `: ${discoveryError.message}` : '.'}`
+    );
+    detailLines.push(
+      'A timeout usually means the MCP server did not respond in time, is unreachable, or is taking too long to start up.'
+    );
+  } else if (discoveryError.type === 'connection_error') {
+    shortReason = `the connection could not be established (${discoveryError.error.code})`;
+    detailLines.push(
+      `Metorial could not establish a connection to the provider (code: ${
+        discoveryError.error.code
+      }${discoveryError.error.message ? `, ${discoveryError.error.message}` : ''}).`
+    );
+    detailLines.push(
+      'This usually means the MCP server is unreachable, the connection URL or command is misconfigured, or the provided credentials are invalid.'
+    );
+  } else {
+    shortReason = `the provider returned an error (${discoveryError.error.code})`;
+    detailLines.push(
+      `The provider returned an MCP error during discovery (code: ${
+        discoveryError.error.code
+      }): ${discoveryError.error.message}.`
+    );
+  }
+
+  let shortMessage = `Could not connect to the MCP server "${providerName}" because ${shortReason}.`;
+
+  let longMessage = [
+    `Metorial attempted to discover and connect to the MCP server "${providerName}", but the connection could not be established, so its tools are currently unavailable.`,
+    ...detailLines,
+    "Other providers and tools in this session are unaffected and can still be used. To recover, the provider's deployment, connection URL/command, and authentication configuration should be checked, then the connection retried later."
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+
+  return {
+    shortMessage,
+    longMessage,
+    data: {
+      provider_id: provider.id,
+      provider_name: providerName,
+      discovery_error: discoveryError ?? null
+    }
+  };
+};
+
+export let buildConnectionFailedTool = (
+  provider: ConnectionFailedProvider,
+  detail: ReturnType<typeof buildConnectionFailedDetail>
+) =>
+  buildSyntheticTool({
+    sessionProvider: provider,
+    idSuffix: CONNECTION_FAILED_TOOL_KEY,
+    key: applySessionProviderNameTemplate(provider.nameTemplate!, CONNECTION_FAILED_TOOL_KEY),
+    name: `${provider.provider.name} connection failed`,
+    description: detail.longMessage,
+    metadata: { metorialConnectionFailed: true }
+  });

--- a/src/systems/subspace/modules/connection/src/lib/syntheticTool.ts
+++ b/src/systems/subspace/modules/connection/src/lib/syntheticTool.ts
@@ -1,0 +1,90 @@
+import type {
+  ProviderTool,
+  SessionProvider,
+  SessionProviderInstance
+} from '@metorial-subspace/db';
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+
+export interface SyntheticToolInput<P extends SessionProvider> {
+  sessionProvider: P;
+  idSuffix: string;
+  key: string;
+  name: string;
+  title?: string;
+  description: string;
+  inputJsonSchema?: Record<string, any>;
+  outputJsonSchema?: Record<string, any>;
+  annotations?: ToolAnnotations;
+  tags?: { readOnly?: boolean; destructive?: boolean };
+  metadata?: Record<string, any>;
+}
+
+export type SyntheticProviderTool<P extends SessionProvider = SessionProvider> =
+  ProviderTool & {
+    key: string;
+    sessionProvider: P;
+    sessionProviderInstance: SessionProviderInstance;
+    __metorialSynthetic: true;
+  };
+
+export let buildSyntheticTool = <P extends SessionProvider>(
+  input: SyntheticToolInput<P>
+): SyntheticProviderTool<P> => {
+  let title = input.title ?? input.name;
+  let now = new Date();
+
+  let placeholderId = `metorial_synthetic_${input.idSuffix}`;
+
+  let value: PrismaJson.ProviderToolValue = {
+    specId: placeholderId,
+    callableId: placeholderId,
+    key: input.key,
+    name: input.name,
+    title,
+    description: input.description,
+    inputJsonSchema: input.inputJsonSchema ?? {
+      type: 'object',
+      properties: {},
+      additionalProperties: false
+    },
+    outputJsonSchema: input.outputJsonSchema,
+    constraints: [],
+    instructions: [],
+    mcpToolType: {
+      type: 'mcp.tool',
+      key: input.key,
+      title,
+      icons: undefined,
+      annotations: input.annotations ?? { readOnlyHint: true, destructiveHint: false },
+      execution: undefined,
+      _meta: undefined
+    },
+    capabilities: {},
+    tags: input.tags ?? { readOnly: true, destructive: false },
+    metadata: input.metadata ?? {}
+  };
+
+  return {
+    oid: 0n,
+    id: `${input.sessionProvider.id}:${input.idSuffix}`,
+    specId: value.specId,
+    specUniqueIdentifier: value.specId,
+    callableId: value.callableId,
+    key: input.key,
+    name: input.name,
+    description: input.description,
+    value,
+    hash: `${placeholderId}_${input.sessionProvider.id}`,
+    providerOid: 0n,
+    specificationOid: 0n,
+    globalOid: 0n,
+    createdAt: now,
+    updatedAt: now,
+    sessionProvider: input.sessionProvider,
+    sessionProviderInstance: null as any,
+    __metorialSynthetic: true as const
+  };
+};
+
+export let isSyntheticTool = (tool: unknown): boolean =>
+  !!tool && (tool as any).__metorialSynthetic === true;

--- a/src/systems/subspace/modules/connection/src/sender/manager.ts
+++ b/src/systems/subspace/modules/connection/src/sender/manager.ts
@@ -37,8 +37,8 @@ import {
 } from '@metorial-subspace/module-agent';
 import { enclaveIngressPolicyService } from '@metorial-subspace/module-enclave';
 import {
-  checkToolAuthMethodSatisfied,
   checkToolAccess,
+  checkToolAuthMethodSatisfied,
   checkToolScopesSatisfied,
   providerDeploymentConfigPairInternalService,
   providerDeploymentInternalService,
@@ -58,6 +58,13 @@ import {
 } from '../const';
 import { env } from '../env';
 import { conduit } from '../lib/conduit';
+import {
+  buildConnectionFailedDetail,
+  buildConnectionFailedTool,
+  CONNECTION_FAILED_TOOL_KEY,
+  type ConnectionFailedProvider
+} from '../lib/connectionFailedTool';
+import { isSyntheticTool } from '../lib/syntheticTool';
 import { topics } from '../lib/topic';
 import { completeMessage } from '../shared/completeMessage';
 import { createError } from '../shared/createError';
@@ -105,18 +112,20 @@ export interface SenderMangerProps {
   tenantId: string;
   connectionToken?: string;
   transport: SessionConnectionTransport;
-  agentClient?: {
-    name: string;
-    type: 'mcp_client_oauth';
-    privateMetadata?: Record<string, any>;
-    foreignId: string;
-    oauthRegistrationId: string;
-  } | {
-    name: string;
-    type: 'system_client';
-    privateMetadata?: Record<string, any>;
-    foreignId: string;
-  };
+  agentClient?:
+    | {
+        name: string;
+        type: 'mcp_client_oauth';
+        privateMetadata?: Record<string, any>;
+        foreignId: string;
+        oauthRegistrationId: string;
+      }
+    | {
+        name: string;
+        type: 'system_client';
+        privateMetadata?: Record<string, any>;
+        foreignId: string;
+      };
   connectionPrivateMetadata?: Record<string, any>;
   ingressPolicyCheck?: {
     sourceIp: string;
@@ -516,14 +525,21 @@ export class SenderManager {
               }
         });
 
+        let detail = buildConnectionFailedDetail({
+          provider: fullProvider,
+          discoveryError: rec?.error
+        });
+
         return {
           status: 'discovery_failed' as const,
+          discoveryError: rec?.error ?? null,
+          detail,
           mcpError:
             rec?.error?.type == 'mcp_error'
-              ? rec.error.error
+              ? { ...rec.error.error, message: detail.shortMessage }
               : {
                   code: -32603,
-                  message: 'Failed to discover provider specification'
+                  message: detail.shortMessage
                 }
         };
       }
@@ -565,7 +581,7 @@ export class SenderManager {
       };
     }
 
-    if (res.status === 'discovery_failed') return res;
+    if (res.status === 'discovery_failed') return { ...res, provider };
 
     let specificationOid = await resolveProviderToolListingSpecificationOid({
       pairVersion: res.instance.pairVersion
@@ -625,23 +641,37 @@ export class SenderManager {
       providers.map(provider => this.listToolsForProvider(provider))
     );
 
-    for (let res of discoveryRes) {
-      if (res.status === 'discovery_failed') {
+    let failedRes = discoveryRes.filter(
+      (res): res is Extract<typeof res, { status: 'discovery_failed' }> =>
+        res.status === 'discovery_failed'
+    );
+
+    let tools = discoveryRes.flatMap(r => (r.status == 'ok' ? r.tools : []));
+
+    if (failedRes.length > 0) {
+      // Only surface the hard discovery error when no provider could be
+      // discovered. Otherwise the session keeps working and we inject a
+      // synthetic `{provider}_connection_failed` tool per failed provider.
+      if (failedRes.length === discoveryRes.length) {
         return {
           status: 'discovery_failed' as const,
-          mcpError: res.mcpError
+          mcpError: failedRes[0]!.mcpError
         };
+      }
+
+      for (let failed of failedRes) {
+        tools.push(
+          buildConnectionFailedTool(
+            failed.provider,
+            failed.detail
+          ) as unknown as (typeof tools)[number]
+        );
       }
     }
 
-    let tools = discoveryRes
-      .map(r => (r.status == 'ok' ? r.tools : []))
-      .flat()
-      .sort((a, b) => a.id.localeCompare(b.id));
-
     return {
       status: 'ok' as const,
-      tools
+      tools: tools.sort((a, b) => a.id.localeCompare(b.id))
     };
   }
 
@@ -652,7 +682,8 @@ export class SenderManager {
     return {
       status: 'ok' as const,
       tools: allToolsRes.tools.filter(
-        tool => checkToolAccess(tool, tool.sessionProvider, 'list').allowed
+        tool =>
+          isSyntheticTool(tool) || checkToolAccess(tool, tool.sessionProvider, 'list').allowed
       )
     };
   }
@@ -733,7 +764,7 @@ export class SenderManager {
     if (instanceRes.status === 'discovery_failed') {
       throw new ServiceError(
         preconditionFailedError({
-          message: 'Failed to discover provider specification',
+          message: instanceRes.detail.shortMessage,
           _mcpError: instanceRes.mcpError
         })
       );
@@ -766,7 +797,10 @@ export class SenderManager {
       throw new ServiceError(badRequestError({ message: 'Tool access not allowed' }));
     }
 
-    let authMethodCheck = checkToolAuthMethodSatisfied(tool, d.provider.authConfig?.authMethod);
+    let authMethodCheck = checkToolAuthMethodSatisfied(
+      tool,
+      d.provider.authConfig?.authMethod
+    );
     if (!authMethodCheck.allowed) {
       throw new ServiceError(
         badRequestError({ message: 'Tool is not available for this authentication method' })
@@ -800,6 +834,18 @@ export class SenderManager {
     };
   }
 
+  private async resolveConnectionFailedTool(provider: ConnectionFailedProvider) {
+    let instanceRes = await this.ensureProviderInstance(provider);
+    if (!instanceRes || instanceRes.status !== 'discovery_failed') return null;
+
+    return {
+      provider,
+      instance: null,
+      detail: instanceRes.detail,
+      tool: buildConnectionFailedTool(provider, instanceRes.detail)
+    };
+  }
+
   async getToolById(d: { toolId: string }) {
     let providers = await this.listProviders();
 
@@ -829,6 +875,16 @@ export class SenderManager {
       throw new ServiceError(badRequestError({ message: 'Invalid tool ID format' }));
     }
 
+    // If the requested tool is the synthetic `{provider}_connection_failed`
+    // tool of a provider that failed discovery, resolve it without dispatching
+    // to a real provider instance.
+    for (let match of matches) {
+      if (match!.originalToolName === CONNECTION_FAILED_TOOL_KEY) {
+        let synthetic = await this.resolveConnectionFailedTool(match!.provider);
+        if (synthetic) return synthetic;
+      }
+    }
+
     for (let match of matches) {
       let resolved = await this.getProviderToolByResolvedName(match!);
       if (resolved) return resolved;
@@ -845,7 +901,7 @@ export class SenderManager {
     if (toolsRes.status === 'discovery_failed') {
       throw new ServiceError(
         preconditionFailedError({
-          message: 'Failed to discover provider specification',
+          message: toolsRes.detail.shortMessage,
           _mcpError: toolsRes.mcpError
         })
       );
@@ -867,6 +923,62 @@ export class SenderManager {
     });
   }
 
+  private async completeConnectionFailedCall(d: {
+    provider: SessionProvider;
+    tool: { key: string };
+    detail: ReturnType<typeof buildConnectionFailedDetail>;
+    participant: SessionParticipant;
+    callProps: CallToolProps;
+  }) {
+    let extractedToolCall = extractToolCallOperation({
+      input: d.callProps.input,
+      rationale: d.callProps.rationale,
+      operation: d.callProps.operation
+    });
+
+    let system = await upsertParticipant({
+      session: this.session,
+      from: { type: 'system' }
+    });
+
+    // The connection-failed tool is synthetic and has no ProviderTool row, so
+    // we pass `methodOrToolKey` (not `tool`) to avoid creating a toolCall with
+    // an invalid foreign key. The message is completed immediately with a
+    // detailed, agent-targeted error explaining the failure.
+    let message = await this.createMessage({
+      status: 'failed',
+      type: d.callProps.transport === 'mcp' ? 'mcp_message' : 'tool_call',
+      source: 'client',
+      input: extractedToolCall.input,
+      rationale: extractedToolCall.rationale,
+      operation: extractedToolCall.operation,
+      senderParticipant: d.participant,
+      responderParticipant: system,
+      failureReason: 'provider_error',
+      clientMcpId: d.callProps.clientMcpId,
+      transport: d.callProps.transport,
+      methodOrToolKey: d.tool.key,
+      isProductive: true,
+      provider: d.provider,
+      parentMessage: d.callProps.parentMessage,
+      output: {
+        type: 'error',
+        data: {
+          code: 'provider_connection_failed',
+          message: d.detail.longMessage,
+          ...d.detail.data
+        }
+      }
+    });
+
+    return {
+      message,
+      output: message.output,
+      status: message.status,
+      completedAt: message.completedAt
+    } satisfies ConduitResult;
+  }
+
   async callTool(d: CallToolProps) {
     let connection = this.connection;
     if (!connection) {
@@ -882,7 +994,22 @@ export class SenderManager {
       throw new Error('Connection participant not loaded');
     }
 
-    let { provider, tool, instance } = await this.getToolById({ toolId: d.toolId });
+    let resolved = await this.getToolById({ toolId: d.toolId });
+
+    // The synthetic connection-failed tool has no backing provider instance;
+    // complete the call immediately with a detailed error for the agent.
+    if (!resolved.instance) {
+      return await this.completeConnectionFailedCall({
+        provider: resolved.provider,
+        tool: resolved.tool,
+        detail: resolved.detail,
+        participant,
+        callProps: d
+      });
+    }
+
+    let { provider, tool, instance } = resolved;
+
     let extractedToolCall = extractToolCallOperation({
       input: d.input,
       rationale: d.rationale,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core `SenderManager` tool listing, resolution, and `callTool` behavior for multi-provider sessions; mis-handling could affect which tools appear or how failures surface to agents.
> 
> **Overview**
> When one MCP provider fails discovery but others succeed, sessions **no longer fail entirely** on tool listing. The connection layer injects a per-provider synthetic `{provider}_connection_failed` tool (built via new `syntheticTool` / `connectionFailedTool` helpers) so agents can still use healthy providers and get a readable failure if they invoke the placeholder.
> 
> **Discovery errors are richer end-to-end:** `buildConnectionFailedDetail` turns timeout, connection, and MCP discovery records into short and long messages (provider name, codes, recovery hints). Those messages feed `mcpError`, precondition failures on real tool resolution, and the integration API’s `tool.list` error payload (`mcpError?.message`, `_mcpError`). Calling the synthetic tool completes immediately with `provider_connection_failed` and structured provider metadata—no provider instance or conduit dispatch.
> 
> Hard `discovery_failed` is reserved for the case where **every** provider fails discovery; partial failures return `ok` with mixed real and synthetic tools, and synthetic entries bypass normal list access checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c50a337b863747155edc424fc0579e0d2435da6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->