### PR TITLE
Reduce discover doc cache time

### DIFF
--- a/src/systems/shuttle/service/src/services/oauth/remote/discovery.ts
+++ b/src/systems/shuttle/service/src/services/oauth/remote/discovery.ts
@@ -1,5 +1,6 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { Service } from '@lowerdeck/service';
+import { differenceInMinutes } from 'date-fns';
 import { db } from '../../../db';
 import { getId } from '../../../id';
 import { OAuthDiscovery } from '../../../lib/oauth/discovery';
@@ -11,7 +12,9 @@ class remoteOAuthDiscoveryServiceImpl {
     let existingDoc = await db.remoteOAuthDiscoveryDocument.findUnique({
       where: { discoveryUrl: d.discoveryUrl }
     });
-    if (existingDoc) return existingDoc;
+    if (existingDoc && differenceInMinutes(new Date(), existingDoc.refreshedAt) < 15) {
+      return existingDoc;
+    }
 
     let doc = await OAuthDiscovery.discover(d.discoveryUrl);
     if (!doc) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small caching behavior change in OAuth discovery; slightly more outbound discovery traffic but no auth or data-model changes.
> 
> **Overview**
> Remote OAuth discovery documents are no longer treated as valid forever once stored. **`discoverOauthConfigWithoutRegistration`** now returns a cached row only when **`refreshedAt`** is within the last **15 minutes** (via **`differenceInMinutes`** from `date-fns`).
> 
> If the document is missing or older than that window, the service fetches the discovery URL again and continues through validation and the existing upsert path, so provider metadata can be refreshed periodically instead of staying pinned to the first fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86ad90298f349cc2821ba58fe3cb78257029b435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->