### PR TITLE
Improve provider paths

### DIFF
--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/_layout.tsx
@@ -68,7 +68,7 @@ export let CustomProviderLayout = () => {
                   organization.data,
                   project.data,
                   instance.data,
-                  customProvider.data.provider.id
+                  customProvider.data.provider.slug
                 )}
               >
                 <Button as="span" size="2" variant="outline">

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/settings/listing.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(custom-providers)/custom-provider/settings/listing.tsx
@@ -60,7 +60,7 @@ export let CustomProviderListingPage = () => {
             instance.data?.organization,
             instance.data?.project,
             instance.data,
-            customProvider.data?.provider?.id ?? customProvider.data?.id
+            customProvider.data?.provider?.slug ?? customProvider.data?.id
           )}
         >
           <Button as="span" size="2" variant="outline">

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/(capapbilities)/_layout.tsx
@@ -3,7 +3,8 @@ import { SimpleSidebarLayout } from '@metorial/layout';
 import {
   useCurrentInstance,
   useCurrentOrganization,
-  useCurrentProject
+  useCurrentProject,
+  useProvider
 } from '@metorial/state';
 import { Select } from '@metorial/ui';
 import { Outlet, useParams } from 'react-router-dom';
@@ -13,7 +14,10 @@ export let ProviderCapabilitiesLayout = () => {
   let organization = useCurrentOrganization();
   let project = useCurrentProject();
   let instance = useCurrentInstance();
+
   let { providerId } = useParams();
+  let provider = useProvider(instance.data?.id, providerId);
+
   let { selectedVersionId, setSelectedVersionId, currentVersionId, allVersions } =
     useProviderVersionContext();
 
@@ -21,7 +25,7 @@ export let ProviderCapabilitiesLayout = () => {
     organization.data,
     project.data,
     instance.data,
-    providerId
+    provider.data?.slug ?? providerId
   ] as const;
 
   return (

--- a/src/frontend/apps/dashboard/src/slices/product/pages/provider/_layout.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/provider/_layout.tsx
@@ -16,7 +16,7 @@ import {
 } from '@metorial/state';
 import { Avatar, Callout, Flex, LinkTabs, Spacer } from '@metorial/ui';
 import { useEffect, useMemo, useState } from 'react';
-import { Link, Outlet, useLocation, useParams } from 'react-router-dom';
+import { Link, Outlet, useLocation, useParams, useNavigate } from 'react-router-dom';
 import { OpenExplorerButton } from '../../components/openExplorer';
 import { UseProviderButton } from '../../scenes/providers/useProviderButton';
 import {
@@ -39,6 +39,15 @@ export let ProviderLayout = () => {
   let providerData: ProviderData | null = provider.data;
 
   let pathname = useLocation().pathname;
+  let navigate = useNavigate();
+
+  useEffect(() => {
+    if (!provider.data) return;
+
+    if (providerId !== provider.data.slug) {
+      navigate(pathname.replace(providerId ?? '', provider.data.slug), { replace: true });
+    }
+  }, [providerId, provider.data]);
 
   let versions = useProviderVersions(instance.data?.id, providerId);
   let allVersions: ProviderVersion[] = versions.data?.items ?? [];
@@ -136,8 +145,9 @@ export let ProviderLayout = () => {
     organization.data,
     project.data,
     instance.data,
-    providerData?.id ?? providerId
+    providerData?.slug ?? providerId
   ] as const;
+
   return (
     <ProviderVersionContext.Provider value={versionContext}>
       <ContentLayout>
@@ -152,13 +162,13 @@ export let ProviderLayout = () => {
           description={listing?.description ?? providerData?.description ?? undefined}
           actions={
             <>
-            <OpenExplorerButton
-              variant="outline"
-              disabled={!providerData?.id}
+              <OpenExplorerButton
+                variant="outline"
+                disabled={!providerData?.id}
                 to={Paths.instance.explorer(organization.data, project.data, instance.data, {
                   provider_id: providerData?.id
                 })}
-            />
+              />
 
               <UseProviderButton
                 providerId={providerData?.id}

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/grid.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/grid.tsx
@@ -60,8 +60,8 @@ export let ProvidersGrid = ({ mode = 'default', ...filter }: ProvidersGridProps)
           width={isHome ? '220px' : '300px'}
         >
           {providers.data.items.map(listing => {
-            let providerId = listing.provider?.id;
-            if (!providerId) return null;
+            let providerSlug = listing.provider?.slug;
+            if (!providerSlug) return null;
 
             let description = listing.description
               ? listing.description.slice(0, 100) +
@@ -72,7 +72,7 @@ export let ProvidersGrid = ({ mode = 'default', ...filter }: ProvidersGridProps)
               instance.data?.organization,
               instance.data?.project,
               instance.data,
-              providerId
+              providerSlug
             );
 
             return (

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/homeTable.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/homeTable.tsx
@@ -115,14 +115,14 @@ export let HomeProvidersTable = (filter: DashboardInstanceProviderListingsListQu
       {providers.data.items.length > 0 && (
         <Table>
           {providers.data.items.map(listing => {
-            let providerId = listing.provider?.id;
-            if (!providerId) return null;
+            let providerSlug = listing.provider?.slug;
+            if (!providerSlug) return null;
 
             let href = Paths.instance.provider(
               instance.data?.organization,
               instance.data?.project,
               instance.data,
-              providerId
+              providerSlug
             );
 
             return (

--- a/src/frontend/apps/dashboard/src/slices/product/scenes/providers/table.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/scenes/providers/table.tsx
@@ -43,7 +43,7 @@ export let ProvidersTable = ({
               instance.data?.organization,
               instance.data?.project,
               instance.data,
-              provider.id
+              provider.slug
             )
           }))}
       />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Routing and deep-link behavior change across the provider area; broken redirects or missed link updates could strand users on wrong pages, though scope is limited to frontend navigation.
> 
> **Overview**
> Provider detail and listing navigation now builds `Paths.instance.provider` links with **`provider.slug`** instead of **`provider.id`** (custom-provider “Open Listing”, provider grid/home table, providers table, and provider/capabilities tab routes).
> 
> **`ProviderLayout`** adds a **replace** redirect when the route param does not match the loaded provider’s slug, so bookmarks or old ID-based URLs normalize to slug paths. Tabs and nested layouts use `providerData?.slug ?? providerId` for path segments while explorer/actions still pass **`provider_id`** as the internal id where required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f817a0e4ee0bc073357bf0e9c991a81c9bf30196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->