### PR TITLE
Normalize protoguard name

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/protoguard/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/protoguard/_layout.tsx
@@ -17,7 +17,7 @@ export let ProtoGuardLayout = () => {
   return (
     <ContentLayout>
       <PageHeader
-        title="ProtoGuard"
+        title="Protoguard"
         description="Configure prompt-injection filters and alert thresholds for this instance."
       />
 

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/protoguard/filter/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(logs)/protoguard/filter/_layout.tsx
@@ -11,11 +11,10 @@ import {
   useCurrentProject,
   useProtoGuardConfig
 } from '@metorial/state';
-import { Button, Flex, Text } from '@metorial/ui';
+import { Button, Text } from '@metorial/ui';
 import { RiArrowLeftSLine } from '@remixicon/react';
 import { Link, Outlet, useLocation, useParams } from 'react-router-dom';
 import styled from 'styled-components';
-import { ProtoGuardSeverityBadge } from '../../../../scenes/monitoring/badges';
 
 let OutletWrapper = styled.div`
   flex: 1;
@@ -36,7 +35,7 @@ export let ProtoGuardFilterLayout = () => {
       header={
         <Link to={Paths.instance.protoguard(organization.data, project.data, instance.data)}>
           <Button size="2" variant="outline" iconLeft={<RiArrowLeftSLine />}>
-            Back to ProtoGuard
+            Back to Protoguard
           </Button>
         </Link>
       }
@@ -48,7 +47,7 @@ export let ProtoGuardFilterLayout = () => {
           return (
             <ContentPanelLayout title="Filter not found">
               <Text size="2" color="gray600">
-                This ProtoGuard filter does not exist in the current configuration.
+                This Protoguard filter does not exist in the current configuration.
               </Text>
             </ContentPanelLayout>
           );
@@ -60,7 +59,7 @@ export let ProtoGuardFilterLayout = () => {
             description={filter.description ?? undefined}
             breadcrumbs={[
               {
-                label: 'ProtoGuard',
+                label: 'Protoguard',
                 to: Paths.instance.protoguard(organization.data, project.data, instance.data)
               },
               {

--- a/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/connection/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/magic-mcp/connection/_layout.tsx
@@ -1,18 +1,31 @@
 import { InitialLoadBoundary } from '@metorial/data-hooks';
 import { Paths } from '@metorial/frontend-config';
-import { ContentLayout, PageHeader } from '@metorial/layout';
+import { ContentPanelLayout, ContentPanelLayoutInner } from '@metorial/layout';
 import {
   useCurrentInstance,
   useCurrentOrganization,
   useCurrentProject
 } from '@metorial/state';
-import { LinkTabs, RenderDate, Text } from '@metorial/ui';
+import { RenderDate, Text } from '@metorial/ui';
 import { ID } from '@metorial/ui-product';
 import { Outlet, useLocation, useParams } from 'react-router-dom';
+import styled from 'styled-components';
 import { AttributesLayout } from '../../../scenes/attributesLayout';
 import { DeletedRecordCallout } from '../../../scenes/deletedRecordCallout';
 import { RenderWithResolvedMagicMcpSession } from '../../../scenes/magicMcp/resolvedSession';
 import { SessionConnectionStatusBadge } from '../../../scenes/providerSessions/table';
+
+let OutletWrapper = styled.div`
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+
+  > * {
+    flex: 1;
+    min-height: 0;
+  }
+`;
 
 export let MagicMcpConnectionLayout = () => {
   let instance = useCurrentInstance();
@@ -23,110 +36,115 @@ export let MagicMcpConnectionLayout = () => {
   let { connectionId } = useParams();
 
   return (
-    <ContentLayout>
-      <RenderWithResolvedMagicMcpSession magicMcpSessionId={connectionId}>
-        {({ magicMcpSession, session }) => {
-          let magicMcpServer = magicMcpSession.magicMcpServer;
-          let connectionPathParams = [
-            organization.data,
-            project.data,
-            instance.data,
-            magicMcpSession.id
-          ] as const;
+    <RenderWithResolvedMagicMcpSession magicMcpSessionId={connectionId}>
+      {({ magicMcpSession, session }) => {
+        let magicMcpServer = magicMcpSession.magicMcpServer;
+        let connectionPathParams = [
+          organization.data,
+          project.data,
+          instance.data,
+          magicMcpSession.id
+        ] as const;
+        let isLogsPage =
+          pathname === Paths.instance.magicMcp.connection(...connectionPathParams);
+        let outlet = (
+          <InitialLoadBoundary>
+            <Outlet />
+          </InitialLoadBoundary>
+        );
 
-          return (
-            <>
-              <PageHeader
-                title={session.name ?? `Session ${session.id.slice(0, 8)}...`}
-                description={session.description ?? magicMcpServer?.description ?? undefined}
-                pagination={[
-                  {
-                    label: 'Connections',
-                    href: Paths.instance.magicMcp.connections(
-                      organization.data,
-                      project.data,
-                      instance.data
-                    )
-                  },
-                  {
-                    label: session.name ?? 'Connection',
-                    href: Paths.instance.magicMcp.connection(...connectionPathParams)
-                  }
-                ]}
-              />
-
-              <DeletedRecordCallout status={session.status} />
-
-              <LinkTabs
-                current={pathname}
-                links={[
-                  {
-                    label: 'Logs',
-                    to: Paths.instance.magicMcp.connection(...connectionPathParams)
-                  },
-                  {
-                    label: 'Deployments',
-                    to: Paths.instance.magicMcp.connection(
-                      ...connectionPathParams,
-                      'providers'
-                    )
-                  },
-                  {
-                    label: 'Provider Runs',
-                    to: Paths.instance.magicMcp.connection(...connectionPathParams, 'runs')
-                  }
-                ]}
-              />
-
-              <AttributesLayout
-                variant="large"
-                items={[
-                  {
-                    label: 'Status',
-                    value: (
-                      <SessionConnectionStatusBadge
-                        connectionStatus={session.connectionState}
-                        hasErrors={session.hasErrors}
-                        hasWarnings={session.hasWarnings}
-                      />
-                    )
-                  },
-                  {
-                    label: 'Magic MCP Server',
-                    value: magicMcpServer?.name ?? (
-                      <Text size="2" color="gray600">
-                        Unnamed Server
-                      </Text>
-                    )
-                  },
-                  {
-                    label: 'Magic MCP Session ID',
-                    value: <ID id={magicMcpSession.id} />
-                  },
-                  {
-                    label: 'Session ID',
-                    value: <ID id={session.id} />
-                  },
-                  {
-                    label: 'Created At',
-                    value: <RenderDate date={magicMcpSession.createdAt} />
-                  },
-                  {
-                    label: 'Messages',
-                    value:
-                      (session.usage?.totalProductiveClientMessageCount ?? 0) +
-                      (session.usage?.totalProductiveProviderMessageCount ?? 0)
-                  }
-                ]}
-              >
-                <InitialLoadBoundary>
-                  <Outlet />
-                </InitialLoadBoundary>
-              </AttributesLayout>
-            </>
-          );
-        }}
-      </RenderWithResolvedMagicMcpSession>
-    </ContentLayout>
+        return (
+          <ContentPanelLayout
+            title={session.name ?? `Session ${session.id.slice(0, 8)}...`}
+            description={session.description ?? magicMcpServer?.description ?? undefined}
+            breadcrumbs={[
+              {
+                label: 'Connections',
+                to: Paths.instance.magicMcp.connections(
+                  organization.data,
+                  project.data,
+                  instance.data
+                )
+              },
+              {
+                label: session.name ?? 'Connection',
+                to: Paths.instance.magicMcp.connection(...connectionPathParams)
+              }
+            ]}
+            extra={<DeletedRecordCallout status={session.status} />}
+            links={{
+              current: pathname,
+              items: [
+                {
+                  label: 'Logs',
+                  to: Paths.instance.magicMcp.connection(...connectionPathParams)
+                },
+                {
+                  label: 'Deployments',
+                  to: Paths.instance.magicMcp.connection(
+                    ...connectionPathParams,
+                    'providers'
+                  )
+                },
+                {
+                  label: 'Provider Runs',
+                  to: Paths.instance.magicMcp.connection(...connectionPathParams, 'runs')
+                }
+              ]
+            }}
+          >
+            {isLogsPage ? (
+              <OutletWrapper>{outlet}</OutletWrapper>
+            ) : (
+              <ContentPanelLayoutInner>
+                <AttributesLayout
+                  variant="large"
+                  items={[
+                    {
+                      label: 'Status',
+                      value: (
+                        <SessionConnectionStatusBadge
+                          connectionStatus={session.connectionState}
+                          hasErrors={session.hasErrors}
+                          hasWarnings={session.hasWarnings}
+                        />
+                      )
+                    },
+                    {
+                      label: 'Magic MCP Server',
+                      value: magicMcpServer?.name ?? (
+                        <Text size="2" color="gray600">
+                          Unnamed Server
+                        </Text>
+                      )
+                    },
+                    {
+                      label: 'Magic MCP Session ID',
+                      value: <ID id={magicMcpSession.id} />
+                    },
+                    {
+                      label: 'Session ID',
+                      value: <ID id={session.id} />
+                    },
+                    {
+                      label: 'Created At',
+                      value: <RenderDate date={magicMcpSession.createdAt} />
+                    },
+                    {
+                      label: 'Messages',
+                      value:
+                        (session.usage?.totalProductiveClientMessageCount ?? 0) +
+                        (session.usage?.totalProductiveProviderMessageCount ?? 0)
+                    }
+                  ]}
+                >
+                  {outlet}
+                </AttributesLayout>
+              </ContentPanelLayoutInner>
+            )}
+          </ContentPanelLayout>
+        );
+      }}
+    </RenderWithResolvedMagicMcpSession>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/monitoring/alertsTable.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/monitoring/alertsTable.tsx
@@ -44,7 +44,7 @@ let getSourceFilterValue = (value: FilterPayload | undefined) =>
   getEnumListFilterValue(value, ['protoguard', 'specification_change']);
 
 let getAlertSourceLabel = (alert: MonitorAlert) => {
-  if (alert.protoGuardAlertId) return 'ProtoGuard';
+  if (alert.protoGuardAlertId) return 'Protoguard';
   if (alert.specificationChangeNotification) return 'Schema Change';
   return 'Monitor';
 };
@@ -297,13 +297,13 @@ let createAlertsTable = () =>
       {
         id: 'protoGuardAlertId',
         isDefault: false,
-        header: 'ProtoGuard Alert ID',
+        header: 'Protoguard Alert ID',
         render: alert => alert.protoGuardAlertId && <ID id={alert.protoGuardAlertId} />
       },
       {
         id: 'protoGuardRunId',
         isDefault: false,
-        header: 'ProtoGuard Run ID',
+        header: 'Protoguard Run ID',
         render: alert => alert.protoGuardRunId && <ID id={alert.protoGuardRunId} />
       },
       {
@@ -350,7 +350,7 @@ let createAlertsTable = () =>
         description: 'Filter by alert source',
         type: 'select',
         options: [
-          { id: 'protoguard', label: 'ProtoGuard' },
+          { id: 'protoguard', label: 'Protoguard' },
           { id: 'specification_change', label: 'Schema Change' }
         ]
       },
@@ -361,7 +361,7 @@ let createAlertsTable = () =>
         description: 'Filter by monitor target',
         type: 'select',
         options: [
-          { id: 'protoguard_filter', label: 'ProtoGuard Filter' },
+          { id: 'protoguard_filter', label: 'Protoguard Filter' },
           { id: 'schema_change', label: 'Schema Change' }
         ]
       },

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/monitoring/badges.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/monitoring/badges.tsx
@@ -27,7 +27,7 @@ export let MonitorStatusBadge = ({ status }: { status: string }) => {
 export let MonitorTargetBadge = ({ target }: { target: string }) => {
   return (
     <Badge color={target === 'protoguard_filter' ? 'purple' : 'blue'}>
-      {target === 'protoguard_filter' ? 'ProtoGuard Filter' : 'Schema Change'}
+      {target === 'protoguard_filter' ? 'Protoguard Filter' : 'Schema Change'}
     </Badge>
   );
 };

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/monitoring/monitorsTable.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/monitoring/monitorsTable.tsx
@@ -146,7 +146,7 @@ let monitorsTable = new DashboardTable<MonitorsTableStateProps, Monitor>('monito
     {
       id: 'protoGuardFilterId',
       isDefault: false,
-      header: 'ProtoGuard Filter ID',
+      header: 'Protoguard Filter ID',
       render: monitor => monitor.protoGuardFilterId && <ID id={monitor.protoGuardFilterId} />
     },
     {
@@ -164,7 +164,7 @@ let monitorsTable = new DashboardTable<MonitorsTableStateProps, Monitor>('monito
       description: 'Filter by monitor target',
       type: 'select',
       options: [
-        { id: 'protoguard_filter', label: 'ProtoGuard Filter' },
+        { id: 'protoguard_filter', label: 'Protoguard Filter' },
         { id: 'schema_change', label: 'Schema Change' }
       ]
     },
@@ -196,8 +196,8 @@ let monitorsTable = new DashboardTable<MonitorsTableStateProps, Monitor>('monito
     {
       id: 'protoGuardFilterId',
       fields: ['protoGuardFilterId'],
-      label: 'ProtoGuard Filter ID',
-      description: 'Filter by ProtoGuard filter ID',
+      label: 'Protoguard Filter ID',
+      description: 'Filter by Protoguard filter ID',
       type: 'string'
     },
     {

--- a/src/systems/subspace/apps/controller/src/controllers/protoGuardAlert.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/protoGuardAlert.ts
@@ -8,7 +8,7 @@ import { tenantApp } from './tenant';
 
 export let protoGuardAlertApp = tenantApp.use(async ctx => {
   let alertId = ctx.body.alertId;
-  if (!alertId) throw new Error('ProtoGuard alert ID is required');
+  if (!alertId) throw new Error('Protoguard alert ID is required');
 
   let alert = await protoGuardAlertService.getAlertById({
     alertId,

--- a/src/systems/subspace/modules/monitor/src/services/monitorInternal.ts
+++ b/src/systems/subspace/modules/monitor/src/services/monitorInternal.ts
@@ -39,7 +39,7 @@ class monitorInternalServiceImpl {
       create: {
         ...getId('monitor'),
         key,
-        name: `ProtoGuard: ${d.filter.name}`,
+        name: `Protoguard: ${d.filter.name}`,
         description: d.filter.description,
         target: 'protoguard_filter',
         status: 'active',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Display-string and layout-only changes; no auth, data, or API contract changes beyond error message wording.
> 
> **Overview**
> User-facing **ProtoGuard** copy is normalized to **Protoguard** across protoguard pages, monitoring tables/badges/filters, API error text, and auto-created monitor names (`Protoguard: …`).
> 
> The **Magic MCP connection** detail shell is refactored from `ContentLayout` / `PageHeader` / `LinkTabs` to **`ContentPanelLayout`** (breadcrumbs, tab links, deleted-record callout). On the **Logs** tab the child route renders full-height without the attributes sidebar; **Deployments** and **Provider Runs** still show session metadata via `AttributesLayout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63d725c8ebc672eb02231a156d40f72de59b5bcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->