### PR TITLE
Improve anonymization for logs export

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3280,6 +3280,7 @@
         "@metorial-subspace/module-provider-internal": "^1.0.0",
         "@metorial-subspace/module-tenant": "^1.0.0",
         "@metorial-subspace/provider": "^1.0.0",
+        "openredaction": "^1.1.2",
         "p-queue": "^8.0.1",
       },
       "devDependencies": {
@@ -7348,6 +7349,8 @@
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
     "openid-client": ["openid-client@6.5.0", "", { "dependencies": { "jose": "^6.0.10", "oauth4webapi": "^3.5.1" } }, "sha512-fAfYaTnOYE2kQCqEJGX9KDObW2aw7IQy4jWpU/+3D3WoCFLbix5Hg6qIPQ6Js9r7f8jDUmsnnguRNCSw4wU/IQ=="],
+
+    "openredaction": ["openredaction@1.1.2", "", { "peerDependencies": { "mammoth": "^1.6.0", "pdf-parse": "^1.1.1", "react": "^18.0.0 || ^19.0.0", "tesseract.js": "^5.0.0" }, "optionalPeers": ["mammoth", "pdf-parse", "react", "tesseract.js"] }, "sha512-jxHG+LcNvqCFJDrDpCsNygE26XFCfj3kafyVfNtdbQBSApDDNcoQYWMp5rIKstQQ70Eg5AjEU41jFRp6pnfIqw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 

--- a/src/systems/subspace/modules/session/package.json
+++ b/src/systems/subspace/modules/session/package.json
@@ -26,6 +26,7 @@
     "@metorial-subspace/module-deployment": "^1.0.0",
     "@metorial-subspace/module-provider-internal": "^1.0.0",
     "@metorial-subspace/module-tenant": "^1.0.0",
+    "openredaction": "^1.1.2",
     "p-queue": "^8.0.1"
   },
   "devDependencies": {

--- a/src/systems/subspace/modules/session/src/lib/providerTelemetryErrorGroupExport.test.ts
+++ b/src/systems/subspace/modules/session/src/lib/providerTelemetryErrorGroupExport.test.ts
@@ -23,7 +23,6 @@ vi.mock('../services/sessionMessage', () => ({
 
 import {
   PROVIDER_TELEMETRY_FAILED_MESSAGES_STATE_KEY,
-  anonymizeProviderTelemetryExportValue,
   getProviderTelemetryFailedMessagesExportChunkKey,
   listProviderTelemetryFailedMessagesForExport,
   runProviderTelemetryErrorGroupsExport,
@@ -122,11 +121,13 @@ let createPresentedMessage = (candidate: ProviderTelemetryFailedMessageExportCan
   input: {
     data: {
       email: 'alice@example.com',
-      token: 'secret-token',
+      token: 'Bearer abcdefghijklmnopqrstuvwxyz012345',
+      phone: '+1 202-555-0110',
       query: 'https://api.example.com/callback?client_secret=top-secret&safe=yes',
       retryCount: 2,
       ok: false,
-      missing: null
+      missing: null,
+      createdAt: new Date('2026-06-18T00:09:00.000Z')
     }
   },
   output: {
@@ -164,7 +165,7 @@ let createPresentedMessage = (candidate: ProviderTelemetryFailedMessageExportCan
     code: candidate.error.code,
     message: 'Top-level provider error',
     data: {
-      authorization: 'Bearer abc123',
+      authorization: 'Bearer abcdefghijklmnopqrstuvwxyz012345',
       code: 'PROVIDER_ERROR',
       object: 'provider.error',
       status: 500,
@@ -174,7 +175,8 @@ let createPresentedMessage = (candidate: ProviderTelemetryFailedMessageExportCan
       }
     },
     groupId: candidate.error.group.id
-  }
+  },
+  createdAt: new Date('2026-06-18T00:10:00.000Z')
 });
 
 describe('runProviderTelemetryErrorGroupsExport', () => {
@@ -329,9 +331,49 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
         }
       ]
     });
-    expect(exportChunk.items[0].payload).toEqual(
-      anonymizeProviderTelemetryExportValue(createPresentedMessage(candidate))
-    );
+    let payload = exportChunk.items[0].payload;
+    expect(payload).toMatchObject({
+      object: 'session.message',
+      id: 'msg_1',
+      type: 'tool_call',
+      status: 'failed',
+      source: 'model',
+      input: {
+        data: {
+          token: '[REDACTED]',
+          phone: '[REDACTED]',
+          retryCount: 2,
+          ok: false,
+          missing: null,
+          createdAt: '2026-06-18T00:09:00.000Z'
+        }
+      },
+      toolCall: {
+        id: 'tc_1',
+        toolKey: 'elasticsearch_search_documents',
+        rationale: '[REDACTED]',
+        operation: 'call_tool',
+        tool: {
+          id: 'tool_1',
+          key: 'elasticsearch_search_documents',
+          name: '[REDACTED]',
+          providerId: 'prv_1'
+        }
+      },
+      error: {
+        id: 'serr_1',
+        code: 'provider_error',
+        message: '[REDACTED]',
+        data: {
+          authorization: '[REDACTED]',
+          code: 'PROVIDER_ERROR',
+          object: 'provider.error',
+          status: 500
+        },
+        groupId: 'serg_1'
+      },
+      createdAt: '2026-06-18T00:10:00.000Z'
+    });
 
     let stateFile = parseJsonCall(storage.putObject.mock.calls[1]!);
     expect(stateFile).toEqual({
@@ -346,6 +388,183 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
       exportedKeys: [expectedKey],
       state: stateFile,
       exportedCount: 1
+    });
+  });
+
+  it('redacts a broad set of OpenRedaction-supported PII categories in export payloads', async () => {
+    let now = new Date('2026-06-18T00:15:00.000Z');
+    let storage = createStorage(undefined);
+    let candidate = createCandidate();
+    let listFailedMessages = vi.fn(
+      async (_input: ProviderTelemetryFailedMessagesExportListInput) => ({
+        items: [candidate],
+        nextWatermark: {
+          occurred_at: '2026-06-18T00:10:00.000Z',
+          id: 'serr_1'
+        },
+        hasMore: false
+      })
+    );
+
+    await runProviderTelemetryErrorGroupsExport({
+      now,
+      storage,
+      bucketName: 'exports',
+      listFailedMessages,
+      presentMessage: async () => ({
+        object: 'session.message',
+        id: candidate.message.id,
+        status: 'failed',
+        input: {
+          samples: {
+            personal: {
+              name: 'John Smith',
+              phone: '+1 202-555-0110',
+              address: '123 Main Street, Springfield, IL 62704'
+            },
+            financial: {
+              creditCard: '4111 1111 1111 1111',
+              iban: 'IBAN GB82 WEST 1234 5698 7654 32',
+              routingNumber: 'routing number 021000021',
+              swiftBic: 'SWIFT BIC DEUTDEFF',
+              bankAccount: 'bank account 12345678',
+              vatNumber: 'VAT GB123456789'
+            },
+            government: {
+              passport: 'Passport A1234567',
+              taxId: 'Tax ID 12-3456789'
+            },
+            healthcare: {
+              medicalRecord: 'MRN MR123456',
+              nhsNumber: 'NHS 943 476 5919',
+              deaNumber: 'DEA AB1234563',
+              npiNumber: 'NPI 1234567893',
+              providerLicense: 'Provider license AB123456'
+            },
+            digitalIdentity: {
+              jwt: [
+                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+                'eyJzdWIiOiIxMjM0NTY3ODkwIn0',
+                's5x9IXdBaxnU7D6yH4bVq9U1xIr3W5y33C0w6eLLq3s'
+              ].join('.'),
+              bearer: 'Bearer abcdefghijklmnopqrstuvwxyz012345',
+              macAddress: '00:1B:44:11:3A:B7',
+              bitcoinAddress: '1BoatSLRHtKNngkdXEeobR76b53LETtpyT',
+              ethereumAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e'
+            },
+            education: {
+              studentId: 'Student ID AB123456',
+              teachingLicense: 'Teacher license EDU123456'
+            },
+            transportation: {
+              vin: 'VIN 1HGCM82633A004352',
+              fedexTracking: 'FedEx tracking 123456789012',
+              upsTracking: 'UPS tracking 1Z999AA10123456784',
+              licensePlate: 'Plate ABC1234'
+            },
+            insuranceAndLegal: {
+              policyNumber: 'Policy AB12345678',
+              claimId: 'Claim 1234567890',
+              caseNumber: 'Case CV-2024-123456'
+            },
+            professionalAndProperty: {
+              nursingLicense: 'RN-123456',
+              cpaLicense: 'CPA-123456',
+              parcelNumber: 'APN-123-456-789'
+            },
+            operationalMetadata: {
+              providerSlug: 'slack',
+              toolKey: 'users_info',
+              statusCode: 500,
+              retryable: false,
+              tags: ['provider_error', 'tool_call']
+            }
+          },
+          safeDiagnostics: {
+            retryCount: 2,
+            ok: false,
+            missing: null
+          }
+        },
+        createdAt: new Date('2026-06-18T00:10:00.000Z')
+      })
+    });
+
+    let exportChunk = parseJsonCall(storage.putObject.mock.calls[0]!);
+    let payload = exportChunk.items[0].payload;
+
+    expect(payload.input.samples).toEqual({
+      personal: {
+        name: '[REDACTED]',
+        phone: '[REDACTED]',
+        address: '[REDACTED]'
+      },
+      financial: {
+        creditCard: '[REDACTED]',
+        iban: '[REDACTED]',
+        routingNumber: '[REDACTED]',
+        swiftBic: '[REDACTED]',
+        bankAccount: '[REDACTED]',
+        vatNumber: '[REDACTED]'
+      },
+      government: {
+        passport: '[REDACTED]',
+        taxId: '[REDACTED]'
+      },
+      healthcare: {
+        medicalRecord: '[REDACTED]',
+        nhsNumber: '[REDACTED]',
+        deaNumber: '[REDACTED]',
+        npiNumber: '[REDACTED]',
+        providerLicense: '[REDACTED]'
+      },
+      digitalIdentity: {
+        jwt: '[REDACTED]',
+        bearer: '[REDACTED]',
+        macAddress: '[REDACTED]',
+        bitcoinAddress: '[REDACTED]',
+        ethereumAddress: '[REDACTED]'
+      },
+      education: {
+        studentId: '[REDACTED]',
+        teachingLicense: '[REDACTED]'
+      },
+      transportation: {
+        vin: '[REDACTED]',
+        fedexTracking: '[REDACTED]',
+        upsTracking: '[REDACTED]',
+        licensePlate: '[REDACTED]'
+      },
+      insuranceAndLegal: {
+        policyNumber: '[REDACTED]',
+        claimId: '[REDACTED]',
+        caseNumber: '[REDACTED]'
+      },
+      professionalAndProperty: {
+        nursingLicense: '[REDACTED]',
+        cpaLicense: '[REDACTED]',
+        parcelNumber: '[REDACTED]'
+      },
+      operationalMetadata: {
+        providerSlug: 'slack',
+        toolKey: 'users_info',
+        statusCode: 500,
+        retryable: false,
+        tags: ['provider_error', 'tool_call']
+      }
+    });
+    expect(payload).toMatchObject({
+      object: 'session.message',
+      id: 'msg_1',
+      status: 'failed',
+      input: {
+        safeDiagnostics: {
+          retryCount: 2,
+          ok: false,
+          missing: null
+        }
+      },
+      createdAt: '2026-06-18T00:10:00.000Z'
     });
   });
 
@@ -535,156 +754,6 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
     });
     expect(result.exportedKeys).toEqual([]);
     expect(result.exportedCount).toBe(0);
