### PR TITLE
Export telemetry errors without sanitization

### DIFF
--- a/src/systems/subspace/modules/session/src/lib/providerTelemetryErrorGroupExport.test.ts
+++ b/src/systems/subspace/modules/session/src/lib/providerTelemetryErrorGroupExport.test.ts
@@ -23,7 +23,6 @@ vi.mock('../services/sessionMessage', () => ({
 
 import {
   PROVIDER_TELEMETRY_FAILED_MESSAGES_STATE_KEY,
-  anonymizeProviderTelemetryExportValue,
   getProviderTelemetryFailedMessagesExportChunkKey,
   listProviderTelemetryFailedMessagesForExport,
   runProviderTelemetryErrorGroupsExport,
@@ -329,9 +328,7 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
         }
       ]
     });
-    expect(exportChunk.items[0].payload).toEqual(
-      anonymizeProviderTelemetryExportValue(createPresentedMessage(candidate))
-    );
+    expect(exportChunk.items[0].payload).toEqual(createPresentedMessage(candidate));
 
     let stateFile = parseJsonCall(storage.putObject.mock.calls[1]!);
     expect(stateFile).toEqual({
@@ -535,156 +532,6 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
     });
     expect(result.exportedKeys).toEqual([]);
     expect(result.exportedCount).toBe(0);
-  });
-});
-
-describe('anonymizeProviderTelemetryExportValue', () => {
-  it('redacts payload strings while preserving safe diagnostic identifiers', () => {
-    let date = new Date('2026-06-18T00:00:00.000Z');
-    let anonymized = anonymizeProviderTelemetryExportValue({
-      id: 'msg_1',
-      messageId: 'msg_1',
-      toolKey: 'users.info',
-      nested: {
-        email: 'person@example.com',
-        text: 'Contact admin@example.com with Basic abc123',
-        callbackUrl: 'https://example.com/callback?client_secret=secret-value&safe=yes',
-        retryCount: 2,
-        ok: true,
-        missing: null,
-        date,
-        values: ['a', 1, false]
-      },
-      output: {
-        error: {
-          code: -32000,
-          message: 'Output error message',
-          data: {
-            code: 'MCP_ERROR',
-            Message: 'Case-insensitive message',
-            values: ['visible', 2, false]
-          }
-        }
-      },
-      error: {
-        id: 'serr_1',
-        code: 'provider_error',
-        message: 'Top-level error message',
-        data: {
-          authorization: 'Bearer abc123',
-          object: 'provider.error',
-          status: 500,
-          message: 'Nested message',
-          nested: {
-            MESSAGE: 'Uppercase message'
-          }
-        }
-      },
-      toolCall: {
-        id: 'tc_1',
-        toolKey: 'users.info',
-        rationale: 'User asked for it',
-        operation: 'call_tool',
-        tool: {
-          id: 'tool_1',
-          key: 'users.info',
-          name: 'Users Info',
-          providerId: 'prv_1'
-        },
-        nested: {
-          operation: 'nested operation',
-          detail: 'visible detail'
-        }
-      }
-    }) as any;
-
-    expect(anonymized).toEqual({
-      id: '[string]',
-      messageId: '[string]',
-      toolKey: '[string]',
-      nested: {
-        email: '[string]',
-        text: '[string]',
-        callbackUrl: '[string]',
-        retryCount: 2,
-        ok: true,
-        missing: null,
-        date,
-        values: ['[string]', 1, false]
-      },
-      output: {
-        error: {
-          code: -32000,
-          data: {
-            code: 'MCP_ERROR',
-            values: ['[string]', 2, false]
-          }
-        }
-      },
-      error: {
-        id: 'serr_1',
-        code: 'provider_error',
-        data: {
-          authorization: '[string]',
-          object: 'provider.error',
-          status: 500,
-          nested: {}
-        }
-      },
-      toolCall: {
-        id: 'tc_1',
-        toolKey: 'users.info',
-        tool: {
-          id: 'tool_1',
-          key: 'users.info',
-          name: 'Users Info',
-          providerId: 'prv_1'
-        },
-        nested: {
-          detail: '[string]'
-        }
-      }
-    });
-  });
-
-  it('keeps preserve exceptions scoped by path and key', () => {
-    let anonymized = anonymizeProviderTelemetryExportValue({
-      detail: 'ordinary detail',
-      notToolCall: {
-        rationale: 'ordinary rationale',
-        operation: 'ordinary operation'
-      },
-      notError: {
-        message: 'ordinary message',
-        code: 'ordinary_code'
-      },
-      Error: {
-        code: 'CASE_INSENSITIVE_ERROR',
-        Message: 'removed message'
-      },
-      ToolCall: {
-        toolKey: 'case.insensitive.tool',
-        Operation: 'removed operation'
-      }
-    }) as any;
-
-    expect(anonymized).toEqual({
-      detail: '[string]',
-      notToolCall: {
-        rationale: '[string]',
-        operation: '[string]'
-      },
-      notError: {
-        message: '[string]',
-        code: '[string]'
-      },
-      Error: {
-        code: 'CASE_INSENSITIVE_ERROR'
-      },
-      ToolCall: {
-        toolKey: 'case.insensitive.tool'
-      }
-    });
   });
 });
 

--- a/src/systems/subspace/modules/session/src/lib/providerTelemetryErrorGroupExport.ts
+++ b/src/systems/subspace/modules/session/src/lib/providerTelemetryErrorGroupExport.ts
@@ -13,7 +13,6 @@ export let PROVIDER_TELEMETRY_ERROR_GROUPS_STATE_KEY =
 
 let DEFAULT_EXPORT_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
 let EXPORT_PAGE_SIZE = 100;
