### PR TITLE
Fix credential docs

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/lib/providerDocs.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/lib/providerDocs.tsx
@@ -1,31 +1,23 @@
+import { ProviderListingsGetOutput } from '@metorial/dashboard-sdk';
 import { theme } from '@metorial/ui';
 import React from 'react';
 import styled from 'styled-components';
 
-export type ProviderDocReference = {
-  type?: string | null;
-  name: string;
-  url: string;
-};
+type ProviderListingDocs = ProviderListingsGetOutput['docs'];
 
-type ProviderListingDocs = {
-  provider?: ProviderDocReference[] | null;
-  config?: ProviderDocReference[] | null;
-  auth_methods?:
-    | {
-        key?: string | null;
-        name?: string | null;
-        type?: string | null;
-        docs?: ProviderDocReference[] | null;
-      }[]
-    | null;
-};
+export type ProviderDocReference =
+  NonNullable<ProviderListingDocs>['authMethods'][number]['docs'][number];
 
 type AuthMethodDocTarget = {
   key?: string | null;
   name?: string | null;
   type?: string | null;
 };
+
+export let AUTH_METHOD_DOC_TYPES = {
+  oauth: 'docs.auth.oauth',
+  oauthScopes: 'docs.auth.oauth_scopes'
+} as const;
 
 let DocsLink = styled.a`
   display: inline-flex;
@@ -50,9 +42,6 @@ let getDocs = (providerListing: unknown): ProviderListingDocs | null => {
   return docs as ProviderListingDocs;
 };
 
-let getFirstDoc = (docs: ProviderDocReference[] | null | undefined) =>
-  (docs ?? []).find(doc => !!doc?.url) ?? null;
-
 let matchesAuthMethod = (
   docMethod: AuthMethodDocTarget,
   authMethod?: AuthMethodDocTarget | null
@@ -66,27 +55,38 @@ let matchesAuthMethod = (
   return false;
 };
 
-export let getProviderDoc = (providerListing: unknown) =>
-  getFirstDoc(getDocs(providerListing)?.provider);
-
-export let getConfigDoc = (providerListing: unknown) =>
-  getFirstDoc(getDocs(providerListing)?.config);
-
-export let getAuthMethodDoc = (
+let findAuthMethodDocs = (
   providerListing: unknown,
   authMethod?: AuthMethodDocTarget | null
-) => {
+): ProviderDocReference[] => {
   let docs = getDocs(providerListing);
-  let authMethodDocs = docs?.auth_methods ?? [];
-  let exactMatch = authMethodDocs.find(docMethod => matchesAuthMethod(docMethod, authMethod));
+  if (!docs || !authMethod) return [];
 
-  return (
-    getFirstDoc(exactMatch?.docs) ?? getFirstDoc(authMethodDocs.flatMap(m => m.docs ?? []))
+  let authMethodEntry = (docs.authMethods ?? []).find(entry =>
+    matchesAuthMethod(entry, authMethod)
   );
+
+  return authMethodEntry?.docs ?? [];
 };
 
-export let getScopeDoc = (providerListing: unknown, authMethod?: AuthMethodDocTarget | null) =>
-  getAuthMethodDoc(providerListing, authMethod) ?? getProviderDoc(providerListing);
+let findAuthMethodDocByType = (
+  providerListing: unknown,
+  authMethod: AuthMethodDocTarget | null | undefined,
+  type: string
+) =>
+  findAuthMethodDocs(providerListing, authMethod).find(
+    doc => doc.type === type && !!doc.url
+  ) ?? null;
+
+export let getAuthMethodOAuthDoc = (
+  providerListing: unknown,
+  authMethod?: AuthMethodDocTarget | null
+) => findAuthMethodDocByType(providerListing, authMethod, AUTH_METHOD_DOC_TYPES.oauth);
+
+export let getAuthMethodOAuthScopesDoc = (
+  providerListing: unknown,
+  authMethod?: AuthMethodDocTarget | null
+) => findAuthMethodDocByType(providerListing, authMethod, AUTH_METHOD_DOC_TYPES.oauthScopes);
 
 export let ProviderDocsLink = ({
   doc,

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/settings.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(deployments)/provider-auth-credential/settings.tsx
@@ -11,7 +11,7 @@ import { Button, Callout, Input, Spacer } from '@metorial/ui';
 import { Box } from '@metorial/ui-product';
 import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { getScopeDoc, ProviderDocsLink } from '../../../lib/providerDocs';
+import { getAuthMethodOAuthScopesDoc, ProviderDocsLink } from '../../../lib/providerDocs';
 import { DeleteResourceDangerZone } from '../../../scenes/deleteResourceDangerZone';
 import { ScopePicker } from './components/scopePicker';
 
@@ -34,7 +34,7 @@ export let ProviderAuthCredentialSettingsPage = () => {
     [authMethods.data?.items]
   );
   let availableScopes = oauthMethod?.scopes ?? [];
-  let scopeDoc = getScopeDoc(providerListing.data, oauthMethod);
+  let oauthScopesDoc = getAuthMethodOAuthScopesDoc(providerListing.data, oauthMethod);
 
   let [selectedScopes, setSelectedScopes] = useState<string[] | null>(null);
 
@@ -108,7 +108,7 @@ export let ProviderAuthCredentialSettingsPage = () => {
           <Box
             title="Scopes"
             description="Select which OAuth scopes this credential should request."
-            rightActions={<ProviderDocsLink doc={scopeDoc}>Scope docs</ProviderDocsLink>}
+            rightActions={<ProviderDocsLink doc={oauthScopesDoc} />}
           >
             <ScopePicker
               scopes={availableScopes}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/modal.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerAuthCredentials/modal.tsx
@@ -24,9 +24,8 @@ import {
 import { useEffect, useMemo, useState } from 'react';
 import { useProviderAuthCreationCapabilities } from '../../lib/providerCreationCapabilities';
 import {
-  getConfigDoc,
-  getProviderDoc,
-  getScopeDoc,
+  getAuthMethodOAuthDoc,
+  getAuthMethodOAuthScopesDoc,
   ProviderDocsLink
 } from '../../lib/providerDocs';
 import { ScopePickerField } from '../../pages/(deployments)/provider-auth-credential/components/scopePicker';
@@ -76,9 +75,8 @@ export let ProviderAuthCredentialsForm = ({
   let oauthMethodName = oauthMethod?.name ?? 'OAuth';
   let authCreation = useProviderAuthCreationCapabilities(instanceId, deploymentId, providerId);
   let providerListing = useProviderListing(instanceId, providerId);
-  let providerDoc = getProviderDoc(providerListing.data);
-  let configDoc = getConfigDoc(providerListing.data);
-  let scopeDoc = getScopeDoc(providerListing.data, oauthMethod);
+  let oauthDoc = getAuthMethodOAuthDoc(providerListing.data, oauthMethod);
+  let oauthScopesDoc = getAuthMethodOAuthScopesDoc(providerListing.data, oauthMethod);
   let availableScopes = oauthMethod?.scopes ?? [];
   let defaultScopes = useMemo(
     () => availableScopes.map(scope => scope.scope),
@@ -216,12 +214,15 @@ export let ProviderAuthCredentialsForm = ({
               Redirect URI
             </Text>
             <Text size="1" color="gray600" style={{ marginBottom: 5 }}>
-              You must configure this redirect URI in your OAuth app.
-              {configDoc ? (
-                <>
-                  <ProviderDocsLink doc={configDoc}>View config docs</ProviderDocsLink>
-                </>
-              ) : null}
+              <span>
+                You must configure this redirect URI in your OAuth app.
+                {oauthDoc ? (
+                  <>
+                    {' '}
+                    <ProviderDocsLink doc={oauthDoc} />
+                  </>
+                ) : null}
+              </span>
             </Text>
             <Copy value={redirectUri} />
             <Spacer size={10} />
@@ -241,7 +242,7 @@ export let ProviderAuthCredentialsForm = ({
         <Input
           label="Client ID"
           placeholder="Enter client ID from provider"
-          help={<ProviderDocsLink doc={providerDoc}>Provider docs</ProviderDocsLink>}
+          help={<ProviderDocsLink doc={oauthDoc} />}
           required
           {...form.getFieldProps('clientId')}
         />
@@ -265,7 +266,7 @@ export let ProviderAuthCredentialsForm = ({
               scopes={availableScopes}
               selectedScopes={effectiveScopes}
               onSelectedScopesChange={setSelectedScopes}
-              help={<ProviderDocsLink doc={scopeDoc}>Scope docs</ProviderDocsLink>}
+              help={<ProviderDocsLink doc={oauthScopesDoc} />}
             />
           </>
         )}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/index.tsx
@@ -15,7 +15,7 @@ import { Button, Flex, Text } from '@metorial/ui';
 import { sortBy } from 'lodash';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Stepper } from '../../../../../components/stepper';
-import { getConfigDoc, getProviderDoc } from '../../../lib/providerDocs';
+import { getAuthMethodOAuthDoc } from '../../../lib/providerDocs';
 import { getProviderOAuthAutoRegistrationEnabled } from '../../../lib/providerOAuthAutoRegistration';
 import {
   ConnectStep,
@@ -213,8 +213,7 @@ export let ProviderSetupSessionEmbed = ({
   let projectBrandImageUrl = projectBrand.data?.imageUrl;
   let projectBrandName = projectBrand.data?.name ?? project.data?.name ?? 'Metorial';
   let providerImageUrl = provider.data?.publisher.imageUrl;
-  let providerDoc = getProviderDoc(providerListing.data);
-  let configDoc = getConfigDoc(providerListing.data);
+  let oauthDoc = getAuthMethodOAuthDoc(providerListing.data, selectedMethod);
 
   let visibleAuthCredentials = sortBy(authCredentials.data?.items ?? [], [
     credential => Number(!credential.isManaged),
@@ -882,8 +881,8 @@ export let ProviderSetupSessionEmbed = ({
     isManagedSelected,
     error,
     createCredentials,
-    providerDoc,
-    configDoc,
+    providerDoc: oauthDoc,
+    configDoc: oauthDoc,
     showHiddenMethodStep,
     includeMethodStep,
     skipMethodStep,
@@ -906,8 +905,8 @@ export let ProviderSetupSessionEmbed = ({
     hasManagedVisibleCredentials,
     createCredentials,
     createSetupSession,
-    providerDoc,
-    configDoc,
+    providerDoc: oauthDoc,
+    configDoc: oauthDoc,
     error,
     setupSession,
     setupWindowBlocked,

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/stepContent.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providerDeployments/setupSessionEmbed/stepContent.tsx
@@ -143,7 +143,7 @@ let RedirectUriField = (p: {
         {p.configDoc ? (
           <>
             {' '}
-            <ProviderDocsLink doc={p.configDoc}>View config docs</ProviderDocsLink>
+            <ProviderDocsLink doc={p.configDoc} />
           </>
         ) : null}
       </Text>
@@ -178,7 +178,7 @@ let NewCredentialsFields = (p: {
         disabled={p.disabled}
         onChange={e => p.credentialsForm.setFieldValue('newCredClientId', e.target.value)}
         placeholder="Enter client ID from provider"
-        help={<ProviderDocsLink doc={p.providerDoc}>Provider docs</ProviderDocsLink>}
+        help={<ProviderDocsLink doc={p.providerDoc} />}
       />
       <p.credentialsForm.RenderError field="newCredClientId" />
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dashboard-only doc URL resolution and link labels; no auth, API, or credential persistence changes.
> 
> **Overview**
> Aligns provider listing documentation with the SDK shape and **typed auth-method doc entries** instead of legacy `provider` / `config` buckets and “first URL wins” fallbacks.
> 
> **`providerDocs`** now types docs from `ProviderListingsGetOutput`, reads `docs.authMethods`, and exposes `getAuthMethodOAuthDoc` and `getAuthMethodOAuthScopesDoc` using `docs.auth.oauth` and `docs.auth.oauth_scopes`. Scope settings, the create-credentials modal, and setup-session embed flows use those helpers so redirect URI, client ID, and scope pickers link to the correct docs for the selected OAuth method.
> 
> **`ProviderDocsLink`** drops hard-coded labels like “Scope docs” and uses each doc’s **`name`** when no children are passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 685b224fb1aebcb44f67a7d8e1a6a0eeb790aad9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->