-  });
-});
-
-describe('anonymizeProviderTelemetryExportValue', () => {
-  it('redacts payload strings while preserving safe diagnostic identifiers', () => {
-    let date = new Date('2026-06-18T00:00:00.000Z');
-    let anonymized = anonymizeProviderTelemetryExportValue({
-      id: 'msg_1',
-      messageId: 'msg_1',
-      toolKey: 'users.info',
-      nested: {
-        email: 'person@example.com',
-        text: 'Contact admin@example.com with Basic abc123',
-        callbackUrl: 'https://example.com/callback?client_secret=secret-value&safe=yes',
-        retryCount: 2,
-        ok: true,
-        missing: null,
-        date,
-        values: ['a', 1, false]
-      },
-      output: {
-        error: {
-          code: -32000,
-          message: 'Output error message',
-          data: {
-            code: 'MCP_ERROR',
-            Message: 'Case-insensitive message',
-            values: ['visible', 2, false]
-          }
-        }
-      },
-      error: {
-        id: 'serr_1',
-        code: 'provider_error',
-        message: 'Top-level error message',
-        data: {
-          authorization: 'Bearer abc123',
-          object: 'provider.error',
-          status: 500,
-          message: 'Nested message',
-          nested: {
-            MESSAGE: 'Uppercase message'
-          }
-        }
-      },
-      toolCall: {
-        id: 'tc_1',
-        toolKey: 'users.info',
-        rationale: 'User asked for it',
-        operation: 'call_tool',
-        tool: {
-          id: 'tool_1',
-          key: 'users.info',
-          name: 'Users Info',
-          providerId: 'prv_1'
-        },
-        nested: {
-          operation: 'nested operation',
-          detail: 'visible detail'
-        }
-      }
-    }) as any;
-
-    expect(anonymized).toEqual({
-      id: '[string]',
-      messageId: '[string]',
-      toolKey: '[string]',
-      nested: {
-        email: '[string]',
-        text: '[string]',
-        callbackUrl: '[string]',
-        retryCount: 2,
-        ok: true,
-        missing: null,
-        date,
-        values: ['[string]', 1, false]
-      },
-      output: {
-        error: {
-          code: -32000,
-          data: {
-            code: 'MCP_ERROR',
-            values: ['[string]', 2, false]
-          }
-        }
-      },
-      error: {
-        id: 'serr_1',
-        code: 'provider_error',
-        data: {
-          authorization: '[string]',
-          object: 'provider.error',
-          status: 500,
-          nested: {}
-        }
-      },
-      toolCall: {
-        id: 'tc_1',
-        toolKey: 'users.info',
-        tool: {
-          id: 'tool_1',
-          key: 'users.info',
-          name: 'Users Info',
-          providerId: 'prv_1'
-        },
-        nested: {
-          detail: '[string]'
-        }
-      }
-    });
-  });
-
-  it('keeps preserve exceptions scoped by path and key', () => {
-    let anonymized = anonymizeProviderTelemetryExportValue({
-      detail: 'ordinary detail',
-      notToolCall: {
-        rationale: 'ordinary rationale',
-        operation: 'ordinary operation'
-      },
-      notError: {
-        message: 'ordinary message',
-        code: 'ordinary_code'
-      },
-      Error: {
-        code: 'CASE_INSENSITIVE_ERROR',
-        Message: 'removed message'
-      },
-      ToolCall: {
-        toolKey: 'case.insensitive.tool',
-        Operation: 'removed operation'
-      }
-    }) as any;
-
-    expect(anonymized).toEqual({
-      detail: '[string]',
-      notToolCall: {
-        rationale: '[string]',
-        operation: '[string]'
-      },
-      notError: {
-        message: '[string]',
-        code: '[string]'
-      },
-      Error: {
-        code: 'CASE_INSENSITIVE_ERROR'
-      },
-      ToolCall: {
-        toolKey: 'case.insensitive.tool'
-      }
-    });
   });
 });
 