-let STRING_PLACEHOLDER = '[string]';
 
 export type ProviderTelemetryFailedMessagesExportWatermark = {
   occurred_at: string;
@@ -258,95 +257,8 @@ let writeJsonObject = async (d: {
   );
 };
 
-let OMIT_PROVIDER_TELEMETRY_EXPORT_VALUE = Symbol('omitProviderTelemetryExportValue');
-
-type ProviderTelemetryExportSanitizerState = {
-  key: string | null;
-  inError: boolean;
-  inToolCall: boolean;
-};
-
-let ERROR_DIAGNOSTIC_STRING_KEYS = new Set(['id', 'code', 'object', 'groupid', 'type']);
-let TOOL_CALL_DIAGNOSTIC_STRING_KEYS = new Set(['id', 'toolkey', 'key', 'name', 'providerid']);
-
-let shouldOmitProviderTelemetryExportField = (
-  keyLower: string | null,
-  state: ProviderTelemetryExportSanitizerState
-) => {
-  if (state.inError && keyLower === 'message') return true;
-  if (state.inToolCall && (keyLower === 'rationale' || keyLower === 'operation')) {
-    return true;
-  }
-
-  return false;
-};
-
-let shouldPreserveProviderTelemetryExportString = (
-  keyLower: string | null,
-  state: ProviderTelemetryExportSanitizerState
-) => {
-  if (!keyLower) return false;
-  if (state.inError && ERROR_DIAGNOSTIC_STRING_KEYS.has(keyLower)) return true;
-  if (state.inToolCall && TOOL_CALL_DIAGNOSTIC_STRING_KEYS.has(keyLower)) return true;
-
-  return false;
-};
-
-let sanitizeProviderTelemetryExportValue = (
-  value: unknown,
-  state: ProviderTelemetryExportSanitizerState
-): unknown | typeof OMIT_PROVIDER_TELEMETRY_EXPORT_VALUE => {
-  let keyLower = state.key?.toLowerCase() ?? null;
-
-  if (shouldOmitProviderTelemetryExportField(keyLower, state)) {
-    return OMIT_PROVIDER_TELEMETRY_EXPORT_VALUE;
-  }
-
-  if (value === null || value === undefined) return value;
-  if (value instanceof Date) return value;
-  if (typeof value === 'string') {
-    if (shouldPreserveProviderTelemetryExportString(keyLower, state)) return value;
-    return STRING_PLACEHOLDER;
-  }
-  if (typeof value !== 'object') return value;
-
-  if (Array.isArray(value)) {
-    return value.map(item => {
-      let sanitized = sanitizeProviderTelemetryExportValue(item, {
-        ...state,
-        key: null
-      });
-
-      return sanitized === OMIT_PROVIDER_TELEMETRY_EXPORT_VALUE ? undefined : sanitized;
-    });
-  }
-
-  return Object.fromEntries(
-    Object.entries(value).flatMap(([entryKey, entryValue]) => {
-      let entryKeyLower = entryKey.toLowerCase();
-      let sanitized = sanitizeProviderTelemetryExportValue(entryValue, {
-        key: entryKey,
-        inError: state.inError || entryKeyLower === 'error',
-        inToolCall: state.inToolCall || entryKeyLower === 'toolcall'
-      });
-
-      return sanitized === OMIT_PROVIDER_TELEMETRY_EXPORT_VALUE ? [] : [[entryKey, sanitized]];
-    })
-  );
-};
-
-export let anonymizeProviderTelemetryExportValue = (value: unknown): unknown => {
-  let sanitized = sanitizeProviderTelemetryExportValue(value, {
-    key: null,
-    inError: false,
-    inToolCall: false
-  });
-
-  return sanitized === OMIT_PROVIDER_TELEMETRY_EXPORT_VALUE ? undefined : sanitized;
-};
-
-let sanitizeS3KeyComponent = (value: string | null | undefined) => {
-  let sanitized = String(value ?? '')
+let normalizeS3KeyComponent = (value: string | null | undefined) => {
+  let normalized = String(value ?? '')
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9._-]+/g, '_')
@@ -354,7 +266,7 @@ let sanitizeS3KeyComponent = (value: string | null | undefined) => {
     .replace(/^[-_.]+|[-_.]+$/g, '')
     .slice(0, 120);
 
-  return sanitized || 'unknown';
+  return normalized || 'unknown';
 };
 
 export let getProviderTelemetryFailedMessagesExportChunkKey = (
@@ -373,7 +285,7 @@ export let getProviderTelemetryFailedMessagesExportChunkKey = (
     first.error.id,
     last.error.id
   ]
-    .map(sanitizeS3KeyComponent)
+    .map(normalizeS3KeyComponent)
     .join('-');
 
   return ['provider-telemetry', `${filename}.json`].join('/');
@@ -446,7 +358,7 @@ let createExportItem = async (d: {
     message_id: d.candidate.message.id,
     provider: d.candidate.provider,
     tool: d.candidate.tool,
-    payload: anonymizeProviderTelemetryExportValue(payload)
+    payload
   };
 };
 


### PR DESCRIPTION
Export telemetry errors without sanitization

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Exported JSON may now contain secrets, tokens, emails, and full error text in the configured telemetry bucket, increasing data-exposure risk for anyone with bucket access.
> 
> **Overview**
> **Provider telemetry failed-message exports now write the full presented session message payload** instead of running it through `anonymizeProviderTelemetryExportValue`. The export sanitizer (string redaction to `[string]`, stripping error `message` fields, tool-call rationale/operation, and path-scoped diagnostic preserves) is removed entirely, along with its unit tests.
> 
> Export chunk **S3 key building** is unchanged in behavior; the helper is only renamed from `sanitizeS3KeyComponent` to `normalizeS3KeyComponent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e2b24d014b8cc2d865ed044a17b7db1b37666f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->