### PR TITLE
Update instance paths

### DIFF
--- a/src/backend/db/prisma/schema/organization/instance.prisma
+++ b/src/backend/db/prisma/schema/organization/instance.prisma
@@ -70,10 +70,12 @@ model Instance {
   status InstanceStatus
 
   slug          String   @unique
+  oldSlug       String?  @unique
   previousSlugs String[]
   name          String
 
-  hasBeenReconciled Boolean @default(false)
+  hasBeenReconciled  Boolean @default(false)
+  hasBeenReconciled2 Boolean @default(false)
 
   projectOid BigInt
   project    Project @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
@@ -138,4 +140,6 @@ model Instance {
   internalOAuthTokens                  InternalOAuthToken[]
 
   @@index([previousSlugs])
+  @@index([oldSlug])
+  @@index([slug])
 }

--- a/src/backend/modules/organization/src/queues/reconcileProjectInstances.ts
+++ b/src/backend/modules/organization/src/queues/reconcileProjectInstances.ts
@@ -1,26 +1,25 @@
 import { createCron } from '@metorial/cron';
 import { db } from '@metorial/db';
 import { combineQueueProcessors, createQueue, QueueRetryError } from '@metorial/queue';
-import { instanceService } from '../services/instance';
-import { organizationActorService } from '../services/organizationActor';
+import { instanceService } from '../services';
 
 export let RECONCILE_PROJECT_INSTANCES_BATCH_SIZE = 500;
 
 export let reconcileProjectInstancesCron = createCron(
   {
-    name: 'org/project-instances/reconcile/cron',
+    name: 'org/instances/reconcile/cron',
     cron: '0 5 * * *'
   },
   async () => {
     await reconcileProjectInstancesSearchQueue.add(
       {},
-      { id: 'org-project-instances-reconcile-search' }
+      { id: 'org-instances-reconcile-search' }
     );
   }
 );
 
 export let reconcileProjectInstancesSearchQueue = createQueue<{ cursor?: string }>({
-  name: 'org/project-instances/reconcile/search'
+  name: 'org/instances/reconcile/search'
 });
 
 setTimeout(() => {
@@ -29,16 +28,11 @@ setTimeout(() => {
 
 export let reconcileProjectInstancesSearchQueueProcessor =
   reconcileProjectInstancesSearchQueue.process(async data => {
-    let projects = await db.project.findMany({
+    let instances = await db.instance.findMany({
       where: {
         status: 'active',
         id: data.cursor ? { gt: data.cursor } : undefined,
-        instances: {
-          some: {
-            status: 'active',
-            hasBeenReconciled: false
-          }
-        }
+        hasBeenReconciled2: false
       },
       orderBy: { id: 'asc' },
       take: RECONCILE_PROJECT_INSTANCES_BATCH_SIZE,
@@ -46,46 +40,56 @@ export let reconcileProjectInstancesSearchQueueProcessor =
         id: true
       }
     });
-    if (projects.length === 0) return;
+    if (instances.length === 0) return;
 
-    for (let project of projects) {
-      await reconcileProjectInstancesQueue.add(
-        {
-          projectId: project.id
-        },
-        { id: project.id }
-      );
-    }
+    await reconcileProjectInstancesQueue.addMany(
+      instances.map(instance => ({
+        instanceId: instance.id
+      }))
+    );
 
-    let lastProject = projects[projects.length - 1];
-    if (!lastProject) return;
+    let lastInstance = instances[instances.length - 1];
+    if (!lastInstance) return;
 
     await reconcileProjectInstancesSearchQueue.add({
-      cursor: lastProject.id
+      cursor: lastInstance.id
     });
   });
 
-export let reconcileProjectInstancesQueue = createQueue<{ projectId: string }>({
-  name: 'org/project-instances/reconcile/project',
+export let reconcileProjectInstancesQueue = createQueue<{ instanceId: string }>({
+  name: 'org/instances/reconcile/instance',
   workerOpts: { concurrency: 5 }
 });
 
 export let reconcileProjectInstancesQueueProcessor = reconcileProjectInstancesQueue.process(
   async data => {
-    let project = await db.project.findUnique({
-      where: { id: data.projectId },
-      include: { organization: true }
+    let instance = await db.instance.findUnique({
+      where: { id: data.instanceId },
+      include: { project: true }
     });
-    if (!project) throw new QueueRetryError();
+    if (!instance) throw new QueueRetryError();
 
-    let systemActor = await organizationActorService.getSystemActor({
-      organization: project.organization
+    if (instance.oldSlug) return;
+
+    let slug = await instanceService.generateInstanceSlug({
+      project: instance.project,
+      input: instance
     });
 
-    await instanceService.reconcileProjectInstances({
-      project,
-      performedBy: systemActor,
-      context: { ip: '0.0.0.0', ua: 'Metorial' }
+    await db.instance.updateMany({
+      where: {
+        id: data.instanceId,
+        oldSlug: null,
+        hasBeenReconciled2: false
+      },
+      data: {
+        hasBeenReconciled2: true,
+        slug,
+        oldSlug: instance.slug,
+        previousSlugs: {
+          push: instance.slug
+        }
+      }
     });
   }
 );

--- a/src/backend/modules/organization/src/services/instance.ts
+++ b/src/backend/modules/organization/src/services/instance.ts
@@ -32,7 +32,7 @@ let getInstanceSlug = createSlugGenerator(
   async slug =>
     !(await db.instance.findFirst({
       where: {
-        OR: [{ slug }, { previousSlugs: { has: slug } }]
+        OR: [{ slug }, { oldSlug: slug }, { previousSlugs: { has: slug } }]
       }
     }))
 );
@@ -261,6 +261,21 @@ class InstanceService {
     return sandbox;
   }
 
+  async generateInstanceSlug(d: {
+    project: Project;
+    input: {
+      name: string;
+      type: InstanceType;
+    };
+  }) {
+    return await getInstanceSlug({
+      input:
+        d.input.type === 'development'
+          ? `${d.project.name}-${d.input.name}-${generateCode(5)}`
+          : `${d.project.name}`
+    });
+  }
+
   async createInstance(d: {
     project: Project;
     organization: Organization;
@@ -278,14 +293,17 @@ class InstanceService {
         await this.ensureCanCreateProductionInstance({ project: d.project });
       }
 
+      let slug = await this.generateInstanceSlug(d);
+
       let instance = await db.instance.create({
         data: {
           id: await ID.generateId('instance'),
           status: 'active',
-          slug: await getInstanceSlug({ input: `${d.input.name}-${generateCode(5)}` }),
+          slug,
           name: d.input.name,
           type: d.input.type,
           hasBeenReconciled: true,
+          hasBeenReconciled2: true,
           organizationOid: d.organization.oid,
           projectOid: d.project.oid
         },
@@ -787,94 +805,6 @@ class InstanceService {
           })
       )
     );
-  }
-
-  async reconcileProjectInstances(d: {
-    project: Project & { organization: Organization };
-    performedBy: OrganizationActor;
-    context: Context;
-  }) {
-    return withTransaction(async db => {
-      let instances = await db.instance.findMany({
-        where: {
-          projectOid: d.project.oid,
-          status: 'active',
-          hasBeenReconciled: false
-        },
-        orderBy: { createdAt: 'asc' },
-        include: {
-          organization: true,
-          project: true
-        }
-      });
-
-      if (instances.length === 0) return { reconciled: 0 };
-
-      let productionInstance = await db.instance.findFirst({
-        where: {
-          projectOid: d.project.oid,
-          status: 'active',
-          type: 'production'
-        },
-        select: {
-          id: true
-        }
-      });
-      let promotedInstanceId: string | undefined;
-
-      if (!productionInstance) {
-        let oldestDevelopmentInstance = instances[0];
-        let slug = await getInstanceSlug({ input: `Production-${generateCode(5)}` });
-
-        let instance = await db.instance.update({
-          where: { oid: oldestDevelopmentInstance.oid },
-          data: {
-            name: 'Production',
-            slug,
-            previousSlugs: getNextPreviousSlugs({
-              previousSlugs: oldestDevelopmentInstance.previousSlugs ?? [],
-              currentSlug: oldestDevelopmentInstance.slug,
-              nextSlug: slug
-            }),
-            type: 'production',
-            hasBeenReconciled: true
-          },
-          include: {
-            organization: true,
-            project: true
-          }
-        });
-
-        promotedInstanceId = instance.id;
-
-        await this.syncInstanceCompanions({
-          instance,
-          performedBy: d.performedBy
-        });
-      }
-
-      for (let instance of instances) {
-        if (instance.id === promotedInstanceId) continue;
-
-        await this.syncInstanceCompanions({
-          instance,
-          performedBy: d.performedBy
-        });
-
-        await db.instance.update({
-          where: { oid: instance.oid },
-          data: {
-            hasBeenReconciled: true
-          }
-        });
-      }
-
-      await addAfterTransactionHook(() =>
-        syncSubspaceTenantQueue.add({ projectId: d.project.id })
-      );
-
-      return { reconciled: instances.length };
-    });
   }
 }
 

--- a/src/backend/modules/organization/test/instance.test.ts
+++ b/src/backend/modules/organization/test/instance.test.ts
@@ -977,32 +977,6 @@ describe('InstanceService', () => {
 
         return callback(mockDb as any);
       });
-
-      let result = await instanceService.reconcileProjectInstances({
-        project: {
-          id: 'proj-1',
-          oid: 1,
-          organization: { id: 'org-1', oid: 1 }
-        } as any,
-        performedBy: { id: 'actor-1', oid: 7 } as any,
-        context: {} as any
-      });
-
-      expect(result).toEqual({ reconciled: 1 });
-      expect(update).toHaveBeenCalledWith({
-        where: { oid: 1 },
-        data: {
-          name: 'Production',
-          slug: 'test-slug',
-          previousSlugs: ['development'],
-          type: 'production',
-          hasBeenReconciled: true
-        },
-        include: {
-          organization: true,
-          project: true
-        }
-      });
     });
   });
 

--- a/src/backend/modules/organization/test/reconcileProjectInstances.test.ts
+++ b/src/backend/modules/organization/test/reconcileProjectInstances.test.ts
@@ -1,14 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-let { reconcileProjectInstancesCronHandler } = vi.hoisted(() => ({
-  reconcileProjectInstancesCronHandler: undefined as (() => Promise<void>) | undefined
-}));
+let reconcileProjectInstancesCronHandler:
+  | (() => Promise<void>)
+  | undefined;
+
+process.env.REDIS_URL = 'redis://localhost:6379';
 
 vi.mock('@metorial/db', () => ({
   db: {
-    project: {
+    instance: {
       findMany: vi.fn(),
-      findUnique: vi.fn()
+      findUnique: vi.fn(),
+      updateMany: vi.fn()
     }
   }
 }));
@@ -17,6 +20,14 @@ vi.mock('@metorial/cron', () => ({
   createCron: vi.fn((_config, handler) => {
     reconcileProjectInstancesCronHandler = handler;
     return { handler };
+  })
+}));
+
+vi.mock('@metorial/config', () => ({
+  getConfig: () => ({
+    service: {
+      REDIS_URL: 'redis://localhost:6379'
+    }
   })
 }));
 
@@ -36,28 +47,28 @@ vi.mock('@metorial/queue', () => ({
   }
 }));
 
-vi.mock('../src/services/instance', () => ({
+vi.mock('@metorial/internal-clients', () => ({
+  ensureInternalProjectTenant: vi.fn(),
+  ensureInternalScope: vi.fn()
+}));
+
+vi.mock('../src/services', () => ({
   instanceService: {
-    reconcileProjectInstances: vi.fn()
+    generateInstanceSlug: vi.fn()
   }
 }));
 
-vi.mock('../src/services/organizationActor', () => ({
-  organizationActorService: {
-    getSystemActor: vi.fn()
-  }
-}));
+const { db } = await import('@metorial/db');
+const { instanceService } = await import('../src/services');
 
-import { db } from '@metorial/db';
-import { instanceService } from '../src/services/instance';
-import { organizationActorService } from '../src/services/organizationActor';
-import {
-  reconcileProjectInstancesCron,
-  reconcileProjectInstancesQueueProcessor,
-  reconcileProjectInstancesQueue,
-  reconcileProjectInstancesSearchQueue,
-  reconcileProjectInstancesSearchQueueProcessor
-} from '../src/queues/reconcileProjectInstances';
+let reconcileProjectInstancesModule:
+  | typeof import('../src/queues/reconcileProjectInstances')
+  | undefined;
+
+let getModule = async () => {
+  reconcileProjectInstancesModule ??= await import('../src/queues/reconcileProjectInstances');
+  return reconcileProjectInstancesModule;
+};
 
 describe('reconcileProjectInstances queues', () => {
   beforeEach(() => {
@@ -65,70 +76,93 @@ describe('reconcileProjectInstances queues', () => {
   });
 
   it('creates a daily cron that enqueues the search queue', async () => {
+    let {
+      reconcileProjectInstancesCron,
+      reconcileProjectInstancesSearchQueue
+    } = await getModule();
+
     expect(reconcileProjectInstancesCron).toBeDefined();
 
     await reconcileProjectInstancesCronHandler!();
 
     expect(reconcileProjectInstancesSearchQueue.add).toHaveBeenCalledWith(
       {},
-      { id: 'org-project-instances-reconcile-search' }
+      { id: 'org-instances-reconcile-search' }
     );
   });
 
-  it('fans out active projects into single reconcile jobs', async () => {
-    vi.mocked(db.project.findMany).mockResolvedValue([
-      { id: 'proj-1' },
-      { id: 'proj-2' }
+  it('fans out active instances into single reconcile jobs', async () => {
+    let {
+      reconcileProjectInstancesQueue,
+      reconcileProjectInstancesSearchQueue,
+      reconcileProjectInstancesSearchQueueProcessor
+    } = await getModule();
+
+    (db.instance.findMany as any).mockResolvedValue([
+      { id: 'instance-1' },
+      { id: 'instance-2' }
     ] as any);
 
     await (reconcileProjectInstancesSearchQueueProcessor as any).handler({});
 
-    expect(db.project.findMany).toHaveBeenCalledWith({
+    expect(db.instance.findMany).toHaveBeenCalledWith({
       where: {
         status: 'active',
         id: undefined,
-        instances: {
-          some: {
-            status: 'active',
-            hasBeenReconciled: false
-          }
-        }
+        hasBeenReconciled2: false
       },
       orderBy: { id: 'asc' },
       take: 500,
       select: { id: true }
     });
-    expect(reconcileProjectInstancesQueue.add).toHaveBeenCalledWith(
-      { projectId: 'proj-1' },
-      { id: 'proj-1' }
-    );
-    expect(reconcileProjectInstancesQueue.add).toHaveBeenCalledWith(
-      { projectId: 'proj-2' },
-      { id: 'proj-2' }
-    );
+    expect(reconcileProjectInstancesQueue.addMany).toHaveBeenCalledWith([
+      { instanceId: 'instance-1' },
+      { instanceId: 'instance-2' }
+    ]);
     expect(reconcileProjectInstancesSearchQueue.add).toHaveBeenCalledWith({
-      cursor: 'proj-2'
+      cursor: 'instance-2'
     });
   });
 
-  it('delegates single project reconciliation to instanceService', async () => {
-    let project = {
-      id: 'proj-1',
-      organization: { id: 'org-1' }
-    };
-    let systemActor = { id: 'actor-system' };
+  it('reconciles a single instance by generating a slug and updating it', async () => {
+    let { reconcileProjectInstancesQueueProcessor } = await getModule();
 
-    vi.mocked(db.project.findUnique).mockResolvedValue(project as any);
-    vi.mocked(organizationActorService.getSystemActor).mockResolvedValue(systemActor as any);
+    let instance = {
+      id: 'instance-1',
+      slug: 'old-slug',
+      oldSlug: null,
+      project: { id: 'project-1', name: 'Project One' }
+    };
+
+    (db.instance.findUnique as any).mockResolvedValue(instance as any);
+    (instanceService.generateInstanceSlug as any).mockResolvedValue('new-slug' as any);
 
     await (reconcileProjectInstancesQueueProcessor as any).handler({
-      projectId: 'proj-1'
+      instanceId: 'instance-1'
     });
 
-    expect(instanceService.reconcileProjectInstances).toHaveBeenCalledWith({
-      project,
-      performedBy: systemActor,
-      context: { ip: '0.0.0.0', ua: 'Metorial' }
+    expect(db.instance.findUnique).toHaveBeenCalledWith({
+      where: { id: 'instance-1' },
+      include: { project: true }
+    });
+    expect(instanceService.generateInstanceSlug).toHaveBeenCalledWith({
+      project: instance.project,
+      input: instance
+    });
+    expect(db.instance.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: 'instance-1',
+        oldSlug: null,
+        hasBeenReconciled2: false
+      },
+      data: {
+        hasBeenReconciled2: true,
+        slug: 'new-slug',
+        oldSlug: 'old-slug',
+        previousSlugs: {
+          push: 'old-slug'
+        }
+      }
     });
   });
 });

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/_layout.tsx
@@ -68,7 +68,7 @@ export let CustomProviderLayout = () => {
                   organization.data,
                   project.data,
                   instance.data,
-                  customProvider.data.provider.id
+                  customProvider.data.provider.slug
                 )}
               >
                 <Button as="span" size="2" variant="outline">

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/settings/listing.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/settings/listing.tsx
@@ -60,7 +60,7 @@ export let CustomProviderListingPage = () => {
             instance.data?.organization,
             instance.data?.project,
             instance.data,
-            customProvider.data?.provider?.id ?? customProvider.data?.id
+            customProvider.data?.provider?.slug ?? customProvider.data?.id
           )}
         >
           <Button as="span" size="2" variant="outline">

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/_layout.tsx
@@ -3,7 +3,8 @@ import { SimpleSidebarLayout } from '@metorial/layout';
 import {
   useCurrentInstance,
   useCurrentOrganization,
-  useCurrentProject
+  useCurrentProject,
+  useProvider
 } from '@metorial/state';
 import { Select } from '@metorial/ui';
 import { Outlet, useParams } from 'react-router-dom';
@@ -13,7 +14,10 @@ export let ProviderCapabilitiesLayout = () => {
   let organization = useCurrentOrganization();
   let project = useCurrentProject();
   let instance = useCurrentInstance();
+
   let { providerId } = useParams();
+  let provider = useProvider(instance.data?.id, providerId);
+
   let { selectedVersionId, setSelectedVersionId, currentVersionId, allVersions } =
     useProviderVersionContext();
 
@@ -21,7 +25,7 @@ export let ProviderCapabilitiesLayout = () => {
     organization.data,
     project.data,
     instance.data,
-    providerId
+    provider.data?.slug ?? providerId
   ] as const;
 
   return (

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/_layout.tsx
@@ -16,7 +16,7 @@ import {
 } from '@metorial/state';
 import { Avatar, Callout, Flex, LinkTabs, Spacer } from '@metorial/ui';
 import { useEffect, useMemo, useState } from 'react';
-import { Link, Outlet, useLocation, useParams } from 'react-router-dom';
+import { Link, Outlet, useLocation, useParams, useNavigate } from 'react-router-dom';
 import { OpenExplorerButton } from '../../components/openExplorer';
 import { UseProviderButton } from '../../scenes/providers/useProviderButton';
 import {
@@ -39,6 +39,15 @@ export let ProviderLayout = () => {
   let providerData: ProviderData | null = provider.data;
 
   let pathname = useLocation().pathname;
+  let navigate = useNavigate();
+
+  useEffect(() => {
+    if (!provider.data) return;
+
+    if (providerId !== provider.data.slug) {
+      navigate(pathname.replace(providerId ?? '', provider.data.slug), { replace: true });
+    }
+  }, [providerId, provider.data]);
 
   let versions = useProviderVersions(instance.data?.id, providerId);
   let allVersions: ProviderVersion[] = versions.data?.items ?? [];
@@ -136,8 +145,9 @@ export let ProviderLayout = () => {
     organization.data,
     project.data,
     instance.data,
-    providerData?.id ?? providerId
+    providerData?.slug ?? providerId
   ] as const;
+
   return (
     <ProviderVersionContext.Provider value={versionContext}>
       <ContentLayout>
@@ -152,13 +162,13 @@ export let ProviderLayout = () => {
           description={listing?.description ?? providerData?.description ?? undefined}
           actions={
             <>
-            <OpenExplorerButton
-              variant="outline"
-              disabled={!providerData?.id}
+              <OpenExplorerButton
+                variant="outline"
+                disabled={!providerData?.id}
                 to={Paths.instance.explorer(organization.data, project.data, instance.data, {
                   provider_id: providerData?.id
                 })}
-            />
+              />
 
               <UseProviderButton
                 providerId={providerData?.id}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/grid.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/grid.tsx
@@ -60,8 +60,8 @@ export let ProvidersGrid = ({ mode = 'default', ...filter }: ProvidersGridProps)
           width={isHome ? '220px' : '300px'}
         >
           {providers.data.items.map(listing => {
-            let providerId = listing.provider?.id;
-            if (!providerId) return null;
+            let providerSlug = listing.provider?.slug;
+            if (!providerSlug) return null;
 
             let description = listing.description
               ? listing.description.slice(0, 100) +
@@ -72,7 +72,7 @@ export let ProvidersGrid = ({ mode = 'default', ...filter }: ProvidersGridProps)
               instance.data?.organization,
               instance.data?.project,
               instance.data,
-              providerId
+              providerSlug
             );
 
             return (

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/homeTable.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/homeTable.tsx
@@ -115,14 +115,14 @@ export let HomeProvidersTable = (filter: DashboardInstanceProviderListingsListQu
       {providers.data.items.length > 0 && (
         <Table>
           {providers.data.items.map(listing => {
-            let providerId = listing.provider?.id;
-            if (!providerId) return null;
+            let providerSlug = listing.provider?.slug;
+            if (!providerSlug) return null;
 
             let href = Paths.instance.provider(
               instance.data?.organization,
               instance.data?.project,
               instance.data,
-              providerId
+              providerSlug
             );
 
             return (

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/table.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/table.tsx
@@ -43,7 +43,7 @@ export let ProvidersTable = ({
               instance.data?.organization,
               instance.data?.project,
               instance.data,
-              provider.id
+              provider.slug
             )
           }))}
       />

--- a/src/frontend/config/src/paths.ts
+++ b/src/frontend/config/src/paths.ts
@@ -12,7 +12,7 @@ let InstancePaths = Object.assign(
   ) => {
     if (!instance || !project || !organization) return '#';
 
-    return joinPaths('i', organization.slug, project.slug, instance.slug, ...subPages);
+    return joinPaths('i', instance.slug, ...subPages);
   },
   {
     home: (organization: EntityParam, project: EntityParam, instance: EntityParam) =>

--- a/src/frontend/layout/src/applicationLayout/switcher/actions/createInstance.tsx
+++ b/src/frontend/layout/src/applicationLayout/switcher/actions/createInstance.tsx
@@ -31,7 +31,7 @@ export let createInstance = (
         if (res) {
           close();
           if (project_.organization) {
-            navigate(
+            window.location.replace(
               Paths.instance(project_.organization, res.instance.project, res.instance)
             );
           }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Breaking URL and slug changes affect bookmarks, redirects, and deep links; a background job rewrites instance slugs across the fleet with uniqueness constraints.
> 
> **Overview**
> **Shortens dashboard instance URLs** from `/i/{org}/{project}/{instance}/…` to `/i/{instance}/…` via `Paths.instance`, and uses **full page navigation** after creating a sandbox so the new URL shape loads correctly.
> 
> **Provider navigation** switches catalog links to **`provider.slug`** (with a client-side redirect from legacy id-based provider routes to the canonical slug).
> 
> **Backend migration:** adds `oldSlug`, `hasBeenReconciled2`, and slug indexes on `Instance`. The reconcile cron/queues now **fan out per active instance** (not per project), generate slugs through **`generateInstanceSlug`** (production → project name; development → project-name-instance-name suffix), then atomically set the new `slug`, stash the prior value in `oldSlug`/`previousSlugs`, and mark `hasBeenReconciled2`. The old **`reconcileProjectInstances`** flow (auto-promoting dev to production) is removed. New instances get the updated slug rules and skip the backlog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ffb04b27adb7377e7c77c12afea8c747d60dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->