--- a/src/systems/subspace/modules/session/src/lib/providerTelemetryErrorGroupExport.ts
+++ b/src/systems/subspace/modules/session/src/lib/providerTelemetryErrorGroupExport.ts
@@ -3,6 +3,7 @@ import {
   getProviderTelemetryErrorGroupsStorageTarget
 } from '@metorial-subspace/connection-utils';
 import { db, messageTranslator } from '@metorial-subspace/db';
+import { JsonProcessor, OpenRedaction } from 'openredaction';
 import { sessionMessageService } from '../services/sessionMessage';
 
 export let PROVIDER_TELEMETRY_FAILED_MESSAGES_STATE_KEY =
@@ -13,7 +14,6 @@ export let PROVIDER_TELEMETRY_ERROR_GROUPS_STATE_KEY =
 
 let DEFAULT_EXPORT_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
 let EXPORT_PAGE_SIZE = 100;
-let STRING_PLACEHOLDER = '[string]';
 
 export type ProviderTelemetryFailedMessagesExportWatermark = {
   occurred_at: string;
@@ -258,95 +258,37 @@ let writeJsonObject = async (d: {
   );
 };
 
-let OMIT_PROVIDER_TELEMETRY_EXPORT_VALUE = Symbol('omitProviderTelemetryExportValue');
-
-type ProviderTelemetryExportSanitizerState = {
-  key: string | null;
-  inError: boolean;
-  inToolCall: boolean;
+let providerTelemetryExportRedactionOptions = {
+  deterministic: true,
+  redactionMode: 'placeholder' as const,
+  enableLearning: false,
+  enableCache: true
 };
 
-let ERROR_DIAGNOSTIC_STRING_KEYS = new Set(['id', 'code', 'object', 'groupid', 'type']);
-let TOOL_CALL_DIAGNOSTIC_STRING_KEYS = new Set(['id', 'toolkey', 'key', 'name', 'providerid']);
+let providerTelemetryExportRedactor = new OpenRedaction(
+  providerTelemetryExportRedactionOptions
+);
+let providerTelemetryExportJsonProcessor = new JsonProcessor();
 
-let shouldOmitProviderTelemetryExportField = (
-  keyLower: string | null,
-  state: ProviderTelemetryExportSanitizerState
-) => {
-  if (state.inError && keyLower === 'message') return true;
-  if (state.inToolCall && (keyLower === 'rationale' || keyLower === 'operation')) {
-    return true;
-  }
-
-  return false;
+let normalizeJsonValue = (value: unknown) => {
+  let json = JSON.stringify(value);
+  return json === undefined ? undefined : JSON.parse(json);
 };
 
-let shouldPreserveProviderTelemetryExportString = (
-  keyLower: string | null,
-  state: ProviderTelemetryExportSanitizerState
-) => {
-  if (!keyLower) return false;
-  if (state.inError && ERROR_DIAGNOSTIC_STRING_KEYS.has(keyLower)) return true;
-  if (state.inToolCall && TOOL_CALL_DIAGNOSTIC_STRING_KEYS.has(keyLower)) return true;
+let redactProviderTelemetryExportPayload = async (value: unknown) => {
+  let normalized = normalizeJsonValue(value);
+  if (normalized === undefined) return normalized;
 
-  return false;
-};
-
-let sanitizeProviderTelemetryExportValue = (
-  value: unknown,
-  state: ProviderTelemetryExportSanitizerState
-): unknown | typeof OMIT_PROVIDER_TELEMETRY_EXPORT_VALUE => {
-  let keyLower = state.key?.toLowerCase() ?? null;
-
-  if (shouldOmitProviderTelemetryExportField(keyLower, state)) {
-    return OMIT_PROVIDER_TELEMETRY_EXPORT_VALUE;
-  }
-
-  if (value === null || value === undefined) return value;
-  if (value instanceof Date) return value;
-  if (typeof value === 'string') {
-    if (shouldPreserveProviderTelemetryExportString(keyLower, state)) return value;
-    return STRING_PLACEHOLDER;
-  }
-  if (typeof value !== 'object') return value;
-
-  if (Array.isArray(value)) {
-    return value.map(item => {
-      let sanitized = sanitizeProviderTelemetryExportValue(item, {
-        ...state,
-        key: null
-      });
-
-      return sanitized === OMIT_PROVIDER_TELEMETRY_EXPORT_VALUE ? undefined : sanitized;
-    });
-  }
-
-  return Object.fromEntries(
-    Object.entries(value).flatMap(([entryKey, entryValue]) => {
-      let entryKeyLower = entryKey.toLowerCase();
-      let sanitized = sanitizeProviderTelemetryExportValue(entryValue, {
-        key: entryKey,
-        inError: state.inError || entryKeyLower === 'error',
-        inToolCall: state.inToolCall || entryKeyLower === 'toolcall'
-      });
-
-      return sanitized === OMIT_PROVIDER_TELEMETRY_EXPORT_VALUE ? [] : [[entryKey, sanitized]];
-    })
+  let detection = await providerTelemetryExportJsonProcessor.detect(
+    normalized,
+    providerTelemetryExportRedactor
   );
+
+  return providerTelemetryExportJsonProcessor.redact(normalized, detection);
 };
 
-export let anonymizeProviderTelemetryExportValue = (value: unknown): unknown => {
-  let sanitized = sanitizeProviderTelemetryExportValue(value, {
-    key: null,
-    inError: false,
-    inToolCall: false
-  });
-
-  return sanitized === OMIT_PROVIDER_TELEMETRY_EXPORT_VALUE ? undefined : sanitized;
-};
-
-let sanitizeS3KeyComponent = (value: string | null | undefined) => {
-  let sanitized = String(value ?? '')
+let normalizeS3KeyComponent = (value: string | null | undefined) => {
+  let normalized = String(value ?? '')
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9._-]+/g, '_')
@@ -354,7 +296,7 @@ let sanitizeS3KeyComponent = (value: string | null | undefined) => {
     .replace(/^[-_.]+|[-_.]+$/g, '')
     .slice(0, 120);
 
-  return sanitized || 'unknown';
+  return normalized || 'unknown';
 };
 
 export let getProviderTelemetryFailedMessagesExportChunkKey = (
@@ -373,7 +315,7 @@ export let getProviderTelemetryFailedMessagesExportChunkKey = (
     first.error.id,
     last.error.id
   ]
-    .map(sanitizeS3KeyComponent)
+    .map(normalizeS3KeyComponent)
     .join('-');
 
   return ['provider-telemetry', `${filename}.json`].join('/');
@@ -446,7 +388,7 @@ let createExportItem = async (d: {
     message_id: d.candidate.message.id,
     provider: d.candidate.provider,
     tool: d.candidate.tool,
-    payload: anonymizeProviderTelemetryExportValue(payload)
+    payload: await redactProviderTelemetryExportPayload(payload)
   };
 };
 


### PR DESCRIPTION
Improve sanitisation for logs export

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how sensitive data is stripped before external export; behavior differs from the old sanitizer (e.g. more fields redacted, `[REDACTED]` vs `[string]`), which could affect downstream consumers of export chunks.
> 
> **Overview**
> Provider telemetry **failed-message export** payloads are no longer scrubbed by the in-house `anonymizeProviderTelemetryExportValue` walker (blanket `[string]` placeholders and path-based preserves). They now go through **`openredaction`** (`OpenRedaction` + `JsonProcessor`) with deterministic placeholder mode (`[REDACTED]`), learning disabled, and cache enabled.
> 
> **`redactProviderTelemetryExportPayload`** JSON-normalizes the presented message, runs detect/redact, and is awaited when building each export item. S3 chunk key segment normalization is renamed from `sanitizeS3KeyComponent` to **`normalizeS3KeyComponent`** (behavior unchanged).
> 
> Tests drop the dedicated anonymizer suite and assert redaction via the full export path, including a broad PII-category fixture and updated expectations (e.g. tokens, phones, tool names, error messages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aab6706112a3e0c67c13c18d82d1ca274b45f4ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->